### PR TITLE
Add custom checkbox

### DIFF
--- a/ui/src/checkbox.tsx
+++ b/ui/src/checkbox.tsx
@@ -1,0 +1,35 @@
+import CheckBoxIcon from "@mui/icons-material/CheckBox";
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
+import IconButton from "@mui/material/IconButton";
+
+export type CheckboxProps = {
+  checked?: boolean;
+  onChange?: () => void;
+  size?: "small" | "medium" | "large";
+  fontSize?: "small" | "medium" | "large" | "inherit";
+};
+
+export default function Checkbox({
+  checked,
+  onChange,
+  size,
+  fontSize,
+}: CheckboxProps) {
+  return (
+    <IconButton
+      role={"checkbox"}
+      size={size}
+      onClick={() => {
+        if (onChange) {
+          onChange();
+        }
+      }}
+    >
+      {checked ? (
+        <CheckBoxIcon fontSize={fontSize} />
+      ) : (
+        <CheckBoxOutlineBlankIcon fontSize={fontSize} />
+      )}
+    </IconButton>
+  );
+}

--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -1,10 +1,10 @@
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import Button from "@mui/material/Button";
-import Checkbox from "@mui/material/Checkbox";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { EntityInstancesApiContext } from "apiContext";
+import Checkbox from "checkbox";
 import {
   Cohort,
   CriteriaConfig,
@@ -263,8 +263,8 @@ function ConceptEdit(props: ConceptEditProps) {
             return (
               <Checkbox
                 size="small"
+                fontSize="inherit"
                 checked={index > -1}
-                inputProps={{ "aria-label": "controlled" }}
                 onChange={() => {
                   dispatch(
                     updateCriteriaData({


### PR DESCRIPTION
This makes the checkboxes and expansion icons in the criteria be the
same size. Because the Material UI Checkbox and IconButton are built out
of different components, making them the same size is much more
complicated than it should be.