### PR TITLE
Standardize current underlay and cohort access

### DIFF
--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -2,6 +2,7 @@ describe("Basic tests", () => {
   it("Contains title", () => {
     cy.visit("http://localhost:3000/");
 
+    cy.contains("underlay_name").click();
     cy.contains("Datasets");
   });
 });

--- a/ui/src/actionBar.tsx
+++ b/ui/src/actionBar.tsx
@@ -4,17 +4,18 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import { useUnderlay } from "hooks";
 import * as React from "react";
 import { Link as RouterLink } from "react-router-dom";
-import { Cohort } from "./cohort";
 
 type ActionBarProps = {
   title: string;
   backUrl?: string;
-  cohort?: Cohort;
 };
 
 export default function ActionBar(props: ActionBarProps) {
+  const underlay = useUnderlay();
+
   return (
     <Box sx={{ flexGrow: 1 }} className="action-bar">
       <AppBar position="fixed">
@@ -31,9 +32,9 @@ export default function ActionBar(props: ActionBarProps) {
           <Typography variant="h3" sx={{ flexGrow: 1 }}>
             {props.title}
           </Typography>
-          {props.cohort ? (
+          {underlay ? (
             <Typography variant="h6" className="underlay-name">
-              Dataset: {props.cohort.underlayName}
+              Dataset: {underlay.name}
             </Typography>
           ) : null}
         </Toolbar>

--- a/ui/src/app.test.tsx
+++ b/ui/src/app.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import { Provider } from "react-redux";
 import { store } from "store";
@@ -10,6 +11,12 @@ test("render included datasets heading", async () => {
       <App entityName={"person"} />
     </Provider>
   );
+  await waitFor(() => {
+    expect(screen.getByText(/select dataset/i)).toBeInTheDocument();
+    expect(screen.getByText(/underlay_name/i)).toBeInTheDocument();
+  });
+
+  userEvent.click(screen.getByText("underlay_name"));
   await waitFor(() =>
     expect(screen.getByText(/datasets/i)).toBeInTheDocument()
   );

--- a/ui/src/edit.tsx
+++ b/ui/src/edit.tsx
@@ -1,4 +1,5 @@
 import ActionBar from "actionBar";
+import { useCohortOrFail, useUnderlayOrFail } from "hooks";
 import React from "react";
 import { Redirect, useParams } from "react-router-dom";
 import { Cohort, getCriteriaPlugin } from "./cohort";
@@ -8,21 +9,18 @@ type EditProps = {
 };
 
 export default function Edit(props: EditProps) {
-  const params =
-    useParams<{ cohortId: string; group: string; criteria: string }>();
-  const backUrl = `/cohort/${params.cohortId}`;
+  const underlay = useUnderlayOrFail();
+  const cohort = useCohortOrFail();
+  const backUrl = `/${underlay.name}/${cohort.id}`;
 
+  const params = useParams<{ group: string; criteria: string }>();
   const group = props.cohort.groups.find((g) => g.id === params.group);
   const criteria = group?.criteria.find((c) => c.id === params.criteria);
 
   return (
     <>
       {!criteria ? <Redirect to={backUrl} /> : null}
-      <ActionBar
-        title={criteria?.name || "Unknown"}
-        backUrl={backUrl}
-        cohort={props.cohort}
-      />
+      <ActionBar title={criteria?.name || "Unknown"} backUrl={backUrl} />
       {!!criteria && !!group
         ? getCriteriaPlugin(criteria).renderEdit(props.cohort, group)
         : null}

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,5 +1,40 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
 import { AppDispatch, RootState } from "store";
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export const useUnderlay = () => {
+  const { underlayName } = useParams<{ underlayName: string }>();
+  return useAppSelector((state) =>
+    state.underlays.find((underlay) => underlay.name === underlayName)
+  );
+};
+
+// The useXOrFail versions are generally the correct choice since they can be
+// used where the existence of X is enforced by higher level parts of the UI
+// (e.g. the underlay should always be valid once past the underlay selection
+// page) so the code doesn't have to handle the undefined case.
+export const useUnderlayOrFail = () => {
+  const underlay = useUnderlay();
+  if (!underlay) {
+    throw new Error("Unknown underlay.");
+  }
+  return underlay;
+};
+
+export const useCohort = () => {
+  const { cohortId } = useParams<{ cohortId: string }>();
+  return useAppSelector((state) =>
+    state.cohorts.find((cohort) => cohort.id === cohortId)
+  );
+};
+
+export const useCohortOrFail = () => {
+  const cohort = useCohort();
+  if (!cohort) {
+    throw new Error("Unknown cohort.");
+  }
+  return cohort;
+};

--- a/ui/src/underlaySelect.tsx
+++ b/ui/src/underlaySelect.tsx
@@ -1,0 +1,26 @@
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import ActionBar from "actionBar";
+import { useAppSelector } from "hooks";
+import { Link as RouterLink } from "react-router-dom";
+
+export function UnderlaySelect() {
+  const underlays = useAppSelector((state) => state.underlays);
+
+  return (
+    <>
+      <ActionBar title="Select Dataset" />
+      <List>
+        {underlays.map((underlay) => (
+          <ListItem key={underlay.name}>
+            <ListItemButton component={RouterLink} to={`/${underlay.name}`}>
+              <ListItemText primary={underlay.name}></ListItemText>
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </>
+  );
+}

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -1,9 +1,11 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { CriteriaConfig } from "cohort";
 import * as tanagra from "tanagra-api";
 
 export type Underlay = {
   name: string;
   entities: tanagra.Entity[];
+  criteriaConfigs: CriteriaConfig[];
 };
 
 const initialState: Underlay[] = [];


### PR DESCRIPTION
* Adds common functions for accessing the current underlay and cohort
  based on the current URL. The higher components redirect when
  presented with invalid values so the lower components don't need to
  worry about them.
* Handling the multi-level redirects and id checking with fixed URL
  pieces (i.e.  `/underlays/`) ends up being surprisingly complicated,
  at least with this version of react-router. We could look into options
  if desired but for now I've just removed them.
* Adds an inital underlay selection page. The previous behavior of
  choosing per cohort is weird once concept sets are introduced because
  they can't be mixed and matched.  The selection page could instead be
  a dropdown in the action bar or a menu but that's awkward too because
  there's nothing to do when switching except jump back to the initial
  datasets page.  We'll need to give more thought to what behavior we
  actually want when there are multiple underlays.
* Moves criteria config to the App where it can eventually be fetched
  along with the other underlay config and changes accesses to go
  through the common functions.
* Removes underlay selection from the New Cohort dialog since it's
  determined by the selection page.