### PR TITLE
Define attribute map as separate API object.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/service/query/api/QueryResultConverter.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/api/QueryResultConverter.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.service.query.api;
 
 import bio.terra.tanagra.generated.model.ApiAttributeValue;
+import bio.terra.tanagra.generated.model.ApiEntityCountGroupDefinitionStruct;
 import bio.terra.tanagra.generated.model.ApiEntityCountStruct;
 import bio.terra.tanagra.generated.model.ApiEntityInstanceStruct;
 import bio.terra.tanagra.service.databaseaccess.CellValue;
@@ -48,7 +49,10 @@ public final class QueryResultConverter {
         convertRowToAttributeMap(rowResult, columnHeaderSchema);
     ApiAttributeValue count = attributeMap.remove(QueryService.COUNT_ALIAS);
     result.setCount(Math.toIntExact(count.getInt64Val()));
-    result.putAll(attributeMap);
+
+    ApiEntityCountGroupDefinitionStruct definition = new ApiEntityCountGroupDefinitionStruct();
+    definition.putAll(attributeMap);
+    result.setDefinition(definition);
     return result;
   }
 

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -716,6 +716,14 @@ components:
         count:
           type: integer
           description: The number of entity instances in this group.
+        definition:
+          type: object
+          description: The set of attribute names and values that defines this group of entity instances.
+          $ref: "#/components/schemas/EntityCountGroupDefinitionStruct"
+
+    EntityCountGroupDefinitionStruct:
+      type: object
+      description: The definition of a group of entity instances.
       additionalProperties:
         type: object
         description: The set of attribute names and values that defines this group of entity instances.

--- a/api/src/test/java/bio/terra/tanagra/service/query/api/QueryResultConverterTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/api/QueryResultConverterTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.tanagra.generated.model.ApiAttributeValue;
+import bio.terra.tanagra.generated.model.ApiEntityCountGroupDefinitionStruct;
 import bio.terra.tanagra.generated.model.ApiEntityCountStruct;
 import bio.terra.tanagra.generated.model.ApiEntityInstanceStruct;
 import bio.terra.tanagra.service.databaseaccess.ColumnHeaderSchema;
@@ -93,12 +94,16 @@ public class QueryResultConverterTest {
 
     ApiEntityCountStruct struct0 = new ApiEntityCountStruct();
     struct0.setCount(5);
-    struct0.put("a", new ApiAttributeValue().stringVal("foo"));
-    struct0.put("b", new ApiAttributeValue().int64Val(42L));
+    ApiEntityCountGroupDefinitionStruct struct0d = new ApiEntityCountGroupDefinitionStruct();
+    struct0d.put("a", new ApiAttributeValue().stringVal("foo"));
+    struct0d.put("b", new ApiAttributeValue().int64Val(42L));
+    struct0.setDefinition(struct0d);
     ApiEntityCountStruct struct1 = new ApiEntityCountStruct();
     struct1.setCount(106);
-    struct1.put("a", new ApiAttributeValue().stringVal("bar"));
-    struct1.put("b", new ApiAttributeValue().int64Val(43L));
+    ApiEntityCountGroupDefinitionStruct struct1d = new ApiEntityCountGroupDefinitionStruct();
+    struct1d.put("a", new ApiAttributeValue().stringVal("bar"));
+    struct1d.put("b", new ApiAttributeValue().int64Val(43L));
+    struct1.setDefinition(struct1d);
 
     assertThat(structs, Matchers.contains(struct0, struct1));
   }


### PR DESCRIPTION
Fixed the API definition for the response from the `counts:search` API endpoint. Previously, I had defined the count and list of attribute values in the same object. While testing against the Swagger API, I realized that the count property was not being returned. Instead it was just returning a list of the possible groups e.g. `[Male,American], [Female,Japanese]`. Defining the list of attribute values as a separate object fixed this. Now it returns `{20,[Male, American]}, {15, [Female, Japanese]}`, as originally intended.

Example request:
underlay = `aou_synthetic`
entity = `person`
request body =
```
{
  "entityCounts": {
    "entityVariable": "p",
    "additionalSelectedAttributes": [
      "gender", "race"
    ],
    "groupByAttributes": [
      "gender_concept_id", "race_concept_id"
    ]
  }
}
```

response = 
```
{
  "counts": [
    {
      "count": 6580,
      "definition": {
        "gender_concept_id": {
          "int64Val": 45878463,
          "stringVal": null,
          "boolVal": null
        },
        "gender": {
          "int64Val": null,
          "stringVal": "Female",
          "boolVal": null
        },
        "race": {
          "int64Val": null,
          "stringVal": "More than one population",
          "boolVal": null
        },
        "race_concept_id": {
          "int64Val": 2000000008,
          "stringVal": null,
          "boolVal": null
        }
      }
    },
    {
      "count": 28427,
      "definition": {
        "gender_concept_id": {
          "int64Val": 45878463,
          "stringVal": null,
          "boolVal": null
        },
        "gender": {
          "int64Val": null,
          "stringVal": "Female",
          "boolVal": null
        },
        "race": {
          "int64Val": null,
          "stringVal": "Black or African American",
          "boolVal": null
        },
        "race_concept_id": {
          "int64Val": 8516,
          "stringVal": null,
          "boolVal": null
        }
      }
    },
    {
      "count": 2748,
      "definition": {
        "gender_concept_id": {
          "int64Val": 45880669,
          "stringVal": null,
          "boolVal": null
        },
        "gender": {
          "int64Val": null,
          "stringVal": "Male",
          "boolVal": null
        },
        "race": {
          "int64Val": null,
          "stringVal": "Asian",
          "boolVal": null
        },
        "race_concept_id": {
          "int64Val": 8515,
          "stringVal": null,
          "boolVal": null
        }
      }
    }, ...
  ],
  "nextPageToken": null
}
```