### PR TITLE
Add an underlay for a dev synpuf omop dataset.

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -16,4 +16,4 @@ spring:
 
 tanagra:
   underlay:
-    underlay-yaml-files: "underlays/omop_test.yaml"
+    underlay-yaml-files: ["underlays/omop_test.yaml", "underlays/synpuf.yaml"]

--- a/api/src/main/resources/underlays/synpuf.yaml
+++ b/api/src/main/resources/underlays/synpuf.yaml
@@ -1,0 +1,437 @@
+# An initial OMOP underlay schema on the SynPUFs OMOP dataset for development.
+
+name: synpuf
+entities:
+  - name: person
+    attributes:
+      - name: person_id
+        dataType: INT64
+      - name: gender_concept_id
+        dataType: INT64
+      - name: gender
+        dataType: STRING
+      - name: race_concept_id
+        dataType: INT64
+      - name: race
+        dataType: STRING
+      - name: ethnicity_concept_id
+        dataType: INT64
+      - name: ethnicity
+        dataType: STRING
+      - name: sex_at_birth_concept_id
+        dataType: INT64
+      - name: sex_at_birth
+        dataType: STRING
+  - name: condition_occurrence
+    attributes:
+      - name: condition_occurrence_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: condition_concept_id
+        dataType: INT64
+      - name: condition_name
+        dataType: STRING
+      - name: condition_standard
+        dataType: STRING
+      - name: condition_concept_code
+        dataType: INT64
+  - name: concept
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: domain_id
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: INT64
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: INT64
+relationships:
+  - name: person_condition_occurrence
+    entity1: person
+    entity2: condition_occurrence
+  - name: concept_id_person_gender
+    entity1: concept
+    entity2: person
+  - name: concept_id_person_race
+    entity1: concept
+    entity2: person
+  - name: concept_id_person_ethnicity
+    entity1: concept
+    entity2: person
+  - name: concept_id_person_sex_at_birth
+    entity1: concept
+    entity2: person
+  - name: concept_id_condition
+    entity1: concept
+    entity2: condition_occurrence
+datasets:
+  - name: omop_test
+    bigQueryDataset:
+      projectId: broad-tanagra-dev
+      datasetId: synpuf
+    tables:
+      - name: person
+        columns:
+          - name: person_id
+            dataType: INT64
+          - name: gender_concept_id
+            dataType: INT64
+          - name: race_concept_id
+            dataType: INT64
+          - name: ethnicity_concept_id
+            dataType: INT64
+          - name: sex_at_birth_concept_id
+            dataType: INT64
+      - name: condition_occurrence
+        columns:
+          - name: condition_occurrence_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: condition_concept_id
+            dataType: INT64
+      - name: concept
+        columns:
+          - name: concept_id
+            dataType: INT64
+          - name: concept_name
+            dataType: STRING
+          - name: domain_id
+            dataType: STRING
+          - name: standard_concept
+            dataType: STRING
+          - name: vocabulary_id
+            dataType: INT64
+          - name: concept_code
+            dataType: STRING
+      - name: vocabulary
+        columns:
+          - name: vocabulary_id
+            dataType: INT64
+          - name: vocabulary_name
+            dataType: STRING
+entityMappings:
+  - entity: person
+    primaryKey:
+      dataset: omop_test
+      table: person
+      column: person_id
+  - entity: condition_occurrence
+    primaryKey:
+      dataset: omop_test
+      table: condition_occurrence
+      column: condition_occurrence_id
+  - entity: concept
+    primaryKey:
+      dataset: omop_test
+      table: concept
+      column: concept_id
+attributeMappings:
+  - attribute:
+      entity: person
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: person
+        column: person_id
+  - attribute:
+      entity: person
+      attribute: gender_concept_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: person
+        column: gender_concept_id
+  - attribute:
+      entity: person
+      attribute: gender
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: person
+        column: gender_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: person
+      attribute: race_concept_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: person
+        column: race_concept_id
+  - attribute:
+      entity: person
+      attribute: race
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: person
+        column: race_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: person
+      attribute: ethnicity_concept_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: person
+        column: ethnicity_concept_id
+  - attribute:
+      entity: person
+      attribute: ethnicity
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: person
+        column: ethnicity_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: person
+      attribute: sex_at_birth_concept_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: person
+        column: sex_at_birth_concept_id
+  - attribute:
+      entity: person
+      attribute: sex_at_birth
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: person
+        column: sex_at_birth_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: condition_occurrence
+        column: condition_occurrence_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: condition_occurrence
+        column: person_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_concept_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: condition_occurrence
+        column: condition_concept_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: condition_occurrence
+        column: condition_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_standard
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: condition_occurrence
+        column: condition_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_concept_code
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: condition_occurrence
+        column: condition_concept_id
+      lookupTableKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: omop_test
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: concept
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: concept
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: concept
+      attribute: domain_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: concept
+        column: domain_id
+  - attribute:
+      entity: concept
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: concept
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: omop_test
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: omop_test
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: omop_test
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: concept
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: concept
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: omop_test
+        table: concept
+        column: concept_code
+relationshipMappings:
+  - name: person_condition_occurrence
+    foreignKey:
+      primaryKey:
+        dataset: omop_test
+        table: person
+        column: person_id
+      foreignKey:
+        dataset: omop_test
+        table: condition_occurrence
+        column: person_id
+  - name: concept_id_person_gender
+    foreignKey:
+      primaryKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: omop_test
+        table: person
+        column: gender_concept_id
+  - name: concept_id_person_race
+    foreignKey:
+      primaryKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: omop_test
+        table: person
+        column: race_concept_id
+  - name: concept_id_person_ethnicity
+    foreignKey:
+      primaryKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: omop_test
+        table: person
+        column: ethnicity_concept_id
+  - name: concept_id_person_sex_at_birth
+    foreignKey:
+      primaryKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: omop_test
+        table: person
+        column: sex_at_birth_concept_id
+  - name: concept_id_condition
+    foreignKey:
+      primaryKey:
+        dataset: omop_test
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: omop_test
+        table: condition_occurrence
+        column: condition_concept_id


### PR DESCRIPTION
The mapping is copied form the existing omop_test.yaml underlay, but pointed at a different backing datset.
More sophisticated omop templating and copying will come later.