### PR TITLE
Generalize criteria data updating

### DIFF
--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -92,7 +92,7 @@ export interface CriteriaConfig {
 export interface CriteriaPlugin<DataType> {
   id: string;
   data: DataType;
-  renderEdit: (cohort: Cohort, group: Group) => JSX.Element;
+  renderEdit: (dispatchFn: (data: DataType) => void) => JSX.Element;
   renderDetails: () => JSX.Element;
   generateFilter: (
     entityVar: string,

--- a/ui/src/criteria/concept.test.tsx
+++ b/ui/src/criteria/concept.test.tsx
@@ -5,6 +5,8 @@ import { createCriteria, getCriteriaPlugin, GroupKind } from "cohort";
 import { insertCohort, insertGroup } from "cohortsSlice";
 import "criteria/concept";
 import { Provider } from "react-redux";
+import { StaticRouter } from "react-router-dom";
+import { AppRouter } from "router";
 import { store } from "store";
 import * as tanagra from "./tanagra-api";
 
@@ -105,9 +107,7 @@ test("selection", async () => {
   expect(getSelected()).toEqual([101]);
 });
 
-async function renderCriteria(
-  instances: Array<{ [key: string]: tanagra.AttributeValue }>
-) {
+beforeAll(() => {
   const action = store.dispatch(
     insertCohort("test-cohort", "test-underlay", "test-entity", [])
   );
@@ -134,7 +134,11 @@ async function renderCriteria(
       })
     )
   );
+});
 
+async function renderCriteria(
+  instances: Array<{ [key: string]: tanagra.AttributeValue }>
+) {
   const getCriteria = () => store.getState().cohorts[0].groups[0].criteria[0];
 
   const api = {
@@ -147,13 +151,20 @@ async function renderCriteria(
     },
   };
 
+  const cohort = store.getState().cohorts[0];
+  const group = cohort.groups[0];
+  const criteria = group.criteria[0];
+
   const components = () => (
     <Provider store={store}>
       <EntityInstancesApiContext.Provider value={api}>
-        {getCriteriaPlugin(getCriteria()).renderEdit(
-          store.getState().cohorts[0],
-          store.getState().cohorts[0].groups[0]
-        )}
+        <StaticRouter
+          location={`/test-underlay/cohorts/${cohort.id}/edit/${group.id}/${criteria.id}`}
+        >
+          <AppRouter>
+            {getCriteriaPlugin(getCriteria()).renderEdit(jest.fn())}
+          </AppRouter>
+        </StaticRouter>
       </EntityInstancesApiContext.Provider>
     </Provider>
   );

--- a/ui/src/edit.tsx
+++ b/ui/src/edit.tsx
@@ -1,16 +1,27 @@
 import ActionBar from "actionBar";
-import { useCohort, useGroupAndCriteria } from "hooks";
+import { updateCriteriaData } from "cohortsSlice";
+import { useAppDispatch, useCohort, useGroupAndCriteria } from "hooks";
 import React from "react";
 import { getCriteriaPlugin } from "./cohort";
 
 export default function Edit() {
+  const dispatch = useAppDispatch();
   const cohort = useCohort();
   const { group, criteria } = useGroupAndCriteria();
 
   return (
     <>
       <ActionBar title={criteria.name} />
-      {getCriteriaPlugin(criteria).renderEdit(cohort, group)}
+      {getCriteriaPlugin(criteria).renderEdit((data: unknown) => {
+        dispatch(
+          updateCriteriaData({
+            cohortId: cohort.id,
+            groupId: group.id,
+            criteriaId: criteria.id,
+            data: data,
+          })
+        );
+      })}
     </>
   );
 }


### PR DESCRIPTION
This moves the actual data updating out of the criteria which will allow
criteria to be used for bor cohorts and concept sets.

concept.test.tsx is a bit of a mess. It was creating cohorts for each
test case but only using the first one. I think the solution will be to
split out some of the logic and test that with unit tests, while leaving
most of the UI testing to a broader level. That aligns with Redux's
testing suggestions but I need to think about it some more.