### PR TITLE
Make names for selections mandatory.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/query/QueryService.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/QueryService.java
@@ -38,7 +38,10 @@ public class QueryService {
         Query.builder()
             .selections(
                 ImmutableList.of(
-                    Selection.PrimaryKey.create(entityFilter.primaryEntity(), Optional.empty())))
+                    Selection.PrimaryKey.builder()
+                        .entityVariable(entityFilter.primaryEntity())
+                        .name("primary_key")
+                        .build()))
             .primaryEntity(entityFilter.primaryEntity())
             .filter(entityFilter.filter())
             .build();
@@ -57,7 +60,7 @@ public class QueryService {
                             AttributeExpression.create(
                                 AttributeVariable.create(
                                     attribute, entityDataset.primaryEntity().variable())))
-                        .alias(attribute.name())
+                        .name(attribute.name())
                         .build())
             .collect(ImmutableList.toImmutableList());
     Query query =

--- a/api/src/main/java/bio/terra/tanagra/service/search/Selection.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Selection.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.service.search;
 
 import com.google.auto.value.AutoValue;
-import java.util.Optional;
 
 /**
  * A construct in a query that represents a value to be selected.
@@ -9,6 +8,10 @@ import java.util.Optional;
  * <p>Represents a single column in a SELECT SQL clause.
  */
 public interface Selection {
+  /** The name for the value being selected. Selection names should be unique within a query. */
+  // TODO check names for SQL stop words.
+  String name();
+
   /**
    * A visitor pattern interface for a {@link Selection}.
    *
@@ -30,17 +33,8 @@ public interface Selection {
   abstract class SelectExpression implements Selection {
     abstract Expression expression();
 
-    /** An alias to name this selection. */
-    // TODO check alias for SQL stop words.
-    abstract Optional<String> alias();
-
-    public static SelectExpression create(Expression expression, Optional<String> alias) {
-      return builder().expression(expression).alias(alias).build();
-    }
-
-    public static SelectExpression create(Expression expression) {
-      return create(expression, Optional.empty());
-    }
+    @Override
+    public abstract String name();
 
     @Override
     public <R> R accept(Visitor<R> visitor) {
@@ -57,9 +51,7 @@ public interface Selection {
 
       public abstract Builder expression(Expression expression);
 
-      public abstract Builder alias(Optional<String> alias);
-
-      public abstract Builder alias(String alias);
+      public abstract Builder name(String name);
 
       public abstract SelectExpression build();
     }
@@ -72,16 +64,27 @@ public interface Selection {
     /** The entity to count. */
     public abstract EntityVariable entityVariable();
 
-    /** An alias to name this selection. */
-    abstract Optional<String> alias();
-
-    public static Count create(EntityVariable entityVariable, Optional<String> alias) {
-      return new AutoValue_Selection_Count(entityVariable, alias);
-    }
+    @Override
+    public abstract String name();
 
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.count(this);
+    }
+
+    public static Builder builder() {
+      return new AutoValue_Selection_Count.Builder();
+    }
+
+    /** Builder for {@link Count}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder entityVariable(EntityVariable entityVariable);
+
+      public abstract Builder name(String name);
+
+      public abstract Count build();
     }
   }
 
@@ -91,16 +94,27 @@ public interface Selection {
     /** The entity to select the primary key of. */
     public abstract EntityVariable entityVariable();
 
-    /** An alias to name this selection. */
-    abstract Optional<String> alias();
-
-    public static PrimaryKey create(EntityVariable entityVariable, Optional<String> alias) {
-      return new AutoValue_Selection_PrimaryKey(entityVariable, alias);
-    }
+    @Override
+    public abstract String name();
 
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.primaryKey(this);
+    }
+
+    public static Builder builder() {
+      return new AutoValue_Selection_PrimaryKey.Builder();
+    }
+
+    /** Builder for {@link PrimaryKey}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      public abstract Builder entityVariable(EntityVariable entityVariable);
+
+      public abstract Builder name(String name);
+
+      public abstract PrimaryKey build();
     }
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -61,13 +61,13 @@ public class SqlVisitor {
     public String selectExpression(Selection.SelectExpression selectExpression) {
       String expression =
           selectExpression.expression().accept(new ExpressionVisitor(searchContext));
-      return expression.concat(aliasSuffix(selectExpression.alias()));
+      return String.format("%s AS %s", expression, selectExpression.name());
     }
 
     @Override
     public String count(Selection.Count count) {
       return String.format(
-          "COUNT(%s)%s", count.entityVariable().variable().name(), aliasSuffix(count.alias()));
+          "COUNT(%s) AS %s", count.entityVariable().variable().name(), count.name());
     }
 
     @Override
@@ -79,15 +79,10 @@ public class SqlVisitor {
           "Unable to find a primary key for entity '%s'",
           primaryKey.entityVariable().entity());
       return String.format(
-          "%s.%s%s",
+          "%s.%s AS %s",
           primaryKey.entityVariable().variable().name(),
           primaryKeyColumn.name(),
-          aliasSuffix(primaryKey.alias()));
-    }
-
-    /** Returns " AS alias" or else "" if the alias is not present. */
-    private static String aliasSuffix(Optional<String> alias) {
-      return alias.map(" AS "::concat).orElse("");
+          primaryKey.name());
     }
   }
 

--- a/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesFilterApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesFilterApiControllerTest.java
@@ -40,7 +40,8 @@ public class EntitiesFilterApiControllerTest extends BaseSpringUnitTest {
             NauticalUnderlayUtils.NAUTICAL_UNDERLAY_NAME, "sailors", apiEntityFilter);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(
-        "SELECT s.s_id FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42",
+        "SELECT s.s_id AS primary_key FROM `my-project-id.nautical`.sailors AS s "
+            + "WHERE s.rating = 42",
         response.getBody().getQuery());
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
@@ -24,7 +24,8 @@ public class QueryServiceTest extends BaseSpringUnitTest {
   @Test
   void generatePrimaryKeySql() {
     assertEquals(
-        "SELECT s.s_id FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42",
+        "SELECT s.s_id AS primary_key FROM `my-project-id.nautical`.sailors AS s "
+            + "WHERE s.rating = 42",
         queryService.generatePrimaryKeySql(
             EntityFilter.builder()
                 .primaryEntity(EntityVariable.create(SAILOR, Variable.create("s")))

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -41,10 +41,14 @@ public class SqlVisitorTest {
         Query.builder()
             .selections(
                 ImmutableList.of(
-                    Selection.SelectExpression.create(
-                        Expression.AttributeExpression.create(S_RATING)),
-                    Selection.SelectExpression.create(
-                        Expression.AttributeExpression.create(S_NAME))))
+                    Selection.SelectExpression.builder()
+                        .expression(Expression.AttributeExpression.create(S_RATING))
+                        .name("rating")
+                        .build(),
+                    Selection.SelectExpression.builder()
+                        .expression(Expression.AttributeExpression.create(S_NAME))
+                        .name("name")
+                        .build()))
             .primaryEntity(S_SAILOR)
             .filter(
                 Optional.of(
@@ -54,7 +58,7 @@ public class SqlVisitorTest {
                         Expression.Literal.create(DataType.INT64, "62"))))
             .build();
     assertEquals(
-        "SELECT s.rating, s.s_name FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 62",
+        "SELECT s.rating AS rating, s.s_name AS name FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 62",
         new SqlVisitor(SIMPLE_CONTEXT).createSql(query));
   }
 
@@ -65,14 +69,7 @@ public class SqlVisitorTest {
         "s.rating AS rt",
         Selection.SelectExpression.builder()
             .expression(Expression.AttributeExpression.create(S_RATING))
-            .alias(Optional.of("rt"))
-            .build()
-            .accept(visitor));
-    assertEquals(
-        "s.rating",
-        Selection.SelectExpression.builder()
-            .expression(Expression.AttributeExpression.create(S_RATING))
-            .alias(Optional.empty())
+            .name("rt")
             .build()
             .accept(visitor));
   }
@@ -81,8 +78,8 @@ public class SqlVisitorTest {
   void selectionCount() {
     SqlVisitor.SelectionVisitor visitor = new SelectionVisitor(SIMPLE_CONTEXT);
     assertEquals(
-        "COUNT(s) AS c", Selection.Count.create(S_SAILOR, Optional.of("c")).accept(visitor));
-    assertEquals("COUNT(s)", Selection.Count.create(S_SAILOR, Optional.empty()).accept(visitor));
+        "COUNT(s) AS c",
+        Selection.Count.builder().entityVariable(S_SAILOR).name("c").build().accept(visitor));
   }
 
   @Test
@@ -90,8 +87,11 @@ public class SqlVisitorTest {
     SqlVisitor.SelectionVisitor visitor = new SelectionVisitor(SIMPLE_CONTEXT);
     assertEquals(
         "s.s_id AS primary_id",
-        Selection.PrimaryKey.create(S_SAILOR, Optional.of("primary_id")).accept(visitor));
-    assertEquals("s.s_id", Selection.PrimaryKey.create(S_SAILOR, Optional.empty()).accept(visitor));
+        Selection.PrimaryKey.builder()
+            .entityVariable(S_SAILOR)
+            .name("primary_id")
+            .build()
+            .accept(visitor));
   }
 
   @Test


### PR DESCRIPTION
This will be useful in creating results for executed queries that can describe themselves.
Also convert all selection factory methods to builders.