### PR TITLE
Add maven publishing for Tanagra service

### DIFF
--- a/.github/workflows/api-publish-maven.yaml
+++ b/.github/workflows/api-publish-maven.yaml
@@ -1,0 +1,34 @@
+# This workflow builds a JAR and publish it to Artifactory with Maven.
+
+name: Publish Maven JAR
+
+on:
+  workflow_dispatch: {}
+env:
+  ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+  ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up AdoptOpenJDK 11
+        uses: joschi/setup-jdk@v2
+        with:
+          java-version: 11
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+      - name: Publish to artifactory
+        working-directory: api
+        run: ./gradlew artifactoryPublish

--- a/.github/workflows/api-publish-maven.yaml
+++ b/.github/workflows/api-publish-maven.yaml
@@ -11,9 +11,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -16,9 +16,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,11 +10,13 @@ plugins {
     id "idea"
     id "java"
     id "jacoco"
+    id "maven-publish"
 
     id "com.diffplug.spotless" version "5.10.2"
     id "com.github.spotbugs" version "4.5.1"
     id 'com.google.cloud.tools.jib' version '3.1.2'
     id "com.google.protobuf" version "0.8.15"
+    id "com.jfrog.artifactory" version "4.18.2"
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id "org.hidetake.swagger.generator" version "2.18.2"
     id "org.springframework.boot" version "2.5.1"
@@ -25,6 +27,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_11
 
 group = "bio.terra"
+version = "0.0.0"
 
 ext {
     artifactGroup = "${group}.tanagra"
@@ -91,6 +94,7 @@ dependencies {
 
 // Apply Gradle Script Plugins for more modular gradle files.
 // See also https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins
+apply from: "$rootDir/gradle/artifactory.gradle"
 apply from: "$rootDir/gradle/dependency-locking.gradle"
 apply from: "$rootDir/gradle/javadoc.gradle"
 apply from: "$rootDir/gradle/open-api.gradle"

--- a/api/gradle/artifactory.gradle
+++ b/api/gradle/artifactory.gradle
@@ -1,0 +1,40 @@
+/** Configs for publishing a maven package to artifactory. */
+publishing {
+    publications {
+        tanagraApi(MavenPublication) {
+            from components.java
+            versionMapping {
+                usage("java-runtime"){
+                    fromResolutionResult()
+                }
+            }
+        }
+    }
+}
+
+def artifactory_username = System.getenv("ARTIFACTORY_USERNAME")
+def artifactory_password = System.getenv("ARTIFACTORY_PASSWORD")
+
+gradle.taskGraph.whenReady { taskGraph ->
+    if (taskGraph.hasTask(artifactoryPublish) &&
+    (artifactory_username == null || artifactory_password == null)) {
+        throw new GradleException("Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish")
+    }
+}
+
+artifactory {
+    publish {
+        contextUrl = "https://broadinstitute.jfrog.io/broadinstitute/"
+        repository {
+            repoKey = "libs-snapshot-local" // The Artifactory repository key to publish to
+            username = "${artifactory_username}" // The publisher user name
+            password = "${artifactory_password}" // The publisher password
+        }
+        defaults {
+            // Reference to Gradle Maven publications defined in the build script.
+            publications("tanagraApi")
+            publishArtifacts = true
+            publishPom = true
+        }
+    }
+}


### PR DESCRIPTION
gradle tasks for maven publishing and pushing to artifactory.
Add a github workflow for pushing to the Broad's artifactory.
Remove github action permissions on api-publish since we're not using GHCR and they're unnecessary.

I'll publish the first package after this is merged and I can test the github action. Will add fixes as needed.