### PR TITLE
Add new entity relationship type IntermediateTable.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
@@ -391,12 +392,58 @@ public class SqlVisitor {
                 .build();
         return StringSubstitutor.replace(template, params);
       } else if (relationshipMapping instanceof IntermediateTable) {
-        return "mariko"; // !!!
+        IntermediateTable intermediateTable = (IntermediateTable) relationshipMapping;
+
+        Column outerColumn;
+        Column innerColumn;
+        Column outerIntermediateColumn;
+        Column innerIntermediateColumn;
+        if (outerVariable.entity().equals(relationship.get().entity1())) {
+          // outer variable = entity 1, inner variable = entity 2
+          outerColumn = intermediateTable.entity1EntityTableKey();
+          innerColumn = intermediateTable.entity2EntityTableKey();
+          outerIntermediateColumn = intermediateTable.entity1IntermediateTableKey();
+          innerIntermediateColumn = intermediateTable.entity2IntermediateTableKey();
+        } else {
+          // outer variable = entity 2, inner variable = entity 1
+          outerColumn = intermediateTable.entity2EntityTableKey();
+          innerColumn = intermediateTable.entity1EntityTableKey();
+          outerIntermediateColumn = intermediateTable.entity2IntermediateTableKey();
+          innerIntermediateColumn = intermediateTable.entity1IntermediateTableKey();
+        }
+
+        String template =
+            "${outer_var}.${outer_column} IN "
+                + "(SELECT ${intermediate_var}.${outer_intermediate_column} FROM ${intermediate_table} AS ${intermediate_var} WHERE ${intermediate_var}.${inner_intermediate_column} IN "
+                + "(SELECT ${inner_var}.${inner_column} FROM ${inner_table} WHERE ${inner_filter}))";
+        Map<String, String> params =
+            ImmutableMap.<String, String>builder()
+                .put("outer_var", outerVariable.variable().name())
+                .put("outer_column", outerColumn.name())
+                .put("inner_var", innerVariable.variable().name())
+                .put("inner_column", innerColumn.name())
+                .put("inner_table", resolveTable(innerVariable))
+                .put("inner_filter", innerFilterSql)
+                .put("intermediate_var", generateIntermediateTableAlias(relationship.get().name()))
+                .put(
+                    "intermediate_table",
+                    resolveTable(intermediateTable.entity1IntermediateTableKey().table()))
+                .put("outer_intermediate_column", outerIntermediateColumn.name())
+                .put("inner_intermediate_column", innerIntermediateColumn.name())
+                .build();
+        return StringSubstitutor.replace(template, params);
       } else {
         throw new IllegalArgumentException(
             String.format(
                 "Unknown relationship mapping type for relationship %s", relationship.get()));
       }
+    }
+
+    /**
+     * Generate an alias for an intermediate table with prefixed with the given relationship name.
+     */
+    private static String generateIntermediateTableAlias(String relationshipName) {
+      return relationshipName + UUID.randomUUID().toString().replace('-', '_');
     }
 
     /** Returns the primary key or the foreign key that matches the table, or else throw. */

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -14,6 +14,7 @@ import bio.terra.tanagra.service.underlay.Column;
 import bio.terra.tanagra.service.underlay.ForeignKey;
 import bio.terra.tanagra.service.underlay.Hierarchy;
 import bio.terra.tanagra.service.underlay.Hierarchy.DescendantsTable;
+import bio.terra.tanagra.service.underlay.IntermediateTable;
 import bio.terra.tanagra.service.underlay.Table;
 import bio.terra.tanagra.service.underlay.TableFilter;
 import bio.terra.tanagra.service.underlay.Underlay;
@@ -362,31 +363,40 @@ public class SqlVisitor {
                 "Unable to resolve RelationshipFilter for unknown relationship. Outer entity {%s}, inner entity {%s}",
                 outerVariable.entity(), innerVariable.entity()));
       }
-      ForeignKey foreignKey = underlay.foreignKeys().get(relationship.get());
-      if (foreignKey == null) {
-        // TODO implement other kinds of relationship mappings.
+      Object relationshipMapping = underlay.relationshipMappings().get(relationship.get());
+      if (relationshipMapping == null) {
         throw new IllegalArgumentException(
             String.format(
-                "Unable to find foreign key mapping for relationship %s", relationship.get()));
+                "Unable to find relationship mapping for relationship %s", relationship.get()));
       }
-      Table outerPrimaryTable = underlay.primaryKeys().get(outerVariable.entity()).table();
-      Table innerPrimaryTable = underlay.primaryKeys().get(innerVariable.entity()).table();
 
-      Column outerColumn = getKeyForTable(foreignKey, outerPrimaryTable);
-      Column innerColumn = getKeyForTable(foreignKey, innerPrimaryTable);
+      if (relationshipMapping instanceof ForeignKey) {
+        ForeignKey foreignKey = (ForeignKey) relationshipMapping;
+        Table outerPrimaryTable = underlay.primaryKeys().get(outerVariable.entity()).table();
+        Table innerPrimaryTable = underlay.primaryKeys().get(innerVariable.entity()).table();
 
-      String template =
-          "${outer_var}.${outer_column} IN (SELECT ${inner_var}.${inner_column} FROM ${inner_table} WHERE ${inner_filter})";
-      Map<String, String> params =
-          ImmutableMap.<String, String>builder()
-              .put("outer_var", outerVariable.variable().name())
-              .put("outer_column", outerColumn.name())
-              .put("inner_var", innerVariable.variable().name())
-              .put("inner_column", innerColumn.name())
-              .put("inner_table", resolveTable(innerVariable))
-              .put("inner_filter", innerFilterSql)
-              .build();
-      return StringSubstitutor.replace(template, params);
+        Column outerColumn = getKeyForTable(foreignKey, outerPrimaryTable);
+        Column innerColumn = getKeyForTable(foreignKey, innerPrimaryTable);
+
+        String template =
+            "${outer_var}.${outer_column} IN (SELECT ${inner_var}.${inner_column} FROM ${inner_table} WHERE ${inner_filter})";
+        Map<String, String> params =
+            ImmutableMap.<String, String>builder()
+                .put("outer_var", outerVariable.variable().name())
+                .put("outer_column", outerColumn.name())
+                .put("inner_var", innerVariable.variable().name())
+                .put("inner_column", innerColumn.name())
+                .put("inner_table", resolveTable(innerVariable))
+                .put("inner_filter", innerFilterSql)
+                .build();
+        return StringSubstitutor.replace(template, params);
+      } else if (relationshipMapping instanceof IntermediateTable) {
+        return "mariko"; // !!!
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unknown relationship mapping type for relationship %s", relationship.get()));
+      }
     }
 
     /** Returns the primary key or the foreign key that matches the table, or else throw. */

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -440,7 +440,10 @@ public class SqlVisitor {
     }
 
     /**
-     * Generate an alias for an intermediate table with prefixed with the given relationship name.
+     * Generate an alias for an intermediate table prefixed with the given relationship name.
+     *
+     * <p>The logic in this method needs to be kept in sync with
+     * GeneratedSqlUtils.replaceGeneratedIntermediateTableAliasDiffs method.
      */
     private static String generateIntermediateTableAlias(String relationshipName) {
       return relationshipName + UUID.randomUUID().toString().replace('-', '_');

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/ForeignKey.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/ForeignKey.java
@@ -2,7 +2,7 @@ package bio.terra.tanagra.service.underlay;
 
 import com.google.auto.value.AutoValue;
 
-/** A foreign key constraint between two SLQ columns. */
+/** A foreign key constraint between two SQL columns. */
 @AutoValue
 public abstract class ForeignKey {
   /** The primary key column in the constraint. */

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/IntermediateTable.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/IntermediateTable.java
@@ -1,0 +1,35 @@
+package bio.terra.tanagra.service.underlay;
+
+import com.google.auto.value.AutoValue;
+
+/** An intermediate table that holds relationships between two SQL columns in different tables. */
+@AutoValue
+public abstract class IntermediateTable {
+  /** The column in the first entity's primary table that FKs to the intermediate table. */
+  public abstract Column entity1EntityTableKey();
+  /** The column in the intermediate table that FKs to the first entity's primary table. */
+  public abstract Column entity1IntermediateTableKey();
+
+  /** The column in the second entity's primary table that FKs to the intermediate table. */
+  public abstract Column entity2EntityTableKey();
+  /** The column in the intermediate table that FKs to the second entity's primary table. */
+  public abstract Column entity2IntermediateTableKey();
+
+  public static Builder builder() {
+    return new AutoValue_IntermediateTable.Builder();
+  }
+
+  /** A builder for {@link IntermediateTable}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder entity1EntityTableKey(Column value);
+
+    public abstract Builder entity1IntermediateTableKey(Column value);
+
+    public abstract Builder entity2EntityTableKey(Column value);
+
+    public abstract Builder entity2IntermediateTableKey(Column value);
+
+    public abstract IntermediateTable build();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/Underlay.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/Underlay.java
@@ -41,11 +41,18 @@ public abstract class Underlay {
   public abstract ImmutableMap<Entity, TableFilter> tableFilters();
   /** Map from attributes to their {@link AttributeMapping}s. */
   public abstract ImmutableMap<Attribute, AttributeMapping> attributeMappings();
+
   /**
-   * Map from relationships to the foreign keys describing the relation between the tables. The
-   * {@link Relationship#entity1()} should correspond to the {@link ForeignKey#primaryKey()}.
+   * Map from relationships to the objects describing the relation between the entity tables.
+   *
+   * <p>For foreign key relationships, the {@link Relationship#entity1()} should correspond to the
+   * {@link ForeignKey#primaryKey()}.
+   *
+   * <p>For intermediate table relationships, the {@link Relationship#entity1()} should correspond
+   * to the {@link IntermediateTable#entity1EntityTableKey()} and the {@link Relationship#entity2()}
+   * should correspond to the {@link IntermediateTable#entity2EntityTableKey()}.
    */
-  public abstract ImmutableMap<Relationship, ForeignKey> foreignKeys();
+  public abstract ImmutableMap<Relationship, Object> relationshipMappings();
 
   /** Map from attributes to their {@link Hierarchy}, if the attribute is a part of a hierarchy. */
   public abstract ImmutableMap<Attribute, Hierarchy> hierarchies();
@@ -108,7 +115,7 @@ public abstract class Underlay {
 
     public abstract Builder attributeMappings(Map<Attribute, AttributeMapping> attributeMappings);
 
-    public abstract Builder foreignKeys(Map<Relationship, ForeignKey> value);
+    public abstract Builder relationshipMappings(Map<Relationship, Object> value);
 
     public abstract Builder hierarchies(Map<Attribute, Hierarchy> value);
 

--- a/api/src/test/java/bio/terra/tanagra/aousynthetic/UnderlayUtils.java
+++ b/api/src/test/java/bio/terra/tanagra/aousynthetic/UnderlayUtils.java
@@ -12,10 +12,6 @@ public final class UnderlayUtils {
 
   public static final String UNDERLAY_NAME = "aou_synthetic";
 
-  public static final String BQ_PROJECT_ID = "broad-tanagra-dev";
-  public static final String BQ_DATASET_ID = "aou_synthetic_SR2019q4r4";
-  public static final String BQ_DATASET_SQL_REFERENCE = BQ_PROJECT_ID + "." + BQ_DATASET_ID;
-
   public static final String PERSON_ENTITY = "person";
   public static final List<String> ALL_PERSON_ATTRIBUTES =
       ImmutableList.of(

--- a/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesApiControllerTest.java
@@ -58,7 +58,11 @@ public class EntitiesApiControllerTest extends BaseSpringUnitTest {
                   new ApiRelationship()
                       .name("sailor_reservation")
                       .relatedEntity("reservations")
-                      .filterable(true)));
+                      .filterable(true),
+                  new ApiRelationship()
+                      .name("sailor_boat")
+                      .relatedEntity("boats")
+                      .filterable(false)));
 
   @Test
   void getEntity() {

--- a/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesFilterApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesFilterApiControllerTest.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.app.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.generated.model.ApiAttributeValue;
 import bio.terra.tanagra.generated.model.ApiAttributeVariable;
@@ -8,9 +9,15 @@ import bio.terra.tanagra.generated.model.ApiBinaryFilter;
 import bio.terra.tanagra.generated.model.ApiBinaryFilterOperator;
 import bio.terra.tanagra.generated.model.ApiEntityFilter;
 import bio.terra.tanagra.generated.model.ApiFilter;
+import bio.terra.tanagra.generated.model.ApiRelationshipFilter;
 import bio.terra.tanagra.generated.model.ApiSqlQuery;
 import bio.terra.tanagra.service.underlay.NauticalUnderlayUtils;
 import bio.terra.tanagra.testing.BaseSpringUnitTest;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.text.StringSubstitutor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,7 +29,7 @@ public class EntitiesFilterApiControllerTest extends BaseSpringUnitTest {
   @Autowired private EntitiesFiltersApiController apiController;
 
   @Test
-  void generateSqlQuery() {
+  void generateSqlQueryBinaryFilter() {
     ApiEntityFilter apiEntityFilter =
         new ApiEntityFilter()
             .entityVariable("s")
@@ -43,5 +50,84 @@ public class EntitiesFilterApiControllerTest extends BaseSpringUnitTest {
         "SELECT s.s_id AS primary_key FROM `my-project-id.nautical`.sailors AS s "
             + "WHERE s.rating = 42",
         response.getBody().getQuery());
+  }
+
+  @Test
+  void generateSqlQueryRelationshipFilter() {
+    // filter for "sailors" entity instances that have name=Jim
+    // i.e. give me all the sailors named Jim
+    ApiBinaryFilter sailorsNamedJim =
+        new ApiBinaryFilter()
+            .attributeVariable(new ApiAttributeVariable().variable("sailor").name("name"))
+            .operator(ApiBinaryFilterOperator.EQUALS)
+            .attributeValue(new ApiAttributeValue().stringVal("Jim"));
+
+    // filter for "boats" entity instances that are related to "sailors" entity instances that have
+    // name=Jim
+    // i.e. give me all the favorite boats for sailors named Jim
+    ApiEntityFilter apiEntityFilter =
+        new ApiEntityFilter()
+            .entityVariable("boat")
+            .filter(
+                new ApiFilter()
+                    .relationshipFilter(
+                        new ApiRelationshipFilter()
+                            .outerVariable("boat")
+                            .newVariable("sailor")
+                            .newEntity("sailors")
+                            .filter(new ApiFilter().binaryFilter(sailorsNamedJim))));
+
+    ResponseEntity<ApiSqlQuery> response =
+        apiController.generateSqlQuery(
+            NauticalUnderlayUtils.NAUTICAL_UNDERLAY_NAME, "boats", apiEntityFilter);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    String actualSql = response.getBody().getQuery();
+    String expectedSql =
+        "SELECT boat.b_id AS primary_key FROM `my-project-id.nautical`.boats AS boat "
+            + "WHERE boat.b_id IN "
+            + "(SELECT sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635.b_id FROM `my-project-id.nautical`.sailors_favorite_boats AS sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635 "
+            + "WHERE sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635.s_id IN ("
+            + "SELECT sailor.s_id FROM `my-project-id.nautical`.sailors AS sailor WHERE sailor.s_name = 'Jim'))";
+    expectedSql =
+        replaceGeneratedIntermediateTableAliasDiffs(expectedSql, actualSql, "sailor_boat");
+    assertEquals(expectedSql, actualSql);
+  }
+
+  /**
+   * Replace the generated table aliases in the expected SQL with those in the actual SQL. The
+   * purpose of this helper method is to allow a test to compare the expected and actual SQL without
+   * failing on the generated alias names. This is necessary because the generated table names
+   * include a randomly generated UUID, and so we will get a different alias each time.
+   *
+   * @param expected the expected SQL string that contains generated table aliases (e.g.
+   *     sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635)
+   * @param actual the actual SQL string that contains generated table aliases (e.g.
+   *     sailor_boat237e13f7_ab74_42b4_9b0c_e5a45299f942)
+   * @param relationshipName the name of the relationship with the intermediate table
+   * @return the expected SQL string, with its generated table aliases replaced with those in the
+   *     actual SQL string
+   */
+  public static String replaceGeneratedIntermediateTableAliasDiffs(
+      String expected, String actual, String relationshipName) {
+    Pattern generatedTableAliasRegex =
+        Pattern.compile(
+            relationshipName
+                + "[a-fA-F0-9]{8}_[a-fA-F0-9]{4}_[a-fA-F0-9]{4}_[a-fA-F0-9]{4}_[a-fA-F0-9]{12}");
+
+    // find the generated table alias in the actual SQL
+    Matcher actualAliasMatcher = generatedTableAliasRegex.matcher(actual);
+    assertTrue(actualAliasMatcher.find(), "generated intermediate table alias not found");
+    String actualAlias = actual.substring(actualAliasMatcher.start(), actualAliasMatcher.end());
+
+    // replace all the generated table aliases in the expected SQL with ${generated_table_alias}
+    String expectedTemplate =
+        generatedTableAliasRegex.matcher(expected).replaceAll("\\$\\{generated_table_alias\\}");
+
+    // substitute the ${generated_table_alias} in the expected SQL with the alias from the actual
+    // SQL
+    Map<String, String> params =
+        ImmutableMap.<String, String>builder().put("generated_table_alias", actualAlias).build();
+    return StringSubstitutor.replace(expectedTemplate, params);
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesFilterApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/EntitiesFilterApiControllerTest.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.app.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.generated.model.ApiAttributeValue;
 import bio.terra.tanagra.generated.model.ApiAttributeVariable;
@@ -13,11 +12,8 @@ import bio.terra.tanagra.generated.model.ApiRelationshipFilter;
 import bio.terra.tanagra.generated.model.ApiSqlQuery;
 import bio.terra.tanagra.service.underlay.NauticalUnderlayUtils;
 import bio.terra.tanagra.testing.BaseSpringUnitTest;
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import org.apache.commons.text.StringSubstitutor;
+import bio.terra.tanagra.testing.GeneratedSqlUtils;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -53,7 +49,54 @@ public class EntitiesFilterApiControllerTest extends BaseSpringUnitTest {
   }
 
   @Test
-  void generateSqlQueryRelationshipFilter() {
+  @DisplayName(
+      "correct SQL string for filtering entity instances based on a relationship where the entity=entity1")
+  void generateSqlQueryRelationshipFilterForEntity1() {
+    // filter for "boats" entity instances that have color=red
+    // i.e. give me all the boats that are red
+    ApiBinaryFilter boatsThatAreRed =
+        new ApiBinaryFilter()
+            .attributeVariable(new ApiAttributeVariable().variable("boat").name("color"))
+            .operator(ApiBinaryFilterOperator.EQUALS)
+            .attributeValue(new ApiAttributeValue().stringVal("red"));
+
+    // filter for "sailors" entity instances that are related to "boats" entity instances that have
+    // color=red
+    // i.e. give me all the sailors with a favorite boat that is red
+    ApiEntityFilter apiEntityFilter =
+        new ApiEntityFilter()
+            .entityVariable("sailor")
+            .filter(
+                new ApiFilter()
+                    .relationshipFilter(
+                        new ApiRelationshipFilter()
+                            .outerVariable("sailor")
+                            .newVariable("boat")
+                            .newEntity("boats")
+                            .filter(new ApiFilter().binaryFilter(boatsThatAreRed))));
+
+    ResponseEntity<ApiSqlQuery> response =
+        apiController.generateSqlQuery(
+            NauticalUnderlayUtils.NAUTICAL_UNDERLAY_NAME, "sailors", apiEntityFilter);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    String actualSql = response.getBody().getQuery();
+    String expectedSql =
+        "SELECT sailor.s_id AS primary_key FROM `my-project-id.nautical`.sailors AS sailor "
+            + "WHERE sailor.s_id IN "
+            + "(SELECT sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635.s_id FROM `my-project-id.nautical`.sailors_favorite_boats AS sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635 "
+            + "WHERE sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635.b_id IN ("
+            + "SELECT boat.b_id FROM `my-project-id.nautical`.boats AS boat WHERE boat.color = 'red'))";
+    expectedSql =
+        GeneratedSqlUtils.replaceGeneratedIntermediateTableAliasDiffs(
+            expectedSql, actualSql, "sailor_boat");
+    assertEquals(expectedSql, actualSql);
+  }
+
+  @Test
+  @DisplayName(
+      "correct SQL string for filtering entity instances based on a relationship where the entity=entity2")
+  void generateSqlQueryRelationshipFilterForEntity2() {
     // filter for "sailors" entity instances that have name=Jim
     // i.e. give me all the sailors named Jim
     ApiBinaryFilter sailorsNamedJim =
@@ -90,44 +133,8 @@ public class EntitiesFilterApiControllerTest extends BaseSpringUnitTest {
             + "WHERE sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635.s_id IN ("
             + "SELECT sailor.s_id FROM `my-project-id.nautical`.sailors AS sailor WHERE sailor.s_name = 'Jim'))";
     expectedSql =
-        replaceGeneratedIntermediateTableAliasDiffs(expectedSql, actualSql, "sailor_boat");
+        GeneratedSqlUtils.replaceGeneratedIntermediateTableAliasDiffs(
+            expectedSql, actualSql, "sailor_boat");
     assertEquals(expectedSql, actualSql);
-  }
-
-  /**
-   * Replace the generated table aliases in the expected SQL with those in the actual SQL. The
-   * purpose of this helper method is to allow a test to compare the expected and actual SQL without
-   * failing on the generated alias names. This is necessary because the generated table names
-   * include a randomly generated UUID, and so we will get a different alias each time.
-   *
-   * @param expected the expected SQL string that contains generated table aliases (e.g.
-   *     sailor_boatb61b6fa5_9756_4de7_9c68_bc57fe223635)
-   * @param actual the actual SQL string that contains generated table aliases (e.g.
-   *     sailor_boat237e13f7_ab74_42b4_9b0c_e5a45299f942)
-   * @param relationshipName the name of the relationship with the intermediate table
-   * @return the expected SQL string, with its generated table aliases replaced with those in the
-   *     actual SQL string
-   */
-  public static String replaceGeneratedIntermediateTableAliasDiffs(
-      String expected, String actual, String relationshipName) {
-    Pattern generatedTableAliasRegex =
-        Pattern.compile(
-            relationshipName
-                + "[a-fA-F0-9]{8}_[a-fA-F0-9]{4}_[a-fA-F0-9]{4}_[a-fA-F0-9]{4}_[a-fA-F0-9]{12}");
-
-    // find the generated table alias in the actual SQL
-    Matcher actualAliasMatcher = generatedTableAliasRegex.matcher(actual);
-    assertTrue(actualAliasMatcher.find(), "generated intermediate table alias not found");
-    String actualAlias = actual.substring(actualAliasMatcher.start(), actualAliasMatcher.end());
-
-    // replace all the generated table aliases in the expected SQL with ${generated_table_alias}
-    String expectedTemplate =
-        generatedTableAliasRegex.matcher(expected).replaceAll("\\$\\{generated_table_alias\\}");
-
-    // substitute the ${generated_table_alias} in the expected SQL with the alias from the actual
-    // SQL
-    Map<String, String> params =
-        ImmutableMap.<String, String>builder().put("generated_table_alias", actualAlias).build();
-    return StringSubstitutor.replace(expectedTemplate, params);
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
@@ -84,6 +84,8 @@ public final class NauticalUnderlayUtils {
           .build();
   public static final Relationship BOAT_RESERVATION_RELATIONSHIP =
       Relationship.builder().name("boat_reservation").entity1(BOAT).entity2(RESERVATION).build();
+  public static final Relationship SAILOR_BOAT_RELATIONSHIP =
+      Relationship.builder().name("sailor_boat").entity1(SAILOR).entity2(BOAT).build();
 
   public static final BigQueryDataset NAUTICAL_DATASET =
       BigQueryDataset.builder()
@@ -93,6 +95,8 @@ public final class NauticalUnderlayUtils {
           .build();
   public static final Table SAILOR_TABLE = Table.create("sailors", NAUTICAL_DATASET);
   public static final Table BOAT_TABLE = Table.create("boats", NAUTICAL_DATASET);
+  public static final Table SAILORS_FAVORITE_BOATS_TABLE =
+      Table.create("sailors_favorite_boats", NAUTICAL_DATASET);
   public static final Table RESERVATION_TABLE = Table.create("reservations", NAUTICAL_DATASET);
   public static final Table BOAT_TYPE_TABLE = Table.create("boat_types", NAUTICAL_DATASET);
   public static final Table BOAT_TYPE_DESCENDANTS_TABLE =
@@ -113,6 +117,18 @@ public final class NauticalUnderlayUtils {
       Column.builder().name("color").dataType(DataType.STRING).table(BOAT_TABLE).build();
   public static final Column BOAT_BT_ID_COL =
       Column.builder().name("bt_id").dataType(DataType.INT64).table(BOAT_TABLE).build();
+  public static final Column SAILORS_FAVORITE_BOATS_S_ID_COL =
+      Column.builder()
+          .name("s_id")
+          .dataType(DataType.INT64)
+          .table(SAILORS_FAVORITE_BOATS_TABLE)
+          .build();
+  public static final Column SAILORS_FAVORITE_BOATS_B_ID_COL =
+      Column.builder()
+          .name("b_id")
+          .dataType(DataType.INT64)
+          .table(SAILORS_FAVORITE_BOATS_TABLE)
+          .build();
   public static final Column RESERVATION_ID_COL =
       Column.builder().name("r_id").dataType(DataType.INT64).table(RESERVATION_TABLE).build();
   public static final Column RESERVATION_S_ID_COL =

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
@@ -33,6 +33,9 @@ import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.RESERVATI
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.RESERVATION_S_ID;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.RESERVATION_S_ID_COL;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILORS_FAVORITE_BOATS_B_ID_COL;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILORS_FAVORITE_BOATS_S_ID_COL;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_BOAT_RELATIONSHIP;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_ID;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_ID_COL;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_NAME;
@@ -93,6 +96,7 @@ public class UnderlayConversionTest {
         ImmutableMap.builder()
             .put(SAILOR_RESERVATION_RELATIONSHIP.name(), SAILOR_RESERVATION_RELATIONSHIP)
             .put(BOAT_RESERVATION_RELATIONSHIP.name(), BOAT_RESERVATION_RELATIONSHIP)
+            .put(SAILOR_BOAT_RELATIONSHIP.name(), SAILOR_BOAT_RELATIONSHIP)
             .build(),
         nautical.relationships());
     assertEquals(
@@ -168,6 +172,14 @@ public class UnderlayConversionTest {
                 ForeignKey.builder()
                     .primaryKey(BOAT_ID_COL)
                     .foreignKey(RESERVATION_B_ID_COL)
+                    .build())
+            .put(
+                SAILOR_BOAT_RELATIONSHIP,
+                IntermediateTable.builder()
+                    .entity1EntityTableKey(SAILOR_ID_COL)
+                    .entity1IntermediateTableKey(SAILORS_FAVORITE_BOATS_S_ID_COL)
+                    .entity2EntityTableKey(BOAT_ID_COL)
+                    .entity2IntermediateTableKey(SAILORS_FAVORITE_BOATS_B_ID_COL)
                     .build())
             .build(),
         nautical.relationshipMappings());

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
@@ -170,7 +170,7 @@ public class UnderlayConversionTest {
                     .foreignKey(RESERVATION_B_ID_COL)
                     .build())
             .build(),
-        nautical.foreignKeys());
+        nautical.relationshipMappings());
     assertEquals(
         ImmutableMap.builder()
             .put(

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
@@ -56,6 +56,7 @@ import bio.terra.tanagra.service.underlay.Hierarchy.DescendantsTable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import java.util.HashMap;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -218,6 +219,13 @@ public class UnderlayConversionTest {
                                     .build())
                             .build())
                     .filterableRelationships(ImmutableSet.of(SAILOR_RESERVATION_RELATIONSHIP))
+                    .build())
+            .put(
+                BOAT,
+                EntityFiltersSchema.builder()
+                    .entity(BOAT)
+                    .filterableAttributes(new HashMap<>())
+                    .filterableRelationships(ImmutableSet.of(SAILOR_BOAT_RELATIONSHIP))
                     .build())
             .put(
                 RESERVATION,

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayTest.java
@@ -1,9 +1,11 @@
 package bio.terra.tanagra.service.underlay;
 
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_RESERVATION_RELATIONSHIP;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.RESERVATION;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_BOAT_RELATIONSHIP;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.SAILOR_RESERVATION_RELATIONSHIP;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.loadNauticalUnderlay;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,17 +29,19 @@ public class UnderlayTest {
     assertEquals(
         Optional.of(SAILOR_RESERVATION_RELATIONSHIP),
         NAUTICAL_UNDERLAY.getRelationship(RESERVATION, SAILOR));
-    assertEquals(Optional.empty(), NAUTICAL_UNDERLAY.getRelationship(SAILOR, BOAT));
+    assertEquals(
+        Optional.of(SAILOR_BOAT_RELATIONSHIP), NAUTICAL_UNDERLAY.getRelationship(SAILOR, BOAT));
+    assertEquals(Optional.empty(), NAUTICAL_UNDERLAY.getRelationship(SAILOR, BOAT_ENGINE));
   }
 
   @Test
   void getRelationshipsOf() {
     assertThat(
         NAUTICAL_UNDERLAY.getRelationshipsOf(SAILOR),
-        Matchers.hasItems(SAILOR_RESERVATION_RELATIONSHIP));
+        Matchers.hasItems(SAILOR_RESERVATION_RELATIONSHIP, SAILOR_BOAT_RELATIONSHIP));
     assertThat(
         NAUTICAL_UNDERLAY.getRelationshipsOf(BOAT),
-        Matchers.hasItems(BOAT_RESERVATION_RELATIONSHIP));
+        Matchers.hasItems(BOAT_RESERVATION_RELATIONSHIP, SAILOR_BOAT_RELATIONSHIP));
     assertThat(
         NAUTICAL_UNDERLAY.getRelationshipsOf(Entity.builder().underlay("foo").name("bar").build()),
         Matchers.empty());

--- a/api/src/test/resources/underlays/nautical.pbtext
+++ b/api/src/test/resources/underlays/nautical.pbtext
@@ -83,6 +83,11 @@ relationships: {
   entity1: "boats"
   entity2: "reservations"
 }
+relationships: {
+  name: "sailor_boat"
+  entity1: "sailors"
+  entity2: "boats"
+}
 datasets: {
   name: "nautical"
   big_query_dataset: {
@@ -120,6 +125,21 @@ datasets: {
     }
     columns: {
       name: "bt_id"
+      data_type: INT64
+    }
+  }
+  tables: {
+    name: "sailors_favorite_boats"
+    columns: {
+      name: "sfb_id"
+      data_type: INT64
+    }
+    columns: {
+      name: "s_id"
+      data_type: INT64
+    }
+    columns: {
+      name: "b_id"
       data_type: INT64
     }
   }
@@ -441,6 +461,31 @@ relationship_mappings: {
     foreign_key: {
       dataset: "nautical"
       table: "reservations"
+      column: "b_id"
+    }
+  }
+}
+relationship_mappings: {
+  name: "sailor_boat"
+  intermediate_table: {
+    entity1_entity_table_key: {
+      dataset: "nautical"
+      table: "sailors"
+      column: "s_id"
+    }
+    entity1_intermediate_table_key: {
+      dataset: "nautical"
+      table: "sailors_favorite_boats"
+      column: "s_id"
+    }
+    entity2_entity_table_key: {
+      dataset: "nautical"
+      table: "boats"
+      column: "b_id"
+    }
+    entity2_intermediate_table_key: {
+      dataset: "nautical"
+      table: "sailors_favorite_boats"
       column: "b_id"
     }
   }

--- a/api/src/test/resources/underlays/nautical.pbtext
+++ b/api/src/test/resources/underlays/nautical.pbtext
@@ -506,6 +506,12 @@ entity_filters_schemas: {
     relationship_name: "sailor_reservation"
   }
 }
+entity_filters_schemas: {
+  entity: "boats"
+  relationships: {
+    relationship_name: "sailor_boat"
+  }
+}
 hierarchies: {
   attribute: {
     entity: "boats"

--- a/api/src/test/resources/underlays/nautical.yaml
+++ b/api/src/test/resources/underlays/nautical.yaml
@@ -324,6 +324,9 @@ entityFiltersSchemas:
       - attributeName: name
     relationships:
       - relationshipName: sailor_reservation
+  - entity: boats
+    relationships:
+      - relationshipName: sailor_boat
   - entity: reservations
     attributes:
       - attributeName: day

--- a/api/src/test/resources/underlays/nautical.yaml
+++ b/api/src/test/resources/underlays/nautical.yaml
@@ -47,6 +47,9 @@ relationships:
   - name: boat_reservation
     entity1: boats
     entity2: reservations
+  - name: sailor_boat
+    entity1: sailors
+    entity2: boats
 datasets:
   - name: nautical
     bigQueryDataset:
@@ -70,6 +73,14 @@ datasets:
           - name: color
             dataType: STRING
           - name: bt_id
+            dataType: INT64
+      - name: sailors_favorite_boats
+        columns:
+          - name: sfb_id
+            dataType: INT64
+          - name: s_id
+            dataType: INT64
+          - name: b_id
             dataType: INT64
       - name: reservations
         columns:
@@ -271,6 +282,24 @@ relationshipMappings:
       foreignKey:
         dataset: nautical
         table: reservations
+        column: b_id
+  - name: sailor_boat
+    intermediateTable:
+      entity1EntityTableKey:
+        dataset: nautical
+        table: sailors
+        column: s_id
+      entity1IntermediateTableKey:
+        dataset: nautical
+        table: sailors_favorite_boats
+        column: s_id
+      entity2EntityTableKey:
+        dataset: nautical
+        table: boats
+        column: b_id
+      entity2IntermediateTableKey:
+        dataset: nautical
+        table: sailors_favorite_boats
         column: b_id
 hierarchies:
   - attribute:

--- a/lib/src/main/proto/bio/terra/tanagra/underlay/mapping.proto
+++ b/lib/src/main/proto/bio/terra/tanagra/underlay/mapping.proto
@@ -72,8 +72,23 @@ message RelationshipMapping {
     ColumnId foreign_key = 2;
   }
 
+  // A mapping where a relationship is navigated by a separate intermediate table.
+  // Each entity table has a column that foreign keys to a column in the intermediate table.
+  message IntermediateTable {
+    // The column in the entity1 table that FKs to the relationship table.
+    ColumnId entity1_entity_table_key = 1;
+    // The column in the relationship table that FKs to the entity1 table.
+    ColumnId entity1_intermediate_table_key = 2;
+
+    // The column in the entity2 table that FKs to the intermediate table.
+    ColumnId entity2_entity_table_key = 3;
+    // The column in the intermediate table that FKs to the entity2 table.
+    ColumnId entity2_intermediate_table_key = 4;
+  }
+
   // The mapping for this relationship.
   oneof mapping {
     ForeignKey foreign_key = 2;
+    IntermediateTable intermediate_table = 3;
   }
 }

--- a/lib/src/main/proto/bio/terra/tanagra/underlay/mapping.proto
+++ b/lib/src/main/proto/bio/terra/tanagra/underlay/mapping.proto
@@ -74,6 +74,11 @@ message RelationshipMapping {
 
   // A mapping where a relationship is navigated by a separate intermediate table.
   // Each entity table has a column that foreign keys to a column in the intermediate table.
+  // Note that, it's also possible to express such a relationship (table 1 FKs to intermediate table FKs to table 2)
+  // using two FK mappings. This would require 3 entity definitions, one for each table.
+  // The reason for defining a new relationship mapping type instead of using the existing FK one was to allow
+  // defining this relationship with just 2 entities. The intermediate table may not really mean anything to the UI,
+  // in the same way that the other two tables do. The goal is to avoid defining extra entities just based on the SQL schema.
   message IntermediateTable {
     // The column in the entity1 table that FKs to the relationship table.
     ColumnId entity1_entity_table_key = 1;


### PR DESCRIPTION
Previously, there is one type of relationship between two entities, defined by a direct foreign key relationship between the two entity primary tables. This change adds a second type of relationship, defined by an intermediate table that has foreign key relationships with the two entity primary tables.

The purpose of this change is to allow defining a relationship between the "brand" and "ingredient" entities. The OMOP `concept_relationship` table holds the mapping of which ingredients are included in a brand.