### PR TITLE
Add basic container building & publishing with Jib & GH actions

### DIFF
--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: tanagra-api:${{ github.event.inputs.version }}
+  IMAGE_NAME: ${{ env.REGISTRY }}/DataBiosphere/tanagra-api:${{ github.event.inputs.version }}
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -47,4 +47,4 @@ jobs:
         run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --stacktrace"
       - name: Push image
         working-directory: api
-        run: "docker push ${IMAGE_NAME}"
+        run: "docker push ${REGISTRY}/DataBiosphere/${IMAGE_NAME}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
           service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Auth Docker for gcloud
-        run: "gcloud auth configure-docker --quiet"
+        run: gcloud auth configure-docker --quiet
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2
         with:
@@ -47,7 +47,7 @@ jobs:
           echo ::set-output name=name::gcr.io/${GCR_PROJECT}/tanagra-api:${{ github.event.inputs.version }}
       - name: Build image locally with jib
         working-directory: api
-        run: "./gradlew jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain --stacktrace"
+        run: ./gradlew jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain --stacktrace
       - name: Push image
         working-directory: api
-        run: "echo ${{ steps.image-name.outputs.name }}"
+        run: docker push ${{ steps.image-name.outputs.name }}

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -3,6 +3,7 @@
 name: Build & Push API image
 
 on:
+  # TODO consider automatic publishing.
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -1,4 +1,6 @@
-name: Create and publish an API Docker image
+# This workflow builds a docker image with jib and pushes it to Github Container Repository.
+
+name: Build & Push API image
 
 on:
   workflow_dispatch:
@@ -17,7 +19,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -39,7 +40,7 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-      - name: Echo version
+      - name: Echo image name
         run: "echo ${IMAGE_NAME}"
       - name: Build image locally with jib
         working-directory: api

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
       - name: Build image locally with jib
         working-directory: api
-        run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --debug"
+        run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --stacktrace"
       - name: Push image
         working-directory: api
         run: "docker push ${IMAGE_NAME}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -47,7 +47,7 @@ jobs:
           echo ::set-output name=name::gcr.io/${GCR_PROJECT}/tanagra-api:${{ github.event.inputs.version }}
       - name: Build image locally with jib
         working-directory: api
-        run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --stacktrace"
+        run: "./gradlew jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain --stacktrace"
       - name: Push image
         working-directory: api
         run: "echo ${{ steps.image-name.outputs.name }}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -10,8 +10,7 @@ on:
         required: true
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ env.REGISTRY }}/DataBiosphere/tanagra-api:${{ github.event.inputs.version }}
+  GCR_PROJECT: broad-dsp-gcr-public
 
 jobs:
   build-and-push-image:
@@ -22,12 +21,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      - name: Auth with gcloud
+        uses: google-github-actions/setup-gcloud@master
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          version: '270.0.0'
+          service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
+          service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
+      - name: Auth Docker for gcloud
+        run: "gcloud auth configure-docker --quiet"
       - name: Set up AdoptOpenJDK 11
         uses: joschi/setup-jdk@v2
         with:
@@ -40,11 +41,13 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-      - name: Echo image name
-        run: "echo ${IMAGE_NAME}"
+      - name: Construct docker image name
+        id: image-name
+        run: |
+          echo ::set-output name=name::gcr.io/${GCR_PROJECT}/tanagra-api:${{ github.event.inputs.version }}
       - name: Build image locally with jib
         working-directory: api
         run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --stacktrace"
       - name: Push image
         working-directory: api
-        run: "docker push ${REGISTRY}/DataBiosphere/${IMAGE_NAME}"
+        run: "echo ${{ steps.image-name.outputs.name }}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -1,4 +1,4 @@
-# This workflow builds a docker image with jib and pushes it to Github Container Repository.
+# This workflow builds a docker image with jib and pushes it to Google Container Repository.
 
 name: Build & Push API image
 

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-api:${{ github.event.inputs.version }}
+  IMAGE_NAME: tanagra-api:${{ github.event.inputs.version }}
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -39,9 +39,9 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-    - name: Build image locally with jib
-      working-directory: api
-      run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain"
-    - name: Push image
-      working-directory: api
-      run: "docker push ${IMAGE_NAME}"
+      - name: Build image locally with jib
+        working-directory: api
+        run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain"
+      - name: Push image
+        working-directory: api
+        run: "docker push ${IMAGE_NAME}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -1,0 +1,47 @@
+name: Create and publish an API Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to tag the image with, e.g. "1.2.3"'
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-api:${{ github.event.inputs.version }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up AdoptOpenJDK 11
+        uses: joschi/setup-jdk@v2
+        with:
+          java-version: 11
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+    - name: Build image locally with jib
+      working-directory: api
+      run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain"
+    - name: Push image
+      working-directory: api
+      run: "docker push ${IMAGE_NAME}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
       - name: Build image locally with jib
         working-directory: api
-        run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain"
+        run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --debug"
       - name: Push image
         working-directory: api
         run: "docker push ${IMAGE_NAME}"

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           version: '270.0.0'
           service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
-          service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
+          service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Auth Docker for gcloud
         run: "gcloud auth configure-docker --quiet"
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -39,6 +39,8 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+      - name: Echo version
+        run: "echo ${IMAGE_NAME}"
       - name: Build image locally with jib
         working-directory: api
         run: "./gradlew jibDockerBuild --image=${IMAGE_NAME} -Djib.console=plain --stacktrace"

--- a/.github/workflows/api-test.yaml
+++ b/.github/workflows/api-test.yaml
@@ -33,6 +33,10 @@ jobs:
         working-directory: api
         # The check task runs static analysis on main & test sources.
         run: ./gradlew check
+      - name: Jib build
+        working-directory: api
+        # Check that jib builds a docker container.
+        run: ./gradlew jibDockerBuild
       - name: Upload Test Reports
         if: always()
         uses: actions/upload-artifact@v1

--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,8 @@
 # Tanagra Service
 The API service backing the Tanagra application.
 
+Images hosted at [gcr.io/broad-dsp-gcr-public/tanagra-api](gcr.io/broad-dsp-gcr-public/tanagra-api).
+
 # Development
 To get started, run `./gradlew build` to build and test.
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -13,6 +13,7 @@ plugins {
 
     id "com.diffplug.spotless" version "5.10.2"
     id "com.github.spotbugs" version "4.5.1"
+    id 'com.google.cloud.tools.jib' version '3.1.2'
     id "com.google.protobuf" version "0.8.15"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "org.hidetake.swagger.generator" version "2.18.2"

--- a/api/gradle/jib.gradle
+++ b/api/gradle/jib.gradle
@@ -1,0 +1,5 @@
+jib {
+    from {
+        image = "adoptopenjdk:11-jre-hotspot"
+    }
+}


### PR DESCRIPTION
Do the easiest first pass on creating a docker container for the service with Jib. Use a simple manual github action to publish images versions to GCR.

Initial image at gcr.io/broad-dsp-gcr-public/tanagra-api