### PR TITLE
Add backticks around project & database ids for BQ

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -198,9 +198,9 @@ public class SqlVisitor {
     }
 
     private String resolveTable(Table table) {
-      // projectId.datasetId.table
+      // `projectId.datasetId.table`
       return String.format(
-          "%s.%s.%s", table.dataset().projectId(), table.dataset().datasetId(), table.name());
+          "`%s.%s.%s`", table.dataset().projectId(), table.dataset().datasetId(), table.name());
     }
 
     /** Resolve an {@link AttributeExpression} as an SQL expression. */

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -198,9 +198,9 @@ public class SqlVisitor {
     }
 
     private String resolveTable(Table table) {
-      // `projectId.datasetId.table`
+      // `projectId.datasetId`.table
       return String.format(
-          "`%s.%s.%s`", table.dataset().projectId(), table.dataset().datasetId(), table.name());
+          "`%s.%s`.%s", table.dataset().projectId(), table.dataset().datasetId(), table.name());
     }
 
     /** Resolve an {@link AttributeExpression} as an SQL expression. */

--- a/api/src/test/java/bio/terra/tanagra/app/EntitiesFilterApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/EntitiesFilterApiControllerTest.java
@@ -41,7 +41,7 @@ public class EntitiesFilterApiControllerTest extends BaseSpringUnitTest {
             NauticalUnderlayUtils.NAUTICAL_UNDERLAY_NAME, "sailors", apiEntityFilter);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(
-        "SELECT s.s_id FROM my-project-id.nautical.sailors AS s WHERE s.rating = 42",
+        "SELECT s.s_id FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42",
         response.getBody().getQuery());
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
@@ -22,7 +22,7 @@ public class QueryServiceTest extends BaseSpringUnitTest {
   @Test
   void generatePrimaryKeySql() {
     assertEquals(
-        "SELECT s.s_id FROM my-project-id.nautical.sailors AS s WHERE s.rating = 42",
+        "SELECT s.s_id FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42",
         queryService.generatePrimaryKeySql(
             EntityFilter.builder()
                 .primaryEntity(EntityVariable.create(SAILOR, Variable.create("s")))

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -47,7 +47,7 @@ public class SqlVisitorTest {
                         Expression.Literal.create(DataType.INT64, "62"))))
             .build();
     assertEquals(
-        "SELECT s.rating, s.s_name FROM my-project-id.nautical.sailors AS s WHERE s.rating = 62",
+        "SELECT s.rating, s.s_name FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 62",
         new SqlVisitor(SIMPLE_CONTEXT).createSql(query));
   }
 
@@ -136,7 +136,7 @@ public class SqlVisitorTest {
   @Test
   void filterRelationship() {
     assertEquals(
-        "s.s_id IN (SELECT r.s_id FROM my-project-id.nautical.reservations AS r WHERE r.day = 'Tuesday')",
+        "s.s_id IN (SELECT r.s_id FROM `my-project-id.nautical`.reservations AS r WHERE r.day = 'Tuesday')",
         Filter.RelationshipFilter.builder()
             .outerVariable(S_SAILOR)
             .newVariable(R_RESERVATION)
@@ -153,9 +153,9 @@ public class SqlVisitorTest {
   void filterRelationshipNested() {
     Variable r2 = Variable.create("r2");
     assertEquals(
-        "s.s_id IN (SELECT r.s_id FROM my-project-id.nautical.reservations AS r WHERE "
+        "s.s_id IN (SELECT r.s_id FROM `my-project-id.nautical`.reservations AS r WHERE "
             + "r.day = 'Tuesday' AND s.s_id IN (SELECT r2.s_id FROM "
-            + "my-project-id.nautical.reservations AS r2 WHERE r2.day = 'Wednesday'))",
+            + "`my-project-id.nautical`.reservations AS r2 WHERE r2.day = 'Wednesday'))",
         Filter.RelationshipFilter.builder()
             .outerVariable(S_SAILOR)
             .newVariable(R_RESERVATION)
@@ -199,7 +199,7 @@ public class SqlVisitorTest {
         "b.b_name", Expression.AttributeExpression.create(B_NAME).accept(expressionVisitor));
     // NormalizedColumn attribute mapping
     assertEquals(
-        "(SELECT boat_types.bt_name FROM my-project-id.nautical.boat_types WHERE boat_types.bt_id = b.bt_id)",
+        "(SELECT boat_types.bt_name FROM `my-project-id.nautical`.boat_types WHERE boat_types.bt_id = b.bt_id)",
         Expression.AttributeExpression.create(B_TYPE).accept(expressionVisitor));
   }
 }


### PR DESCRIPTION
While backticks aren't necessary in BQ SQL APIs, they're still needed on some BQ consoles. Adding backticks around always for now.
When we support non BQ tables, we can adjust how these kinds of specializations happen.