### PR TITLE
Add some naming restrictions for Tanagra objects

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/search/Attribute.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Attribute.java
@@ -24,10 +24,17 @@ public abstract class Attribute {
   public abstract static class Builder {
     public abstract Builder name(String name);
 
+    public abstract String name();
+
     public abstract Builder dataType(DataType dataType);
 
     public abstract Builder entity(Entity entity);
 
-    public abstract Attribute build();
+    public Attribute build() {
+      NameUtils.checkName(name(), "Attribute name");
+      return autoBuild();
+    }
+
+    abstract Attribute autoBuild();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/Entity.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Entity.java
@@ -25,9 +25,19 @@ public abstract class Entity {
 
     public abstract Builder name(String name);
 
+    public abstract String name();
+
     public abstract Builder underlay(String underlay);
 
+    public abstract String underlay();
+
     // TODO validate entity/attribute names are non-empty.
-    public abstract Entity build();
+    public Entity build() {
+      NameUtils.checkName(name(), "Entity name");
+      NameUtils.checkName(underlay(), "Entity underlay name");
+      return autoBuild();
+    }
+
+    abstract Entity autoBuild();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/NameUtils.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/NameUtils.java
@@ -1,0 +1,33 @@
+package bio.terra.tanagra.service.search;
+
+import com.google.common.base.Preconditions;
+import java.util.regex.Pattern;
+
+/**
+ * Utilities for checking Tanagra names.
+ *
+ * <p>Some names traverse Tanagra from HTTP requests to SQL generation. For these names, it's
+ * important that they are relatively friendly and simple.
+ */
+final class NameUtils {
+  private NameUtils() {}
+
+  // Start with simple lower case letters, numbers, and underscores of less than 32 characters.
+  // We could add more valid characters, or allow different characters for different places, but
+  // this is a simple starting point.
+  private static final String NAME_REGEX = "^[a-z][a-zA-Z0-9_]{0,31}$";
+  private static final Pattern NAME_VALIDATOR = Pattern.compile(NAME_REGEX);
+
+  /**
+   * Check that the {@code name} matches the {@link #NAME_REGEX}, or else throws an
+   * IllegalArgumentException.
+   */
+  public static void checkName(String name, String fieldName) {
+    Preconditions.checkArgument(
+        NAME_VALIDATOR.matcher(name).matches(),
+        "%s must match regex '%s' but name was '%s'",
+        fieldName,
+        NAME_REGEX,
+        name);
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/search/Relationship.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Relationship.java
@@ -24,10 +24,17 @@ public abstract class Relationship {
 
     public abstract Builder name(String name);
 
+    public abstract String name();
+
     public abstract Builder entity1(Entity entity1);
 
     public abstract Builder entity2(Entity entity2);
 
-    public abstract Relationship build();
+    public Relationship build() {
+      NameUtils.checkName(name(), "Relationship name");
+      return autoBuild();
+    }
+
+    abstract Relationship autoBuild();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
@@ -1,21 +1,28 @@
 package bio.terra.tanagra.service.search;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import java.util.regex.Pattern;
 
 /**
  * A variable to bound to an entity to allow referring to multiple instances of the same entity.
  *
- * <p>A variable name must a be letters, numbers, and underscores, but must start with a
- * lower case letter.
+ * <p>A variable name must be lowercase a-z letters, numbers, and underscores, but must start with a
+ * letter.
  */
 @AutoValue
 public abstract class Variable {
+  private static final String NAME_REGEX = "[a-z][a-z0-9_]*";
+  private static final Pattern NAME_VALIDATOR = Pattern.compile(NAME_REGEX);
+
   public abstract String name();
 
   public static Variable create(String name) {
-    // Use NameUtils for consistency, even though Variables are only ever client generated.
-    // We could consisder having a different naming validation as needed.
-    NameUtils.checkName(name, "Variable name");
+    Preconditions.checkArgument(
+        NAME_VALIDATOR.matcher(name).matches(),
+        "Variable name must match regex '%s' but name was '%s'",
+        NAME_REGEX,
+        name);
     return new AutoValue_Variable(name);
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
@@ -1,8 +1,6 @@
 package bio.terra.tanagra.service.search;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
-import java.util.regex.Pattern;
 
 /**
  * A variable to bound to an entity to allow referring to multiple instances of the same entity.
@@ -12,17 +10,10 @@ import java.util.regex.Pattern;
  */
 @AutoValue
 public abstract class Variable {
-  private static final String NAME_REGEX = "[a-z][a-z0-9_]*";
-  private static final Pattern NAME_VALIDATOR = Pattern.compile(NAME_REGEX);
-
   public abstract String name();
 
   public static Variable create(String name) {
-    Preconditions.checkArgument(
-        NAME_VALIDATOR.matcher(name).matches(),
-        "Variable name must match regex '%s' but name was '%s'",
-        NAME_REGEX,
-        name);
+    NameUtils.checkName(name, "Variable name");
     return new AutoValue_Variable(name);
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
@@ -5,14 +5,16 @@ import com.google.auto.value.AutoValue;
 /**
  * A variable to bound to an entity to allow referring to multiple instances of the same entity.
  *
- * <p>A variable name must be lowercase a-z letters, numbers, and underscores, but must start with a
- * letter.
+ * <p>A variable name must a be letters, numbers, and underscores, but must start with a
+ * lower case letter.
  */
 @AutoValue
 public abstract class Variable {
   public abstract String name();
 
   public static Variable create(String name) {
+    // Use NameUtils for consistency, even though Variables are only ever client generated.
+    // We could consisder having a different naming validation as needed.
     NameUtils.checkName(name, "Variable name");
     return new AutoValue_Variable(name);
   }

--- a/api/src/test/java/bio/terra/tanagra/service/search/AttributeTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/AttributeTest.java
@@ -1,0 +1,22 @@
+package bio.terra.tanagra.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class AttributeTest {
+
+  @Test
+  void nameValidation() {
+    Entity entity = Entity.builder().name("foo").underlay("bar").build();
+    Attribute.builder().name("foo_Bar").dataType(DataType.STRING).entity(entity).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Attribute.builder().name("").dataType(DataType.STRING).entity(entity).build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Attribute.builder().name("f?:").dataType(DataType.STRING).entity(entity).build());
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/search/EntityTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/EntityTest.java
@@ -1,0 +1,19 @@
+package bio.terra.tanagra.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class EntityTest {
+
+  @Test
+  void nameValidation() {
+    Entity.builder().name("foo_Bar").underlay("baz2").build();
+    assertThrows(
+        IllegalArgumentException.class, () -> Entity.builder().name("").underlay("foo").build());
+    assertThrows(
+        IllegalArgumentException.class, () -> Entity.builder().name("foo").underlay("f?:").build());
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/search/RelationshipTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/RelationshipTest.java
@@ -1,0 +1,22 @@
+package bio.terra.tanagra.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class RelationshipTest {
+
+  @Test
+  void nameValidation() {
+    Entity entity = Entity.builder().name("foo").underlay("bar").build();
+    Relationship.builder().name("foo_Bar").entity1(entity).entity2(entity).build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Relationship.builder().name("").entity1(entity).entity2(entity).build());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Relationship.builder().name("f?:").entity1(entity).entity2(entity).build());
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
@@ -33,7 +33,7 @@ public final class NauticalUnderlayUtils {
     return builder.build();
   }
 
-  public static final String NAUTICAL_UNDERLAY_NAME = "Nautical Underlay";
+  public static final String NAUTICAL_UNDERLAY_NAME = "nautical_underlay";
   public static final Entity SAILOR =
       Entity.builder().underlay(NAUTICAL_UNDERLAY_NAME).name("sailors").build();
   public static final Entity BOAT =

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
@@ -14,7 +14,7 @@ public class UnderlayConversionTest {
   void convertUnderlay() throws Exception {
     Underlay nautical = UnderlayConversion.convert(loadNauticalUnderlayProto());
 
-    assertEquals("Nautical Underlay", nautical.name());
+    assertEquals("nautical_underlay", nautical.name());
     assertEquals(
         ImmutableMap.builder()
             .put(SAILOR.name(), SAILOR)

--- a/api/src/test/resources/underlays/nautical.pbtext
+++ b/api/src/test/resources/underlays/nautical.pbtext
@@ -4,7 +4,7 @@
 # reservations for testing.
 # This should be euivalent to nautical.yaml
 
-name: "Nautical Underlay"
+name: "nautical_underlay"
 entities: {
   name: "sailors"
   attributes: {

--- a/api/src/test/resources/underlays/nautical.yaml
+++ b/api/src/test/resources/underlays/nautical.yaml
@@ -2,7 +2,7 @@
 # reservations for testing.
 # This should be equivalent to nautical.pbtext.
 
-name: Nautical Underlay
+name: nautical_underlay
 entities:
   - name: sailors
     attributes:


### PR DESCRIPTION
Add some simple name validation restrictions for Entities, Attributes, and Relationships. We need to refere to these names in APIs and probably don't want to allow anything of any length.