### PR TITLE
Implement entity instance search SQL generation

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/app/controller/EntityInstancesApiController.java
+++ b/api/src/main/java/bio/terra/tanagra/app/controller/EntityInstancesApiController.java
@@ -1,0 +1,37 @@
+package bio.terra.tanagra.app.controller;
+
+import bio.terra.tanagra.generated.controller.EntityInstancesApi;
+import bio.terra.tanagra.generated.model.ApiGenerateDatasetSqlQueryRequest;
+import bio.terra.tanagra.generated.model.ApiSqlQuery;
+import bio.terra.tanagra.service.query.EntityDataset;
+import bio.terra.tanagra.service.query.QueryService;
+import bio.terra.tanagra.service.query.api.ApiConversionService;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+/** An {@link EntityInstancesApi} controller for operating on entity instances. */
+@Controller
+public class EntityInstancesApiController implements EntityInstancesApi {
+  private final ApiConversionService apiConversionService;
+  private final QueryService queryService;
+
+  @Autowired
+  public EntityInstancesApiController(
+      ApiConversionService apiConversionService, QueryService queryService) {
+    this.apiConversionService = apiConversionService;
+    this.queryService = queryService;
+  }
+
+  @Override
+  public ResponseEntity<ApiSqlQuery> generateDatasetSqlQuery(
+      String underlayName, String entityName, @Valid ApiGenerateDatasetSqlQueryRequest body) {
+    // TODO authorization check.
+    EntityDataset entityDataset =
+        apiConversionService.convertEntityDataset(
+            underlayName, entityName, body.getEntityDataset());
+    String sql = queryService.generateSql(entityDataset);
+    return ResponseEntity.ok(new ApiSqlQuery().query(sql));
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/query/EntityDataset.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/EntityDataset.java
@@ -1,0 +1,38 @@
+package bio.terra.tanagra.service.query;
+
+import bio.terra.tanagra.service.search.Attribute;
+import bio.terra.tanagra.service.search.EntityVariable;
+import bio.terra.tanagra.service.search.Filter;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+/** A query for a dataset of entity instances. */
+@AutoValue
+public abstract class EntityDataset {
+  /** The primary entity and variable that the dataset is being created from. */
+  public abstract EntityVariable primaryEntity();
+
+  /** The attributes selected to make the columns of the dataset. */
+  public abstract ImmutableList<Attribute> selectedAttributes();
+
+  /** The filter to apply to the primary entity. */
+  public abstract Filter filter();
+
+  public static Builder builder() {
+    return new AutoValue_EntityDataset.Builder();
+  }
+
+  /** Builder for {@link EntityDataset}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder primaryEntity(EntityVariable primaryEntity);
+
+    public abstract Builder selectedAttributes(List<Attribute> selectedAttributes);
+
+    public abstract Builder filter(Filter filter);
+
+    public abstract EntityDataset build();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/query/EntityDataset.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/EntityDataset.java
@@ -8,7 +8,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
-/** A query for a dataset of entity instances. */
+/**
+ * A query for a dataset of entity instances. Contains the selected attributes of an entity with a
+ * filter applied on it.
+ */
 @AutoValue
 public abstract class EntityDataset {
   /** The primary entity and variable that the dataset is being created from. */

--- a/api/src/main/java/bio/terra/tanagra/service/query/EntityDataset.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/EntityDataset.java
@@ -4,6 +4,7 @@ import bio.terra.tanagra.service.search.Attribute;
 import bio.terra.tanagra.service.search.EntityVariable;
 import bio.terra.tanagra.service.search.Filter;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
@@ -13,7 +14,10 @@ public abstract class EntityDataset {
   /** The primary entity and variable that the dataset is being created from. */
   public abstract EntityVariable primaryEntity();
 
-  /** The attributes selected to make the columns of the dataset. */
+  /**
+   * The attributes selected to make the columns of the dataset. These must be attributes of the
+   * primary entity.
+   */
   public abstract ImmutableList<Attribute> selectedAttributes();
 
   /** The filter to apply to the primary entity. */
@@ -29,10 +33,26 @@ public abstract class EntityDataset {
 
     public abstract Builder primaryEntity(EntityVariable primaryEntity);
 
+    public abstract EntityVariable primaryEntity();
+
     public abstract Builder selectedAttributes(List<Attribute> selectedAttributes);
+
+    public abstract ImmutableList<Attribute> selectedAttributes();
 
     public abstract Builder filter(Filter filter);
 
-    public abstract EntityDataset build();
+    public EntityDataset build() {
+      for (Attribute attribute : selectedAttributes()) {
+        Preconditions.checkArgument(
+            attribute.entity().equals(primaryEntity().entity()),
+            "Selected attribute's '%s' entity '%s' did not match primary entity '%s'.",
+            attribute.name(),
+            attribute.entity().name(),
+            primaryEntity().entity().name());
+      }
+      return autoBuild();
+    }
+
+    abstract EntityDataset autoBuild();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/query/QueryService.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/QueryService.java
@@ -14,7 +14,12 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-/** A service for executing queries. */
+/**
+ * A service for executing queries.
+ *
+ * <p>Tanagra logical query types, like {@link EntityFilter}, are used here to create {@link Query}s
+ * and execute them.
+ */
 @Service
 public class QueryService {
 
@@ -47,10 +52,13 @@ public class QueryService {
         entityDataset.selectedAttributes().stream()
             .map(
                 attribute ->
-                    Selection.SelectExpression.create(
-                        AttributeExpression.create(
-                            AttributeVariable.create(
-                                attribute, entityDataset.primaryEntity().variable()))))
+                    Selection.SelectExpression.builder()
+                        .expression(
+                            AttributeExpression.create(
+                                AttributeVariable.create(
+                                    attribute, entityDataset.primaryEntity().variable())))
+                        .alias(attribute.name())
+                        .build())
             .collect(ImmutableList.toImmutableList());
     Query query =
         Query.builder()

--- a/api/src/main/java/bio/terra/tanagra/service/query/api/ApiConversionService.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/api/ApiConversionService.java
@@ -1,13 +1,17 @@
 package bio.terra.tanagra.service.query.api;
 
 import bio.terra.common.exception.NotFoundException;
+import bio.terra.tanagra.generated.model.ApiEntityDataset;
 import bio.terra.tanagra.generated.model.ApiEntityFilter;
+import bio.terra.tanagra.service.query.EntityDataset;
 import bio.terra.tanagra.service.query.EntityFilter;
+import bio.terra.tanagra.service.search.Attribute;
 import bio.terra.tanagra.service.search.Entity;
 import bio.terra.tanagra.service.search.EntityVariable;
 import bio.terra.tanagra.service.search.Filter;
 import bio.terra.tanagra.service.underlay.Underlay;
 import bio.terra.tanagra.service.underlay.UnderlayService;
+import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -25,24 +29,69 @@ public class ApiConversionService {
 
   public EntityFilter convertEntityFilter(
       String underlayName, String entityName, ApiEntityFilter apiEntityFilter) {
-    Optional<Underlay> underlay = underlayService.getUnderlay(underlayName);
-    if (underlay.isEmpty()) {
-      throw new NotFoundException(String.format("No known underlay with name '%s'", underlayName));
-    }
-    Entity primaryEntity = underlay.get().entities().get(entityName);
-    if (primaryEntity == null) {
-      throw new NotFoundException(
-          String.format(
-              "No known entity with name '%s' in underlay '%s'", entityName, underlayName));
-    }
+    Underlay underlay = getUnderlay(underlayName);
+    Entity primaryEntity = getEntity(entityName, underlay);
     EntityVariable primaryVariable =
         EntityVariable.create(
             primaryEntity,
             ConversionUtils.createAndValidateVariable(apiEntityFilter.getEntityVariable()));
 
     VariableScope scope = new VariableScope().add(primaryVariable);
-    Filter filter = new FilterConverter(underlay.get()).convert(apiEntityFilter.getFilter(), scope);
+    Filter filter = new FilterConverter(underlay).convert(apiEntityFilter.getFilter(), scope);
 
     return EntityFilter.builder().primaryEntity(primaryVariable).filter(filter).build();
+  }
+
+  public EntityDataset convertEntityDataset(
+      String underlayName, String entityName, ApiEntityDataset apiEntityDataset) {
+    Underlay underlay = getUnderlay(underlayName);
+    Entity primaryEntity = getEntity(entityName, underlay);
+    EntityVariable primaryVariable =
+        EntityVariable.create(
+            primaryEntity,
+            ConversionUtils.createAndValidateVariable(apiEntityDataset.getEntityVariable()));
+
+    VariableScope scope = new VariableScope().add(primaryVariable);
+    Filter filter = new FilterConverter(underlay).convert(apiEntityDataset.getFilter(), scope);
+
+    ImmutableList<Attribute> selectedAttributes =
+        apiEntityDataset.getSelectedAttributes().stream()
+            .map(attributeName -> getAttribute(attributeName, primaryEntity, underlay))
+            .collect(ImmutableList.toImmutableList());
+
+    return EntityDataset.builder()
+        .primaryEntity(primaryVariable)
+        .selectedAttributes(selectedAttributes)
+        .filter(filter)
+        .build();
+  }
+
+  private Underlay getUnderlay(String underlayName) {
+    Optional<Underlay> underlay = underlayService.getUnderlay(underlayName);
+    if (underlay.isEmpty()) {
+      throw new NotFoundException(String.format("No known underlay with name '%s'", underlayName));
+    }
+    return underlay.get();
+  }
+
+  private static Entity getEntity(String entityName, Underlay underlay) {
+    Entity entity = underlay.entities().get(entityName);
+    if (entity == null) {
+      throw new NotFoundException(
+          String.format(
+              "No known entity with name '%s' in underlay '%s'", entityName, underlay.name()));
+    }
+    return entity;
+  }
+
+  private static Attribute getAttribute(String attributeName, Entity entity, Underlay underlay) {
+    Attribute attribute = underlay.attributes().get(entity, attributeName);
+    if (attribute == null) {
+      throw new NotFoundException(
+          String.format(
+              "No known attribute with name '%s' in entity '%s' in underlay '%s'",
+              attributeName, entity.name(), underlay.name()));
+    }
+    return attribute;
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/Selection.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Selection.java
@@ -34,7 +34,7 @@ public interface Selection {
     abstract Optional<String> alias();
 
     public static SelectExpression create(Expression expression, Optional<String> alias) {
-      return new AutoValue_Selection_SelectExpression(expression, alias);
+      return builder().expression(expression).alias(alias).build();
     }
 
     public static SelectExpression create(Expression expression) {
@@ -44,6 +44,23 @@ public interface Selection {
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.selectExpression(this);
+    }
+
+    public static Builder builder() {
+      return new AutoValue_Selection_SelectExpression.Builder();
+    }
+
+    /** Builder for {@link SelectExpression}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder expression(Expression expression);
+
+      public abstract Builder alias(Optional<String> alias);
+
+      public abstract Builder alias(String alias);
+
+      public abstract SelectExpression build();
     }
   }
 

--- a/api/src/main/java/bio/terra/tanagra/service/search/Selection.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Selection.java
@@ -31,6 +31,7 @@ public interface Selection {
     abstract Expression expression();
 
     /** An alias to name this selection. */
+    // TODO check alias for SQL stop words.
     abstract Optional<String> alias();
 
     public static SelectExpression create(Expression expression, Optional<String> alias) {

--- a/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Variable.java
@@ -15,6 +15,7 @@ public abstract class Variable {
   private static final String NAME_REGEX = "[a-z][a-z0-9_]*";
   private static final Pattern NAME_VALIDATOR = Pattern.compile(NAME_REGEX);
 
+  // TODO check name for SQL stop words.
   public abstract String name();
 
   public static Variable create(String name) {

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -99,7 +99,7 @@ paths:
 
 
   # TODO implement "real" export endpoints
-  '/underlays/{underlay}/entities/{entity}/instances:generateSqlQuery':
+  '/underlays/{underlayName}/entities/{entityName}/instances:generateSqlQuery':
     parameters:
       - $ref: '#/components/parameters/Underlay'
       - $ref: '#/components/parameters/Entity'
@@ -119,7 +119,7 @@ paths:
         200:
           $ref: '#/components/responses/SqlQueryResponse'
 
-  '/underlays/{underlayName}/entities/{entities}/instances:search':
+  '/underlays/{underlayName}/entities/{entityName}/instances:search':
     parameters:
       - $ref: '#/components/parameters/Entity'
       - $ref: '#/components/parameters/PageSize'

--- a/api/src/test/java/bio/terra/tanagra/app/controller/EntityInstancesApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/EntityInstancesApiControllerTest.java
@@ -1,0 +1,51 @@
+package bio.terra.tanagra.app.controller;
+
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.NAUTICAL_UNDERLAY_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.tanagra.generated.model.ApiAttributeValue;
+import bio.terra.tanagra.generated.model.ApiAttributeVariable;
+import bio.terra.tanagra.generated.model.ApiBinaryFilter;
+import bio.terra.tanagra.generated.model.ApiBinaryFilterOperator;
+import bio.terra.tanagra.generated.model.ApiEntityDataset;
+import bio.terra.tanagra.generated.model.ApiFilter;
+import bio.terra.tanagra.generated.model.ApiGenerateDatasetSqlQueryRequest;
+import bio.terra.tanagra.generated.model.ApiSqlQuery;
+import bio.terra.tanagra.testing.BaseSpringUnitTest;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("nautical")
+public class EntityInstancesApiControllerTest extends BaseSpringUnitTest {
+  @Autowired private EntityInstancesApiController controller;
+
+  @Test
+  void generateDatasetSqlQuery() {
+    ResponseEntity<ApiSqlQuery> response =
+        controller.generateDatasetSqlQuery(
+            NAUTICAL_UNDERLAY_NAME,
+            "sailors",
+            new ApiGenerateDatasetSqlQueryRequest()
+                .entityDataset(
+                    new ApiEntityDataset()
+                        .entityVariable("s")
+                        .selectedAttributes(ImmutableList.of("name", "rating"))
+                        .filter(
+                            new ApiFilter()
+                                .binaryFilter(
+                                    new ApiBinaryFilter()
+                                        .attributeVariable(
+                                            new ApiAttributeVariable().variable("s").name("rating"))
+                                        .operator(ApiBinaryFilterOperator.EQUALS)
+                                        .attributeValue(new ApiAttributeValue().int64Val(42L))))));
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(
+        "SELECT s.s_name AS name, s.rating AS rating "
+            + "FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42",
+        response.getBody().getQuery());
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/query/EntityDatasetTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/EntityDatasetTest.java
@@ -1,6 +1,9 @@
 package bio.terra.tanagra.service.query;
 
-import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.*;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_NAME;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_NAME;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_RATING;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import bio.terra.tanagra.service.search.AttributeVariable;

--- a/api/src/test/java/bio/terra/tanagra/service/query/EntityDatasetTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/EntityDatasetTest.java
@@ -1,0 +1,48 @@
+package bio.terra.tanagra.service.query;
+
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.tanagra.service.search.AttributeVariable;
+import bio.terra.tanagra.service.search.DataType;
+import bio.terra.tanagra.service.search.EntityVariable;
+import bio.terra.tanagra.service.search.Expression;
+import bio.terra.tanagra.service.search.Filter;
+import bio.terra.tanagra.service.search.Variable;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class EntityDatasetTest {
+
+  @Test
+  void attributesMustMatchPrimaryEntity() {
+    EntityDataset.Builder builder =
+        EntityDataset.builder()
+            .primaryEntity(EntityVariable.create(SAILOR, Variable.create("s")))
+            .selectedAttributes(ImmutableList.of(SAILOR_RATING, SAILOR_NAME))
+            .filter(
+                Filter.BinaryFunction.create(
+                    Expression.AttributeExpression.create(
+                        AttributeVariable.create(SAILOR_RATING, Variable.create("s"))),
+                    Filter.BinaryFunction.Operator.EQUALS,
+                    Expression.Literal.create(DataType.INT64, "42")));
+    // All sailor attributes build without issue.
+    builder.build();
+
+    // Non-sailor attribute throws.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            builder
+                .selectedAttributes(ImmutableList.of(BOAT_NAME, SAILOR_RATING))
+                .filter(
+                    Filter.BinaryFunction.create(
+                        Expression.AttributeExpression.create(
+                            AttributeVariable.create(SAILOR_RATING, Variable.create("s"))),
+                        Filter.BinaryFunction.Operator.EQUALS,
+                        Expression.Literal.create(DataType.INT64, "42")))
+                .build());
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.service.query;
 
-import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR;
-import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_RATING;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.tanagra.service.search.AttributeVariable;
@@ -11,6 +10,7 @@ import bio.terra.tanagra.service.search.Expression;
 import bio.terra.tanagra.service.search.Filter;
 import bio.terra.tanagra.service.search.Variable;
 import bio.terra.tanagra.testing.BaseSpringUnitTest;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,6 +26,24 @@ public class QueryServiceTest extends BaseSpringUnitTest {
         queryService.generatePrimaryKeySql(
             EntityFilter.builder()
                 .primaryEntity(EntityVariable.create(SAILOR, Variable.create("s")))
+                .filter(
+                    Filter.BinaryFunction.create(
+                        Expression.AttributeExpression.create(
+                            AttributeVariable.create(SAILOR_RATING, Variable.create("s"))),
+                        Filter.BinaryFunction.Operator.EQUALS,
+                        Expression.Literal.create(DataType.INT64, "42")))
+                .build()));
+  }
+
+  @Test
+  void generateSqlEntityDataset() {
+    assertEquals(
+        "SELECT s.rating AS rating, s.s_name AS name "
+            + "FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42",
+        queryService.generateSql(
+            EntityDataset.builder()
+                .primaryEntity(EntityVariable.create(SAILOR, Variable.create("s")))
+                .selectedAttributes(ImmutableList.of(SAILOR_RATING, SAILOR_NAME))
                 .filter(
                     Filter.BinaryFunction.create(
                         Expression.AttributeExpression.create(

--- a/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
@@ -1,6 +1,8 @@
 package bio.terra.tanagra.service.query;
 
-import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.*;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_NAME;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_RATING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.tanagra.service.search.AttributeVariable;

--- a/api/src/test/java/bio/terra/tanagra/service/query/api/ApiConversionServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/api/ApiConversionServiceTest.java
@@ -10,8 +10,10 @@ import bio.terra.tanagra.generated.model.ApiAttributeValue;
 import bio.terra.tanagra.generated.model.ApiAttributeVariable;
 import bio.terra.tanagra.generated.model.ApiBinaryFilter;
 import bio.terra.tanagra.generated.model.ApiBinaryFilterOperator;
+import bio.terra.tanagra.generated.model.ApiEntityDataset;
 import bio.terra.tanagra.generated.model.ApiEntityFilter;
 import bio.terra.tanagra.generated.model.ApiFilter;
+import bio.terra.tanagra.service.query.EntityDataset;
 import bio.terra.tanagra.service.query.EntityFilter;
 import bio.terra.tanagra.service.search.AttributeVariable;
 import bio.terra.tanagra.service.search.DataType;
@@ -20,6 +22,7 @@ import bio.terra.tanagra.service.search.Expression;
 import bio.terra.tanagra.service.search.Filter;
 import bio.terra.tanagra.service.search.Variable;
 import bio.terra.tanagra.testing.BaseSpringUnitTest;
+import com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,6 +76,55 @@ public class ApiConversionServiceTest extends BaseSpringUnitTest {
             () ->
                 apiConversionService.convertEntityFilter(
                     NAUTICAL_UNDERLAY_NAME, "bogus_entity", new ApiEntityFilter()));
+    assertThat(bogusEntity.getMessage(), Matchers.containsString("No known entity with name"));
+  }
+
+  @Test
+  void entityDataset() {
+    ApiEntityDataset apiEntityDataset =
+        new ApiEntityDataset()
+            .entityVariable("s")
+            .selectedAttributes(ImmutableList.of("name", "rating"))
+            .filter(
+                new ApiFilter()
+                    .binaryFilter(
+                        new ApiBinaryFilter()
+                            .attributeVariable(
+                                new ApiAttributeVariable().variable("s").name("rating"))
+                            .operator(ApiBinaryFilterOperator.EQUALS)
+                            .attributeValue(new ApiAttributeValue().int64Val(42L))));
+
+    Variable sVar = Variable.create("s");
+    assertEquals(
+        EntityDataset.builder()
+            .primaryEntity(EntityVariable.create(SAILOR, Variable.create("s")))
+            .selectedAttributes(ImmutableList.of(SAILOR_NAME, SAILOR_RATING))
+            .filter(
+                Filter.BinaryFunction.create(
+                    Expression.AttributeExpression.create(
+                        AttributeVariable.create(SAILOR_RATING, sVar)),
+                    Filter.BinaryFunction.Operator.EQUALS,
+                    Expression.Literal.create(DataType.INT64, "42")))
+            .build(),
+        apiConversionService.convertEntityDataset(
+            NAUTICAL_UNDERLAY_NAME, "sailors", apiEntityDataset));
+  }
+
+  @Test
+  void entityDatasetUnknownNamesThrow() {
+    NotFoundException bogusUnderlay =
+        assertThrows(
+            NotFoundException.class,
+            () ->
+                apiConversionService.convertEntityDataset(
+                    "bogus_underlay", "sailors", new ApiEntityDataset()));
+    assertThat(bogusUnderlay.getMessage(), Matchers.containsString("No known underlay with name"));
+    NotFoundException bogusEntity =
+        assertThrows(
+            NotFoundException.class,
+            () ->
+                apiConversionService.convertEntityDataset(
+                    NAUTICAL_UNDERLAY_NAME, "bogus_entity", new ApiEntityDataset()));
     assertThat(bogusEntity.getMessage(), Matchers.containsString("No known entity with name"));
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -1,6 +1,13 @@
 package bio.terra.tanagra.service.search;
 
-import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.*;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_NAME;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_TYPE_NAME;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.RESERVATION;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.RESERVATION_DAY;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_NAME;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_RATING;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.loadNauticalUnderlay;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -56,13 +56,17 @@ public class SqlVisitorTest {
     SqlVisitor.SelectionVisitor visitor = new SelectionVisitor(SIMPLE_CONTEXT);
     assertEquals(
         "s.rating AS rt",
-        Selection.SelectExpression.create(
-                Expression.AttributeExpression.create(S_RATING), Optional.of("rt"))
+        Selection.SelectExpression.builder()
+            .expression(Expression.AttributeExpression.create(S_RATING))
+            .alias(Optional.of("rt"))
+            .build()
             .accept(visitor));
     assertEquals(
         "s.rating",
-        Selection.SelectExpression.create(
-                Expression.AttributeExpression.create(S_RATING), Optional.empty())
+        Selection.SelectExpression.builder()
+            .expression(Expression.AttributeExpression.create(S_RATING))
+            .alias(Optional.empty())
+            .build()
             .accept(visitor));
   }
 


### PR DESCRIPTION
Implements the entity instance search endpoint for generating SQL.
Add a builder for Selection.SelectExpression.
Fix parametr names in open api paths. Noticed through manual usage of the swagger UI.