### PR TITLE
Add a business logic layer between the API and UI

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/api/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -70,6 +70,6 @@ public class UnderlaysApiController implements UnderlaysApi {
     return new ApiUnderlay()
         .name(underlay.name())
         .entityNames(entityNames)
-        .criteriaConfigs(underlay.criteriaConfigs());
+        .uiConfiguration(underlay.uiConfiguration());
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/query/api/ApiConversionService.java
+++ b/api/src/main/java/bio/terra/tanagra/service/query/api/ApiConversionService.java
@@ -162,8 +162,8 @@ public class ApiConversionService {
   private void validateLimitSize(ApiEntityDataset apiEntityDataset) {
     if (apiEntityDataset.getLimit() != null && apiEntityDataset.getLimit() <= 0) {
       throw new IllegalArgumentException(
-              String.format(
-                      "The provided limit '%d' is not a positive integer", apiEntityDataset.getLimit()));
+          String.format(
+              "The provided limit '%d' is not a positive integer", apiEntityDataset.getLimit()));
     }
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/Underlay.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/Underlay.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 public abstract class Underlay {
   public abstract String name();
   /** JSON string for criteria configs */
-  public abstract String criteriaConfigs();
+  public abstract String uiConfiguration();
   /** Map from entity names to entities. */
   public abstract ImmutableMap<String, Entity> entities();
   /** Table of entity and attribute names to attributes. */
@@ -107,7 +107,7 @@ public abstract class Underlay {
 
     public abstract Builder name(String name);
 
-    public abstract Builder criteriaConfigs(String criteriaConfigs);
+    public abstract Builder uiConfiguration(String uiConfiguration);
 
     public abstract Builder entities(Map<String, Entity> entities);
 

--- a/api/src/main/java/bio/terra/tanagra/service/underlay/UnderlayConversion.java
+++ b/api/src/main/java/bio/terra/tanagra/service/underlay/UnderlayConversion.java
@@ -67,7 +67,7 @@ public final class UnderlayConversion {
 
     return Underlay.builder()
         .name(underlayProto.getName())
-        .criteriaConfigs(underlayProto.getCriteriaConfigs())
+        .uiConfiguration(underlayProto.getUiConfiguration())
         .entities(entities)
         .attributes(attributes)
         .relationships(relationships)

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -632,8 +632,8 @@ components:
           type: array
           items:
             type: string
-        criteriaConfigs:
-          description: The concepts and attributes that can be specified to create a cohort.
+        uiConfiguration:
+          description: Underlay specific configuration for the UI.
           type: string
 
     ListUnderlaysResponse:

--- a/api/src/main/resources/underlays/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/aou_synthetic.yaml
@@ -290,138 +290,243 @@ entities:
         dataType: STRING
       - name: concept_code
         dataType: STRING
-criteriaConfigs: >-
-  [{
-    "type":"concept",
-    "title":"Conditions",
-    "defaultName":"Contains Conditions Codes",
-    "plugin": {
-      "columns":
-        [{"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}],
-      "entities":[
-        {"name":"condition","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
+uiConfiguration: >-
   {
-    "type":"concept",
-    "title":"Procedures",
-    "defaultName":"Contains Procedures Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"procedure","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
-  {
-    "type":"concept",
-    "title":"Observations",
-    "defaultName":"Contains Observations Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"observation","selectable":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
-  {
-    "type":"concept",
-    "title":"Drugs",
-    "defaultName":"Contains Drugs Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"ingredient","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"},
+    "dataConfig": {
+      "primaryEntity": {
+        "displayName": "Person",
+        "entity": "person",
+        "key": "person_id"
+      },
+      "occurrences": [
         {
-          "name":"brand",
-          "sourceConcepts":true,
-          "attributes":[
-            "concept_name",
-            "concept_id",
-            "standard_concept",
-            "concept_code"
-          ],
-          "orderBy":"concept_name",
-          "orderDirection":"ASC",
-          "listChildren":{
-            "entity":"ingredient",
-            "idPath":"relationshipFilter.filter.binaryFilter.attributeValue",
-            "filter":{
-              "relationshipFilter":{
-                "outerVariable":"ingredient",
-                "newVariable":"brand",
-                "newEntity":"brand",
-                "filter":{
-                  "binaryFilter":{
-                    "attributeVariable":{
-                      "variable":"brand",
-                      "name":"concept_id"
-                    },
-                    "operator":"EQUALS",
-                    "attributeValue":{
-                      "int64Val":0
-                    }
-                  }
+          "id": "condition_occurrence",
+          "displayName": "Condition Occurrences",
+          "entity": "condition_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "condition",
+              "attribute": "condition_concept_id",
+              "entity": "condition",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "condition"
+                  },
+                  "operator": "NOT_EQUALS"
                 }
               }
             }
-          }
+          ]
+        },
+        {
+          "id": "procedure_occurrence",
+          "displayName": "Procedure Occurrences",
+          "entity": "procedure_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "procedure",
+              "attribute": "procedure_concept_id",
+              "entity": "procedure",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "procedure"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "observation_occurrence",
+          "displayName": "Observation Occurrence",
+          "entity": "observation_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "observation",
+              "attribute": "observation_concept_id",
+              "entity": "observation",
+              "entityAttribute": "concept_id",
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "observation"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "ingredient_occurrence",
+          "displayName": "Drug Occurrence",
+          "entity": "ingredient_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "ingredient",
+              "attribute": "ingredient_concept_id",
+              "entity": "ingredient",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "ingredient"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              },
+              "groupings": [
+                {
+                  "id": "brand",
+                  "entity": "brand",
+                  "defaultSort": {
+                    "attribute": "concept_name",
+                    "direction": "ASC"
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
-    }
-  },
-  {
-    "type":"attribute",
-    "title":"Ethnicity",
-    "defaultName":"Contains Ethnicity Codes",
-    "plugin":{"attribute":"ethnicity_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Gender Identity",
-    "defaultName":"Contains Gender Identity Codes",
-    "plugin":{"attribute":"gender_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Race",
-    "defaultName":"Contains Race Codes",
-    "plugin":{"attribute":"race_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Sex Assigned at Birth",
-    "defaultName":"Contains Sex Assigned at Birth Codes",
-    "plugin":{"attribute":"sex_at_birth_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Year at Birth",
-    "defaultName":"Contains Year at Birth Values",
-    "plugin":{"attribute":"year_of_birth"}
-  }]
+    },
+    "criteriaConfigs": [{
+      "type":"concept",
+      "title":"Conditions",
+      "defaultName":"Contains Conditions Codes",
+      "plugin": {
+        "columns":
+          [{"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Condition"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "condition_occurrence",
+        "classification": "condition"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Procedures",
+      "defaultName":"Contains Procedures Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Procedure"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "procedure_occurrence",
+        "classification": "procedure"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Observations",
+      "defaultName":"Contains Observations Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "occurrence": "observation_occurrence",
+        "classification": "observation"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Drugs",
+      "defaultName":"Contains Drugs Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Drug"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "ingredient_occurrence",
+        "classification": "ingredient"
+      }
+    },
+    {
+      "type":"attribute",
+      "title":"Ethnicity",
+      "defaultName":"Contains Ethnicity Codes",
+      "plugin":{"attribute":"ethnicity_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Gender Identity",
+      "defaultName":"Contains Gender Identity Codes",
+      "plugin":{"attribute":"gender_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Race",
+      "defaultName":"Contains Race Codes",
+      "plugin":{"attribute":"race_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Sex Assigned at Birth",
+      "defaultName":"Contains Sex Assigned at Birth Codes",
+      "plugin":{"attribute":"sex_at_birth_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Year at Birth",
+      "defaultName":"Contains Year at Birth Values",
+      "plugin":{"attribute":"year_of_birth"}
+    }]
+  }
 relationships:
   - name: brand_ingredient
     entity1: brand

--- a/api/src/main/resources/underlays/sd.yaml
+++ b/api/src/main/resources/underlays/sd.yaml
@@ -272,131 +272,242 @@ entities:
         dataType: STRING
       - name: concept_code
         dataType: STRING
-criteriaConfigs: >-
-  [{
-    "type":"concept",
-    "title":"Conditions",
-    "defaultName":"Contains Conditions Codes",
-    "plugin": {
-      "columns":
-        [{"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}],
-      "entities":[
-        {"name":"condition","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
+uiConfiguration: >-
   {
-    "type":"concept",
-    "title":"Procedures",
-    "defaultName":"Contains Procedures Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"procedure","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
-  {
-    "type":"concept",
-    "title":"Observations",
-    "defaultName":"Contains Observations Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"observation","selectable":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
-  {
-    "type":"concept",
-    "title":"Drugs",
-    "defaultName":"Contains Drugs Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"ingredient","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"},
+    "dataConfig": {
+      "primaryEntity": {
+        "displayName": "Person",
+        "entity": "person",
+        "key": "person_id"
+      },
+      "occurrences": [
         {
-          "name":"brand",
-          "sourceConcepts":true,
-          "attributes":[
-            "concept_name",
-            "concept_id",
-            "standard_concept",
-            "concept_code"
-          ],
-          "orderBy":"concept_name",
-          "orderDirection":"ASC",
-          "listChildren":{
-            "entity":"ingredient",
-            "idPath":"relationshipFilter.filter.binaryFilter.attributeValue",
-            "filter":{
-              "relationshipFilter":{
-                "outerVariable":"ingredient",
-                "newVariable":"brand",
-                "newEntity":"brand",
-                "filter":{
-                  "binaryFilter":{
-                    "attributeVariable":{
-                      "variable":"brand",
-                      "name":"concept_id"
-                    },
-                    "operator":"EQUALS",
-                    "attributeValue":{
-                      "int64Val":0
-                    }
-                  }
+          "id": "condition_occurrence",
+          "displayName": "Condition Occurrences",
+          "entity": "condition_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "condition",
+              "name": "Conditions",
+              "attribute": "condition_concept_id",
+              "entity": "condition",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "condition"
+                  },
+                  "operator": "NOT_EQUALS"
                 }
               }
             }
-          }
+          ]
+        },
+        {
+          "id": "procedure_occurrence",
+          "displayName": "Procedure Occurrences",
+          "entity": "procedure_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "procedure",
+              "name": "Procedures",
+              "attribute": "procedure_concept_id",
+              "entity": "procedure",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "procedure"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "observation_occurrence",
+          "displayName": "Observation Occurrence",
+          "entity": "observation_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "observation",
+              "name": "Observation",
+              "attribute": "observation_concept_id",
+              "entity": "observation",
+              "entityAttribute": "concept_id",
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "observation"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "ingredient_occurrence",
+          "displayName": "Drug Occurrence",
+          "entity": "ingredient_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "ingredient",
+              "name": "Ingredient",
+              "attribute": "ingredient_concept_id",
+              "entity": "ingredient",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "ingredient"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              },
+              "groupings": [
+                {
+                  "id": "brand",
+                  "name": "Brand",
+                  "entity": "brand",
+                  "defaultSort": {
+                    "attribute": "concept_name",
+                    "direction": "ASC"
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
-    }
-  },
-  {
-    "type":"attribute",
-    "title":"Ethnicity",
-    "defaultName":"Contains Ethnicity Codes",
-    "plugin":{"attribute":"ethnicity_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Gender Identity",
-    "defaultName":"Contains Gender Identity Codes",
-    "plugin":{"attribute":"gender_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Race",
-    "defaultName":"Contains Race Codes",
-    "plugin":{"attribute":"race_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Year at Birth",
-    "defaultName":"Contains Year at Birth Values",
-    "plugin":{"attribute":"year_of_birth"}
-  }]
+    },
+    "criteriaConfigs": [{
+      "type":"concept",
+      "title":"Conditions",
+      "defaultName":"Contains Conditions Codes",
+      "plugin": {
+        "columns":
+          [{"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Condition"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "condition_occurrence",
+        "classification": "condition"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Procedures",
+      "defaultName":"Contains Procedures Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Procedure"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "procedure_occurrence",
+        "classification": "procedure"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Observations",
+      "defaultName":"Contains Observations Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "occurrence": "observation_occurrence",
+        "classification": "observation"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Drugs",
+      "defaultName":"Contains Drugs Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Drug"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "ingredient_occurrence",
+        "classification": "ingredient"
+      }
+    },
+    {
+      "type":"attribute",
+      "title":"Ethnicity",
+      "defaultName":"Contains Ethnicity Codes",
+      "plugin":{"attribute":"ethnicity_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Gender Identity",
+      "defaultName":"Contains Gender Identity Codes",
+      "plugin":{"attribute":"gender_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Race",
+      "defaultName":"Contains Race Codes",
+      "plugin":{"attribute":"race_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Year at Birth",
+      "defaultName":"Contains Year at Birth Values",
+      "plugin":{"attribute":"year_of_birth"}
+    }]
+  }
 relationships:
   - name: brand_ingredient
     entity1: brand

--- a/api/src/main/resources/underlays/synpuf.yaml
+++ b/api/src/main/resources/underlays/synpuf.yaml
@@ -48,137 +48,248 @@ entities:
         dataType: STRING
       - name: concept_code
         dataType: STRING
-criteriaConfigs: >-
-  [{
-    "type":"concept",
-    "title":"Conditions",
-    "defaultName":"Contains Conditions Codes",
-    "plugin": {
-      "columns":
-        [{"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}],
-      "entities":[
-        {"name":"condition","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
+uiConfiguration: >-
   {
-    "type":"concept",
-    "title":"Procedures",
-    "defaultName":"Contains Procedures Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"procedure","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
-  {
-    "type":"concept",
-    "title":"Observations",
-    "defaultName":"Contains Observations Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},
-        {"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"observation","selectable":true,"orderBy":"person_count","orderDirection":"DESC"}
-      ]
-    }
-  },
-  {
-    "type":"concept",
-    "title":"Drugs",
-    "defaultName":"Contains Drugs Codes",
-    "plugin":{
-      "columns":[
-        {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
-        {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
-      ],
-      "entities":[
-        {"name":"ingredient","selectable":true,"hierarchical":true,"orderBy":"person_count","orderDirection":"DESC"},
+    "dataConfig": {
+      "primaryEntity": {
+        "displayName": "Person",
+        "entity": "person",
+        "key": "person_id"
+      },
+      "occurrences": [
         {
-          "name":"brand",
-          "sourceConcepts":true,
-          "attributes":[
-            "concept_name",
-            "concept_id",
-            "standard_concept",
-            "concept_code"
-          ],
-          "orderBy":"concept_name",
-          "orderDirection":"ASC",
-          "listChildren":{
-            "entity":"ingredient",
-            "idPath":"relationshipFilter.filter.binaryFilter.attributeValue",
-            "filter":{
-              "relationshipFilter":{
-                "outerVariable":"ingredient",
-                "newVariable":"brand",
-                "newEntity":"brand",
-                "filter":{
-                  "binaryFilter":{
-                    "attributeVariable":{
-                      "variable":"brand",
-                      "name":"concept_id"
-                    },
-                    "operator":"EQUALS",
-                    "attributeValue":{
-                      "int64Val":0
-                    }
-                  }
+          "id": "condition_occurrence",
+          "displayName": "Condition Occurrences",
+          "entity": "condition_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "condition",
+              "name": "Conditions",
+              "attribute": "condition_concept_id",
+              "entity": "condition",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "condition"
+                  },
+                  "operator": "NOT_EQUALS"
                 }
               }
             }
-          }
+          ]
+        },
+        {
+          "id": "procedure_occurrence",
+          "displayName": "Procedure Occurrences",
+          "entity": "procedure_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "procedure",
+              "name": "Procedures",
+              "attribute": "procedure_concept_id",
+              "entity": "procedure",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "procedure"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "observation_occurrence",
+          "displayName": "Observation Occurrence",
+          "entity": "observation_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "observation",
+              "name": "Observation",
+              "attribute": "observation_concept_id",
+              "entity": "observation",
+              "entityAttribute": "concept_id",
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "observation"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "ingredient_occurrence",
+          "displayName": "Drug Occurrence",
+          "entity": "ingredient_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "ingredient",
+              "name": "Ingredient",
+              "attribute": "ingredient_concept_id",
+              "entity": "ingredient",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "ingredient"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              },
+              "groupings": [
+                {
+                  "id": "brand",
+                  "name": "Brand",
+                  "entity": "brand",
+                  "defaultSort": {
+                    "attribute": "concept_name",
+                    "direction": "ASC"
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
-    }
-  },
-  {
-    "type":"attribute",
-    "title":"Ethnicity",
-    "defaultName":"Contains Ethnicity Codes",
-    "plugin":{"attribute":"ethnicity_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Gender Identity",
-    "defaultName":"Contains Gender Identity Codes",
-    "plugin":{"attribute":"gender_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Race",
-    "defaultName":"Contains Race Codes",
-    "plugin":{"attribute":"race_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Sex Assigned at Birth",
-    "defaultName":"Contains Sex Assigned at Birth Codes",
-    "plugin":{"attribute":"sex_at_birth_concept_id"}
-  },
-  {
-    "type":"attribute",
-    "title":"Year at Birth",
-    "defaultName":"Contains Year at Birth Values",
-    "plugin":{"attribute":"year_of_birth"}
-  }]
+    },
+    "criteriaConfigs": [{
+      "type":"concept",
+      "title":"Conditions",
+      "defaultName":"Contains Conditions Codes",
+      "plugin": {
+        "columns":
+          [{"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Condition"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "condition_occurrence",
+        "classification": "condition"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Procedures",
+      "defaultName":"Contains Procedures Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Procedure"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "procedure_occurrence",
+        "classification": "procedure"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Observations",
+      "defaultName":"Contains Observations Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "occurrence": "observation_occurrence",
+        "classification": "observation"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Drugs",
+      "defaultName":"Contains Drugs Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Drug"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "ingredient_occurrence",
+        "classification": "ingredient"
+      }
+    },
+    {
+      "type":"attribute",
+      "title":"Ethnicity",
+      "defaultName":"Contains Ethnicity Codes",
+      "plugin":{"attribute":"ethnicity_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Gender Identity",
+      "defaultName":"Contains Gender Identity Codes",
+      "plugin":{"attribute":"gender_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Race",
+      "defaultName":"Contains Race Codes",
+      "plugin":{"attribute":"race_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Sex Assigned at Birth",
+      "defaultName":"Contains Sex Assigned at Birth Codes",
+      "plugin":{"attribute":"sex_at_birth_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Year at Birth",
+      "defaultName":"Contains Year at Birth Values",
+      "plugin":{"attribute":"year_of_birth"}
+    }]
+  }
 relationships:
   - name: person_condition_occurrence
     entity1: person

--- a/api/src/test/java/bio/terra/tanagra/app/controller/EntityInstancesApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/EntityInstancesApiControllerTest.java
@@ -112,27 +112,27 @@ public class EntityInstancesApiControllerTest extends BaseSpringUnitTest {
   @Test
   void generateDatasetSqlQueryWithLimit() {
     ResponseEntity<ApiSqlQuery> response =
-            controller.generateDatasetSqlQuery(
-                    NAUTICAL_UNDERLAY_NAME,
-                    "sailors",
-                    new ApiGenerateDatasetSqlQueryRequest()
-                            .entityDataset(
-                                    new ApiEntityDataset()
-                                            .entityVariable("s")
-                                            .selectedAttributes(ImmutableList.of("name", "rating"))
-                                            .limit(1)
-                                            .filter(
-                                                    new ApiFilter()
-                                                            .binaryFilter(
-                                                                    new ApiBinaryFilter()
-                                                                            .attributeVariable(
-                                                                                    new ApiAttributeVariable().variable("s").name("rating"))
-                                                                            .operator(ApiBinaryFilterOperator.EQUALS)
-                                                                            .attributeValue(new ApiAttributeValue().int64Val(42L))))));
+        controller.generateDatasetSqlQuery(
+            NAUTICAL_UNDERLAY_NAME,
+            "sailors",
+            new ApiGenerateDatasetSqlQueryRequest()
+                .entityDataset(
+                    new ApiEntityDataset()
+                        .entityVariable("s")
+                        .selectedAttributes(ImmutableList.of("name", "rating"))
+                        .limit(1)
+                        .filter(
+                            new ApiFilter()
+                                .binaryFilter(
+                                    new ApiBinaryFilter()
+                                        .attributeVariable(
+                                            new ApiAttributeVariable().variable("s").name("rating"))
+                                        .operator(ApiBinaryFilterOperator.EQUALS)
+                                        .attributeValue(new ApiAttributeValue().int64Val(42L))))));
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(
-            "SELECT s.s_name AS name, s.rating AS rating "
-                    + "FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42 LIMIT 1",
-            response.getBody().getQuery());
+        "SELECT s.s_name AS name, s.rating AS rating "
+            + "FROM `my-project-id.nautical`.sailors AS s WHERE s.rating = 42 LIMIT 1",
+        response.getBody().getQuery());
   }
 }

--- a/api/src/test/java/bio/terra/tanagra/app/controller/UnderlaysApiControllerTest.java
+++ b/api/src/test/java/bio/terra/tanagra/app/controller/UnderlaysApiControllerTest.java
@@ -31,7 +31,7 @@ public class UnderlaysApiControllerTest extends BaseSpringUnitTest {
           .entityNames(
               ImmutableList.of(
                   "boat_electric_anchors", "boat_engines", "boats", "reservations", "sailors"))
-          .criteriaConfigs(NauticalUnderlayUtils.NAUTICAL_CRITERIA_CONFIGS);
+          .uiConfiguration(NauticalUnderlayUtils.NAUTICAL_UI_CONFIGURATION);
 
   @Test
   void getUnderlay() {

--- a/api/src/test/java/bio/terra/tanagra/service/query/api/ApiConversionServiceTest.java
+++ b/api/src/test/java/bio/terra/tanagra/service/query/api/ApiConversionServiceTest.java
@@ -227,7 +227,7 @@ public class ApiConversionServiceTest extends BaseSpringUnitTest {
             IllegalArgumentException.class,
             () ->
                 apiConversionService.convertEntityDataset(
-                        NAUTICAL_UNDERLAY_NAME, "sailors", apiEntityDataset));
+                    NAUTICAL_UNDERLAY_NAME, "sailors", apiEntityDataset));
     assertThat(
         illegalLimitEntityDataset.getMessage(), Matchers.containsString("The provided limit"));
   }

--- a/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
+++ b/api/src/test/java/bio/terra/tanagra/service/underlay/NauticalUnderlayUtils.java
@@ -35,8 +35,7 @@ public final class NauticalUnderlayUtils {
   }
 
   public static final String NAUTICAL_UNDERLAY_NAME = "nautical_underlay";
-  public static final String NAUTICAL_CRITERIA_CONFIGS =
-      "[{\"type\":\"attribute\",\"title\":\"Age\",\"defaultName\":\"Age\",\"plugin\":{\"attribute\":\"age\"}]";
+  public static final String NAUTICAL_UI_CONFIGURATION = "test-ui-configuration";
   public static final Entity SAILOR =
       Entity.builder().underlay(NAUTICAL_UNDERLAY_NAME).name("sailors").build();
   public static final Entity BOAT =

--- a/api/src/test/resources/underlays/nautical.pbtext
+++ b/api/src/test/resources/underlays/nautical.pbtext
@@ -5,7 +5,7 @@
 # This should be equivalent to nautical.yaml
 
 name: "nautical_underlay"
-criteria_configs: '[{"type":"attribute","title":"Age","defaultName":"Age","plugin":{"attribute":"age"}]'
+ui_configuration: 'test-ui-configuration'
 entities: {
   name: "sailors"
   attributes: {

--- a/api/src/test/resources/underlays/nautical.yaml
+++ b/api/src/test/resources/underlays/nautical.yaml
@@ -3,8 +3,7 @@
 # This should be equivalent to nautical.pbtext.
 
 name: nautical_underlay
-criteriaConfigs: >-
-  [{"type":"attribute","title":"Age","defaultName":"Age","plugin":{"attribute":"age"}]
+uiConfiguration: test-ui-configuration
 entities:
   - name: sailors
     attributes:

--- a/lib/src/main/proto/bio/terra/tanagra/underlay/underlay.proto
+++ b/lib/src/main/proto/bio/terra/tanagra/underlay/underlay.proto
@@ -44,7 +44,7 @@ message Underlay {
   repeated EntityFiltersSchema entity_filters_schemas = 8;
   // The entity indexing in the underlay.
   repeated EntityIndexing entity_indexing = 11;
-  
-  // The concepts and attributes in an underlay.
-  string criteria_configs = 12;
+
+  // The underlay specific UI configuration.
+  string ui_configuration = 12;
 }

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -8,44 +8,81 @@ class FakeUnderlaysApi {
       { key: "concept_name", width: "100%", title: "Concept Name" },
     ];
 
-    const criteriaConfigs = [
-      {
-        type: "concept",
-        title: "Conditions",
-        defaultName: "Contains Conditions Codes",
-        plugin: {
-          columns,
-          entities: [
-            { name: "condition", selectable: true, hierarchical: true },
-          ],
+    const uiConfiguration = {
+      dataConfig: {
+        primaryEntity: {
+          entity: "person",
+          key: "person_id",
         },
+        occurrences: [
+          {
+            id: "condition_occurrence",
+            entity: "condition_occurrence",
+            key: "concept_id",
+            classifications: [
+              {
+                id: "condition",
+                attribute: "condition_concept_id",
+                entity: "condition",
+                entityAttribute: "concept_id",
+                hierarchical: true,
+              },
+            ],
+          },
+          {
+            id: "observation_occurrence",
+            entity: "observation_occurrence",
+            key: "concept_id",
+            classifications: [
+              {
+                id: "observation",
+                attribute: "observation_concept_id",
+                entity: "observation",
+                entityAttribute: "concept_id",
+              },
+            ],
+          },
+        ],
       },
-      {
-        type: "concept",
-        title: "Observations",
-        defaultName: "Contains Observations Codes",
-        plugin: {
-          columns,
-          entities: [{ name: "observation", selectable: true }],
+      criteriaConfigs: [
+        {
+          type: "concept",
+          title: "Conditions",
+          defaultName: "Contains Conditions Codes",
+          plugin: {
+            columns,
+            occurrence: "condition_occurrence",
+            classification: "condition",
+          },
         },
-      },
-      {
-        type: "attribute",
-        title: "Race",
-        defaultName: "Contains Race Codes",
-        plugin: {
-          attribute: "race_concept_id",
+        {
+          type: "concept",
+          title: "Observations",
+          defaultName: "Contains Observations Codes",
+          plugin: {
+            columns,
+            occurrence: "observation_occurrence",
+            classification: "observation",
+          },
         },
-      },
-      {
-        type: "attribute",
-        title: "Year at Birth",
-        defaultName: "Contains Year at Birth Values",
-        plugin: {
-          attribute: "year_of_birth",
+        {
+          type: "attribute",
+          title: "Race",
+          defaultName: "Contains Race Codes",
+          plugin: {
+            attribute: "race_concept_id",
+          },
         },
-      },
-    ];
+        {
+          type: "attribute",
+          title: "Year at Birth",
+          defaultName: "Contains Year at Birth Values",
+          plugin: {
+            attribute: "year_of_birth",
+          },
+        },
+      ],
+    };
 
     return new Promise<tanagra.ListUnderlaysResponse>((resolve) => {
       resolve({
@@ -53,7 +90,7 @@ class FakeUnderlaysApi {
           {
             name: "underlay_name",
             entityNames: ["person"],
-            criteriaConfigs: JSON.stringify(criteriaConfigs),
+            uiConfiguration: JSON.stringify(uiConfiguration),
           },
         ],
       });

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -80,16 +80,16 @@ export default function App() {
               throw new Error(`No entities in underlay ${name}`);
             }
 
-            const criteriaConfigs = res.underlays?.[i]?.criteriaConfigs;
-            if (!criteriaConfigs) {
-              throw new Error(`No criteria configs in underlay ${name}`);
+            const uiConfiguration = res.underlays?.[i]?.uiConfiguration;
+            if (!uiConfiguration) {
+              throw new Error(`No UI configuration in underlay ${name}`);
             }
 
             return {
               name,
               primaryEntity: "person",
               entities: entitiesRes.entities,
-              criteriaConfigs: JSON.parse(criteriaConfigs),
+              uiConfiguration: JSON.parse(uiConfiguration),
               prepackagedConceptSets,
             };
           })

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -7,11 +7,12 @@ export function generateId(): string {
 }
 
 export function generateQueryFilter(
+  underlay: Underlay,
   cohort: tanagra.Cohort,
   entityVar: string
 ): tanagra.Filter | null {
   const operands = cohort.groups
-    .map((group) => generateFilter(group, entityVar))
+    .map((group) => generateFilter(underlay, group, entityVar))
     .filter((filter) => filter) as Array<tanagra.Filter>;
   if (operands.length === 0) {
     return null;
@@ -26,12 +27,13 @@ export function generateQueryFilter(
 }
 
 function generateFilter(
+  underlay: Underlay,
   group: tanagra.Group,
   entityVar: string
 ): tanagra.Filter | null {
   const operands = group.criteria
     .map((criteria) =>
-      getCriteriaPlugin(criteria).generateFilter(entityVar, false)
+      getCriteriaPlugin(criteria).generateFilter(underlay, entityVar, false)
     )
     .filter((filter) => filter) as Array<tanagra.Filter>;
   if (operands.length === 0) {
@@ -63,10 +65,11 @@ export interface CriteriaPlugin<DataType> {
   renderEdit: (dispatchFn: (data: DataType) => void) => JSX.Element;
   renderDetails: () => JSX.Element;
   generateFilter: (
+    underlay: Underlay,
     entityVar: string,
     fromOccurrence: boolean
   ) => tanagra.Filter | null;
-  occurrenceEntities: () => string[];
+  occurrenceEntities: (underlay: Underlay) => string[];
 }
 
 // registerCriteriaPlugin is a decorator that allows criteria to automatically

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -90,7 +90,7 @@ class _ implements CriteriaPlugin<Data> {
     return <AttributeDetails data={this.data} />;
   }
 
-  generateFilter(entityVar: string) {
+  generateFilter(underlay: Underlay, entityVar: string) {
     if (this.data.dataRanges?.length) {
       return {
         arrayFilter: {

--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -3,7 +3,6 @@ import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import { EntityInstancesApiContext } from "apiContext";
 import { CriteriaPlugin, registerCriteriaPlugin } from "cohort";
 import Checkbox from "components/checkbox";
 import Loading from "components/loading";
@@ -13,50 +12,40 @@ import {
   TreeGridColumn,
   TreeGridData,
   TreeGridId,
+  TreeGridItem,
   TreeGridRowData,
 } from "components/treegrid";
+import { DataKey, findByID } from "data/configuration";
+import {
+  ClassificationNode,
+  SearchClassificationResult,
+  useSource,
+} from "data/source";
 import { useAsyncWithApi } from "errors";
 import { useUnderlay } from "hooks";
 import produce from "immer";
-import React, { useCallback, useContext, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import * as tanagra from "tanagra-api";
 import { CriteriaConfig, Underlay } from "underlaysSlice";
 import { useImmer } from "use-immer";
-import { isValid } from "util/valid";
 
 type Selection = {
-  entity: string;
-  id: number;
+  key: DataKey;
   name: string;
 };
 
-type ListChildrenConfig = {
-  entity: string;
-  // The path within the filter to set the parent ID for the query (e.g.
-  // filter.binaryFilter.attributeValue).
-  idPath: string;
-  filter: tanagra.Filter;
-};
-
-type EntityConfig = {
-  name: string;
-  selectable?: boolean;
-  sourceConcepts?: boolean;
-  attributes?: string[];
-
-  orderBy?: string;
-  orderDirection?: tanagra.OrderByDirection;
-
-  // hierarchical indicates whether the entity supports a hierarchical view.
-  hierarchical?: boolean;
-  // listChildren indicates whether the entity can have children in the list
-  // view.
-  listChildren?: ListChildrenConfig;
+// A custom TreeGridItem allows us to store the ClassificationNode along with
+// the rest of the data.
+type ClassificationNodeItem = TreeGridItem & {
+  node: ClassificationNode;
 };
 
 interface Config extends CriteriaConfig {
   columns: TreeGridColumn[];
-  entities: EntityConfig[];
+  nameColumnIndex?: number;
+  hierarchyColumns?: TreeGridColumn[];
+  occurrence: string;
+  classification: string;
 }
 
 // Exported for testing purposes.
@@ -91,86 +80,89 @@ class _ implements CriteriaPlugin<Data> {
   // via an occurrence table (e.g. person -> condition_occurrence -> condition).
   // fromOccurrence causes entityVar to be treated as the occurrence instead
   // (e.g. condition_occurrence -> condition).
-  generateFilter(entityVar: string, fromOccurrence: boolean) {
-    if (this.data.selected.length === 0) {
+  generateFilter(
+    underlay: Underlay,
+    entityVar: string,
+    fromOccurrence: boolean
+  ) {
+    // TODO(tjennison): Package the data config and helper functions into the
+    // source then pass that in instead of the underlay which is only being used
+    // to access the data config.
+    const occurrence = findByID(
+      this.data.occurrence,
+      underlay.uiConfiguration.dataConfig.occurrences
+    );
+    const classification = findByID(
+      this.data.classification,
+      occurrence.classifications
+    );
+
+    const operands = this.data.selected.map(({ key }) => ({
+      binaryFilter: {
+        attributeVariable: {
+          variable: classification.entity,
+          name: classification.entityAttribute,
+        },
+        operator: tanagra.BinaryFilterOperator.DescendantOfInclusive,
+        attributeValue: {
+          // TODO(tjennison): Handle other key types.
+          int64Val: key as number,
+        },
+      },
+    }));
+
+    if (!operands) {
       return null;
     }
 
-    const operands = (e: string) =>
-      this.data.selected
-        .filter(({ entity }) => entity === e)
-        .map(({ id }) => ({
-          binaryFilter: {
-            attributeVariable: {
-              variable: "concept",
-              name: "concept_id",
-            },
-            operator: tanagra.BinaryFilterOperator.DescendantOfInclusive,
-            attributeValue: {
-              int64Val: id,
-            },
-          },
-        }));
-
-    const occurrenceFilter = (entity: EntityConfig, variable: string) => ({
+    const filter = {
       relationshipFilter: {
-        outerVariable: variable,
-        newVariable: "concept",
-        newEntity: entity.name,
+        outerVariable: fromOccurrence ? entityVar : occurrence.entity,
+        newVariable: classification.entity,
+        newEntity: classification.entity,
         filter: {
           arrayFilter: {
-            operands: operands(entity.name),
+            operands: operands,
             operator: tanagra.ArrayFilterOperator.Or,
           },
         },
       },
-    });
+    };
 
-    const ret = {
-      arrayFilter: {
-        operands: this.data.entities
-          .filter(
-            (entity) =>
-              this.data.selected.findIndex(
-                (sel) => sel.entity === entity.name
-              ) >= 0
-          )
-          .map((entity) =>
-            fromOccurrence
-              ? occurrenceFilter(entity, entityVar)
-              : {
-                  relationshipFilter: {
-                    outerVariable: entityVar,
-                    newVariable: "occurrence",
-                    newEntity: entity.name + "_occurrence",
-                    filter: occurrenceFilter(entity, "occurrence"),
-                  },
-                }
-          ),
-        operator: tanagra.ArrayFilterOperator.Or,
+    if (fromOccurrence) {
+      return filter;
+    }
+
+    return {
+      relationshipFilter: {
+        outerVariable: entityVar,
+        newVariable: occurrence.entity,
+        newEntity: occurrence.entity,
+        filter: filter,
       },
     };
-    return ret;
   }
 
   // TODO(tjennison): Split filter generation into separate paths for
   // occurrences and primary entities. This will allow occurrence logic to be
   // centralized and remove the limitation of having a single selectable entity.
-  occurrenceEntities() {
-    return this.data.entities
-      .filter((entity) => entity.selectable)
-      .map((entity) => entity.name + "_occurrence");
+  occurrenceEntities(underlay: Underlay) {
+    return [
+      findByID(
+        this.data.occurrence,
+        underlay.uiConfiguration.dataConfig.occurrences
+      ).entity,
+    ];
   }
 }
 
-const PATH_ATTRIBUTE = "t_path_concept_id";
-const NUM_CHILDREN_ATTRIBUTE = "t_numChildren_concept_id";
-const ENTITY_ATTRIBUTE = "t_entity";
-
-type HierarchyState = {
-  path: TreeGridId[];
-  entity: string;
-};
+function keyForNode(node: ClassificationNode): DataKey {
+  let key = node.data.key;
+  if (node.grouping) {
+    key = `${node.grouping}~${key}`;
+  }
+  return key;
+}
 
 type ConceptEditProps = {
   dispatchFn: (data: Data) => void;
@@ -180,100 +172,70 @@ type ConceptEditProps = {
 function ConceptEdit(props: ConceptEditProps) {
   const underlay = useUnderlay();
 
-  const [hierarchy, setHierarchy] = useState<HierarchyState | undefined>();
+  const occurrence = findByID(
+    props.data.occurrence,
+    underlay.uiConfiguration.dataConfig.occurrences
+  );
+  const classification = findByID(
+    props.data.classification,
+    occurrence.classifications
+  );
+
+  const [hierarchy, setHierarchy] = useState<DataKey[] | undefined>();
   const [query, setQuery] = useState<string>("");
   const [data, updateData] = useImmer<TreeGridData>({});
-  const api = useContext(EntityInstancesApiContext);
+  const source = useSource();
 
   const processEntities = useCallback(
     (
-      res: tanagra.SearchEntityInstancesResponse,
-      entity: EntityConfig,
-      hierarchy?: HierarchyState,
-      parentId?: number,
-      listChildrenEntity?: EntityConfig
+      res: SearchClassificationResult,
+      hierarchy?: DataKey[],
+      parent?: DataKey
     ) => {
       updateData((data) => {
-        const children: TreeGridId[] = [];
-        if (res.instances) {
-          // TODO(tjennison): Use server side limits.
-          res.instances.slice(0, 100).forEach((instance) => {
-            const id = instance["concept_id"]?.int64Val || 0;
-            if (id === 0) {
-              return;
+        const children: DataKey[] = [];
+        res.nodes.forEach((node) => {
+          const rowData: TreeGridRowData = { ...node.data };
+          if (node.ancestors) {
+            rowData.view_hierarchy = (
+              <IconButton
+                size="small"
+                onClick={() => {
+                  setHierarchy(node.ancestors);
+                }}
+              >
+                <AccountTreeIcon fontSize="inherit" />
+              </IconButton>
+            );
+          }
+
+          const key = keyForNode(node);
+          children.push(key);
+
+          // Copy over existing children in case they're being loaded in
+          // parallel.
+          let childChildren = data[key]?.children;
+          if (!childChildren) {
+            if (!node.grouping && !hierarchy) {
+              childChildren = [];
             }
+          }
 
-            let path: TreeGridId[] | undefined;
-            let hasChildren = false;
-            const entityName = listChildrenEntity?.name || entity.name;
-            const row: TreeGridRowData = {
-              [ENTITY_ATTRIBUTE]: entityName,
-            };
+          const cItem: ClassificationNodeItem = {
+            data: rowData,
+            children: childChildren,
+            node: node,
+          };
+          data[key] = cItem;
+        });
 
-            for (const k in instance) {
-              const v = instance[k];
-              if (k === "standard_concept") {
-                row[k] = v ? "Standard" : "Source";
-              } else if (!v) {
-                row[k] = "";
-              } else if (k === PATH_ATTRIBUTE) {
-                if (v.stringVal) {
-                  path = v.stringVal.split(".").map((id) => +id);
-                } else if (v.stringVal === "") {
-                  path = [];
-                }
-              } else if (k === NUM_CHILDREN_ATTRIBUTE) {
-                hasChildren = !!v.int64Val;
-              } else if (isValid(v.int64Val)) {
-                row[k] = v.int64Val;
-              } else if (isValid(v.boolVal)) {
-                row[k] = v.boolVal;
-              } else {
-                row[k] = v.stringVal;
-              }
-            }
-
-            if (path) {
-              row.view_hierarchy = (
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setHierarchy({ path: path || [], entity: entityName });
-                  }}
-                >
-                  <AccountTreeIcon fontSize="inherit" />
-                </IconButton>
-              );
-            }
-
-            children.push(id);
-
-            // Copy over existing children in case they're being loaded in
-            // parallel.
-            let childChildren = data[id]?.children;
-            if (!childChildren) {
-              if (!hierarchy) {
-                hasChildren = !!entity.listChildren && !listChildrenEntity;
-              }
-              childChildren = !hasChildren ? [] : undefined;
-            }
-
-            data[id] = {
-              data: row,
-              children: childChildren,
-            };
-          });
-        }
-
-        if (parentId) {
+        if (parent) {
           // Store children even if the data isn't loaded yet.
-          data[parentId] = { ...data[parentId], children };
+          data[parent] = { ...data[parent], children };
         } else {
           data.root = {
             children: [...(data?.root?.children || []), ...children],
-            data: {
-              [ENTITY_ATTRIBUTE]: entity.name,
-            },
+            data: {},
           };
         }
       });
@@ -281,63 +243,49 @@ function ConceptEdit(props: ConceptEditProps) {
     []
   );
 
-  const fetchEntities = useCallback(() => {
-    updateData(() => ({}));
-    return Promise.all(
-      props.data.entities
-        .filter((entity) => !hierarchy || entity.name === hierarchy.entity)
-        .map((entity) =>
-          api.searchEntityInstances(
-            searchRequest(
-              props.data.columns,
-              entity,
-              underlay.name,
-              !hierarchy ? query : ""
-            )
-          )
-        )
-    ).then((res) => {
-      res?.forEach((r, i) =>
-        processEntities(r, props.data.entities[i], hierarchy)
-      );
-    });
-  }, [
-    api,
-    props.data.columns,
-    props.data.entities,
-    underlay.name,
-    processEntities,
-    hierarchy,
-    query,
-  ]);
-  const conceptsState = useAsyncWithApi<void>(fetchEntities);
+  const attributes = useMemo(
+    () => props.data.columns.map(({ key }) => key),
+    [props.data.columns]
+  );
 
-  const hierarchyColumns = [
-    {
-      key: "concept_name",
-      width: "100%",
-      title: (
-        <Button
-          variant="contained"
-          onClick={() => {
-            setHierarchy(undefined);
-          }}
-        >
-          Return to List
-        </Button>
-      ),
-    },
-    { key: "concept_id", width: 120, title: "Concept ID" },
-  ];
+  const fetchClassification = useCallback(() => {
+    updateData(() => ({}));
+    return source
+      .searchClassification(attributes, occurrence.id, classification.id, {
+        query: !hierarchy ? query : undefined,
+      })
+      .then((res) => processEntities(res, hierarchy));
+  }, [source, attributes, processEntities, hierarchy, query]);
+  const classificationState = useAsyncWithApi<void>(fetchClassification);
+
+  const hierarchyColumns = useMemo(() => {
+    const columns: TreeGridColumn[] = [...(props.data.hierarchyColumns ?? [])];
+    if (columns.length > 0) {
+      columns[0] = {
+        ...columns[0],
+        title: (
+          <Button
+            variant="contained"
+            onClick={() => {
+              setHierarchy(undefined);
+            }}
+          >
+            Return to List
+          </Button>
+        ),
+      };
+    }
+    return columns;
+  }, [props.data.hierarchyColumns]);
 
   const allColumns: TreeGridColumn[] = useMemo(
     () => [
       ...props.data.columns,
-      ...(props.data.entities.find((entity) => entity.hierarchical)
+      ...(classification.hierarchical
         ? [{ key: "view_hierarchy", width: 160, title: "View Hierarchy" }]
         : []),
     ],
-    [props.data.columns, props.data.entities]
+    [props.data.columns]
   );
 
   return (
@@ -348,19 +296,22 @@ function ConceptEdit(props: ConceptEditProps) {
           onSearch={setQuery}
         />
       )}
-      <Loading status={conceptsState}>
+      <Loading status={classificationState}>
         <TreeGrid
           columns={hierarchy ? hierarchyColumns : allColumns}
           data={data}
-          defaultExpanded={hierarchy?.path}
+          defaultExpanded={hierarchy}
           prefixElements={(id: TreeGridId, rowData: TreeGridRowData) => {
-            const entity = findEntity(props.data.entities, rowData);
-            if (!entity.selectable) {
+            // TODO(tjennison): Make TreeGridData's type generic so we can avoid
+            // this type assertion. Also consider passing the TreeGridItem to
+            // the callback instead of the TreeGridRowData.
+            const item = data[id] as ClassificationNodeItem;
+            if (!item || item.node.grouping) {
               return null;
             }
 
             const index = props.data.selected.findIndex(
-              (row) => row.entity === entity.name && row.id === id
+              (sel) => item.node.data.key === sel.key
             );
 
             return (
@@ -374,10 +325,11 @@ function ConceptEdit(props: ConceptEditProps) {
                       if (index > -1) {
                         data.selected.splice(index, 1);
                       } else {
-                        const name = rowData["concept_name"];
+                        const column =
+                          props.data.columns[props.data.nameColumnIndex ?? 0];
+                        const name = rowData[column.key];
                         data.selected.push({
-                          entity: entity.name,
-                          id: id as number,
+                          key: item.node.data.key,
                           name: !!name ? String(name) : "",
                         });
                       }
@@ -388,184 +340,42 @@ function ConceptEdit(props: ConceptEditProps) {
             );
           }}
           loadChildren={(id: TreeGridId) => {
-            const entity = findEntity(
-              props.data.entities,
-              data[id]?.data,
-              hierarchy?.entity
-            );
-
-            let req: tanagra.SearchEntityInstancesOperationRequest;
-            let childEntity: EntityConfig;
-            if (entity.listChildren && !hierarchy) {
-              childEntity = findEntity(
-                props.data.entities,
-                undefined,
-                entity.listChildren?.entity
-              );
-              req = listChildrenRequest(
-                props.data.columns,
-                entity.listChildren,
-                childEntity,
-                underlay.name,
-                id as number
-              );
-            } else {
-              req = searchRequest(
-                props.data.columns,
-                entity,
-                underlay.name,
-                "",
-                id as number
-              );
+            const item = data[id] as ClassificationNodeItem;
+            if (!item) {
+              throw new Error(`Unknown TreeGridId "${id}"`);
             }
 
-            return api.searchEntityInstances(req).then((res) => {
-              processEntities(
-                res,
-                entity,
-                hierarchy,
-                id as number,
-                childEntity
-              );
-            });
+            const key = keyForNode(item.node);
+            if (item.node.grouping) {
+              return source
+                .searchGrouping(
+                  attributes,
+                  occurrence.id,
+                  classification.id,
+                  item.node
+                )
+                .then((res) => {
+                  processEntities(res, hierarchy, key);
+                });
+            } else {
+              return source
+                .searchClassification(
+                  attributes,
+                  occurrence.id,
+                  classification.id,
+                  {
+                    parent: key,
+                  }
+                )
+                .then((res) => {
+                  processEntities(res, hierarchy, key);
+                });
+            }
           }}
         />
       </Loading>
     </>
   );
-}
-
-function findEntity(
-  entities: EntityConfig[],
-  rowData?: TreeGridRowData,
-  defaultEntity?: string
-) {
-  const entity = entities.find(
-    (entity) =>
-      (rowData && entity.name === rowData?.[ENTITY_ATTRIBUTE]) ||
-      entity.name === defaultEntity
-  );
-  if (!entity) {
-    throw "Unknown entity config: " + rowData;
-  }
-  return entity;
-}
-
-function searchRequest(
-  columns: TreeGridColumn[],
-  entity: EntityConfig,
-  underlay: string,
-  query: string,
-  id?: number
-) {
-  const operands: tanagra.Filter[] = [
-    {
-      binaryFilter: {
-        attributeVariable: {
-          name: "standard_concept",
-          variable: "c",
-        },
-        operator: entity.sourceConcepts
-          ? tanagra.BinaryFilterOperator.Equals
-          : tanagra.BinaryFilterOperator.NotEquals,
-      },
-    },
-  ];
-
-  if (id) {
-    operands.push({
-      binaryFilter: {
-        attributeVariable: {
-          name: "concept_id",
-          variable: "c",
-        },
-        operator: tanagra.BinaryFilterOperator.ChildOf,
-        attributeValue: {
-          int64Val: id as number,
-        },
-      },
-    });
-  } else if (query) {
-    operands.push({
-      textSearchFilter: {
-        entityVariable: "c",
-        term: query,
-      },
-    });
-  } else if (entity.hierarchical) {
-    operands.push({
-      binaryFilter: {
-        attributeVariable: {
-          name: "t_path_concept_id",
-          variable: "c",
-        },
-        operator: tanagra.BinaryFilterOperator.Equals,
-        attributeValue: {
-          stringVal: "",
-        },
-      },
-    });
-  }
-
-  return {
-    entityName: entity.name,
-    underlayName: underlay,
-    searchEntityInstancesRequest: {
-      entityDataset: {
-        entityVariable: "c",
-        selectedAttributes: attributesForEntity(entity, columns),
-        orderByAttribute: entity.orderBy,
-        orderByDirection: entity.orderDirection,
-        filter: {
-          arrayFilter: {
-            operands,
-            operator: tanagra.ArrayFilterOperator.And,
-          },
-        },
-      },
-    },
-  };
-}
-
-function listChildrenRequest(
-  columns: TreeGridColumn[],
-  listChildren: ListChildrenConfig,
-  childEntity: EntityConfig,
-  underlay: string,
-  id: number
-) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const filter = produce(listChildren.filter, (draft: any) => {
-    const keys = listChildren.idPath.split(".");
-    const last = keys.pop();
-    if (!last) {
-      return;
-    }
-
-    keys.forEach((key) => {
-      draft = draft[key];
-    });
-    draft[last].int64Val = id;
-  });
-
-  return {
-    entityName: listChildren.entity,
-    underlayName: underlay,
-    searchEntityInstancesRequest: {
-      entityDataset: {
-        entityVariable: listChildren.entity,
-        selectedAttributes: attributesForEntity(childEntity, columns),
-        filter,
-      },
-    },
-  };
-}
-
-function attributesForEntity(entity: EntityConfig, columns: TreeGridColumn[]) {
-  return [
-    ...(entity.hierarchical ? [PATH_ATTRIBUTE, NUM_CHILDREN_ATTRIBUTE] : []),
-    ...(entity.attributes ? entity.attributes : columns.map(({ key }) => key)),
-  ];
 }
 
 type ConceptDetailsProps = {
@@ -578,9 +388,9 @@ function ConceptDetails(props: ConceptDetailsProps) {
       {props.data.selected.length === 0 ? (
         <Typography variant="body1">None selected</Typography>
       ) : (
-        props.data.selected.map(({ id, name }) => (
-          <Stack direction="row" alignItems="baseline" key={id}>
-            <Typography variant="body1">{id}</Typography>&nbsp;
+        props.data.selected.map(({ key, name }) => (
+          <Stack direction="row" alignItems="baseline" key={key}>
+            <Typography variant="body1">{key}</Typography>&nbsp;
             <Typography variant="body2">{name}</Typography>
           </Stack>
         ))

--- a/ui/src/data/configuration.ts
+++ b/ui/src/data/configuration.ts
@@ -1,0 +1,75 @@
+import * as tanagra from "tanagra-api";
+
+export type DataKey = string | number;
+export type DataValue = string | number | boolean;
+
+export type DataEntry = {
+  key: DataKey;
+  [x: string]: DataValue;
+};
+
+export enum SortDirection {
+  Asc = "ASC",
+  Desc = "DESC",
+}
+
+export type SortOrder = {
+  attribute: string;
+  direction: SortDirection;
+};
+
+export type Classification = {
+  id: string;
+  attribute: string;
+
+  entity: string;
+  entityAttribute: string;
+  hierarchical?: boolean;
+
+  defaultSort?: SortOrder;
+
+  groupings?: Grouping[];
+
+  // TODO(tjennison): This isn't ideal. It would be better if the underlay
+  // supported multiple hierarchies directly but I don't see an alternative to
+  // this for now other than hardcoding the source/standard logic which seems
+  // worse.
+  filter?: tanagra.Filter;
+};
+
+export type Grouping = {
+  id: string;
+  entity: string;
+  defaultSort?: SortOrder;
+};
+
+export type Attribute = {
+  id: string;
+  attribute: string;
+};
+
+export type PrimaryEntity = {
+  entity: string;
+  key: string;
+};
+
+export type Occurrence = {
+  id: string;
+  entity: string;
+  key: string;
+
+  classifications?: Classification[];
+};
+
+export type Configuration = {
+  primaryEntity: PrimaryEntity;
+  occurrences?: Occurrence[];
+};
+
+export function findByID<T extends { id: string }>(id: string, list?: T[]): T {
+  const item = list?.find((item) => item.id === id);
+  if (!item) {
+    throw new Error(`Unknown item "${id}" in ${JSON.stringify(list)}.`);
+  }
+  return item;
+}

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -1,0 +1,363 @@
+import { EntityInstancesApiContext } from "apiContext";
+import { useUnderlay } from "hooks";
+import { useContext, useMemo } from "react";
+import * as tanagra from "tanagra-api";
+import { isValid } from "util/valid";
+import {
+  Classification,
+  Configuration,
+  DataEntry,
+  DataKey,
+  DataValue,
+  findByID,
+  Grouping,
+} from "./configuration";
+
+export type ClassificationNode = {
+  data: DataEntry;
+  grouping?: string;
+  ancestors?: DataKey[];
+  childCount?: number;
+};
+
+export type SearchClassificationOptions = {
+  query?: string;
+  parent?: DataKey;
+};
+
+export type SearchClassificationResult = {
+  nodes: ClassificationNode[];
+};
+
+export interface Source {
+  searchClassification(
+    requestedAttributes: string[],
+    occurrenceID: string,
+    classificationID: string,
+    options?: SearchClassificationOptions
+  ): Promise<SearchClassificationResult>;
+
+  searchGrouping(
+    requestedAttributes: string[],
+    occurrenceID: string,
+    classificationID: string,
+    root: ClassificationNode
+  ): Promise<SearchClassificationResult>;
+}
+
+// TODO(tjennison): Create the source once and put it into the context instead
+// of recreating it. Move "fake" logic into a separate source instead of APIs.
+export function useSource(): Source {
+  const underlay = useUnderlay();
+  const context = useContext(
+    EntityInstancesApiContext
+  ) as tanagra.EntityInstancesApi;
+  return useMemo(
+    () =>
+      new BackendSource(
+        context,
+        underlay.name,
+        underlay.uiConfiguration.dataConfig
+      ),
+    [underlay]
+  );
+}
+
+export class BackendSource implements Source {
+  constructor(
+    private entityInstancesApi: tanagra.EntityInstancesApi,
+    private underlay: string,
+    private config: Configuration
+  ) {}
+
+  searchClassification(
+    requestedAttributes: string[],
+    occurrenceID: string,
+    classificationID: string,
+    options?: SearchClassificationOptions
+  ): Promise<SearchClassificationResult> {
+    const occurrence = findByID(occurrenceID, this.config.occurrences);
+    const classification = findByID(
+      classificationID,
+      occurrence.classifications
+    );
+
+    const ra = [...requestedAttributes];
+    if (classification?.hierarchical) {
+      ra.push(
+        makePathAttribute(classification.entityAttribute),
+        makeNumChildrenAttribute(classification.entityAttribute)
+      );
+    }
+
+    const query = !options?.parent ? options?.query || "" : undefined;
+    return Promise.all([
+      this.entityInstancesApi.searchEntityInstances(
+        searchRequest(
+          ra,
+          this.underlay,
+          classification,
+          undefined,
+          query,
+          options?.parent
+        )
+      ),
+      ...(classification.groupings?.map((grouping) =>
+        this.entityInstancesApi.searchEntityInstances(
+          searchRequest(
+            ra,
+            this.underlay,
+            classification,
+            grouping,
+            query,
+            options?.parent
+          )
+        )
+      ) || []),
+    ]).then((res) => {
+      const result: SearchClassificationResult = { nodes: [] };
+      res?.forEach((r, i) => {
+        result.nodes.push(
+          ...processEntitiesResponse(
+            classification.entityAttribute,
+            r,
+            i > 0 ? classification.groupings?.[i - 1].id : undefined
+          )
+        );
+      });
+      return result;
+    });
+  }
+
+  searchGrouping(
+    requestedAttributes: string[],
+    occurrenceID: string,
+    classificationID: string,
+    root: ClassificationNode
+  ): Promise<SearchClassificationResult> {
+    const occurrence = findByID(occurrenceID, this.config.occurrences);
+    const classification = findByID(
+      classificationID,
+      occurrence.classifications
+    );
+
+    if (!root.grouping) {
+      throw new Error(`Grouping undefined while searching from "${root}"`);
+    }
+    const grouping = findByID(root.grouping, classification.groupings);
+
+    return this.entityInstancesApi
+      .searchEntityInstances({
+        entityName: classification.entity,
+        underlayName: this.underlay,
+        searchEntityInstancesRequest: {
+          entityDataset: {
+            entityVariable: classification.entity,
+            selectedAttributes: requestedAttributes,
+            filter: {
+              relationshipFilter: {
+                outerVariable: classification.entity,
+                newVariable: grouping.entity,
+                newEntity: grouping.entity,
+                filter: {
+                  binaryFilter: {
+                    attributeVariable: {
+                      variable: grouping.entity,
+                      name: classification.entityAttribute,
+                    },
+                    operator: tanagra.BinaryFilterOperator.Equals,
+                    attributeValue: attributeValueFromDataValue(root.data.key),
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+      .then((res) => ({
+        nodes: processEntitiesResponse(classification.entityAttribute, res),
+      }));
+  }
+}
+
+function makePathAttribute(attribute: string) {
+  return "t_path_" + attribute;
+}
+
+function makeNumChildrenAttribute(attribute: string) {
+  return "t_numChildren_" + attribute;
+}
+
+function attributeValueFromDataValue(value: DataValue): tanagra.AttributeValue {
+  switch (typeof value) {
+    case "string":
+      return {
+        stringVal: value,
+      };
+    case "number":
+      return {
+        int64Val: value,
+      };
+    case "boolean":
+      return {
+        boolVal: value,
+      };
+  }
+  throw new Error(`Unknown data value type ${typeof value}.`);
+}
+
+function searchRequest(
+  requestedAttributes: string[],
+  underlay: string,
+  classification: Classification,
+  grouping?: Grouping,
+  query?: string,
+  parent?: DataValue
+) {
+  // TODO(tjennison): Make brands support the same columns as ingredients since
+  // they're displayed in the same table instead of trying to route separate
+  // attributes.
+  if (grouping?.id === "brand") {
+    requestedAttributes = [
+      "concept_name",
+      "concept_id",
+      "standard_concept",
+      "concept_code",
+    ];
+  }
+
+  const operands: tanagra.Filter[] = [];
+  if (classification.filter && !grouping) {
+    operands.push(classification.filter);
+  }
+
+  const entity = grouping?.entity || classification.entity;
+
+  if (parent) {
+    operands.push({
+      binaryFilter: {
+        attributeVariable: {
+          name: classification.entityAttribute,
+          variable: entity,
+        },
+        operator: tanagra.BinaryFilterOperator.ChildOf,
+        attributeValue: attributeValueFromDataValue(parent),
+      },
+    });
+  } else if (query) {
+    operands.push({
+      textSearchFilter: {
+        entityVariable: entity,
+        term: query,
+      },
+    });
+  } else if (classification?.hierarchical && !grouping) {
+    operands.push({
+      binaryFilter: {
+        attributeVariable: {
+          name: makePathAttribute(classification.entityAttribute),
+          variable: entity,
+        },
+        operator: tanagra.BinaryFilterOperator.Equals,
+        attributeValue: {
+          stringVal: "",
+        },
+      },
+    });
+  }
+
+  let filter: tanagra.Filter | undefined;
+  if (operands.length > 0) {
+    filter = {
+      arrayFilter: {
+        operands,
+        operator: tanagra.ArrayFilterOperator.And,
+      },
+    };
+  }
+
+  const orderByAttribute =
+    grouping?.defaultSort?.attribute ?? classification.defaultSort?.attribute;
+  const orderByDirection =
+    grouping?.defaultSort?.direction ?? classification.defaultSort?.direction;
+
+  const req = {
+    entityName: entity,
+    underlayName: underlay,
+    searchEntityInstancesRequest: {
+      entityDataset: {
+        entityVariable: entity,
+        selectedAttributes: requestedAttributes,
+        orderByAttribute: orderByAttribute,
+        orderByDirection: orderByDirection as
+          | tanagra.OrderByDirection
+          | undefined,
+        filter: filter,
+      },
+    },
+  };
+  return req;
+}
+
+function processEntitiesResponse(
+  attributeID: string,
+  response: tanagra.SearchEntityInstancesResponse,
+  grouping?: string
+): ClassificationNode[] {
+  const pathAttribute = makePathAttribute(attributeID);
+  const numChildrenAttribute = makeNumChildrenAttribute(attributeID);
+
+  const nodes: ClassificationNode[] = [];
+  if (response.instances) {
+    // TODO(tjennison): Use server side limits.
+    response.instances.slice(0, 100).forEach((instance) => {
+      let ancestors: DataKey[] | undefined;
+      let childCount: number | undefined;
+      const data: DataEntry = {
+        key: 0,
+      };
+
+      for (const k in instance) {
+        const v = instance[k];
+        // TODO(tjennison): Add support for computed columns.
+        if (k === "standard_concept") {
+          data[k] = v ? "Standard" : "Source";
+        } else if (!v) {
+          data[k] = "";
+        } else if (k === pathAttribute) {
+          if (v.stringVal) {
+            // TODO(tjennison): There's no way to tell if the IDs should
+            // be numbers or strings and getting it wrong will cause
+            // queries using them to fail because the types don't match.
+            // Figure out a way to handle this generically.
+            ancestors = v.stringVal.split(".").map((id) => +id);
+          } else if (v.stringVal === "") {
+            ancestors = [];
+          }
+        } else if (k === numChildrenAttribute) {
+          childCount = v.int64Val;
+        } else if (isValid(v.int64Val)) {
+          data[k] = v.int64Val;
+        } else if (isValid(v.boolVal)) {
+          data[k] = v.boolVal;
+        } else if (isValid(v.stringVal)) {
+          data[k] = v.stringVal;
+        }
+      }
+
+      const key = data[attributeID];
+      if (!key || typeof key === "boolean") {
+        return;
+      }
+      data.key = key;
+
+      nodes.push({
+        data: data,
+        grouping: grouping,
+        ancestors: ancestors,
+        childCount: childCount,
+      });
+    });
+  }
+  return nodes;
+}

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -129,7 +129,7 @@ export function Datasets() {
   };
 
   const [menu, showInsertConceptSet] = useMenu({
-    children: underlay.criteriaConfigs.map((config) => (
+    children: underlay.uiConfiguration.criteriaConfigs.map((config) => (
       <MenuItem
         key={config.title}
         onClick={() => {
@@ -353,12 +353,12 @@ function useConceptSetEntities(
   );
   workspaceConceptSets.forEach((conceptSet) => {
     const plugin = getCriteriaPlugin(conceptSet.criteria);
-    if (plugin.occurrenceEntities().length != 1) {
+    if (plugin.occurrenceEntities(underlay).length != 1) {
       throw new Error("Only one entity per concept set is supported.");
     }
 
-    const entity = plugin.occurrenceEntities()[0];
-    addFilter(entity, plugin.generateFilter(entity, true));
+    const entity = plugin.occurrenceEntities(underlay)[0];
+    addFilter(entity, plugin.generateFilter(underlay, entity, true));
   });
 
   return Array.from(entities)
@@ -402,7 +402,7 @@ function Preview(props: PreviewProps) {
             arrayFilter: {
               operands: cohorts
                 .map((cohort) =>
-                  generateQueryFilter(cohort, underlay.primaryEntity)
+                  generateQueryFilter(underlay, cohort, underlay.primaryEntity)
                 )
                 .filter((filter): filter is tanagra.Filter => !!filter),
               operator: tanagra.ArrayFilterOperator.Or,

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -101,7 +101,7 @@ function AddCriteriaButton(props: {
   const history = useHistory();
   const dispatch = useAppDispatch();
 
-  const configs = underlay.criteriaConfigs;
+  const configs = underlay.uiConfiguration.criteriaConfigs;
 
   const onAddCriteria = (criteria: tanagra.Criteria) => {
     let groupId = "";
@@ -339,7 +339,7 @@ function DemographicCharts({ cohort }: DemographicChartsProps) {
           "race_concept_id",
           "year_of_birth",
         ],
-        filter: generateQueryFilter(cohort, "p"),
+        filter: generateQueryFilter(underlay, cohort, "p"),
       },
     };
 
@@ -434,7 +434,7 @@ function DemographicCharts({ cohort }: DemographicChartsProps) {
         }
       ),
     };
-  }, [cohort]);
+  }, [underlay, cohort]);
 
   const demographicState = useAsyncWithApi(fetchDemographicData);
 

--- a/ui/src/storage/storage.tsx
+++ b/ui/src/storage/storage.tsx
@@ -6,7 +6,7 @@ import { AnyAction, Dispatch, Middleware, MiddlewareAPI } from "redux";
 import { loadUserData, RootState } from "rootReducer";
 import * as tanagra from "tanagra-api";
 
-const currentVersion = 1;
+const currentVersion = 2;
 
 export interface StoragePlugin {
   store(data: tanagra.UserData): Promise<void>;
@@ -49,6 +49,13 @@ export function LoadingUserData(props: { children?: React.ReactNode }) {
           throw new Error(
             `Unable to load newer data: verson ${data.version} > current version ${currentVersion}`
           );
+        }
+
+        // TODO(tjennison): Handle backwards compatability when we're closer to
+        // launch.
+        if (data.version != currentVersion) {
+          data.cohorts = [];
+          data.conceptSets = [];
         }
 
         data.cohorts = data.cohorts || [];

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Configuration } from "data/configuration";
 import * as tanagra from "tanagra-api";
 
 export type PrepackagedConceptSet = {
@@ -12,8 +13,13 @@ export type Underlay = {
   name: string;
   primaryEntity: string;
   entities: tanagra.Entity[];
-  criteriaConfigs: CriteriaConfig[];
+  uiConfiguration: UIConfiguration;
   prepackagedConceptSets: PrepackagedConceptSet[];
+};
+
+export type UIConfiguration = {
+  dataConfig: Configuration;
+  criteriaConfigs: CriteriaConfig[];
 };
 
 // CriteriaConfigs are used to initialize CriteriaPlugins and provide a list of


### PR DESCRIPTION
This layer will allow the UI to remain generic by pushing any underlay
specific logic into one place, and ideally into configuration. This will
make it easier to evolve the underlay and API as part of the underlay
overhaul. It also makes it much easier to understand what logic
is actually being applied when it's not scattered throughout the UI and
will make it possible to test the logic and UI separately which will
make both sets of tests easier to write.

This change involves three major pieces:
* Moving logic about the structure of the data (occurrences,
  hierarchies, etc.) to configuration in the underlay and adding an
  interface to make requests based on it.
* Restructuring the UI configuration in the underlay to contain
  multiple elements, including the new configuration.
* Changing the concept criteria to use the new interface and validate
  the configurantion and interface are sufficient.

What's not yet complete:
* Datasets page, aattribute criteria, and a few other minor items have
  not been migrated.
* There are some TODOs for places that where the new layer was
  insufficient and some improvements to the current API or data model
  will be needed.
* There are some TODOs left to clean up some adjacent code.