### PR TITLE
Add dev instance info to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 ![API Build](https://github.com/DataBiosphere/tanagra/actions/workflows/api-test.yaml/badge.svg?branch=main)
 ![Workflow Build](https://github.com/DataBiosphere/tanagra/actions/workflows/workflow-test.yaml/badge.svg?branch=main)
+
 # Tanagra
-Repo for the Tanagra service being developed by the All of Us DRC
+Repo for the Tanagra service being developed by the All of Us DRC.
+
+## Dev Instance
+There is a [development instance](https://verily-tanagra-dev-ui-cluster.api.verily.com/#/) of Tanagra maintained by Verily.
+
+All members of the `Tanagra Dev Instance` VerilyGroup have access to the dev instance.
+Request access to this group from one of the admins: Shimon Rura, Tim Jennison, Mariko Medlock.


### PR DESCRIPTION
Added a link to the dev instance and a note to request access to the appropriate VerilyGroup to the README. Goal is just to have this info in a central place where people can find it. I decided to put this here instead of in a Google doc because I think it's more likely we won't forget to keep this up-to-date. I will add a `go/` link to this section of the README also.