### PR TITLE
Add support for use generated concept sets

### DIFF
--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -12,8 +12,14 @@ describe("Basic tests", () => {
     cy.get("button[role=checkbox]").click();
     cy.get("a[aria-label=back]").click();
     cy.get("a[aria-label=back]").click();
-    cy.get("input[name='New Cohort']").click();
-    cy.get("input[name=Demographics]").click();
+
+    cy.get("button[id=insert-concept-set]").click();
+    cy.get("li:Contains(Condition)").click();
+    cy.get("button[role=checkbox]").click();
+    cy.get("a[aria-label=back]").click();
+
+    cy.get("button[name='New Cohort']").click();
+    cy.get("button[name='Contains Conditions Codes']").click();
     cy.contains("SELECT *");
   });
 });

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -37,6 +37,35 @@ class FakeEntitiesApi {
               },
             ],
           },
+          {
+            name: "condition_occurrence",
+            attributes: [
+              {
+                name: "attribute_name",
+                dataType: tanagra.DataType.Int64,
+                attributeFilterHint: {
+                  enumHint: {
+                    enumHintValues: [
+                      {
+                        displayName: "Yes",
+                        description: "Yes description",
+                        attributeValue: {
+                          int64Val: 2001,
+                        },
+                      },
+                      {
+                        displayName: "No",
+                        description: "No description",
+                        attributeValue: {
+                          int64Val: 2002,
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
         ],
       });
     });

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -98,6 +98,7 @@ export interface CriteriaPlugin<DataType> {
     entityVar: string,
     fromOccurrence: boolean
   ) => tanagra.Filter | null;
+  occurrenceEntities: () => string[];
 }
 
 // registerCriteriaPlugin is a decorator that allows criteria to automatically

--- a/ui/src/components/checkbox.tsx
+++ b/ui/src/components/checkbox.tsx
@@ -7,6 +7,7 @@ export type CheckboxProps = {
   onChange?: () => void;
   size?: "small" | "medium" | "large";
   fontSize?: "small" | "medium" | "large" | "inherit";
+  name?: string;
 };
 
 export default function Checkbox({
@@ -14,11 +15,13 @@ export default function Checkbox({
   onChange,
   size,
   fontSize,
+  name,
 }: CheckboxProps) {
   return (
     <IconButton
       role={"checkbox"}
       size={size}
+      name={name}
       onClick={() => {
         if (onChange) {
           onChange();

--- a/ui/src/conceptSetEdit.tsx
+++ b/ui/src/conceptSetEdit.tsx
@@ -1,0 +1,24 @@
+import ActionBar from "actionBar";
+import { getCriteriaPlugin } from "cohort";
+import { updateConceptSetData } from "conceptSetsSlice";
+import { useAppDispatch, useConceptSet } from "hooks";
+import React from "react";
+
+export default function Edit() {
+  const dispatch = useAppDispatch();
+  const conceptSet = useConceptSet();
+
+  return (
+    <>
+      <ActionBar title={conceptSet.criteria.name} />
+      {getCriteriaPlugin(conceptSet.criteria).renderEdit((data: unknown) => {
+        dispatch(
+          updateConceptSetData({
+            conceptSetId: conceptSet.id,
+            data: data,
+          })
+        );
+      })}
+    </>
+  );
+}

--- a/ui/src/conceptSetsSlice.ts
+++ b/ui/src/conceptSetsSlice.ts
@@ -1,0 +1,61 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Criteria, generateId } from "cohort";
+
+export type ConceptSet = {
+  id: string;
+  underlayName: string;
+  criteria: Criteria;
+};
+
+const initialState: ConceptSet[] = [];
+
+const conceptSetsSlice = createSlice({
+  name: "conceptSets",
+  initialState,
+  reducers: {
+    insertConceptSet: {
+      reducer: (state, action: PayloadAction<ConceptSet>) => {
+        state.push(action.payload);
+      },
+      prepare: (underlayName: string, criteria: Criteria) => ({
+        payload: {
+          id: generateId(),
+          underlayName,
+          criteria,
+        },
+      }),
+    },
+
+    deleteConceptSet: (
+      state,
+      action: PayloadAction<{
+        conceptSetId: string;
+      }>
+    ) => {
+      state.splice(
+        state.findIndex((cs) => cs.id === action.payload.conceptSetId),
+        1
+      );
+    },
+
+    updateConceptSetData: (
+      state,
+      action: PayloadAction<{
+        conceptSetId: string;
+        data: unknown;
+      }>
+    ) => {
+      const conceptSet = state.find(
+        (cs) => cs.id === action.payload.conceptSetId
+      );
+      if (conceptSet) {
+        conceptSet.criteria.data = action.payload.data;
+      }
+    },
+  },
+});
+
+export const { insertConceptSet, deleteConceptSet, updateConceptSetData } =
+  conceptSetsSlice.actions;
+
+export default conceptSetsSlice.reducer;

--- a/ui/src/criteria/concept.test.tsx
+++ b/ui/src/criteria/concept.test.tsx
@@ -8,6 +8,7 @@ import { Provider } from "react-redux";
 import { StaticRouter } from "react-router-dom";
 import { AppRouter } from "router";
 import { store } from "store";
+import { setUnderlays } from "underlaysSlice";
 import * as tanagra from "./tanagra-api";
 
 test.each([
@@ -108,6 +109,14 @@ test("selection", async () => {
 });
 
 beforeAll(() => {
+  store.dispatch(
+    setUnderlays([
+      {
+        name: "test-underlay",
+      },
+    ])
+  );
+
   const action = store.dispatch(
     insertCohort("test-cohort", "test-underlay", "test-entity", [])
   );

--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -16,7 +16,7 @@ import {
   TreeGridRowData,
 } from "components/treegrid";
 import { useAsyncWithApi } from "errors";
-import { useCohort } from "hooks";
+import { useUnderlay } from "hooks";
 import produce from "immer";
 import React, { useCallback, useContext, useMemo, useState } from "react";
 import * as tanagra from "tanagra-api";
@@ -143,6 +143,15 @@ class _ implements CriteriaPlugin<Data> {
     };
     return ret;
   }
+
+  // TODO(tjennison): Split filter generation into separate paths for
+  // occurrences and primary entities. This will allow occurrence logic to be
+  // centralized and remove the limitation of having a single selectable entity.
+  occurrenceEntities() {
+    return this.data.entities
+      .filter((entity) => entity.selectable)
+      .map((entity) => entity.name + "_occurrence");
+  }
 }
 
 const PATH_ATTRIBUTE = "t_path_concept_id";
@@ -160,7 +169,7 @@ type ConceptEditProps = {
 };
 
 function ConceptEdit(props: ConceptEditProps) {
-  const cohort = useCohort();
+  const underlay = useUnderlay();
 
   const [hierarchy, setHierarchy] = useState<HierarchyState | undefined>();
   const [query, setQuery] = useState<string>("");
@@ -273,7 +282,7 @@ function ConceptEdit(props: ConceptEditProps) {
             searchRequest(
               props.data.columns,
               entity,
-              cohort.underlayName,
+              underlay.name,
               !hierarchy ? query : ""
             )
           )
@@ -287,7 +296,7 @@ function ConceptEdit(props: ConceptEditProps) {
     api,
     props.data.columns,
     props.data.entities,
-    cohort.underlayName,
+    underlay.name,
     processEntities,
     hierarchy,
     query,
@@ -388,14 +397,14 @@ function ConceptEdit(props: ConceptEditProps) {
                 props.data.columns,
                 entity.listChildren,
                 childEntity,
-                cohort.underlayName,
+                underlay.name,
                 id as number
               );
             } else {
               req = searchRequest(
                 props.data.columns,
                 entity,
-                cohort.underlayName,
+                underlay.name,
                 "",
                 id as number
               );

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -43,3 +43,14 @@ export function useGroupAndCriteria() {
   }
   return { group, criteria };
 }
+
+export function useConceptSet() {
+  const { conceptSetId } = useParams<{ conceptSetId: string }>();
+  const conceptSet = useAppSelector((state) =>
+    state.conceptSets.find((conceptSet) => conceptSet.id === conceptSetId)
+  );
+  if (!conceptSet) {
+    throw new PathError(`Unknown concept set "${conceptSetId}".`);
+  }
+  return conceptSet;
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,4 +1,5 @@
 import Button from "@mui/material/Button";
+import ConceptSetEdit from "conceptSetEdit";
 import Edit from "edit";
 import { PathError } from "hooks";
 import Overview from "overview";
@@ -18,6 +19,7 @@ const pages = {
   "/:underlayName": Datasets,
   "/:underlayName/cohorts/:cohortId": Overview,
   "/:underlayName/cohorts/:cohortId/edit/:groupId/:criteriaId": Edit,
+  "/:underlayName/conceptSets/:conceptSetId": ConceptSetEdit,
 };
 
 export function AppRouter() {
@@ -50,6 +52,7 @@ export type UrlParams = {
   cohortId?: string;
   groupId?: string;
   criteriaId?: string;
+  conceptSetId?: string;
 };
 
 export function createUrl(params: UrlParams): string {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import cohortsReducer from "cohortsSlice";
+import conceptSetsReducer from "conceptSetsSlice";
 import underlaysReducer from "underlaysSlice";
 
 export const store = configureStore({
   reducer: {
     cohorts: cohortsReducer,
     underlays: underlaysReducer,
+    conceptSets: conceptSetsReducer,
   },
 });
 


### PR DESCRIPTION
* Add concept sets to the store.
* Add concept editing page.
* Add user generated concept sets to datasets page and menu to create
  them.
* Return concept sets from criteria plugins. Filter generation needs to
  be refactored to clean up occurrence code and support multiple concept
  sets.