### PR TITLE
Use callback as watched value for useAsyncWithApi

### DIFF
--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -265,9 +265,7 @@ function ConceptEdit(props: ConceptEditProps) {
     hierarchy,
     query,
   ]);
-  // TODO(tjennison): Use the callback as the watch parameter instead of a
-  // separate value to avoid having two layers of equality testing.
-  const conceptsState = useAsyncWithApi<void>(fetchEntities, fetchEntities);
+  const conceptsState = useAsyncWithApi<void>(fetchEntities);
 
   const hierarchyColumns = [
     {

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -17,7 +17,7 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { insertCohort } from "cohortsSlice";
 import { useAppDispatch, useAppSelector } from "hooks";
-import { ChangeEvent, ReactNode, useCallback, useState } from "react";
+import { ChangeEvent, ReactNode, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import ActionBar from "./actionBar";
 import { useSqlDialog } from "./sqlDialog";
@@ -145,9 +145,9 @@ function useNewCohortDialog(
   props: NewCohortDialogProps
 ): [ReactNode, () => void] {
   const [open, setOpen] = useState(false);
-  const show = useCallback(() => {
+  const show = () => {
     setOpen(true);
-  }, []);
+  };
 
   const [name, setName] = useState("New Cohort");
   const onNameChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/ui/src/errors.tsx
+++ b/ui/src/errors.tsx
@@ -2,16 +2,13 @@ import { getReasonPhrase } from "http-status-codes";
 import { useCallback } from "react";
 import { useAsync } from "react-async";
 
-export function useAsyncWithApi<T>(
-  promiseFn: () => Promise<T>,
-  watch?: unknown
-) {
+export function useAsyncWithApi<T>(promiseFn: () => Promise<T>) {
   const wrapped = useCallback(() => {
     return promiseFn().catch(async (e) => {
       throw await canonicalizeError(e);
     });
   }, [promiseFn]);
-  return useAsync<T>({ promiseFn: wrapped, watch });
+  return useAsync<T>({ promiseFn: wrapped, watch: wrapped });
 }
 
 async function canonicalizeError(response: unknown): Promise<Error> {

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -2,7 +2,7 @@ import {
   default as BaseMenu,
   MenuProps as BaseMenuProps,
 } from "@mui/material/Menu";
-import { MouseEvent, ReactElement, useCallback, useState } from "react";
+import { MouseEvent, ReactElement, useState } from "react";
 
 type MenuProps = Omit<
   BaseMenuProps,
@@ -17,7 +17,8 @@ export function useMenu({
   (e: MouseEvent<HTMLElement | undefined>) => void
 ] {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>();
-  const show = useCallback((e) => setAnchorEl(e.currentTarget), []);
+  const show = (e: MouseEvent<HTMLElement | undefined>) =>
+    setAnchorEl(e.currentTarget);
 
   return [
     // eslint-disable-next-line react/jsx-key

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -15,7 +15,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { deleteCriteria, insertCriteria, insertGroup } from "cohortsSlice";
 import { useAppDispatch } from "hooks";
-import React, { useCallback } from "react";
+import React from "react";
 import { Link as RouterLink, useHistory, useParams } from "react-router-dom";
 import * as tanagra from "tanagra-api";
 import ActionBar from "./actionBar";
@@ -76,21 +76,17 @@ function AddCriteriaButton(props: { group: string | GroupKind }) {
   const history = useHistory();
   const dispatch = useAppDispatch();
 
-  const onAddCriteria = useCallback(
-    (criteria: Criteria) => {
-      let groupId = "";
-      if (typeof props.group === "string") {
-        groupId = props.group;
-        dispatch(insertCriteria({ cohortId, groupId, criteria }));
-      } else {
-        const action = dispatch(insertGroup(cohortId, props.group, criteria));
-        groupId = action.payload.group.id;
-      }
-      history.push(editRoute(cohortId, groupId, criteria.id));
-    },
-    [props.group]
-  );
-
+  const onAddCriteria = (criteria: Criteria) => {
+    let groupId = "";
+    if (typeof props.group === "string") {
+      groupId = props.group;
+      dispatch(insertCriteria({ cohortId, groupId, criteria }));
+    } else {
+      const action = dispatch(insertGroup(cohortId, props.group, criteria));
+      groupId = action.payload.group.id;
+    }
+    history.push(editRoute(cohortId, groupId, criteria.id));
+  };
   // TODO(tjennison): Fetch configs from the backend.
   const columns = [
     { key: "concept_name", width: "100%", title: "Concept Name" },

--- a/ui/src/sqlDialog.tsx
+++ b/ui/src/sqlDialog.tsx
@@ -3,9 +3,9 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { EntityInstancesApiContext } from "apiContext";
+import { useAsyncWithApi } from "errors";
 import Loading from "loading";
 import { ReactElement, useCallback, useContext, useState } from "react";
-import { useAsync } from "react-async";
 import { Cohort, generateQueryParameters } from "./cohort";
 
 type SqlDialogProps = {
@@ -16,14 +16,14 @@ export function useSqlDialog(
   props: SqlDialogProps
 ): [ReactElement, () => void] {
   const [open, setOpen] = useState(false);
-  const show = useCallback(() => {
+  const show = () => {
     setOpen(true);
-  }, []);
+  };
 
   const api = useContext(EntityInstancesApiContext);
 
-  const sqlState = useAsync<string>({
-    promiseFn: useCallback(() => {
+  const sqlState = useAsyncWithApi<string>(
+    useCallback(() => {
       if (open && props.cohort) {
         const params = generateQueryParameters(props.cohort);
         if (params) {
@@ -49,8 +49,8 @@ export function useSqlDialog(
       return new Promise<string>((resolve) => {
         resolve("");
       });
-    }, [api, props.cohort, open]),
-  });
+    }, [api, props.cohort, open])
+  );
 
   return [
     // eslint-disable-next-line react/jsx-key

--- a/ui/src/treegrid.tsx
+++ b/ui/src/treegrid.tsx
@@ -4,7 +4,7 @@ import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
-import { ReactNode, useCallback, useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import { useImmer } from "use-immer";
 
 export type TreeGridId = string | number;
@@ -49,50 +49,47 @@ export function TreeGrid(props: TreeGridProps) {
     []
   );
 
-  const toggleExpanded = useCallback(
-    (draft: TreeGridState, id: TreeGridId) => {
-      const itemState = draft.get(id) || {
-        status: Status.Collapsed,
-      };
-      switch (itemState.status) {
-        case Status.Loading:
-          return;
-        case Status.Expanded:
-          itemState.status = Status.Collapsed;
-          break;
-        default:
-          if (!props.loadChildren || !!itemState.loaded) {
-            itemState.status = Status.Expanded;
-          } else {
-            itemState.status = Status.Loading;
-            props
-              .loadChildren(id)
-              .then(() => {
-                if (!cancel.current) {
-                  updateState((draft) => {
-                    draft.set(id, {
-                      status: Status.Expanded,
-                      loaded: true,
-                    });
+  const toggleExpanded = (draft: TreeGridState, id: TreeGridId) => {
+    const itemState = draft.get(id) || {
+      status: Status.Collapsed,
+    };
+    switch (itemState.status) {
+      case Status.Loading:
+        return;
+      case Status.Expanded:
+        itemState.status = Status.Collapsed;
+        break;
+      default:
+        if (!props.loadChildren || !!itemState.loaded) {
+          itemState.status = Status.Expanded;
+        } else {
+          itemState.status = Status.Loading;
+          props
+            .loadChildren(id)
+            .then(() => {
+              if (!cancel.current) {
+                updateState((draft) => {
+                  draft.set(id, {
+                    status: Status.Expanded,
+                    loaded: true,
                   });
-                }
-              })
-              .catch((error) => {
-                if (!cancel.current) {
-                  updateState((draft) => {
-                    draft.set(id, {
-                      status: Status.Failed,
-                      errorMessage: error,
-                    });
+                });
+              }
+            })
+            .catch((error) => {
+              if (!cancel.current) {
+                updateState((draft) => {
+                  draft.set(id, {
+                    status: Status.Failed,
+                    errorMessage: error,
                   });
-                }
-              });
-          }
-      }
-      draft.set(id, itemState);
-    },
-    [props.loadChildren]
-  );
+                });
+              }
+            });
+        }
+    }
+    draft.set(id, itemState);
+  };
 
   useEffect(() => {
     const de = props?.defaultExpanded;


### PR DESCRIPTION
This prevents there from being two levels of dependencies, one for
useCallback and one for the useAsync watched value. Now useAsync will
automatically use the dependencies of the callback.

This also removes most uses of useCallbacks since it offers no benefit
except where it's a dependency to something else (i.e. useAsyncWithApi).