### PR TITLE
Fix query generation to start from person

### DIFF
--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -17,15 +17,17 @@ export interface Cohort {
 export function generateQueryParameters(
   cohort: Cohort
 ): tanagra.EntityDataset | null {
+  const entityVar = "entity";
+
   const operands = cohort.groups
-    .map((group) => generateFilter(group))
+    .map((group) => generateFilter(group, entityVar))
     .filter((filter) => filter) as Array<tanagra.Filter>;
   if (operands.length === 0) {
     return null;
   }
 
   return {
-    entityVariable: "co",
+    entityVariable: entityVar,
     selectedAttributes: cohort.attributes,
     filter: {
       arrayFilter: {
@@ -47,9 +49,12 @@ export interface Group {
   criteria: Criteria[];
 }
 
-function generateFilter(group: Group): tanagra.Filter | null {
+function generateFilter(
+  group: Group,
+  entityVar: string
+): tanagra.Filter | null {
   const operands = group.criteria
-    .map((criteria) => getCriteriaPlugin(criteria).generateFilter())
+    .map((criteria) => getCriteriaPlugin(criteria).generateFilter(entityVar))
     .filter((filter) => filter) as Array<tanagra.Filter>;
   if (operands.length === 0) {
     return null;
@@ -93,7 +98,7 @@ export interface CriteriaPlugin<DataType> {
   data: DataType;
   renderEdit: (cohort: Cohort, group: Group) => JSX.Element;
   renderDetails: () => JSX.Element;
-  generateFilter: () => tanagra.Filter | null;
+  generateFilter: (entityVar: string) => tanagra.Filter | null;
 }
 
 // registerCriteriaPlugin is a decorator that allows criteria to automatically

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -43,12 +43,7 @@ export function Datasets(props: DatasetProps) {
           underlayName,
           props.entityName,
           // TODO(tjennison): Populate from an actual source.
-          [
-            "person_id",
-            "condition_occurrence_id",
-            "condition_concept_id",
-            "condition_name",
-          ]
+          ["person_id"]
         )
       );
     },

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -9,7 +9,7 @@ import reportWebVitals from "./reportWebVitals";
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App entityName="condition_occurrence" />
+      <App entityName="person" />
     </Provider>
   </React.StrictMode>,
   document.getElementById("root")


### PR DESCRIPTION
* Uses relationship tables to link to concepts.
* Selection properly takes into account multiple entities, though
  currently no criteria allows more than one. Doing this correctly was
  straightforward so it made more sense to just do it rather than ignore
  it with a hack/TODO.