### PR TITLE
Add an API for searching and returning entity instances

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/search/Expression.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Expression.java
@@ -19,6 +19,7 @@ public interface Expression {
   <R> R accept(Visitor<R> visitor);
 
   /** An {@link Expression} that's a literal value. */
+  // TODO support null value.
   @AutoValue
   abstract class Literal implements Expression {
     public abstract DataType dataType();

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -125,6 +125,7 @@ paths:
       - $ref: '#/components/parameters/PageSize'
       - $ref: '#/components/parameters/PageToken'
       - $ref: '#/components/parameters/Underlay'
+      - $ref: '#/components/parameters/EntityFilter'
     post:
       # TODO authorization
       security: []
@@ -133,7 +134,7 @@ paths:
       tags: [Entities]
       responses:
         200:
-          $ref: '#/components/responses/GetEntityResponse'
+          $ref: '#/components/responses/SearchEntityInstanceResponse'
 
 components:
   parameters:
@@ -152,6 +153,13 @@ components:
       required: true
       schema:
         type: string
+
+    EntityFilter:
+      name: entityFilter
+      in: query
+      description: A parameter for a filter to apply to an entity
+      schema:
+        $ref: '#/components/schemas/EntityFilter'
 
     PageSize:
       name: pageSize
@@ -200,6 +208,14 @@ components:
           schema:
             $ref: '#/components/schemas/ListUnderlaysResponse'
 
+    SearchEntityInstancesResponse:
+      description: Response to searching the entity instances.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SearchEntityInstancesResponse'
+
+
     SqlQueryResponse:
       description: A raw SQL query.
       content:
@@ -232,7 +248,10 @@ components:
 
     AttributeValue:
       type: object
-      description: A possible value of an attribute. Exactly one field must be specified.
+      description: |
+        A possible value of an attribute. Exactly one field must be specified, or else the object
+        must be null to represent NULL.
+      nullable: true
       properties:
         int64Val:
           type: integer
@@ -422,3 +441,23 @@ components:
             $ref: '#/components/schemas/Underlay'
         nextPageToken:
           $ref: '#/components/schemas/NextPageToken'
+
+    SearchEntityInstancesResponse:
+      type: object
+      description: A view of entity instances for a search request.
+      properties:
+        instances:
+          type: array
+          description: Repeated instances results of the search.
+          items:
+            $ref: '#/components/schemas/EntityInstanceStruct'
+        nextPageToken:
+          $ref: '#/components/schemas/NextPageToken'
+
+
+    EntityInstanceStruct:
+      type: object
+      description: A map of an entity instance attribute names to their value for this instance.
+      additionalProperties:
+        type: object
+        $ref: '#/components/schemas/AttributeValue'

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -401,12 +401,6 @@ components:
           items:
             type: string
 
-    GenerateSqlQueryDatasetRequest:
-      type: object
-      properties:
-        entityDataset:
-          $ref: '#/components/schemas/EntityDataset'
-
     NextPageToken:
       type: string
       description: |

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -77,27 +77,6 @@ paths:
           $ref: '#/components/responses/GetEntityResponse'
 
   # TODO implement "real" export endpoints
-  '/underlays/{underlay}/entities/{entity}/dataset:generateSqlQuery':
-    parameters:
-      - $ref: '#/components/parameters/Underlay'
-      - $ref: '#/components/parameters/Entity'
-    post:
-      # TODO authorization
-      security: [ ]
-      summary: Returns an SQL query for selecting a dataset of an Entity's attributes.
-      operationId: generateSqlQuery
-      tags: [EntitiesDataset]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GenerateSqlQueryDatasetRequest'
-        responses:
-          200:
-            $ref: '#/components/responses/SqlQueryResponse'
-
-  # TODO implement "real" export endpoints
   '/underlays/{underlayName}/entities/{entityName}/filters:generateSqlQuery':
     parameters:
       - $ref: '#/components/parameters/Underlay'
@@ -119,22 +98,38 @@ paths:
           $ref: '#/components/responses/SqlQueryResponse'
 
 
+  # TODO implement "real" export endpoints
+  '/underlays/{underlay}/entities/{entity}/instances:generateSqlQuery':
+    parameters:
+      - $ref: '#/components/parameters/Underlay'
+      - $ref: '#/components/parameters/Entity'
+      - $ref: '#/components/parameters/EntityDataset'
+    get:
+      # TODO authorization
+      security: [ ]
+      summary: Returns an SQL query for selecting a dataset of entity instances.
+      operationId: generateDatasetSqlQuery
+      tags: [EntityInstances]
+      responses:
+        200:
+          $ref: '#/components/responses/SqlQueryResponse'
+
   '/underlays/{underlayName}/entities/{entities}/instances:search':
     parameters:
       - $ref: '#/components/parameters/Entity'
       - $ref: '#/components/parameters/PageSize'
       - $ref: '#/components/parameters/PageToken'
       - $ref: '#/components/parameters/Underlay'
-      - $ref: '#/components/parameters/EntityFilter'
-    post:
+      - $ref: '#/components/parameters/EntityDataset'
+    get:
       # TODO authorization
       security: []
       summary: Search for entity instances
       operationId: searchEntityInstance
-      tags: [Entities]
+      tags: [EntityInstances]
       responses:
         200:
-          $ref: '#/components/responses/SearchEntityInstanceResponse'
+          $ref: '#/components/responses/SearchEntityInstancesResponse'
 
 components:
   parameters:
@@ -154,12 +149,12 @@ components:
       schema:
         type: string
 
-    EntityFilter:
-      name: entityFilter
+    EntityDataset:
+      name: entityDataset
       in: query
-      description: A parameter for a filter to apply to an entity
+      description: A parameter for a dataset of instances to select for an entity
       schema:
-        $ref: '#/components/schemas/EntityFilter'
+        $ref: '#/components/schemas/EntityDataset'
 
     PageSize:
       name: pageSize
@@ -287,7 +282,7 @@ components:
         entityVariable:
           description: The variable to use for the primary entity in the filter.
           type: string
-        attributes:
+        selectedAttributes:
           description: The name of the attributes of the primary entity to select for the dataset.
           type: array
           items:

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -118,6 +118,23 @@ paths:
         200:
           $ref: '#/components/responses/SqlQueryResponse'
 
+
+  '/underlays/{underlayName}/entities/{entities}/instances:search':
+    parameters:
+      - $ref: '#/components/parameters/Entity'
+      - $ref: '#/components/parameters/PageSize'
+      - $ref: '#/components/parameters/PageToken'
+      - $ref: '#/components/parameters/Underlay'
+    post:
+      # TODO authorization
+      security: []
+      summary: Search for entity instances
+      operationId: searchEntityInstance
+      tags: [Entities]
+      responses:
+        200:
+          $ref: '#/components/responses/GetEntityResponse'
+
 components:
   parameters:
     Underlay:

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -103,13 +103,18 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Underlay'
       - $ref: '#/components/parameters/Entity'
-      - $ref: '#/components/parameters/EntityDataset'
-    get:
+    post:
       # TODO authorization
       security: [ ]
       summary: Returns an SQL query for selecting a dataset of entity instances.
       operationId: generateDatasetSqlQuery
       tags: [EntityInstances]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateDatasetSqlQueryRequest'
       responses:
         200:
           $ref: '#/components/responses/SqlQueryResponse'
@@ -120,13 +125,18 @@ paths:
       - $ref: '#/components/parameters/PageSize'
       - $ref: '#/components/parameters/PageToken'
       - $ref: '#/components/parameters/Underlay'
-      - $ref: '#/components/parameters/EntityDataset'
-    get:
+    post:
       # TODO authorization
       security: []
       summary: Search for entity instances
-      operationId: searchEntityInstance
+      operationId: searchEntityInstances
       tags: [EntityInstances]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchEntityInstancesRequest'
       responses:
         200:
           $ref: '#/components/responses/SearchEntityInstancesResponse'
@@ -148,13 +158,6 @@ components:
       required: true
       schema:
         type: string
-
-    EntityDataset:
-      name: entityDataset
-      in: query
-      description: A parameter for a dataset of instances to select for an entity
-      schema:
-        $ref: '#/components/schemas/EntityDataset'
 
     PageSize:
       name: pageSize
@@ -209,7 +212,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SearchEntityInstancesResponse'
-
 
     SqlQueryResponse:
       description: A raw SQL query.
@@ -401,6 +403,12 @@ components:
           items:
             type: string
 
+    GenerateDatasetSqlQueryRequest:
+      type: object
+      properties:
+        entityDataset:
+          $ref: '#/components/schemas/EntityDataset'
+
     NextPageToken:
       type: string
       description: |
@@ -431,6 +439,13 @@ components:
         nextPageToken:
           $ref: '#/components/schemas/NextPageToken'
 
+    SearchEntityInstancesRequest:
+      type: object
+      description: A request for searching entity instances.
+      properties:
+        entityDataset:
+          $ref: '#/components/schemas/EntityDataset'
+
     SearchEntityInstancesResponse:
       type: object
       description: A view of entity instances for a search request.
@@ -442,7 +457,6 @@ components:
             $ref: '#/components/schemas/EntityInstanceStruct'
         nextPageToken:
           $ref: '#/components/schemas/NextPageToken'
-
 
     EntityInstanceStruct:
       type: object


### PR DESCRIPTION
Add the first API for returning entity instance value results.
Modify the generate sql for entity instance dataset endpoint to be under `underlays/-/entities/-/instances` to match `:search`.
Make both endpoints `POST` to avoid intermediate storing of any sensitive filter info.