### PR TITLE
Allow null filters that are always true.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/query/api/FilterConverter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/api/FilterConverter.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.Objects;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /** Converts API filters to Tanagra search {@link bio.terra.tanagra.service.search.Filter}s. */
 class FilterConverter {
@@ -28,7 +29,10 @@ class FilterConverter {
     this.expressionConverter = new ExpressionConverter(underlay);
   }
 
-  public Filter convert(ApiFilter apiFilter, VariableScope scope) {
+  public Filter convert(@Nullable ApiFilter apiFilter, VariableScope scope) {
+    if (apiFilter == null) {
+      return Filter.NullFilter.INSTANCE;
+    }
     if (!ConversionUtils.exactlyOneNonNull(
         apiFilter.getArrayFilter(),
         apiFilter.getBinaryFilter(),

--- a/api/src/main/java/bio/terra/tanagra/service/query/api/FilterConverter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/api/FilterConverter.java
@@ -29,6 +29,11 @@ class FilterConverter {
     this.expressionConverter = new ExpressionConverter(underlay);
   }
 
+  /**
+   * Converts an {@link ApiFilter} to a {@link Filter}.
+   *
+   * <p>If the ApiFilter is null, returns a filter that allows everything.
+   */
   public Filter convert(@Nullable ApiFilter apiFilter, VariableScope scope) {
     if (apiFilter == null) {
       return Filter.NullFilter.INSTANCE;

--- a/api/src/main/java/bio/terra/tanagra/service/search/Filter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/Filter.java
@@ -23,6 +23,8 @@ public interface Filter {
     R visitBinaryComparision(BinaryFunction binaryFunction);
 
     R visitRelationship(RelationshipFilter relationshipFilter);
+
+    R visitNull(NullFilter nullFilter);
   }
 
   /** Accept the {@link Visitor} pattern. */
@@ -131,6 +133,19 @@ public interface Filter {
       }
 
       abstract RelationshipFilter autoBuild();
+    }
+  }
+
+  /** A "null object" filter where everything is allowed by the filter. */
+  class NullFilter implements Filter {
+    private NullFilter() {}
+
+    /** Singleton {@link NullFilter} so that all NullFilters are equal to each other. */
+    public static final NullFilter INSTANCE = new NullFilter();
+
+    @Override
+    public <R> R accept(Visitor<R> visitor) {
+      return visitor.visitNull(this);
     }
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.service.search;
 import bio.terra.tanagra.service.search.Expression.AttributeExpression;
 import bio.terra.tanagra.service.search.Filter.ArrayFunction;
 import bio.terra.tanagra.service.search.Filter.BinaryFunction;
+import bio.terra.tanagra.service.search.Filter.NullFilter;
 import bio.terra.tanagra.service.search.Filter.RelationshipFilter;
 import bio.terra.tanagra.service.search.Selection.PrimaryKey;
 import bio.terra.tanagra.service.underlay.AttributeMapping;
@@ -141,6 +142,11 @@ public class SqlVisitor {
       String innerFilterSql = relationshipFilter.filter().accept(this);
       return underlayResolver.resolveRelationship(
           relationshipFilter.outerVariable(), relationshipFilter.newVariable(), innerFilterSql);
+    }
+
+    @Override
+    public String visitNull(NullFilter nullFilter) {
+      return "TRUE";
     }
   }
 

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -403,7 +403,9 @@ components:
       type: object
       description: |
         Base Filter type that contains one-of any Filter subtype.
+        If null, no filter is applied and everything is allowed.
         OpenApi inheritance and one-of code generation support are not great, so we roll our own.
+      nullable: true
       properties:
         arrayFilter:
           $ref: '#/components/schemas/ArrayFilter'

--- a/api/src/test/java/bio/terra/tanagra/service/query/api/FilterConverterTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/api/FilterConverterTest.java
@@ -42,6 +42,13 @@ public class FilterConverterTest {
       EntityVariable.create(SAILOR, Variable.create("s"));
 
   @Test
+  void convertNull() {
+    FilterConverter converter = new FilterConverter(NAUTICAL_UNDERLAY);
+    assertEquals(
+        Filter.NullFilter.INSTANCE, converter.convert((ApiFilter) null, new VariableScope()));
+  }
+
+  @Test
   void convertBinary() {
     VariableScope scope = new VariableScope().add(S_SAILOR);
     FilterConverter converter = new FilterConverter(NAUTICAL_UNDERLAY);

--- a/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/search/SqlVisitorTest.java
@@ -11,6 +11,7 @@ import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.loadNauti
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import bio.terra.tanagra.service.search.Filter.NullFilter;
 import bio.terra.tanagra.service.search.SqlVisitor.SelectionVisitor;
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
@@ -190,6 +191,11 @@ public class SqlVisitorTest {
                     Filter.ArrayFunction.Operator.AND))
             .build()
             .accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
+  }
+
+  @Test
+  void filterNull() {
+    assertEquals("TRUE", NullFilter.INSTANCE.accept(new SqlVisitor.FilterVisitor(SIMPLE_CONTEXT)));
   }
 
   @Test


### PR DESCRIPTION
This allows finding all instances of an entity and will be helpful in initial development.