### PR TITLE
Make isValid work with the compiler

### DIFF
--- a/ui/src/util/valid.tsx
+++ b/ui/src/util/valid.tsx
@@ -1,3 +1,3 @@
-export function isValid<Type>(arg: Type) {
+export function isValid<Type>(arg: Type): arg is NonNullable<Type> {
   return arg !== null && arg !== undefined;
 }


### PR DESCRIPTION
Now the compiler understands that isValid means the passed expression is
not null or undefined.