### PR TITLE
Add first search SQL interpretation for filters.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/search/Attribute.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Attribute.java
@@ -1,0 +1,37 @@
+package bio.terra.tanagra.service.search;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * An Attribute describes a characteristic of an {@link Entity}.
+ *
+ * <p>An attribute of a "person" entity might be their "date of birth."
+ */
+@AutoValue
+public abstract class Attribute {
+  public abstract String name();
+
+  public abstract DataType dataType();
+
+  public abstract Entity entity();
+
+  public static Attribute create(String name, DataType dataType, Entity entity) {
+    return builder().name(name).dataType(dataType).entity(entity).build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_Attribute.Builder();
+  }
+
+  /** A builder for {@link Attribute}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder name(String name);
+
+    public abstract Builder dataType(DataType dataType);
+
+    public abstract Builder entity(Entity entity);
+
+    public abstract Attribute build();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/DataType.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/DataType.java
@@ -1,0 +1,8 @@
+package bio.terra.tanagra.service.search;
+
+/** The type of data in an entity attribute value. */
+public enum DataType {
+  STRING,
+  INT64
+  // TODO add more.
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/Entity.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Entity.java
@@ -1,0 +1,30 @@
+package bio.terra.tanagra.service.search;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * A relational logical entity supported by a dataset underlay.
+ *
+ * <p>In an OMOP schema, you might have a "person" entity, and a "procedure" entity.
+ */
+@AutoValue
+public abstract class Entity {
+  public abstract String name();
+
+  public abstract String underlay();
+
+  public static Builder builder() {
+    return new AutoValue_Entity.Builder();
+  }
+
+  /** A builder for {@link Entity}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder name(String name);
+
+    public abstract Builder underlay(String underlay);
+
+    public abstract Entity build();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/Entity.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Entity.java
@@ -9,8 +9,10 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 public abstract class Entity {
+  /** The name of the entity. */
   public abstract String name();
 
+  /** The name of the dataset underlay that this entity is a part of. */
   public abstract String underlay();
 
   public static Builder builder() {

--- a/api/src/main/java/bio/terra/tanagra/service/search/Expression.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Expression.java
@@ -1,0 +1,54 @@
+package bio.terra.tanagra.service.search;
+
+import com.google.auto.value.AutoValue;
+
+/** A construct in a query syntax tree that evaluates to a value. */
+public interface Expression {
+  /**
+   * A visitor pattern interface for an {@link Expression}.
+   *
+   * @param <R> the return value for the visitor.
+   */
+  interface Visitor<R> {
+    R visitLiteral(Literal literal);
+
+    R visitAttribute(AttributeExpression attributeExpression);
+  }
+
+  /** Accept the {@link Visitor} pattern. */
+  <R> R accept(Visitor<R> visitor);
+
+  /** An {@link Expression} that's a literal value. */
+  @AutoValue
+  abstract class Literal implements Expression {
+    public abstract DataType dataType();
+
+    public abstract String value();
+
+    public static Literal create(DataType dataType, String value) {
+      return new AutoValue_Expression_Literal(dataType, value);
+    }
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      return visitor.visitLiteral(this);
+    }
+  }
+
+  /** An {@link Expression} that's an {@link bio.terra.tanagra.service.search.Attribute} */
+  @AutoValue
+  abstract class AttributeExpression implements Expression {
+    public abstract Attribute attribute();
+
+    public static AttributeExpression create(Attribute attribute) {
+      return new AutoValue_Expression_AttributeExpression(attribute);
+    }
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      return visitor.visitAttribute(this);
+    }
+  }
+
+  // TODO implement math expressions as needed, e.g. minus, plus.
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/Filter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Filter.java
@@ -1,0 +1,78 @@
+package bio.terra.tanagra.service.search;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+/**
+ * A construct in a query that represents a filter on a {@link Entity}.
+ *
+ * <p>A filter is a function that evaluates to true or false on every instance of the associated
+ * {@link Entity}.
+ */
+public interface Filter {
+  /**
+   * A visitor pattern interface for a {@link Filter}.
+   *
+   * @param <R> the return value for the visitor.
+   */
+  interface Visitor<R> {
+    R visitArrayFunction(ArrayFunction arrayFunction);
+
+    R visitBinaryComparision(BinaryFunction binaryFunction);
+  }
+
+  /** Accept the {@link Visitor} pattern. */
+  <R> R accept(Visitor<R> visitor);
+
+  /** A {@link Filter} for the comparison of two {@link Expression} that evaluates to a boolean. */
+  @AutoValue
+  abstract class BinaryFunction implements Filter {
+    public abstract Expression left();
+
+    public abstract Operator operator();
+
+    public abstract Expression right();
+
+    public static BinaryFunction create(Expression left, Operator operator, Expression right) {
+      return new AutoValue_Filter_BinaryFunction(left, operator, right);
+    }
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      return visitor.visitBinaryComparision(this);
+    }
+
+    public enum Operator {
+      EQUALS,
+      LESS_THAN
+      // TODO add more including DESCENDANT_OF
+    }
+  }
+
+  /** A {@link Filter} that composes one or more other {@link Filter}s. */
+  @AutoValue
+  abstract class ArrayFunction implements Filter {
+    public abstract ImmutableList<Filter> operands();
+
+    public abstract Operator operator();
+
+    public static ArrayFunction create(List<Filter> operands, Operator operator) {
+      Preconditions.checkArgument(!operands.isEmpty(), "ArrayFunction Operands must not be empty.");
+      return new AutoValue_Filter_ArrayFunction(ImmutableList.copyOf(operands), operator);
+    }
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      return visitor.visitArrayFunction(this);
+    }
+
+    public enum Operator {
+      AND, // All of the operands must be true.
+      OR // Any of the operands must be true.
+    }
+  }
+
+  // TODO implement a relationship filter tht allows chaining to another entity.
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/SearchContext.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SearchContext.java
@@ -1,0 +1,21 @@
+package bio.terra.tanagra.service.search;
+
+import com.google.auto.value.AutoValue;
+
+/** Value class to hold all the context that's needed to evaluate a search. */
+@AutoValue
+public abstract class SearchContext {
+  public abstract UnderlaySqlResolver underlaySqlResolver();
+
+  public static Builder builder() {
+    return new AutoValue_SearchContext.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder underlaySqlResolver(UnderlaySqlResolver underlaySqlResolver);
+
+    public abstract SearchContext build();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -1,0 +1,85 @@
+package bio.terra.tanagra.service.search;
+
+import bio.terra.tanagra.service.search.Expression.AttributeExpression;
+import bio.terra.tanagra.service.search.Filter.ArrayFunction;
+import bio.terra.tanagra.service.search.Filter.BinaryFunction;
+import bio.terra.tanagra.service.search.Filter.Visitor;
+import java.util.stream.Collectors;
+
+/** Visitors for walking query constructs to create SQL. */
+// TODO consider how this may need to be split for different SQL backends.
+public class SqlVisitor {
+  /** A {@link Visitor} for creating SQL for filters. */
+  static class FilterVisitor implements Visitor<String> {
+    private final SearchContext searchContext;
+
+    FilterVisitor(SearchContext searchContext) {
+      this.searchContext = searchContext;
+    }
+
+    @Override
+    public String visitArrayFunction(ArrayFunction arrayFunction) {
+      String operatorDelimiter = String.format(" %s ", convert(arrayFunction.operator()));
+      // e.g. (operand0) OR (operand1)
+      return String.join(
+          operatorDelimiter,
+          arrayFunction.operands().stream()
+              // Recursively evaluate each operand, wrapping it in parens.
+              .map(f -> String.format("(%s)", f.accept(this)))
+              .collect(Collectors.toList()));
+    }
+
+    private static String convert(ArrayFunction.Operator operator) {
+      switch (operator) {
+        case AND:
+          return "AND";
+        case OR:
+          return "OR";
+        default:
+          throw new UnsupportedOperationException(
+              String.format("Unable to convert ArrayFunction.Operator %s to SQL string", operator));
+      }
+    }
+
+    @Override
+    public String visitBinaryComparision(BinaryFunction binaryFunction) {
+      ExpressionVisitor expressionVisitor = new ExpressionVisitor(searchContext);
+
+      String leftSql = binaryFunction.left().accept(expressionVisitor);
+      String rightSql = binaryFunction.right().accept(expressionVisitor);
+      switch (binaryFunction.operator()) {
+        case LESS_THAN:
+          return String.format("%s < %s", leftSql, rightSql);
+        case EQUALS:
+          return String.format("%s = %s", leftSql, rightSql);
+        default:
+          throw new UnsupportedOperationException(
+              String.format("Unsupported BinaryFunction.Operator %s", binaryFunction.operator()));
+      }
+    }
+  }
+
+  /** A {@link Expression.Visitor} for creating SQL for expressions. */
+  static class ExpressionVisitor implements Expression.Visitor<String> {
+    private final SearchContext searchContext;
+
+    ExpressionVisitor(SearchContext searchContext) {
+      this.searchContext = searchContext;
+    }
+
+    @Override
+    public String visitLiteral(Expression.Literal literal) {
+      // TODO consider parametrizing output to avoid injection.
+      if (DataType.STRING.equals(literal.dataType())) {
+        return String.format("'%s'", literal.value());
+      }
+      return literal.value();
+    }
+
+    @Override
+    public String visitAttribute(AttributeExpression attributeExpression) {
+      // TODO consider aliasing entities.
+      return searchContext.underlaySqlResolver().resolve(attributeExpression.attribute());
+    }
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 /** Visitors for walking query constructs to create SQL. */
 // TODO consider how this may need to be split for different SQL backends.
+// TODO consider the jOOQ DSL.
 public class SqlVisitor {
   /** A {@link Visitor} for creating SQL for filters. */
   static class FilterVisitor implements Visitor<String> {
@@ -69,11 +70,16 @@ public class SqlVisitor {
 
     @Override
     public String visitLiteral(Expression.Literal literal) {
-      // TODO consider parametrizing output to avoid injection.
-      if (DataType.STRING.equals(literal.dataType())) {
-        return String.format("'%s'", literal.value());
+      // TODO parameterize output to avoid injection.
+      switch (literal.dataType()) {
+        case STRING:
+          return String.format("'%s'", literal.value());
+        case INT64:
+          return literal.value();
+        default:
+          throw new UnsupportedOperationException(
+              String.format("Unsupported DataType %s", literal.dataType()));
       }
-      return literal.value();
     }
 
     @Override

--- a/api/src/main/java/bio/terra/tanagra/service/search/UnderlaySqlResolver.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/UnderlaySqlResolver.java
@@ -1,0 +1,9 @@
+package bio.terra.tanagra.service.search;
+
+/** Resolves logical entity model expressions to backing SQL constructs. */
+public interface UnderlaySqlResolver {
+  /** Resolve an {@link Attribute} as an SQL string expression. */
+  String resolve(Attribute attribute);
+
+  // TODO resolve entities and relationships.
+}

--- a/api/src/test/java/bio/terra/tanagra/app/UnauthenticatedApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/UnauthenticatedApiControllerTest.java
@@ -3,12 +3,12 @@ package bio.terra.tanagra.app;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.tanagra.app.controller.UnauthenticatedApiController;
-import bio.terra.tanagra.testing.BaseUnitTest;
+import bio.terra.tanagra.testing.BaseSpringUnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-public class UnauthenticatedApiControllerTest extends BaseUnitTest {
+public class UnauthenticatedApiControllerTest extends BaseSpringUnitTest {
   @Autowired UnauthenticatedApiController controller;
 
   @Test

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -3,7 +3,6 @@ package bio.terra.tanagra.service.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import bio.terra.tanagra.service.search.Filter.BinaryFunction.Operator;
 import bio.terra.tanagra.service.search.testing.SimpleUnderlaySqlResolver;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Tag;
@@ -25,7 +24,7 @@ public class SqlVisitorTest {
     Filter.BinaryFunction lessThanFilter =
         Filter.BinaryFunction.create(
             Expression.AttributeExpression.create(HEIGHT),
-            Operator.LESS_THAN,
+            Filter.BinaryFunction.Operator.LESS_THAN,
             Expression.Literal.create(DataType.INT64, "62"));
     assertEquals(
         "person.height < 62", lessThanFilter.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
@@ -33,7 +32,7 @@ public class SqlVisitorTest {
     Filter.BinaryFunction equalsFilter =
         Filter.BinaryFunction.create(
             Expression.AttributeExpression.create(HEIGHT),
-            Operator.EQUALS,
+            Filter.BinaryFunction.Operator.EQUALS,
             Expression.Literal.create(DataType.INT64, "62"));
     assertEquals(
         "person.height = 62", equalsFilter.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
@@ -45,7 +44,7 @@ public class SqlVisitorTest {
         ImmutableList.of(
             Filter.BinaryFunction.create(
                 Expression.AttributeExpression.create(HEIGHT),
-                Operator.LESS_THAN,
+                Filter.BinaryFunction.Operator.LESS_THAN,
                 Expression.Literal.create(DataType.INT64, "62")),
             Filter.BinaryFunction.create(
                 Expression.AttributeExpression.create(FIRST_NAME),

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -1,0 +1,89 @@
+package bio.terra.tanagra.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.tanagra.service.search.Filter.BinaryFunction.Operator;
+import bio.terra.tanagra.service.search.testing.SimpleUnderlaySqlResolver;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class SqlVisitorTest {
+  private static final SearchContext SIMPLE_CONTEXT =
+      SearchContext.builder().underlaySqlResolver(new SimpleUnderlaySqlResolver()).build();
+
+  private static final Entity PERSON = Entity.builder().name("person").underlay("foo").build();
+  private static final Attribute HEIGHT =
+      Attribute.builder().name("height").dataType(DataType.INT64).entity(PERSON).build();
+  private static final Attribute FIRST_NAME =
+      Attribute.builder().name("first_name").dataType(DataType.STRING).entity(PERSON).build();
+
+  @Test
+  void filterBinaryFunction() {
+    Filter.BinaryFunction lessThanFilter =
+        Filter.BinaryFunction.create(
+            Expression.AttributeExpression.create(HEIGHT),
+            Operator.LESS_THAN,
+            Expression.Literal.create(DataType.INT64, "62"));
+    assertEquals(
+        "person.height < 62", lessThanFilter.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
+
+    Filter.BinaryFunction equalsFilter =
+        Filter.BinaryFunction.create(
+            Expression.AttributeExpression.create(HEIGHT),
+            Operator.EQUALS,
+            Expression.Literal.create(DataType.INT64, "62"));
+    assertEquals(
+        "person.height = 62", equalsFilter.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
+  }
+
+  @Test
+  void filterArrayFunction() {
+    ImmutableList<Filter> operands =
+        ImmutableList.of(
+            Filter.BinaryFunction.create(
+                Expression.AttributeExpression.create(HEIGHT),
+                Operator.LESS_THAN,
+                Expression.Literal.create(DataType.INT64, "62")),
+            Filter.BinaryFunction.create(
+                Expression.AttributeExpression.create(FIRST_NAME),
+                Filter.BinaryFunction.Operator.EQUALS,
+                Expression.Literal.create(DataType.STRING, "John")));
+
+    Filter andFilter = Filter.ArrayFunction.create(operands, Filter.ArrayFunction.Operator.AND);
+    assertEquals(
+        "(person.height < 62) AND (person.first_name = 'John')",
+        andFilter.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
+
+    Filter orFilter = Filter.ArrayFunction.create(operands, Filter.ArrayFunction.Operator.OR);
+    assertEquals(
+        "(person.height < 62) OR (person.first_name = 'John')",
+        orFilter.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
+  }
+
+  @Test
+  void filterArrayFunctionThrowsIfOperandsEmpty() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Filter.ArrayFunction.create(ImmutableList.of(), Filter.ArrayFunction.Operator.AND));
+  }
+
+  @Test
+  void expressionLiteral() {
+    SqlVisitor.ExpressionVisitor expressionVisitor =
+        new SqlVisitor.ExpressionVisitor(SIMPLE_CONTEXT);
+    assertEquals("42", Expression.Literal.create(DataType.INT64, "42").accept(expressionVisitor));
+    assertEquals(
+        "'foo'", Expression.Literal.create(DataType.STRING, "foo").accept(expressionVisitor));
+  }
+
+  @Test
+  void expressionAttribute() {
+    SqlVisitor.ExpressionVisitor expressionVisitor =
+        new SqlVisitor.ExpressionVisitor(SIMPLE_CONTEXT);
+    assertEquals(
+        "person.height", Expression.AttributeExpression.create(HEIGHT).accept(expressionVisitor));
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/search/testing/SimpleUnderlaySqlResolver.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/testing/SimpleUnderlaySqlResolver.java
@@ -1,0 +1,17 @@
+package bio.terra.tanagra.service.search.testing;
+
+import bio.terra.tanagra.service.search.Attribute;
+import bio.terra.tanagra.service.search.UnderlaySqlResolver;
+
+/** A simple {@link UnderlaySqlResolver} for testing. */
+public class SimpleUnderlaySqlResolver implements UnderlaySqlResolver {
+
+  /**
+   * Resolve all attributes as directly related to '{entity name}.{attribute name}', as if there
+   * were a direct correspondence between each entity and a table and each attribute as a column.
+   */
+  @Override
+  public String resolve(Attribute attribute) {
+    return String.format("%s.%s", attribute.entity().name(), attribute.name());
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/testing/BaseSpringUnitTest.java
+++ b/api/src/test/java/bio/terra/tanagra/testing/BaseSpringUnitTest.java
@@ -14,4 +14,4 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(classes = Main.class)
 @SpringBootTest
 /** Base class for Spring unit tests. */
-public class BaseUnitTest {}
+public class BaseSpringUnitTest {}


### PR DESCRIPTION
Starting in the middle, add the first data classes for entities and attributes and the first query classes for filters and expressions.
The query classes are meant to develop a query search grammar that can be walked for validation and sql construction.
Looking at `SqlVisitorTest` might be clearest place to start.