### PR TITLE
Fix Values selection on datasets page

### DIFF
--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -251,6 +251,10 @@ export function Datasets() {
                       }
                       onChange={() =>
                         updateExcludedAttributes((selection) => {
+                          if (!selection?.get(entity.name)) {
+                            selection?.set(entity.name, new Set<string>());
+                          }
+
                           const attributes = selection?.get(entity.name);
                           if (attributes?.has(attribute)) {
                             attributes?.delete(attribute);


### PR DESCRIPTION
Empty Sets weren't being created so no attributes were actually being
added to the selection.