### PR TITLE
Add a SearchTermFilter to the API for text search on entities.

### DIFF
--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -351,6 +351,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Relationship'
+        searchTermSupported:
+          description: Whether a SearchTermFilter can be used to filter on this entity.
+          type: boolean
 
     EntityDataset:
       description: A selection of entity attributes and filters on them.
@@ -411,6 +414,8 @@ components:
           $ref: '#/components/schemas/BinaryFilter'
         relationshipFilter:
           $ref: '#/components/schemas/RelationshipFilter'
+        searchTermFilter:
+          $ref: '#/components/schemas/SearchTermFilter'
         # TODO allow aggregations in filters.
 
     ArrayFilter:
@@ -464,6 +469,19 @@ components:
           type: string
         filter:
           $ref: '#/components/schemas/Filter'
+
+    SearchTermFilter:
+      type: object
+      description: |
+        A filter for finding entity instances that match a free form text search.
+        This is supported only for entities that have searchTermSupported = true.
+      properties:
+        entityVariable:
+          description: The variable of the entity to apply the search term to.
+          type: string
+        term:
+          description: The search term to search against the entity.
+          type: string
     # End Filters
 
     ErrorReport:


### PR DESCRIPTION
This is meant to allow the text search for things like concepts.
This is a somewhat unusual filter in that we maybe don't want to encourage users to include it in their cohort building, but it's mostly used to select entities during cohort construction.

We could do another API approach, like having a dedicated `instances:searchTerm` API and not include SearchTermFilter as a part of a general Filter. That new API may look a lot like `instances:search` as we want to return values for entity instances. I'm ambivalent. LMK if a 1 pager would be helpful.

TODOs for support for this:
Underlay configuration support
Text search indexes for entities
Reconsider how EntitySearchHint should relate to this.
