### PR TITLE
Ensure readable file in run_postgres script

### DIFF
--- a/api/local-dev/run_postgres.sh
+++ b/api/local-dev/run_postgres.sh
@@ -11,6 +11,8 @@ start() {
     echo "starting up postgres container..."
     BASEDIR=$(dirname "$0")
     docker create --name $CONTAINER --rm -e POSTGRES_PASSWORD=password -p "$POSTGRES_PORT:5432" postgres:$POSTGRES_VERSION
+    # Make sure the init script is readable
+    chmod o+r $BASEDIR/local-postgres-init.sql
     docker cp $BASEDIR/local-postgres-init.sql $CONTAINER:/docker-entrypoint-initdb.d/docker_postgres_init.sql
     docker start $CONTAINER
 


### PR DESCRIPTION
Default umask on glinux is 027 which causes `git clone` to write this file without the necessary read permissions.