### PR TITLE
Add preview support for datasets

### DIFF
--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -20,6 +20,10 @@ describe("Basic tests", () => {
 
     cy.get("button[name='New Cohort']").click();
     cy.get("button[name='Contains Conditions Codes']").click();
+
+    cy.get("button:Contains('condition_occurrence')");
+
+    cy.get("input[name='queries-mode']").click();
     cy.contains("SELECT *");
   });
 });

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -18,6 +18,10 @@
   margin: 0em 0em 1em 0em;
 }
 
+.datasets-select-panel {
+  height: 300px;
+}
+
 .new-cohort-dialog .MuiTextField-root {
   margin-bottom: 2em;
 }

--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -27,11 +27,22 @@ Array [
             }
           }
         >
-          <h6
-            className="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+          <div
+            style={
+              Object {
+                "overflow": "hidden",
+                "textOverflow": "ellipsis",
+                "whiteSpace": "nowrap",
+              }
+            }
           >
-            Column 1
-          </h6>
+            <h6
+              className="MuiTypography-root MuiTypography-h6 css-1to91m4-MuiTypography-root"
+              title="Column 1"
+            >
+              Column 1
+            </h6>
+          </div>
         </td>
         <td
           style={
@@ -42,11 +53,22 @@ Array [
             }
           }
         >
-          <h6
-            className="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+          <div
+            style={
+              Object {
+                "overflow": "hidden",
+                "textOverflow": "ellipsis",
+                "whiteSpace": "nowrap",
+              }
+            }
           >
-            Column 2
-          </h6>
+            <h6
+              className="MuiTypography-root MuiTypography-h6 css-1to91m4-MuiTypography-root"
+              title="Column 2"
+            >
+              Column 2
+            </h6>
+          </div>
         </td>
         <td
           style={
@@ -57,21 +79,32 @@ Array [
             }
           }
         >
-          <h6
-            className="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+          <div
+            style={
+              Object {
+                "overflow": "hidden",
+                "textOverflow": "ellipsis",
+                "whiteSpace": "nowrap",
+              }
+            }
           >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-              data-testid="AccountTreeIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <h6
+              className="MuiTypography-root MuiTypography-h6 css-1to91m4-MuiTypography-root"
+              title="[object Object]"
             >
-              <path
-                d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
-              />
-            </svg>
-          </h6>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="AccountTreeIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
+                />
+              </svg>
+            </h6>
+          </div>
         </td>
       </tr>
     </thead>
@@ -79,7 +112,7 @@ Array [
   <div
     style={
       Object {
-        "display": "block",
+        "display": "inline-block",
         "overflowY": "auto",
       }
     }
@@ -116,12 +149,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="1-col1"
               >
                 <button
@@ -178,12 +206,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="1-col2"
               >
                 1-col2
@@ -209,12 +232,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title=""
               >
                 
@@ -249,12 +267,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="2-col1"
               >
                 2-col1
@@ -280,12 +293,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="2-col2"
               >
                 2-col2
@@ -311,12 +319,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="2-col3"
               >
                 2-col3
@@ -347,12 +350,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="3-col1"
               >
                 3-col1
@@ -378,12 +376,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="3-col2"
               >
                 3-col2
@@ -409,12 +402,7 @@ Array [
               }
             >
               <p
-                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-fvtpii-MuiTypography-root"
-                style={
-                  Object {
-                    "display": "inline",
-                  }
-                }
+                className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title=""
               >
                 <svg

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -34,6 +34,8 @@ export type TreeGridProps = {
   defaultExpanded?: TreeGridId[];
   prefixElements?: (id: TreeGridId, data: TreeGridRowData) => ReactNode;
   loadChildren?: (id: TreeGridId) => Promise<void>;
+  variableWidth?: boolean;
+  wrapBodyText?: boolean;
 };
 
 export function TreeGrid(props: TreeGridProps) {
@@ -106,7 +108,7 @@ export function TreeGrid(props: TreeGridProps) {
       <table
         style={{
           tableLayout: "fixed",
-          width: "100%",
+          ...(!props.variableWidth ? { width: "100%" } : undefined),
         }}
       >
         <thead
@@ -126,7 +128,23 @@ export function TreeGrid(props: TreeGridProps) {
                   }),
                 }}
               >
-                <Typography variant="h6">{col.title}</Typography>
+                <div
+                  style={{
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                  }}
+                >
+                  <Typography
+                    variant="h6"
+                    title={String(col.title)}
+                    sx={{
+                      display: "inline",
+                    }}
+                  >
+                    {col.title}
+                  </Typography>
+                </div>
               </td>
             ))}
           </tr>
@@ -135,7 +153,7 @@ export function TreeGrid(props: TreeGridProps) {
       <div
         style={{
           overflowY: "auto",
-          display: "block",
+          display: "inline-block",
         }}
       >
         <table
@@ -207,17 +225,21 @@ function renderChildren(
             >
               <div
                 style={{
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
+                  ...(props.wrapBodyText
+                    ? { wordBreak: "break-all" }
+                    : {
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                      }),
                   ...(i === 0 && { paddingLeft: `${indent}em` }),
                 }}
               >
                 <Typography
                   variant="body1"
-                  noWrap
+                  noWrap={!props.wrapBodyText}
                   title={title}
-                  style={{
+                  sx={{
                     display: "inline",
                   }}
                 >

--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -21,6 +21,7 @@ import produce from "immer";
 import React, { useCallback, useContext, useMemo, useState } from "react";
 import * as tanagra from "tanagra-api";
 import { useImmer } from "use-immer";
+import { isValid } from "util/valid";
 
 type Selection = {
   entity: string;
@@ -425,10 +426,6 @@ function ConceptEdit(props: ConceptEditProps) {
       </Loading>
     </>
   );
-}
-
-function isValid<Type>(arg: Type) {
-  return arg !== null && typeof arg !== "undefined";
 }
 
 function findEntity(

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -1,6 +1,5 @@
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
-import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
@@ -12,6 +11,7 @@ import Link from "@mui/material/Link";
 import MenuItem from "@mui/material/MenuItem";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import TextField from "@mui/material/TextField";
@@ -28,12 +28,13 @@ import { insertCohort } from "cohortsSlice";
 import Checkbox from "components/checkbox";
 import Loading from "components/loading";
 import { useMenu } from "components/menu";
-import { TreeGridData } from "components/treegrid";
+import { TreeGrid, TreeGridData, TreeGridRowData } from "components/treegrid";
 import { insertConceptSet } from "conceptSetsSlice";
 import { useAsyncWithApi } from "errors";
 import { useAppDispatch, useAppSelector, useUnderlay } from "hooks";
 import {
   ChangeEvent,
+  Fragment,
   ReactNode,
   SyntheticEvent,
   useCallback,
@@ -44,6 +45,7 @@ import { Link as RouterLink, useHistory } from "react-router-dom";
 import { createUrl } from "router";
 import * as tanagra from "tanagra-api";
 import { useImmer } from "use-immer";
+import { isValid } from "util/valid";
 
 export function Datasets() {
   const dispatch = useAppDispatch();
@@ -57,6 +59,11 @@ export function Datasets() {
   const [selectedConceptSets, updateSelectedConceptSets] = useImmer(
     new Set<string>()
   );
+  const [excludedAttributes, updateExcludedAttributes] = useImmer(
+    new Map<string, Set<string>>()
+  );
+
+  const conceptSetEntities = useConceptSetEntities(selectedConceptSets);
 
   const [dialog, showNewCohort] = useNewCohortDialog({
     callback: (name: string) => {
@@ -163,7 +170,10 @@ export function Datasets() {
             </IconButton>
             {dialog}
           </Stack>
-          <Paper>
+          <Paper
+            sx={{ overflowY: "auto", display: "block" }}
+            className="datasets-select-panel"
+          >
             {cohorts
               .filter((cohort) => cohort.underlayName === underlay.name)
               .map((cohort) => (
@@ -203,7 +213,10 @@ export function Datasets() {
             </IconButton>
             {menu}
           </Stack>
-          <Paper>
+          <Paper
+            sx={{ overflowY: "auto", display: "block" }}
+            className="datasets-select-panel"
+          >
             <Typography variant="h5">Prepackaged</Typography>
             {listConceptSets(false, underlay.prepackagedConceptSets)}
             <Typography variant="h5">Workspace</Typography>
@@ -223,7 +236,39 @@ export function Datasets() {
             <Typography variant="h4">3. Values</Typography>
             <Typography variant="h5">(Columns)</Typography>
           </Stack>
-          <Paper>{/* TODO(tjennison): Implement attribute selection. */}</Paper>
+          <Paper
+            sx={{ overflowY: "auto", display: "block" }}
+            className="datasets-select-panel"
+          >
+            {conceptSetEntities.map((entity) => (
+              <Fragment key={entity.name}>
+                <Typography variant="h5">{entity.name}</Typography>
+                {entity.attributes.map((attribute) => (
+                  <Stack key={attribute} direction="row" alignItems="center">
+                    <Checkbox
+                      size="small"
+                      fontSize="inherit"
+                      name={entity + "-" + attribute}
+                      checked={
+                        !excludedAttributes.get(entity.name)?.has(attribute)
+                      }
+                      onChange={() =>
+                        updateExcludedAttributes((selection) => {
+                          const attributes = selection?.get(entity.name);
+                          if (attributes?.has(attribute)) {
+                            attributes?.delete(attribute);
+                          } else {
+                            attributes?.add(attribute);
+                          }
+                        })
+                      }
+                    />
+                    <Typography variant="h6">{attribute}</Typography>
+                  </Stack>
+                ))}
+              </Fragment>
+            ))}
+          </Paper>
         </Grid>
         <Grid item xs={3}>
           <Paper>
@@ -231,6 +276,7 @@ export function Datasets() {
               <Preview
                 selectedCohorts={selectedCohorts}
                 selectedConceptSets={selectedConceptSets}
+                conceptSetEntities={conceptSetEntities}
               />
             ) : (
               <Typography variant="h5">
@@ -306,9 +352,65 @@ function useNewCohortDialog(
   ];
 }
 
+type ConceptSetEntity = {
+  name: string;
+  attributes: string[];
+  filters: tanagra.Filter[];
+};
+
+function useConceptSetEntities(
+  selectedConceptSets: Set<string>
+): ConceptSetEntity[] {
+  const underlay = useUnderlay();
+
+  const entities = new Map<string, tanagra.Filter[]>();
+  const addFilter = (entity: string, filter?: tanagra.Filter | null) => {
+    if (!entities.has(entity)) {
+      entities.set(entity, []);
+    }
+    if (filter) {
+      entities.get(entity)?.push(filter);
+    }
+  };
+
+  underlay.prepackagedConceptSets.forEach((conceptSet) => {
+    if (selectedConceptSets.has(conceptSet.id)) {
+      addFilter(conceptSet.entity, conceptSet.filter);
+    }
+  });
+
+  const workspaceConceptSets = useAppSelector((state) =>
+    state.conceptSets.filter((cs) => selectedConceptSets.has(cs.id))
+  );
+  workspaceConceptSets.forEach((conceptSet) => {
+    const plugin = getCriteriaPlugin(conceptSet.criteria);
+    if (plugin.occurrenceEntities().length != 1) {
+      throw new Error("Only one entity per concept set is supported.");
+    }
+
+    const entity = plugin.occurrenceEntities()[0];
+    addFilter(entity, plugin.generateFilter(entity, true));
+  });
+
+  return Array.from(entities)
+    .sort()
+    .map(([entityName, filters]) => {
+      const attributes = underlay.entities
+        .find((entity) => entity.name === entityName)
+        ?.attributes?.map((attribute) => attribute.name || "unknown")
+        ?.filter((attribute) => !attribute.startsWith("t_"));
+      return {
+        name: entityName,
+        attributes: attributes || [],
+        filters,
+      };
+    });
+}
+
 type PreviewProps = {
   selectedCohorts: Set<string>;
   selectedConceptSets: Set<string>;
+  conceptSetEntities: ConceptSetEntity[];
 };
 
 function Preview(props: PreviewProps) {
@@ -316,43 +418,15 @@ function Preview(props: PreviewProps) {
   const cohorts = useAppSelector((state) =>
     state.cohorts.filter((cohort) => props.selectedCohorts.has(cohort.id))
   );
-  const workspaceConceptSets = useAppSelector((state) =>
-    state.conceptSets.filter((cs) => props.selectedConceptSets.has(cs.id))
-  );
   const api = useContext(EntityInstancesApiContext);
 
   const [tab, setTab] = useState(0);
+  const [queriesMode, setQueriesMode] = useState(false);
 
   const tabDataState = useAsyncWithApi<PreviewTabData[]>(
     useCallback(async () => {
-      const entities = new Map<string, tanagra.Filter[]>();
-      const addFilter = (entity: string, filter?: tanagra.Filter | null) => {
-        if (!entities.has(entity)) {
-          entities.set(entity, []);
-        }
-        if (filter) {
-          entities.get(entity)?.push(filter);
-        }
-      };
-
-      underlay.prepackagedConceptSets.forEach((conceptSet) => {
-        if (props.selectedConceptSets.has(conceptSet.id)) {
-          addFilter(conceptSet.entity, conceptSet.filter);
-        }
-      });
-
-      workspaceConceptSets.forEach((conceptSet) => {
-        const plugin = getCriteriaPlugin(conceptSet.criteria);
-        if (plugin.occurrenceEntities().length != 1) {
-          throw new Error("Only one entity per concept set is supported.");
-        }
-
-        const entity = plugin.occurrenceEntities()[0];
-        addFilter(entity, plugin.generateFilter(entity, true));
-      });
-
       return Promise.all(
-        Array.from(entities).map(async ([entity, filters]) => {
+        props.conceptSetEntities.map(async (entity) => {
           let filter: tanagra.Filter = {
             arrayFilter: {
               operands: cohorts
@@ -364,25 +438,25 @@ function Preview(props: PreviewProps) {
             },
           };
 
-          if (entity !== underlay.primaryEntity) {
+          if (entity.name !== underlay.primaryEntity) {
             filter = {
               arrayFilter: {
                 operator: tanagra.ArrayFilterOperator.And,
                 operands: [
                   {
                     relationshipFilter: {
-                      outerVariable: entity,
+                      outerVariable: entity.name,
                       newVariable: underlay.primaryEntity,
                       newEntity: underlay.primaryEntity,
                       filter: filter,
                     },
                   },
-                  ...(filters.length > 0
+                  ...(entity.filters.length > 0
                     ? [
                         {
                           arrayFilter: {
                             operator: tanagra.ArrayFilterOperator.Or,
-                            operands: filters,
+                            operands: entity.filters,
                           },
                         },
                       ]
@@ -392,27 +466,16 @@ function Preview(props: PreviewProps) {
             };
           }
 
-          const attributes = underlay.entities
-            .find((e) => e.name === entity)
-            ?.attributes?.map((attribute) => attribute.name)
-            .filter(
-              (attribute): attribute is string =>
-                !!attribute && !attribute.startsWith("t_")
-            );
-          if (!attributes) {
-            throw new Error(`No attributes for "${entity}"`);
-          }
-
           const entityDataset = {
-            entityVariable: entity,
-            selectedAttributes: attributes,
+            entityVariable: entity.name,
+            selectedAttributes: entity.attributes,
             filter: filter,
           };
 
           const dataParts = await Promise.all([
             (async () => {
               const res = await api.generateDatasetSqlQuery({
-                entityName: entity,
+                entityName: entity.name,
                 underlayName: underlay.name,
                 generateDatasetSqlQueryRequest: {
                   entityDataset,
@@ -425,13 +488,41 @@ function Preview(props: PreviewProps) {
               return res.query;
             })(),
             (async () => {
-              // TODO(tjennison): Fetch entity instances and refactor processing
-              // code from criteria/concept.
-              return {};
+              const res = await api.searchEntityInstances({
+                entityName: entity.name,
+                underlayName: underlay.name,
+                searchEntityInstancesRequest: {
+                  entityDataset,
+                },
+              });
+
+              const data: TreeGridData = {
+                root: { data: {}, children: [] },
+              };
+              // TODO(tjennison): Use server side limits.
+              res?.instances?.slice(0, 100)?.forEach((instance, i) => {
+                const row: TreeGridRowData = {};
+                for (const k in instance) {
+                  const v = instance[k];
+                  if (!v) {
+                    row[k] = "";
+                  } else if (isValid(v.int64Val)) {
+                    row[k] = v.int64Val;
+                  } else if (isValid(v.boolVal)) {
+                    row[k] = v.boolVal;
+                  } else {
+                    row[k] = v.stringVal;
+                  }
+                }
+
+                data[i] = { data: row };
+                data.root?.children?.push(i);
+              });
+              return data;
             })(),
           ]);
           return {
-            entity,
+            entity: entity.name,
             sql: dataParts[0],
             data: dataParts[1],
           };
@@ -440,23 +531,56 @@ function Preview(props: PreviewProps) {
     }, [props.selectedCohorts, props.selectedConceptSets])
   );
 
-  const handleChange = (event: SyntheticEvent, newValue: number) => {
+  const onTabChange = (event: SyntheticEvent, newValue: number) => {
     setTab(newValue);
+  };
+
+  const onQueriesModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQueriesMode(event.target.checked);
   };
 
   return (
     <>
       <Loading status={tabDataState}>
-        <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-          <Tabs value={tab} onChange={handleChange}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          sx={{ borderBottom: 1, borderColor: "divider" }}
+        >
+          <Tabs value={tab} onChange={onTabChange} sx={{ flexGrow: 1 }}>
             {tabDataState.data?.map((data) => (
               <Tab key={data.entity} label={data.entity} />
             ))}
           </Tabs>
-        </Box>
-        <Typography sx={{ fontFamily: "monospace" }}>
-          {tabDataState.data?.[tab]?.sql}
-        </Typography>
+          <Typography variant="button">Data</Typography>
+          <Switch onChange={onQueriesModeChange} name="queries-mode" />
+          <Typography variant="button">Queries</Typography>
+        </Stack>
+        {queriesMode ? (
+          <Typography sx={{ fontFamily: "monospace" }}>
+            {tabDataState.data?.[tab]?.sql}
+          </Typography>
+        ) : tabDataState.data?.[tab]?.data ? (
+          <div
+            style={{
+              overflowX: "auto",
+              display: "block",
+            }}
+          >
+            <TreeGrid
+              data={tabDataState.data?.[tab]?.data}
+              columns={props.conceptSetEntities[tab]?.attributes.map(
+                (attribute) => ({
+                  key: attribute,
+                  width: 120,
+                  title: attribute,
+                })
+              )}
+              variableWidth
+              wrapBodyText
+            />
+          </div>
+        ) : undefined}
       </Loading>
     </>
   );

--- a/ui/src/util/valid.tsx
+++ b/ui/src/util/valid.tsx
@@ -1,0 +1,3 @@
+export function isValid<Type>(arg: Type) {
+  return arg !== null && arg !== undefined;
+}


### PR DESCRIPTION
* Adds ellipses for TreeGrid titles, wrapping for TreeGrid body
  cells, and support for TreeGrids wider than their parent.
* Refactors the list of entity filters and attributes into a shared
  function so it can be used for both the preview and the attribute
  selection.