### PR TITLE
Expand business logic layer to attribute criteria

### DIFF
--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -20,6 +20,7 @@ describe("Basic tests", () => {
 
     cy.get("button:Contains(Add Criteria)").first().click();
     cy.get("li:Contains(Year at Birth)").click();
+    cy.get("button:Contains(Add Range)").click();
     cy.get("input").first().clear().type("30");
     cy.get("a[aria-label=back]").click();
 
@@ -30,6 +31,7 @@ describe("Basic tests", () => {
 
     cy.get("button:Contains(Add Criteria)").last().click();
     cy.get("li:Contains(Year at Birth)").click();
+    cy.get("button:Contains(Add Range)").click();
     cy.get("input").first().clear().type("50");
     cy.get("a[aria-label=back]").click();
     cy.get("a[aria-label=back]").click();

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -13,15 +13,23 @@ import Input from "@mui/material/Input";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { CriteriaPlugin, generateId, registerCriteriaPlugin } from "cohort";
-import { useUnderlay } from "hooks";
+import Loading from "components/loading";
+import { DataValue } from "data/configuration";
+import {
+  attributeValueFromDataValue,
+  EnumHintOption,
+  IntegerHint,
+  Source,
+  useSource,
+} from "data/source";
+import { useAsyncWithApi } from "errors";
 import produce from "immer";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import * as tanagra from "tanagra-api";
-import { CriteriaConfig, Underlay } from "underlaysSlice";
-import { isValid } from "util/valid";
+import { CriteriaConfig } from "underlaysSlice";
 
 type Selection = {
-  id: number | string | boolean;
+  value: DataValue;
   name: string;
 };
 
@@ -51,26 +59,12 @@ type AttributeEditProps = {
 
 @registerCriteriaPlugin(
   "attribute",
-  (underlay: Underlay, config: CriteriaConfig) => {
-    const data = { ...(config.plugin as Config), name: config.title };
-
-    const integerBoundsHint = underlay.entities
-      .find((g) => g.name === underlay.primaryEntity)
-      ?.attributes?.find((attribute) => attribute.name === data.attribute)
-      ?.attributeFilterHint?.integerBoundsHint;
-
+  (source: Source, config: CriteriaConfig) => {
     return {
-      ...data,
-      selected: !integerBoundsHint ? [] : undefined,
-      dataRanges: integerBoundsHint
-        ? [
-            {
-              id: generateId(),
-              min: integerBoundsHint.min || 0,
-              max: integerBoundsHint.max || 10000,
-            },
-          ]
-        : undefined,
+      ...(config.plugin as Config),
+      name: config.title,
+      selected: [],
+      dataRanges: [],
     };
   }
 )
@@ -90,8 +84,8 @@ class _ implements CriteriaPlugin<Data> {
     return <AttributeDetails data={this.data} />;
   }
 
-  generateFilter(underlay: Underlay, entityVar: string) {
-    if (this.data.dataRanges?.length) {
+  generateFilter(source: Source, entityVar: string) {
+    if (this.data.dataRanges.length > 0) {
       return {
         arrayFilter: {
           operands: this.data.dataRanges.map((range) => ({
@@ -128,29 +122,33 @@ class _ implements CriteriaPlugin<Data> {
           operator: tanagra.ArrayFilterOperator.Or,
         },
       };
-    } else if (this.data.selected.length >= 0) {
+    } else if (this.data.selected.length > 0) {
       return {
         arrayFilter: {
-          operands: this.data.selected.map(({ id }) => ({
+          operands: this.data.selected.map(({ value }) => ({
             binaryFilter: {
               attributeVariable: {
                 variable: entityVar,
                 name: this.data.attribute,
               },
               operator: tanagra.BinaryFilterOperator.Equals,
-              attributeValue: {
-                int64Val: typeof id === "number" ? id : undefined,
-                stringVal: typeof id === "string" ? id : undefined,
-                boolVal: typeof id === "boolean" ? id : undefined,
-              },
+              attributeValue: attributeValueFromDataValue(value),
             },
           })),
           operator: tanagra.ArrayFilterOperator.Or,
         },
       };
-    } else {
-      return null;
     }
+
+    return {
+      binaryFilter: {
+        attributeVariable: {
+          variable: entityVar,
+          name: this.data.attribute,
+        },
+        operator: tanagra.BinaryFilterOperator.NotEquals,
+      },
+    };
   }
 
   occurrenceEntities() {
@@ -283,122 +281,99 @@ function AttributeSlider(props: SliderProps) {
 }
 
 function AttributeEdit(props: AttributeEditProps) {
-  const underlay = useUnderlay();
-  const hintDisplayName = (hint: tanagra.EnumHintValue) =>
-    hint.displayName || "Unknown Value";
+  const source = useSource();
 
-  const attributeFilterHint = underlay.entities
-    .find((g) => g.name === underlay.primaryEntity)
-    ?.attributes?.find(
-      (attribute) => attribute.name === props.data.attribute
-    )?.attributeFilterHint;
-  const enumHintValues = attributeFilterHint?.enumHint?.enumHintValues;
-  const integerBoundsHint = attributeFilterHint?.integerBoundsHint;
+  const fetchHintData = useCallback(() => {
+    return source.getHintData("", props.data.attribute);
+  }, [props.data.attribute]);
+  const hintDataState = useAsyncWithApi(fetchHintData);
 
-  if (isValid(integerBoundsHint?.min) && isValid(integerBoundsHint?.max)) {
-    // TODO: The comments can be removed once isValid is fixed.
-
-    // This is to ensure the compiler won't complain the object be undefined.
-    // Although we already know that min and max is valid.
-    const minBound = integerBoundsHint?.min || 0;
-    const maxBound = integerBoundsHint?.max || 0;
-
-    const handleAddRange = () => {
+  const handleAddRange = useCallback(
+    (hint: IntegerHint) => {
       props.dispatchFn(
         produce(props.data, (data) => {
           data.dataRanges.push({
             id: generateId(),
-            min: minBound,
-            max: maxBound,
+            ...hint,
           });
         })
       );
-    };
+    },
+    [props.data]
+  );
 
-    return (
-      <Box>
-        <Grid container spacing={2} direction="column">
-          {props.data.dataRanges.map((range, index) => {
-            return (
-              <AttributeSlider
-                key={range.id}
-                index={index}
-                minBound={minBound}
-                maxBound={maxBound}
-                range={range}
-                data={props.data}
-                dispatchFn={props.dispatchFn}
-              />
-            );
-          })}
-        </Grid>
-        <Button
-          variant="contained"
-          size="large"
-          sx={{ mt: 5 }}
-          onClick={handleAddRange}
-        >
-          Add Range
-        </Button>
-      </Box>
-    );
-  }
-
-  if (enumHintValues?.length && enumHintValues?.length > 0) {
-    const selectionIndex = (hint: tanagra.EnumHintValue) =>
-      props.data.selected.findIndex(
-        (row) =>
-          row.id === hint.attributeValue?.int64Val ||
-          row.id === hint.attributeValue?.stringVal ||
-          row.id === hint.attributeValue?.boolVal
-      );
-
-    const hintId = (hint: tanagra.EnumHintValue) => {
-      return (
-        hint.attributeValue?.int64Val ||
-        hint.attributeValue?.stringVal ||
-        hint.attributeValue?.boolVal ||
-        -1
-      );
-    };
-
-    return (
-      <>
-        {enumHintValues?.map((hint: tanagra.EnumHintValue) => (
-          <ListItem key={hintDisplayName(hint)}>
-            <FormControlLabel
-              label={hintDisplayName(hint)}
-              control={
-                <Checkbox
-                  size="small"
-                  checked={selectionIndex(hint) > -1}
-                  onChange={() => {
-                    props.dispatchFn(
-                      produce(props.data, (data) => {
-                        if (selectionIndex(hint) > -1) {
-                          data.selected.splice(selectionIndex(hint), 1);
-                        } else {
-                          data.selected.push({
-                            id: hintId(hint),
-                            name: hintDisplayName(hint),
-                          });
-                        }
-                      })
-                    );
-                  }}
-                />
-              }
-            />
-          </ListItem>
-        ))}
-      </>
-    );
-  }
+  const selectionIndex = useCallback(
+    (hint: EnumHintOption) =>
+      props.data.selected.findIndex((sel) => sel.value === hint.value) ?? -1,
+    [props.data.selected]
+  );
 
   return (
-    <Typography>
-      No information for attribute {props.data.attribute}.
-    </Typography>
+    <Loading status={hintDataState}>
+      {hintDataState.data?.integerHint && (
+        <Box>
+          <Grid container spacing={2} direction="column">
+            {props.data?.dataRanges?.map(
+              (range, index) =>
+                hintDataState.data?.integerHint && (
+                  <AttributeSlider
+                    key={range.id}
+                    index={index}
+                    minBound={hintDataState.data.integerHint.min}
+                    maxBound={hintDataState.data.integerHint.max}
+                    range={range}
+                    data={props.data}
+                    dispatchFn={props.dispatchFn}
+                  />
+                )
+            )}
+          </Grid>
+          <Button
+            variant="contained"
+            size="large"
+            sx={{ mt: 5 }}
+            onClick={() =>
+              hintDataState.data?.integerHint &&
+              handleAddRange(hintDataState.data.integerHint)
+            }
+          >
+            Add Range
+          </Button>
+        </Box>
+      )}
+      {hintDataState.data?.enumHintOptions?.map((hint: EnumHintOption) => (
+        <ListItem key={hint.name}>
+          <FormControlLabel
+            label={hint.name}
+            control={
+              <Checkbox
+                size="small"
+                checked={selectionIndex(hint) > -1}
+                onChange={() => {
+                  props.dispatchFn(
+                    produce(props.data, (data) => {
+                      if (selectionIndex(hint) > -1) {
+                        data.selected.splice(selectionIndex(hint), 1);
+                      } else {
+                        data.selected.push({
+                          value: hint.value,
+                          name: hint.name,
+                        });
+                      }
+                    })
+                  );
+                }}
+              />
+            }
+          />
+        </ListItem>
+      ))}
+      {!hintDataState.data && (
+        <Typography>
+          No information for attribute {props.data.attribute}.
+        </Typography>
+      )}
+    </Loading>
   );
 }
 
@@ -407,18 +382,20 @@ type AttributeDetailsProps = {
 };
 
 function AttributeDetails(props: AttributeDetailsProps) {
-  if (props.data.selected?.length) {
+  if (props.data.selected.length > 0) {
     return (
       <>
-        {props.data.selected.map(({ id, name }) => (
+        {props.data.selected.map(({ value, name }) => (
           <Stack direction="row" alignItems="baseline" key={Date.now()}>
-            <Typography variant="body1">{id}</Typography>&nbsp;
+            <Typography variant="body1">{value}</Typography>&nbsp;
             <Typography variant="body2">{name}</Typography>
           </Stack>
         ))}
       </>
     );
-  } else if (props.data.dataRanges?.length) {
+  }
+
+  if (props.data.dataRanges.length > 0) {
     return (
       <>
         {props.data.dataRanges.map(({ id, min, max }) => (

--- a/ui/src/data/configuration.ts
+++ b/ui/src/data/configuration.ts
@@ -43,11 +43,6 @@ export type Grouping = {
   defaultSort?: SortOrder;
 };
 
-export type Attribute = {
-  id: string;
-  attribute: string;
-};
-
 export type PrimaryEntity = {
   entity: string;
   key: string;

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -19,6 +19,7 @@ import { useMenu } from "components/menu";
 import { useTextInputDialog } from "components/textInputDialog";
 import { TreeGrid, TreeGridData, TreeGridRowData } from "components/treegrid";
 import { insertConceptSet } from "conceptSetsSlice";
+import { useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
 import { useAppDispatch, useAppSelector, useUnderlay } from "hooks";
 import React, {
@@ -43,6 +44,7 @@ export function Datasets() {
   const history = useHistory();
 
   const underlay = useUnderlay();
+  const source = useSource();
 
   const [selectedCohorts, updateSelectedCohorts] = useImmer(new Set<string>());
   const [selectedConceptSets, updateSelectedConceptSets] = useImmer(
@@ -133,7 +135,7 @@ export function Datasets() {
       <MenuItem
         key={config.title}
         onClick={() => {
-          onInsertConceptSet(createCriteria(underlay, config));
+          onInsertConceptSet(createCriteria(source, config));
         }}
       >
         {config.title}
@@ -331,6 +333,7 @@ function useConceptSetEntities(
   selectedConceptSets: Set<string>
 ): ConceptSetEntity[] {
   const underlay = useUnderlay();
+  const source = useSource();
 
   const entities = new Map<string, tanagra.Filter[]>();
   const addFilter = (entity: string, filter?: tanagra.Filter | null) => {
@@ -353,12 +356,12 @@ function useConceptSetEntities(
   );
   workspaceConceptSets.forEach((conceptSet) => {
     const plugin = getCriteriaPlugin(conceptSet.criteria);
-    if (plugin.occurrenceEntities(underlay).length != 1) {
+    if (plugin.occurrenceEntities(source).length != 1) {
       throw new Error("Only one entity per concept set is supported.");
     }
 
-    const entity = plugin.occurrenceEntities(underlay)[0];
-    addFilter(entity, plugin.generateFilter(underlay, entity, true));
+    const entity = plugin.occurrenceEntities(source)[0];
+    addFilter(entity, plugin.generateFilter(source, entity, true));
   });
 
   return Array.from(entities)
@@ -384,6 +387,7 @@ type PreviewProps = {
 
 function Preview(props: PreviewProps) {
   const underlay = useUnderlay();
+  const source = useSource();
   const cohorts = useAppSelector((state) =>
     state.present.cohorts.filter((cohort) =>
       props.selectedCohorts.has(cohort.id)
@@ -402,7 +406,7 @@ function Preview(props: PreviewProps) {
             arrayFilter: {
               operands: cohorts
                 .map((cohort) =>
-                  generateQueryFilter(underlay, cohort, underlay.primaryEntity)
+                  generateQueryFilter(source, cohort, underlay.primaryEntity)
                 )
                 .filter((filter): filter is tanagra.Filter => !!filter),
               operator: tanagra.ArrayFilterOperator.Or,

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -27,6 +27,7 @@ import {
 import Loading from "components/loading";
 import { useMenu } from "components/menu";
 import { useTextInputDialog } from "components/textInputDialog";
+import { useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
 import { useAppDispatch, useCohort, useUnderlay } from "hooks";
 import { useCallback, useContext } from "react";
@@ -97,6 +98,7 @@ function AddCriteriaButton(props: {
   kind?: tanagra.GroupKindEnum;
 }) {
   const underlay = useUnderlay();
+  const source = useSource();
   const cohort = useCohort();
   const history = useHistory();
   const dispatch = useAppDispatch();
@@ -129,7 +131,7 @@ function AddCriteriaButton(props: {
       <MenuItem
         key={config.title}
         onClick={() => {
-          onAddCriteria(createCriteria(underlay, config));
+          onAddCriteria(createCriteria(source, config));
         }}
       >
         {config.title}
@@ -315,6 +317,7 @@ type DemographicChartsProps = {
 
 function DemographicCharts({ cohort }: DemographicChartsProps) {
   const underlay = useUnderlay();
+  const source = useSource();
 
   const api = useContext(EntityCountsApiContext);
 
@@ -339,7 +342,7 @@ function DemographicCharts({ cohort }: DemographicChartsProps) {
           "race_concept_id",
           "year_of_birth",
         ],
-        filter: generateQueryFilter(underlay, cohort, "p"),
+        filter: generateQueryFilter(source, cohort, "p"),
       },
     };
 

--- a/ui/src/storage/storage.tsx
+++ b/ui/src/storage/storage.tsx
@@ -6,7 +6,7 @@ import { AnyAction, Dispatch, Middleware, MiddlewareAPI } from "redux";
 import { loadUserData, RootState } from "rootReducer";
 import * as tanagra from "tanagra-api";
 
-const currentVersion = 2;
+const currentVersion = 3;
 
 export interface StoragePlugin {
   store(data: tanagra.UserData): Promise<void>;

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -2,10 +2,14 @@ import { configureStore } from "@reduxjs/toolkit";
 import { rootReducer } from "rootReducer";
 import { storeUserData } from "storage/storage";
 
-export const store = configureStore({
-  reducer: rootReducer,
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(storeUserData),
-});
+export function createStore() {
+  return configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(storeUserData),
+  });
+}
+
+export const store = createStore();
 
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
* Adds a function to fetch hints to the data source.
* Converts hint fetching to an asynchronous operation to support hints
  not always being in the underlay.
* Fixes concept.test.tsx to use the data source and removes the global
  store setup.
* Passes the data source to criteria creation instead of the underlay
  now that both criteria have been converted.