### PR TITLE
Add a dummy publish GH workflow to allow iterating for another PR

### DIFF
--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -1,0 +1,20 @@
+# Dummy github action to allow iteration.
+
+name: Build & Push API image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to tag the image with, e.g. "1.2.3"'
+        required: true
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2


### PR DESCRIPTION
GH actions don't really like to work until they're merged on the main branch. Add a dummy workflow to allow iterating for another PR to actually get this action working.