### PR TITLE
Add an intial endpoint OpenApi schema for creating SQL for datasets

### DIFF
--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -36,7 +36,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EntityDataset'
+              $ref: '#/components/schemas/GenerateSqlQueryDatasetRequest'
         responses:
           200:
             $ref: '#/components/responses/SqlQueryResponse'
@@ -119,10 +119,10 @@ components:
       type: object
       properties:
         entityVariable:
-          description: The variable to use for the top level entity in the filter.
+          description: The variable to use for the primary entity in the filter.
           type: string
         attributes:
-          description: The name of the attributes to select for the dataset.
+          description: The name of the attributes of the primary entity to select for the dataset.
           type: array
           items:
             type: string
@@ -229,3 +229,9 @@ components:
           type: array
           items:
             type: string
+
+    GenerateSqlQueryDatasetRequest:
+      type: object
+      properties:
+        entityDataset:
+          $ref: '#/components/schemas/EntityDataset'

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -21,6 +21,28 @@ paths:
           description: Service is broken
 
   # TODO implement "real" export endpoints
+  '/underlays/{underlay}/entities/{entity}/dataset:generateSqlQuery':
+    parameters:
+      - $ref: '#/components/parameters/Underlay'
+      - $ref: '#/components/parameters/Entity'
+    post:
+      # TODO authorization
+      security: [ ]
+      summary: Returns an SQL query for selecting a dataset of an Entity's attributes.
+      operationId: generateSqlQuery
+      tags: [EntitiesDataset]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityDataset'
+        responses:
+          200:
+            $ref: '#/components/responses/SqlQueryResponse'
+
+
+  # TODO implement "real" export endpoints
   '/underlays/{underlay}/entities/{entity}/filters:generateSqlQuery':
     parameters:
       - $ref: '#/components/parameters/Underlay'
@@ -28,7 +50,7 @@ paths:
     post:
       # TODO authorization
       security: []
-      summary: Returns an SQL query for listing all of a Entity's primary keys.
+      summary: Returns an SQL query for listing all of an Entity's primary keys.
       operationId: generateSqlQuery
       tags: [EntitiesFilters]
       requestBody:
@@ -91,6 +113,21 @@ components:
           type: string
         boolVal:
           type: boolean
+
+    EntityDataset:
+      description: A selection of entity attributes and filters on them.
+      type: object
+      properties:
+        entityVariable:
+          description: The variable to use for the top level entity in the filter.
+          type: string
+        attributes:
+          description: The name of the attributes to select for the dataset.
+          type: array
+          items:
+            type: string
+        filter:
+          $ref: '#/components/schemas/Filter'
 
     EntityFilter:
       description: A filter to apply to the given entity.


### PR DESCRIPTION
Start with a simple API for creating SQL queries for datasets.
Initially, this only supports concept sets by having the client compose the filter relationships between entities. I'm not sure that will hold, but it's the simplest place to start. (e.g. to select a 'Conditions' concept set on a 'Person' cohort, the 'Person' entity filter needs to be added as a relationship filter on the 'Conditions' entity.) This also doesn't create an object for the selected attributes list, which may also need to change.