### PR TITLE
Add new ArrayColumnFilter type of TableFilter.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -296,12 +296,14 @@ public class SqlVisitor {
       return String.format("%s AS %s", resolvedTable, entityVariable.variable().name());
     }
 
+    /** Resolve a {@link Table} into a SQL string. */
     private String resolveTable(Table table) {
       // `projectId.datasetId`.table
       return String.format(
           "`%s.%s`.%s", table.dataset().projectId(), table.dataset().datasetId(), table.name());
     }
 
+    /** Resolve a {@link Table} with a {@link TableFilter} into a SQL string. */
     private String resolveTable(Table table, @Nullable TableFilter tableFilter) {
       if (tableFilter == null) {
         return resolveTable(table);
@@ -315,6 +317,12 @@ public class SqlVisitor {
       }
     }
 
+    /**
+     * Resolve a {@link Table} with an {@link ArrayColumnFilter} into a SQL string.
+     *
+     * @param whereClauseOnly If true, only returns the part of the SQL string after the WHERE. This
+     *     is helpful when building an {@link ArrayColumnFilter} composed of multiple sub-filters.
+     */
     private String resolveArrayColumnFilter(
         Table table, ArrayColumnFilter arrayColumnFilter, boolean whereClauseOnly) {
       String joinOperatorInWhereClause;
@@ -361,6 +369,12 @@ public class SqlVisitor {
       }
     }
 
+    /**
+     * Resolve a {@link Table} with an {@link BinaryColumnFilter} into a SQL string.
+     *
+     * @param whereClauseOnly If true, only returns the part of the SQL string after the WHERE. This
+     *     is helpful when building an {@link ArrayColumnFilter} composed of multiple sub-filters.
+     */
     private String resolveBinaryColumnFilter(
         Table table, BinaryColumnFilter binaryColumnFilter, boolean whereClauseOnly) {
       String operatorInWhereClause;

--- a/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
+++ b/api/src/main/java/bio/terra/tanagra/service/search/SqlVisitor.java
@@ -23,6 +23,7 @@ import bio.terra.tanagra.service.underlay.TableFilter;
 import bio.terra.tanagra.service.underlay.Underlay;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -308,23 +309,29 @@ public class SqlVisitor {
       if (tableFilter == null) {
         return resolveTable(table);
       } else if (tableFilter.arrayColumnFilter() != null) {
-        return resolveArrayColumnFilter(table, tableFilter.arrayColumnFilter(), false);
+        // (SELECT * FROM `projectId.datasetId`.table WHERE whereclause)
+        return String.format(
+            "(SELECT * FROM `%s.%s`.%s WHERE %s)",
+            table.dataset().projectId(),
+            table.dataset().datasetId(),
+            table.name(),
+            resolveArrayColumnFilter(tableFilter.arrayColumnFilter()));
       } else if (tableFilter.binaryColumnFilter() != null) {
-        return resolveBinaryColumnFilter(table, tableFilter.binaryColumnFilter(), false);
+        // (SELECT * FROM `projectId.datasetId`.table WHERE whereclause)
+        return String.format(
+            "(SELECT * FROM `%s.%s`.%s WHERE %s)",
+            table.dataset().projectId(),
+            table.dataset().datasetId(),
+            table.name(),
+            resolveBinaryColumnFilter(tableFilter.binaryColumnFilter()));
       } else {
         throw new IllegalArgumentException(
             "Invalid table filter missing binary and array column filters.");
       }
     }
 
-    /**
-     * Resolve a {@link Table} with an {@link ArrayColumnFilter} into a SQL string.
-     *
-     * @param whereClauseOnly If true, only returns the part of the SQL string after the WHERE. This
-     *     is helpful when building an {@link ArrayColumnFilter} composed of multiple sub-filters.
-     */
-    private String resolveArrayColumnFilter(
-        Table table, ArrayColumnFilter arrayColumnFilter, boolean whereClauseOnly) {
+    /** Resolve an {@link ArrayColumnFilter} into a SQL string WHERE clause. */
+    private String resolveArrayColumnFilter(ArrayColumnFilter arrayColumnFilter) {
       String joinOperatorInWhereClause;
       switch (arrayColumnFilter.operator()) {
         case AND:
@@ -340,43 +347,24 @@ public class SqlVisitor {
 
       // %s AND %s AND (%s OR %s) ...
       StringBuilder joinedWhereClauses = new StringBuilder();
-      int subFiltersCtr = 0;
-      for (BinaryColumnFilter subFilter : arrayColumnFilter.binaryColumnFilters()) {
-        if (subFiltersCtr > 0) {
-          joinedWhereClauses.append(" " + joinOperatorInWhereClause + " ");
-        }
-        joinedWhereClauses.append(resolveBinaryColumnFilter(table, subFilter, true));
-        subFiltersCtr++;
-      }
-      for (ArrayColumnFilter subFilter : arrayColumnFilter.arrayColumnFilters()) {
-        if (subFiltersCtr > 0) {
-          joinedWhereClauses.append(" " + joinOperatorInWhereClause + " ");
-        }
-        joinedWhereClauses.append(resolveArrayColumnFilter(table, subFilter, true));
-        subFiltersCtr++;
-      }
+      Streams.concat(
+              arrayColumnFilter.binaryColumnFilters().stream()
+                  .map(f -> resolveBinaryColumnFilter(f)),
+              arrayColumnFilter.arrayColumnFilters().stream()
+                  .map(f -> "(" + resolveArrayColumnFilter(f) + ")"))
+          .forEach(
+              whereClause ->
+                  joinedWhereClauses.append(
+                      (joinedWhereClauses.length() > 0
+                              ? (" " + joinOperatorInWhereClause + " ")
+                              : "")
+                          + whereClause));
 
-      if (whereClauseOnly) {
-        return "(" + joinedWhereClauses + ")";
-      } else {
-        // (SELECT * FROM `projectId.datasetId`.table WHERE joinedWhereClauses)
-        return String.format(
-            "(SELECT * FROM `%s.%s`.%s WHERE %s)",
-            table.dataset().projectId(),
-            table.dataset().datasetId(),
-            table.name(),
-            joinedWhereClauses);
-      }
+      return joinedWhereClauses.toString();
     }
 
-    /**
-     * Resolve a {@link Table} with an {@link BinaryColumnFilter} into a SQL string.
-     *
-     * @param whereClauseOnly If true, only returns the part of the SQL string after the WHERE. This
-     *     is helpful when building an {@link ArrayColumnFilter} composed of multiple sub-filters.
-     */
-    private String resolveBinaryColumnFilter(
-        Table table, BinaryColumnFilter binaryColumnFilter, boolean whereClauseOnly) {
+    /** Resolve a {@link BinaryColumnFilter} into a SQL string WHERE clause. */
+    private String resolveBinaryColumnFilter(BinaryColumnFilter binaryColumnFilter) {
       String operatorInWhereClause;
       switch (binaryColumnFilter.operator()) {
         case EQUALS:
@@ -407,19 +395,9 @@ public class SqlVisitor {
       }
 
       // columnFilter=value
-      String whereClause =
-          String.format(
-              "%s %s %s",
-              binaryColumnFilter.column().name(), operatorInWhereClause, valueInWhereClause);
-
-      if (whereClauseOnly) {
-        return whereClause;
-      } else {
-        // (SELECT * FROM `projectId.datasetId`.table WHERE %s)
-        return String.format(
-            "(SELECT * FROM `%s.%s`.%s WHERE %s)",
-            table.dataset().projectId(), table.dataset().datasetId(), table.name(), whereClause);
-      }
+      return String.format(
+          "%s %s %s",
+          binaryColumnFilter.column().name(), operatorInWhereClause, valueInWhereClause);
     }
 
     /** Resolve an {@link AttributeExpression} as an SQL expression. */

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/ArrayColumnFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/ArrayColumnFilter.java
@@ -1,0 +1,47 @@
+package bio.terra.tanagra.service.underlay;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+/**
+ * A filter on a table in an underlay that is composed of multiple sub-filters on the table's
+ * columns.
+ */
+@AutoValue
+public abstract class ArrayColumnFilter {
+  /** The operator to use when composing the sub-filters. */
+  public abstract ArrayColumnFilterOperator operator();
+
+  /** The array column sub-filters. */
+  public abstract List<ArrayColumnFilter> arrayColumnFilters();
+
+  /** The binary column sub-filters. */
+  public abstract List<BinaryColumnFilter> binaryColumnFilters();
+
+  public static ArrayColumnFilter create(
+      ArrayColumnFilterOperator operator,
+      List<ArrayColumnFilter> arrayColumnFilters,
+      List<BinaryColumnFilter> binaryColumnFilters) {
+    return builder()
+        .operator(operator)
+        .arrayColumnFilters(arrayColumnFilters)
+        .binaryColumnFilters(binaryColumnFilters)
+        .build();
+  }
+
+  public static ArrayColumnFilter.Builder builder() {
+    return new AutoValue_ArrayColumnFilter.Builder();
+  }
+
+  /** A builder for {@link ArrayColumnFilter}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder operator(ArrayColumnFilterOperator value);
+
+    public abstract Builder arrayColumnFilters(List<ArrayColumnFilter> value);
+
+    public abstract Builder binaryColumnFilters(List<BinaryColumnFilter> value);
+
+    public abstract ArrayColumnFilter build();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/ArrayColumnFilterOperator.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/ArrayColumnFilterOperator.java
@@ -1,0 +1,10 @@
+package bio.terra.tanagra.service.underlay;
+
+/**
+ * Possible operators to use when composing multiple column filters into a single array column
+ * filter on a table in an underlay.
+ */
+public enum ArrayColumnFilterOperator {
+  AND,
+  OR
+}

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/TableFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/TableFilter.java
@@ -6,6 +6,10 @@ import javax.annotation.Nullable;
 /** A filter on a SQL column within a table in an underlay. */
 @AutoValue
 public abstract class TableFilter {
+  /** An array filter that composes multiple sub-filters. */
+  @Nullable
+  public abstract ArrayColumnFilter arrayColumnFilter();
+
   /** A binary filter on a single column. */
   @Nullable
   public abstract BinaryColumnFilter binaryColumnFilter();
@@ -22,6 +26,8 @@ public abstract class TableFilter {
   /** A builder for {@link TableFilter}. */
   @AutoValue.Builder
   public abstract static class Builder {
+    public abstract Builder arrayColumnFilter(ArrayColumnFilter value);
+
     public abstract Builder binaryColumnFilter(BinaryColumnFilter columnFilter);
 
     public abstract TableFilter build();

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/UnderlayConversion.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/UnderlayConversion.java
@@ -20,8 +20,10 @@ import com.google.common.collect.HashBasedTable;
 import com.google.protobuf.Message;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Utilities for converting protobuf representations to underlay classes. */
 @VisibleForTesting
@@ -178,17 +180,16 @@ public final class UnderlayConversion {
       // convert the TableFilter proto and do entity table-specific validation
       TableFilter tableFilter = convert(entityMapping.getTableFilter(), columns);
       switch (entityMapping.getTableFilter().getFilterCase()) {
+        case ARRAY_COLUMN_FILTER:
+          tableFilter
+              .arrayColumnFilter()
+              .binaryColumnFilters()
+              .forEach(
+                  bcf -> validateForEntityMapping(bcf, primaryKeys.get(entity), entityMapping));
+          break;
         case BINARY_COLUMN_FILTER:
-          if (!tableFilter
-              .binaryColumnFilter()
-              .column()
-              .table()
-              .equals(primaryKeys.get(entity).table())) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Binary table filter column is not in the same table as the entity primary key: %s",
-                    entityMapping));
-          }
+          validateForEntityMapping(
+              tableFilter.binaryColumnFilter(), primaryKeys.get(entity), entityMapping);
           break;
         case FILTER_NOT_SET:
         default:
@@ -564,6 +565,10 @@ public final class UnderlayConversion {
       bio.terra.tanagra.proto.underlay.TableFilter tableFilterProto,
       Map<ColumnId, Column> columns) {
     switch (tableFilterProto.getFilterCase()) {
+      case ARRAY_COLUMN_FILTER:
+        return TableFilter.builder()
+            .arrayColumnFilter(convert(tableFilterProto.getArrayColumnFilter(), columns))
+            .build();
       case BINARY_COLUMN_FILTER:
         return TableFilter.builder()
             .binaryColumnFilter(convert(tableFilterProto.getBinaryColumnFilter(), columns))
@@ -572,6 +577,48 @@ public final class UnderlayConversion {
       default:
         throw new IllegalArgumentException(
             String.format("Unknown table filter type: %s", tableFilterProto));
+    }
+  }
+
+  private static ArrayColumnFilter convert(
+      bio.terra.tanagra.proto.underlay.ArrayColumnFilter arrayColumnFilterProto,
+      Map<ColumnId, Column> columns) {
+    List<ArrayColumnFilter> arrayColumnFilters =
+        arrayColumnFilterProto.getArrayColumnFiltersList().stream()
+            .map(acf -> convert(acf, columns))
+            .collect(Collectors.toList());
+    List<BinaryColumnFilter> binaryColumnFilters =
+        arrayColumnFilterProto.getBinaryColumnFiltersList().stream()
+            .map(bcf -> convert(bcf, columns))
+            .collect(Collectors.toList());
+
+    return ArrayColumnFilter.builder()
+        .operator(convert(arrayColumnFilterProto.getOperator()))
+        .arrayColumnFilters(arrayColumnFilters)
+        .binaryColumnFilters(binaryColumnFilters)
+        .build();
+  }
+
+  private static ArrayColumnFilterOperator convert(
+      bio.terra.tanagra.proto.underlay.ArrayColumnFilterOperator operator) {
+    switch (operator) {
+      case AND:
+        return ArrayColumnFilterOperator.AND;
+      case OR:
+        return ArrayColumnFilterOperator.OR;
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Unsupported ArrayColumnFilterOperator %s", operator.name()));
+    }
+  }
+
+  private static void validateForEntityMapping(
+      BinaryColumnFilter binaryColumnFilter, Column entityPrimaryKey, EntityMapping entityMapping) {
+    if (!binaryColumnFilter.column().table().equals(entityPrimaryKey.table())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Binary table filter column is not in the same table as the entity primary key: %s",
+              entityMapping));
     }
   }
 

--- a/api/src/test/java/bio/terra/tanagra/app/controller/UnderlaysApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/UnderlaysApiControllerTest.java
@@ -28,7 +28,9 @@ public class UnderlaysApiControllerTest extends BaseSpringUnitTest {
   private static final ApiUnderlay NAUTICAL_API_UNDERLAY =
       new ApiUnderlay()
           .name(NauticalUnderlayUtils.NAUTICAL_UNDERLAY_NAME)
-          .entityNames(ImmutableList.of("boat_engines", "boats", "reservations", "sailors"));
+          .entityNames(
+              ImmutableList.of(
+                  "boat_electric_anchors", "boat_engines", "boats", "reservations", "sailors"));
 
   @Test
   void getUnderlay() {

--- a/api/src/test/java/bio/terra/tanagra/service/query/ArrayColumnFilterTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/ArrayColumnFilterTest.java
@@ -1,0 +1,249 @@
+package bio.terra.tanagra.service.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.tanagra.proto.underlay.ArrayColumnFilter;
+import bio.terra.tanagra.proto.underlay.ArrayColumnFilterOperator;
+import bio.terra.tanagra.proto.underlay.BinaryColumnFilter;
+import bio.terra.tanagra.proto.underlay.BinaryColumnFilterOperator;
+import bio.terra.tanagra.proto.underlay.ColumnId;
+import bio.terra.tanagra.proto.underlay.EntityMapping;
+import bio.terra.tanagra.proto.underlay.TableFilter;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ArrayColumnFilter} used to define an {@link EntityMapping} with a {@link
+ * TableFilter}. Some of these tests check for validation in the conversion from underlay proto ->
+ * Java class. Other tests check the SQL string generated for queries against this underlay.
+ */
+public class ArrayColumnFilterTest extends ColumnFilterTest {
+  @Test
+  @DisplayName(
+      "underlay conversion fails when one of the sub-filters' table doesn't match the entity pk table")
+  void subFilterColumnAndPrimaryKeyFromDifferentTables() {
+    TableFilter tableFilterProto =
+        TableFilter.newBuilder()
+            .setArrayColumnFilter(
+                ArrayColumnFilter.newBuilder()
+                    .addBinaryColumnFilters(
+                        BinaryColumnFilter.newBuilder()
+                            .setColumn(
+                                ColumnId.newBuilder()
+                                    .setDataset("datasetA")
+                                    .setTable("tableB")
+                                    .setColumn("columnC")
+                                    .build())
+                            .setOperator(BinaryColumnFilterOperator.LESS_THAN)
+                            .setInt64Val(45)
+                            .build())
+                    .setOperator(ArrayColumnFilterOperator.AND)
+                    .build())
+            .build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> convertUnderlayFromProto(tableFilterProto),
+            "exception thrown when one of the sub-filters' table doesn't match entity primary key table");
+    assertThat(
+        "exception message says that binary column filter table doesn't match entity primary key table",
+        exception.getMessage(),
+        Matchers.containsString(
+            "Binary table filter column is not in the same table as the entity primary key"));
+  }
+
+  @Test
+  @DisplayName("underlay conversion fails when there are no sub-filters")
+  void noSubFilters() {
+    TableFilter tableFilterProto =
+        TableFilter.newBuilder()
+            .setArrayColumnFilter(
+                ArrayColumnFilter.newBuilder().setOperator(ArrayColumnFilterOperator.OR).build())
+            .build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> convertUnderlayFromProto(tableFilterProto),
+            "exception thrown when array column filter contains no sub-filters");
+    assertThat(
+        "exception message says that array column filter doesn't contain any sub-filters",
+        exception.getMessage(),
+        Matchers.containsString("Array column filter contains no sub-filters"));
+  }
+
+  @Test
+  @DisplayName("correct SQL string when array column filter contains a single sub-filter")
+  void singleSubFilter() {
+    TableFilter tableFilterProto =
+        TableFilter.newBuilder()
+            .setArrayColumnFilter(
+                ArrayColumnFilter.newBuilder()
+                    .addBinaryColumnFilters(
+                        BinaryColumnFilter.newBuilder()
+                            .setColumn(
+                                ColumnId.newBuilder()
+                                    .setDataset("datasetA")
+                                    .setTable("tableA")
+                                    .setColumn("columnA")
+                                    .build())
+                            .setOperator(BinaryColumnFilterOperator.EQUALS)
+                            .setStringVal("stringValueA")
+                            .build())
+                    .setOperator(ArrayColumnFilterOperator.AND)
+                    .build())
+            .build();
+
+    bio.terra.tanagra.service.underlay.Underlay underlay =
+        convertUnderlayFromProto(tableFilterProto);
+    String generatedSql = generateSql(underlay, getEntityDatasetForEntityA(underlay));
+    assertEquals(
+        "SELECT entitya_alias.columnA AS attributeA "
+            + "FROM (SELECT * FROM `my-project-id.my-dataset-id`.tableA WHERE columnA = 'stringValueA') AS entitya_alias "
+            + "WHERE TRUE",
+        generatedSql);
+  }
+
+  @Test
+  @DisplayName("correct SQL string when array column filter contains multiple binary sub-filters")
+  void multipleBinarySubFilters() {
+    TableFilter tableFilterProto =
+        TableFilter.newBuilder()
+            .setArrayColumnFilter(
+                ArrayColumnFilter.newBuilder()
+                    .addBinaryColumnFilters(
+                        BinaryColumnFilter.newBuilder()
+                            .setColumn(
+                                ColumnId.newBuilder()
+                                    .setDataset("datasetA")
+                                    .setTable("tableA")
+                                    .setColumn("columnA")
+                                    .build())
+                            .setOperator(BinaryColumnFilterOperator.EQUALS)
+                            .setStringVal("stringValueA")
+                            .build())
+                    .addBinaryColumnFilters(
+                        BinaryColumnFilter.newBuilder()
+                            .setColumn(
+                                ColumnId.newBuilder()
+                                    .setDataset("datasetA")
+                                    .setTable("tableA")
+                                    .setColumn("columnB")
+                                    .build())
+                            .setOperator(BinaryColumnFilterOperator.LESS_THAN)
+                            .setInt64Val(64)
+                            .build())
+                    .setOperator(ArrayColumnFilterOperator.OR)
+                    .build())
+            .build();
+
+    bio.terra.tanagra.service.underlay.Underlay underlay =
+        convertUnderlayFromProto(tableFilterProto);
+    String generatedSql = generateSql(underlay, getEntityDatasetForEntityA(underlay));
+    assertEquals(
+        "SELECT entitya_alias.columnA AS attributeA "
+            + "FROM (SELECT * FROM `my-project-id.my-dataset-id`.tableA WHERE columnA = 'stringValueA' OR columnB < 64) AS entitya_alias "
+            + "WHERE TRUE",
+        generatedSql);
+  }
+
+  @Test
+  @DisplayName(
+      "correct SQL string when array column filter contains multiple array and binary sub-filters")
+  void multipleBinaryAndArraySubFilters() {
+    TableFilter tableFilterProto =
+        TableFilter.newBuilder()
+            .setArrayColumnFilter(
+                ArrayColumnFilter.newBuilder()
+                    .addBinaryColumnFilters(
+                        BinaryColumnFilter.newBuilder()
+                            .setColumn(
+                                ColumnId.newBuilder()
+                                    .setDataset("datasetA")
+                                    .setTable("tableA")
+                                    .setColumn("columnA")
+                                    .build())
+                            .setOperator(BinaryColumnFilterOperator.EQUALS)
+                            .setStringVal("stringValueA")
+                            .build())
+                    .addBinaryColumnFilters(
+                        BinaryColumnFilter.newBuilder()
+                            .setColumn(
+                                ColumnId.newBuilder()
+                                    .setDataset("datasetA")
+                                    .setTable("tableA")
+                                    .setColumn("columnB")
+                                    .build())
+                            .setOperator(BinaryColumnFilterOperator.LESS_THAN)
+                            .setInt64Val(64)
+                            .build())
+                    .addArrayColumnFilters(
+                        ArrayColumnFilter.newBuilder()
+                            .addBinaryColumnFilters(
+                                BinaryColumnFilter.newBuilder()
+                                    .setColumn(
+                                        ColumnId.newBuilder()
+                                            .setDataset("datasetA")
+                                            .setTable("tableA")
+                                            .setColumn("columnA")
+                                            .build())
+                                    .setOperator(BinaryColumnFilterOperator.EQUALS)
+                                    .setStringVal("stringValueB")
+                                    .build())
+                            .addBinaryColumnFilters(
+                                BinaryColumnFilter.newBuilder()
+                                    .setColumn(
+                                        ColumnId.newBuilder()
+                                            .setDataset("datasetA")
+                                            .setTable("tableA")
+                                            .setColumn("columnB")
+                                            .build())
+                                    .setOperator(BinaryColumnFilterOperator.LESS_THAN)
+                                    .setInt64Val(104)
+                                    .build())
+                            .setOperator(ArrayColumnFilterOperator.AND)
+                            .build())
+                    .addArrayColumnFilters(
+                        ArrayColumnFilter.newBuilder()
+                            .addBinaryColumnFilters(
+                                BinaryColumnFilter.newBuilder()
+                                    .setColumn(
+                                        ColumnId.newBuilder()
+                                            .setDataset("datasetA")
+                                            .setTable("tableA")
+                                            .setColumn("columnA")
+                                            .build())
+                                    .setOperator(BinaryColumnFilterOperator.EQUALS)
+                                    .setStringVal("stringValueC")
+                                    .build())
+                            .addBinaryColumnFilters(
+                                BinaryColumnFilter.newBuilder()
+                                    .setColumn(
+                                        ColumnId.newBuilder()
+                                            .setDataset("datasetA")
+                                            .setTable("tableA")
+                                            .setColumn("columnB")
+                                            .build())
+                                    .setOperator(BinaryColumnFilterOperator.GREATER_THAN)
+                                    .setInt64Val(256)
+                                    .build())
+                            .setOperator(ArrayColumnFilterOperator.AND)
+                            .build())
+                    .setOperator(ArrayColumnFilterOperator.OR)
+                    .build())
+            .build();
+
+    bio.terra.tanagra.service.underlay.Underlay underlay =
+        convertUnderlayFromProto(tableFilterProto);
+    String generatedSql = generateSql(underlay, getEntityDatasetForEntityA(underlay));
+    assertEquals(
+        "SELECT entitya_alias.columnA AS attributeA "
+            + "FROM (SELECT * FROM `my-project-id.my-dataset-id`.tableA WHERE columnA = 'stringValueA' OR columnB < 64 OR (columnA = 'stringValueB' AND columnB < 104) OR (columnA = 'stringValueC' AND columnB > 256)) AS entitya_alias "
+            + "WHERE TRUE",
+        generatedSql);
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/query/BinaryColumnFilterTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/BinaryColumnFilterTest.java
@@ -4,131 +4,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import bio.terra.tanagra.proto.underlay.Attribute;
-import bio.terra.tanagra.proto.underlay.AttributeId;
-import bio.terra.tanagra.proto.underlay.AttributeMapping;
 import bio.terra.tanagra.proto.underlay.BinaryColumnFilter;
 import bio.terra.tanagra.proto.underlay.BinaryColumnFilterOperator;
-import bio.terra.tanagra.proto.underlay.Column;
 import bio.terra.tanagra.proto.underlay.ColumnId;
-import bio.terra.tanagra.proto.underlay.DataType;
-import bio.terra.tanagra.proto.underlay.Dataset;
-import bio.terra.tanagra.proto.underlay.Entity;
 import bio.terra.tanagra.proto.underlay.EntityMapping;
-import bio.terra.tanagra.proto.underlay.Table;
 import bio.terra.tanagra.proto.underlay.TableFilter;
-import bio.terra.tanagra.proto.underlay.Underlay;
-import bio.terra.tanagra.service.search.EntityVariable;
-import bio.terra.tanagra.service.search.Filter;
-import bio.terra.tanagra.service.search.Query;
-import bio.terra.tanagra.service.search.SearchContext;
-import bio.terra.tanagra.service.search.SqlVisitor;
-import bio.terra.tanagra.service.search.Variable;
-import bio.terra.tanagra.service.underlay.UnderlayConversion;
-import bio.terra.tanagra.testing.BaseSpringUnitTest;
-import com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Tests for {@link BinaryColumnFilter} used to define an {@link EntityMapping} with a {@link
  * TableFilter}. Some of these tests check for validation in the conversion from underlay proto ->
  * Java class. Other tests check the SQL string generated for queries against this underlay.
  */
-public class BinaryColumnFilterTest extends BaseSpringUnitTest {
-  @Autowired private QueryService queryService;
-
-  // underlay proto without any entity mappings defined, so that we can vary the table filter in the
-  // entity mapping in each test method
-  private final Underlay.Builder underlayProtoBuilder =
-      Underlay.newBuilder()
-          .setName("underlayA")
-          .addDatasets(
-              Dataset.newBuilder()
-                  .setName("datasetA")
-                  .setBigQueryDataset(
-                      Dataset.BigQueryDataset.newBuilder()
-                          .setDatasetId("my-dataset-id")
-                          .setProjectId("my-project-id")
-                          .build())
-                  .addTables(
-                      Table.newBuilder()
-                          .setName("tableA")
-                          .addColumns(
-                              Column.newBuilder().setName("columnA").setDataType(DataType.STRING))
-                          .addColumns(
-                              Column.newBuilder().setName("columnB").setDataType(DataType.INT64))
-                          .build())
-                  .addTables(
-                      Table.newBuilder()
-                          .setName("tableB")
-                          .addColumns(
-                              Column.newBuilder().setName("columnC").setDataType(DataType.INT64))
-                          .build())
-                  .build())
-          .addEntities(
-              Entity.newBuilder()
-                  .setName("entityA")
-                  .addAttributes(
-                      Attribute.newBuilder()
-                          .setName("attributeA")
-                          .setDataType(DataType.STRING)
-                          .build())
-                  .addAttributes(
-                      Attribute.newBuilder()
-                          .setName("attributeB")
-                          .setDataType(DataType.INT64)
-                          .build())
-                  .build())
-          .addAttributeMappings(
-              AttributeMapping.newBuilder()
-                  .setAttribute(
-                      AttributeId.newBuilder()
-                          .setEntity("entityA")
-                          .setAttribute("attributeA")
-                          .build())
-                  .setSimpleColumn(
-                      AttributeMapping.SimpleColumn.newBuilder()
-                          .setColumnId(
-                              ColumnId.newBuilder()
-                                  .setDataset("datasetA")
-                                  .setTable("tableA")
-                                  .setColumn("columnA")
-                                  .build())
-                          .build())
-                  .build())
-          .addAttributeMappings(
-              AttributeMapping.newBuilder()
-                  .setAttribute(
-                      AttributeId.newBuilder()
-                          .setEntity("entityA")
-                          .setAttribute("attributeB")
-                          .build())
-                  .setSimpleColumn(
-                      AttributeMapping.SimpleColumn.newBuilder()
-                          .setColumnId(
-                              ColumnId.newBuilder()
-                                  .setDataset("datasetA")
-                                  .setTable("tableA")
-                                  .setColumn("columnB")
-                                  .build())
-                          .build())
-                  .build());
-
-  // entity mapping proto without any table filter defined, so that we can vary the table filter in
-  // each test method
-  private final EntityMapping.Builder entityMappingProtoBuilder =
-      EntityMapping.newBuilder()
-          .setEntity("entityA")
-          .setPrimaryKey(
-              ColumnId.newBuilder()
-                  .setDataset("datasetA")
-                  .setTable("tableA")
-                  .setColumn("columnA")
-                  .build());
-
+public class BinaryColumnFilterTest extends ColumnFilterTest {
   @Test
   @DisplayName(
       "underlay conversion fails when binary column filter table doesn't match the entity pk table")
@@ -273,43 +163,5 @@ public class BinaryColumnFilterTest extends BaseSpringUnitTest {
             + "FROM (SELECT * FROM `my-project-id.my-dataset-id`.tableA WHERE columnB > 92) AS entitya_alias "
             + "WHERE TRUE",
         generatedSql);
-  }
-
-  private bio.terra.tanagra.service.underlay.Underlay convertUnderlayFromProto(
-      TableFilter tableFilterProto) {
-    Underlay underlayProto =
-        underlayProtoBuilder
-            .addEntityMappings(entityMappingProtoBuilder.setTableFilter(tableFilterProto).build())
-            .build();
-    return UnderlayConversion.convert(underlayProto);
-  }
-
-  private EntityDataset getEntityDatasetForEntityA(
-      bio.terra.tanagra.service.underlay.Underlay underlay) {
-    bio.terra.tanagra.service.search.Entity entity =
-        bio.terra.tanagra.service.search.Entity.builder()
-            .underlay("underlayA")
-            .name("entityA")
-            .build();
-    bio.terra.tanagra.service.search.Attribute attributeA =
-        bio.terra.tanagra.service.search.Attribute.builder()
-            .name("attributeA")
-            .entity(entity)
-            .dataType(bio.terra.tanagra.service.search.DataType.STRING)
-            .build();
-
-    return EntityDataset.builder()
-        .primaryEntity(
-            EntityVariable.create(
-                underlay.entities().get("entityA"), Variable.create("entitya_alias")))
-        .selectedAttributes(ImmutableList.of(attributeA))
-        .filter(Filter.NullFilter.INSTANCE)
-        .build();
-  }
-
-  private String generateSql(
-      bio.terra.tanagra.service.underlay.Underlay underlay, EntityDataset entityDataset) {
-    Query query = queryService.createQuery(entityDataset);
-    return new SqlVisitor(SearchContext.builder().underlay(underlay).build()).createSql(query);
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/service/query/ColumnFilterTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/ColumnFilterTest.java
@@ -1,0 +1,156 @@
+package bio.terra.tanagra.service.query;
+
+import bio.terra.tanagra.proto.underlay.Attribute;
+import bio.terra.tanagra.proto.underlay.AttributeId;
+import bio.terra.tanagra.proto.underlay.AttributeMapping;
+import bio.terra.tanagra.proto.underlay.Column;
+import bio.terra.tanagra.proto.underlay.ColumnId;
+import bio.terra.tanagra.proto.underlay.DataType;
+import bio.terra.tanagra.proto.underlay.Dataset;
+import bio.terra.tanagra.proto.underlay.Entity;
+import bio.terra.tanagra.proto.underlay.EntityMapping;
+import bio.terra.tanagra.proto.underlay.Table;
+import bio.terra.tanagra.proto.underlay.TableFilter;
+import bio.terra.tanagra.proto.underlay.Underlay;
+import bio.terra.tanagra.service.search.EntityVariable;
+import bio.terra.tanagra.service.search.Filter;
+import bio.terra.tanagra.service.search.Query;
+import bio.terra.tanagra.service.search.SearchContext;
+import bio.terra.tanagra.service.search.SqlVisitor;
+import bio.terra.tanagra.service.search.Variable;
+import bio.terra.tanagra.service.underlay.UnderlayConversion;
+import bio.terra.tanagra.testing.BaseSpringUnitTest;
+import com.google.common.collect.ImmutableList;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/** Base class for different table filters in an underlay definition. */
+public class ColumnFilterTest extends BaseSpringUnitTest {
+  @Autowired private QueryService queryService;
+
+  // underlay proto without any entity mappings defined, so that we can vary the table filter in the
+  // entity mapping in each test method
+  protected final Underlay.Builder underlayProtoBuilder =
+      Underlay.newBuilder()
+          .setName("underlayA")
+          .addDatasets(
+              Dataset.newBuilder()
+                  .setName("datasetA")
+                  .setBigQueryDataset(
+                      Dataset.BigQueryDataset.newBuilder()
+                          .setDatasetId("my-dataset-id")
+                          .setProjectId("my-project-id")
+                          .build())
+                  .addTables(
+                      Table.newBuilder()
+                          .setName("tableA")
+                          .addColumns(
+                              Column.newBuilder().setName("columnA").setDataType(DataType.STRING))
+                          .addColumns(
+                              Column.newBuilder().setName("columnB").setDataType(DataType.INT64))
+                          .build())
+                  .addTables(
+                      Table.newBuilder()
+                          .setName("tableB")
+                          .addColumns(
+                              Column.newBuilder().setName("columnC").setDataType(DataType.INT64))
+                          .build())
+                  .build())
+          .addEntities(
+              Entity.newBuilder()
+                  .setName("entityA")
+                  .addAttributes(
+                      Attribute.newBuilder()
+                          .setName("attributeA")
+                          .setDataType(DataType.STRING)
+                          .build())
+                  .addAttributes(
+                      Attribute.newBuilder()
+                          .setName("attributeB")
+                          .setDataType(DataType.INT64)
+                          .build())
+                  .build())
+          .addAttributeMappings(
+              AttributeMapping.newBuilder()
+                  .setAttribute(
+                      AttributeId.newBuilder()
+                          .setEntity("entityA")
+                          .setAttribute("attributeA")
+                          .build())
+                  .setSimpleColumn(
+                      AttributeMapping.SimpleColumn.newBuilder()
+                          .setColumnId(
+                              ColumnId.newBuilder()
+                                  .setDataset("datasetA")
+                                  .setTable("tableA")
+                                  .setColumn("columnA")
+                                  .build())
+                          .build())
+                  .build())
+          .addAttributeMappings(
+              AttributeMapping.newBuilder()
+                  .setAttribute(
+                      AttributeId.newBuilder()
+                          .setEntity("entityA")
+                          .setAttribute("attributeB")
+                          .build())
+                  .setSimpleColumn(
+                      AttributeMapping.SimpleColumn.newBuilder()
+                          .setColumnId(
+                              ColumnId.newBuilder()
+                                  .setDataset("datasetA")
+                                  .setTable("tableA")
+                                  .setColumn("columnB")
+                                  .build())
+                          .build())
+                  .build());
+
+  // entity mapping proto without any table filter defined, so that we can vary the table filter in
+  // each test method
+  protected final EntityMapping.Builder entityMappingProtoBuilder =
+      EntityMapping.newBuilder()
+          .setEntity("entityA")
+          .setPrimaryKey(
+              ColumnId.newBuilder()
+                  .setDataset("datasetA")
+                  .setTable("tableA")
+                  .setColumn("columnA")
+                  .build());
+
+  protected bio.terra.tanagra.service.underlay.Underlay convertUnderlayFromProto(
+      TableFilter tableFilterProto) {
+    Underlay underlayProto =
+        underlayProtoBuilder
+            .addEntityMappings(entityMappingProtoBuilder.setTableFilter(tableFilterProto).build())
+            .build();
+    return UnderlayConversion.convert(underlayProto);
+  }
+
+  protected EntityDataset getEntityDatasetForEntityA(
+      bio.terra.tanagra.service.underlay.Underlay underlay) {
+    bio.terra.tanagra.service.search.Entity entity =
+        bio.terra.tanagra.service.search.Entity.builder()
+            .underlay("underlayA")
+            .name("entityA")
+            .build();
+    bio.terra.tanagra.service.search.Attribute attributeA =
+        bio.terra.tanagra.service.search.Attribute.builder()
+            .name("attributeA")
+            .entity(entity)
+            .dataType(bio.terra.tanagra.service.search.DataType.STRING)
+            .build();
+
+    return EntityDataset.builder()
+        .primaryEntity(
+            EntityVariable.create(
+                underlay.entities().get("entityA"), Variable.create("entitya_alias")))
+        .selectedAttributes(ImmutableList.of(attributeA))
+        .filter(Filter.NullFilter.INSTANCE)
+        .build();
+  }
+
+  protected String generateSql(
+      bio.terra.tanagra.service.underlay.Underlay underlay, EntityDataset entityDataset) {
+    Query query = queryService.createQuery(entityDataset);
+    return new SqlVisitor(SearchContext.builder().underlay(underlay).build()).createSql(query);
+  }
+}

--- a/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/QueryServiceTest.java
@@ -1,5 +1,8 @@
 package bio.terra.tanagra.service.query;
 
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ELECTRIC_ANCHOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ELECTRIC_ANCHOR_ID;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ELECTRIC_ANCHOR_NAME;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE_ID;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE_NAME;
@@ -60,7 +63,7 @@ public class QueryServiceTest extends BaseSpringUnitTest {
   }
 
   @Test
-  void generateSqlEntityDatasetWithTableFilter() {
+  void generateSqlEntityDatasetWithTableFilterBinary() {
     assertEquals(
         "SELECT boatengine.bp_id AS id, boatengine.bp_name AS name "
             + "FROM (SELECT * FROM `my-project-id.nautical`.boat_parts WHERE bp_type = 'engine') AS boatengine "
@@ -69,6 +72,23 @@ public class QueryServiceTest extends BaseSpringUnitTest {
             EntityDataset.builder()
                 .primaryEntity(EntityVariable.create(BOAT_ENGINE, Variable.create("boatengine")))
                 .selectedAttributes(ImmutableList.of(BOAT_ENGINE_ID, BOAT_ENGINE_NAME))
+                .filter(Filter.NullFilter.INSTANCE)
+                .build()));
+  }
+
+  @Test
+  void generateSqlEntityDatasetWithTableFilterArray() {
+    assertEquals(
+        "SELECT boatelectricanchors.bp_id AS id, boatelectricanchors.bp_name AS name "
+            + "FROM (SELECT * FROM `my-project-id.nautical`.boat_parts WHERE bp_type = 'anchor' AND bp_requires_electricity = 'true') AS boatelectricanchors "
+            + "WHERE TRUE",
+        queryService.generateSql(
+            EntityDataset.builder()
+                .primaryEntity(
+                    EntityVariable.create(
+                        BOAT_ELECTRIC_ANCHOR, Variable.create("boatelectricanchors")))
+                .selectedAttributes(
+                    ImmutableList.of(BOAT_ELECTRIC_ANCHOR_ID, BOAT_ELECTRIC_ANCHOR_NAME))
                 .filter(Filter.NullFilter.INSTANCE)
                 .build()));
   }

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
@@ -43,6 +43,8 @@ public final class NauticalUnderlayUtils {
       Entity.builder().underlay(NAUTICAL_UNDERLAY_NAME).name("reservations").build();
   public static final Entity BOAT_ENGINE =
       Entity.builder().underlay(NAUTICAL_UNDERLAY_NAME).name("boat_engines").build();
+  public static final Entity BOAT_ELECTRIC_ANCHOR =
+      Entity.builder().underlay(NAUTICAL_UNDERLAY_NAME).name("boat_electric_anchors").build();
 
   public static final Attribute SAILOR_ID =
       Attribute.builder().name("id").dataType(DataType.INT64).entity(SAILOR).build();
@@ -75,6 +77,15 @@ public final class NauticalUnderlayUtils {
       Attribute.builder().name("id").dataType(DataType.INT64).entity(BOAT_ENGINE).build();
   public static final Attribute BOAT_ENGINE_NAME =
       Attribute.builder().name("name").dataType(DataType.STRING).entity(BOAT_ENGINE).build();
+
+  public static final Attribute BOAT_ELECTRIC_ANCHOR_ID =
+      Attribute.builder().name("id").dataType(DataType.INT64).entity(BOAT_ELECTRIC_ANCHOR).build();
+  public static final Attribute BOAT_ELECTRIC_ANCHOR_NAME =
+      Attribute.builder()
+          .name("name")
+          .dataType(DataType.STRING)
+          .entity(BOAT_ELECTRIC_ANCHOR)
+          .build();
 
   public static final Relationship SAILOR_RESERVATION_RELATIONSHIP =
       Relationship.builder()
@@ -179,9 +190,19 @@ public final class NauticalUnderlayUtils {
       Column.builder().name("bp_name").dataType(DataType.STRING).table(BOAT_PARTS_TABLE).build();
   public static final Column BOAT_PARTS_TYPE_COL =
       Column.builder().name("bp_type").dataType(DataType.STRING).table(BOAT_PARTS_TABLE).build();
+  public static final Column BOAT_PARTS_REQUIRES_ELECTRICITY_COL =
+      Column.builder()
+          .name("bp_requires_electricity")
+          .dataType(DataType.STRING)
+          .table(BOAT_PARTS_TABLE)
+          .build();
 
   public static final BinaryColumnFilterOperator BOAT_PARTS_TYPE_COL_OPERATOR =
       BinaryColumnFilterOperator.EQUALS;
   public static final ColumnValue BOAT_PARTS_TYPE_COL_ENGINE_VALUE =
       ColumnValue.builder().stringVal("engine").build();
+  public static final ColumnValue BOAT_PARTS_TYPE_COL_ANCHOR_VALUE =
+      ColumnValue.builder().stringVal("anchor").build();
+  public static final ColumnValue BOAT_PARTS_REQUIRES_ELECTRICITY_COL_TRUE_VALUE =
+      ColumnValue.builder().stringVal("true").build();
 }

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
@@ -4,6 +4,9 @@ import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_BT_ID_COL;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_COLOR;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_COLOR_COL;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ELECTRIC_ANCHOR;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ELECTRIC_ANCHOR_ID;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ELECTRIC_ANCHOR_NAME;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE_ID;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_ENGINE_NAME;
@@ -13,7 +16,10 @@ import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_NAME
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_NAME_COL;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_ID_COL;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_NAME_COL;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_REQUIRES_ELECTRICITY_COL;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_REQUIRES_ELECTRICITY_COL_TRUE_VALUE;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_TYPE_COL;
+import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_TYPE_COL_ANCHOR_VALUE;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_TYPE_COL_ENGINE_VALUE;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_PARTS_TYPE_COL_OPERATOR;
 import static bio.terra.tanagra.service.underlay.NauticalUnderlayUtils.BOAT_RESERVATION_RELATIONSHIP;
@@ -56,6 +62,7 @@ import bio.terra.tanagra.proto.underlay.IntegerBoundsHint;
 import bio.terra.tanagra.service.search.Attribute;
 import bio.terra.tanagra.service.underlay.AttributeMapping.LookupColumn;
 import bio.terra.tanagra.service.underlay.Hierarchy.DescendantsTable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
@@ -76,6 +83,7 @@ public class UnderlayConversionTest {
             .put(BOAT.name(), BOAT)
             .put(RESERVATION.name(), RESERVATION)
             .put(BOAT_ENGINE.name(), BOAT_ENGINE)
+            .put(BOAT_ELECTRIC_ANCHOR.name(), BOAT_ELECTRIC_ANCHOR)
             .build(),
         nautical.entities());
     assertEquals(
@@ -94,6 +102,8 @@ public class UnderlayConversionTest {
             .put(RESERVATION, "day", RESERVATION_DAY)
             .put(BOAT_ENGINE, "id", BOAT_ENGINE_ID)
             .put(BOAT_ENGINE, "name", BOAT_ENGINE_NAME)
+            .put(BOAT_ELECTRIC_ANCHOR, "id", BOAT_ELECTRIC_ANCHOR_ID)
+            .put(BOAT_ELECTRIC_ANCHOR, "name", BOAT_ELECTRIC_ANCHOR_NAME)
             .build(),
         nautical.attributes());
     assertEquals(
@@ -109,6 +119,7 @@ public class UnderlayConversionTest {
             .put(BOAT, BOAT_ID_COL)
             .put(RESERVATION, RESERVATION_ID_COL)
             .put(BOAT_ENGINE, BOAT_PARTS_ID_COL)
+            .put(BOAT_ELECTRIC_ANCHOR, BOAT_PARTS_ID_COL)
             .build(),
         nautical.primaryKeys());
     assertEquals(
@@ -121,6 +132,23 @@ public class UnderlayConversionTest {
                             BOAT_PARTS_TYPE_COL,
                             BOAT_PARTS_TYPE_COL_OPERATOR,
                             BOAT_PARTS_TYPE_COL_ENGINE_VALUE))
+                    .build())
+            .put(
+                BOAT_ELECTRIC_ANCHOR,
+                TableFilter.builder()
+                    .arrayColumnFilter(
+                        ArrayColumnFilter.create(
+                            ArrayColumnFilterOperator.AND,
+                            ImmutableList.of(),
+                            ImmutableList.of(
+                                BinaryColumnFilter.create(
+                                    BOAT_PARTS_TYPE_COL,
+                                    BOAT_PARTS_TYPE_COL_OPERATOR,
+                                    BOAT_PARTS_TYPE_COL_ANCHOR_VALUE),
+                                BinaryColumnFilter.create(
+                                    BOAT_PARTS_REQUIRES_ELECTRICITY_COL,
+                                    BOAT_PARTS_TYPE_COL_OPERATOR,
+                                    BOAT_PARTS_REQUIRES_ELECTRICITY_COL_TRUE_VALUE))))
                     .build())
             .build(),
         nautical.tableFilters());

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/UnderlayConversionTest.java
@@ -189,6 +189,13 @@ public class UnderlayConversionTest {
             .put(
                 BOAT_ENGINE_NAME,
                 AttributeMapping.SimpleColumn.create(BOAT_ENGINE_NAME, BOAT_PARTS_NAME_COL))
+            .put(
+                BOAT_ELECTRIC_ANCHOR_ID,
+                AttributeMapping.SimpleColumn.create(BOAT_ELECTRIC_ANCHOR_ID, BOAT_PARTS_ID_COL))
+            .put(
+                BOAT_ELECTRIC_ANCHOR_NAME,
+                AttributeMapping.SimpleColumn.create(
+                    BOAT_ELECTRIC_ANCHOR_NAME, BOAT_PARTS_NAME_COL))
             .build(),
         nautical.attributeMappings());
     assertEquals(

--- a/api/src/test/resources/underlays/nautical.pbtext
+++ b/api/src/test/resources/underlays/nautical.pbtext
@@ -73,6 +73,17 @@ entities: {
     data_type: STRING
   }
 }
+entities: {
+  name: "boat_electric_anchors"
+  attributes: {
+    name: "id"
+    data_type: INT64
+  }
+  attributes: {
+    name: "name"
+    data_type: STRING
+  }
+}
 relationships: {
   name: "sailor_reservation"
   entity1: "sailors"
@@ -213,6 +224,10 @@ datasets: {
       name: "bp_type"
       data_type: STRING
     }
+    columns: {
+      name: "bp_requires_electricity"
+      data_type: STRING
+    }
   }
 }
 entity_mappings: {
@@ -255,6 +270,37 @@ entity_mappings: {
       }
       operator: EQUALS
       string_val: "engine"
+    }
+  }
+}
+entity_mappings: {
+  entity: "boat_electric_anchors"
+  primary_key: {
+    dataset: "nautical"
+    table: "boat_parts"
+    column: "bp_id"
+  }
+  table_filter: {
+    array_column_filter: {
+      operator: AND
+      binary_column_filters: {
+        column: {
+          dataset: "nautical"
+          table: "boat_parts"
+          column: "bp_type"
+        }
+        operator: EQUALS
+        string_val: "anchor"
+      }
+      binary_column_filters: {
+        column: {
+          dataset: "nautical"
+          table: "boat_parts"
+          column: "bp_requires_electricity"
+        }
+        operator: EQUALS
+        string_val: "true"
+      }
     }
   }
 }

--- a/api/src/test/resources/underlays/nautical.pbtext
+++ b/api/src/test/resources/underlays/nautical.pbtext
@@ -496,6 +496,32 @@ attribute_mappings: {
     }
   }
 }
+attribute_mappings: {
+  attribute: {
+    entity: "boat_electric_anchors"
+    attribute: "id"
+  }
+  simple_column: {
+    column_id: {
+      dataset: "nautical"
+      table: "boat_parts"
+      column: "bp_id"
+    }
+  }
+}
+attribute_mappings: {
+  attribute: {
+    entity: "boat_electric_anchors"
+    attribute: "name"
+  }
+  simple_column: {
+    column_id: {
+      dataset: "nautical"
+      table: "boat_parts"
+      column: "bp_name"
+    }
+  }
+}
 relationship_mappings: {
   name: "sailor_reservation"
   foreign_key: {

--- a/api/src/test/resources/underlays/nautical.yaml
+++ b/api/src/test/resources/underlays/nautical.yaml
@@ -40,6 +40,12 @@ entities:
         dataType: INT64
       - name: name
         dataType: STRING
+  - name: boat_electric_anchors
+    attributes:
+      - name: id
+        dataType: INT64
+      - name: name
+        dataType: STRING
 relationships:
   - name: sailor_reservation
     entity1: sailors
@@ -120,6 +126,8 @@ datasets:
             dataType: STRING
           - name: bp_type
             dataType: STRING
+          - name: bp_requires_electricity
+            dataType: STRING
 entityMappings:
   - entity: sailors
     primaryKey:
@@ -149,6 +157,27 @@ entityMappings:
           column: bp_type
         operator: EQUALS
         stringVal: engine
+  - entity: boat_electric_anchors
+    primaryKey:
+      dataset: nautical
+      table: boat_parts
+      column: bp_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        binaryColumnFilters:
+          - column:
+              dataset: nautical
+              table: boat_parts
+              column: bp_type
+            operator: EQUALS
+            stringVal: anchor
+          - column:
+              dataset: nautical
+              table: boat_parts
+              column: bp_requires_electricity
+            operator: EQUALS
+            stringVal: true
 attributeMappings:
   - attribute:
       entity: sailors

--- a/api/src/test/resources/underlays/nautical.yaml
+++ b/api/src/test/resources/underlays/nautical.yaml
@@ -299,6 +299,22 @@ attributeMappings:
         dataset: nautical
         table: boat_parts
         column: bp_name
+  - attribute:
+      entity: boat_electric_anchors
+      attribute: id
+    simpleColumn:
+      columnId:
+        dataset: nautical
+        table: boat_parts
+        column: bp_id
+  - attribute:
+      entity: boat_electric_anchors
+      attribute: name
+    simpleColumn:
+      columnId:
+        dataset: nautical
+        table: boat_parts
+        column: bp_name
 relationshipMappings:
   - name: sailor_reservation
     foreignKey:

--- a/lib/src/main/proto/bio/terra/tanagra/underlay/tables.proto
+++ b/lib/src/main/proto/bio/terra/tanagra/underlay/tables.proto
@@ -51,12 +51,32 @@ message ColumnId {
 
 // A filter specification to get a subset of the rows in a table.
 message TableFilter {
-  // One type of table filter
+  // One type of table filter.
+  // TODO: add more filter types here (see entity search filters for ideas)
   oneof filter {
-    // A condition on a particular column
-    BinaryColumnFilter binary_column_filter = 1;
-    // TODO: add more filter types here (see entity search filters for ideas)
+    // A composition of multiple sub-filters.
+    ArrayColumnFilter array_column_filter = 1;
+
+    // A condition on a particular column.
+    BinaryColumnFilter binary_column_filter = 2;
   }
+}
+
+// A building block for a TableFilter that composes multiple sub-filters.
+message ArrayColumnFilter {
+  // The operator to use between the sub-filters.
+  ArrayColumnFilterOperator operator = 1;
+
+  // A list of array sub-filters to compose.
+  repeated ArrayColumnFilter array_column_filters = 2;
+
+  // A list of binary sub-filters to compose.
+  repeated BinaryColumnFilter binary_column_filters = 3;
+}
+
+enum ArrayColumnFilterOperator {
+  AND = 0;
+  OR = 1;
 }
 
 // A building block for a TableFilter that defines a condition on a single column.


### PR DESCRIPTION
- Added a new type of `TableFilter`. Previously, we could only filter on a single column with a `BinaryColumnFilter`. Now we can compose multiple sub-filters into a new filter that filters on >1 column with an `ArrayColumnFilter`.
- Tests use the nautical underlay.

The purpose of this change is to allow us to define entities as filtered versions of a table, where the filter includes >1 condition. For example, standard conditions may be rows of the `concept` table where `domain_id=Condition AND standard_concept IS NOT NULL`.