### PR TITLE
Fix maven publish

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -27,7 +27,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_11
 
 group = "bio.terra"
-version = "0.0.0"
+version = "0.0.0-SNAPSHOT"
 
 ext {
     artifactGroup = "${group}.tanagra"


### PR DESCRIPTION
Since we're starting by publishing to `libs-snapshot-local`, our version string needs to end in `-SNAPSHOT`.
We can change to publishing to `libs-release` at a later time, but starting with local snapshots for now.

Initial publication at https://broadinstitute.jfrog.io/ui/native/libs-snapshot-local/bio/terra/tanagra/0.0.0-SNAPSHOT/