### PR TITLE
Add underlay for aou_synthetic dataset in verily-tanagra-test project

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -17,4 +17,4 @@ spring:
 tanagra:
   underlay:
     # TODO(tjennison): Split these for different environments.
-    underlay-yaml-files: ["underlays/aou_synthetic.yaml", "underlays/synpuf.yaml", "underlays/sd.yaml"]
+    underlay-yaml-files: ["underlays/aou_synthetic.yaml", "underlays/synpuf.yaml", "underlays/sd.yaml", "underlays/test/aou_synthetic.yaml"]

--- a/api/src/main/resources/underlays/test/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/test/aou_synthetic.yaml
@@ -1,0 +1,3018 @@
+# An initial OMOP underlay schema for development.
+
+name: aou_synthetic_TEST_ENV
+entities:
+  - name: person
+    attributes:
+      - name: person_id
+        dataType: INT64
+      - name: year_of_birth
+        dataType: INT64
+      - name: gender_concept_id
+        dataType: INT64
+      - name: gender
+        dataType: STRING
+      - name: race_concept_id
+        dataType: INT64
+      - name: race
+        dataType: STRING
+      - name: ethnicity_concept_id
+        dataType: INT64
+      - name: ethnicity
+        dataType: STRING
+      - name: sex_at_birth_concept_id
+        dataType: INT64
+      - name: sex_at_birth
+        dataType: STRING
+  - name: condition
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: procedure
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: ingredient
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: brand
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+  - name: measurement
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: visit
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: observation
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: device
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+      - name: person_count
+        dataType: INT64
+  - name: condition_occurrence
+    attributes:
+      - name: condition_occurrence_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: condition_concept_id
+        dataType: INT64
+      - name: condition_start_date
+        dataType: STRING
+      - name: condition_end_date
+        dataType: STRING
+      - name: stop_reason
+        dataType: STRING
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: condition_source_value
+        dataType: STRING
+      - name: condition_source_concept_id
+        dataType: INT64
+  - name: procedure_occurrence
+    attributes:
+      - name: procedure_occurrence_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: procedure_concept_id
+        dataType: INT64
+      - name: procedure_date
+        dataType: STRING
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: procedure_source_value
+        dataType: STRING
+      - name: procedure_source_concept_id
+        dataType: INT64
+  - name: ingredient_occurrence
+    attributes:
+      - name: drug_exposure_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: drug_concept_id
+        dataType: INT64
+      - name: drug_exposure_start_date
+        dataType: STRING
+      - name: drug_exposure_end_date
+        dataType: STRING
+      - name: stop_reason
+        dataType: STRING
+      - name: refills
+        dataType: INT64
+      - name: days_supply
+        dataType: INT64
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: drug_source_value
+        dataType: STRING
+      - name: drug_source_concept_id
+        dataType: INT64
+  - name: measurement_occurrence
+    attributes:
+      - name: measurement_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: measurement_concept_id
+        dataType: INT64
+      - name: measurement_date
+        dataType: STRING
+      - name: value_as_concept_id
+        dataType: INT64
+      - name: unit_concept_id
+        dataType: INT64
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: measurement_source_value
+        dataType: STRING
+      - name: measurement_source_concept_id
+        dataType: INT64
+  - name: visit_occurrence
+    attributes:
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: visit_concept_id
+        dataType: INT64
+      - name: visit_start_date
+        dataType: STRING
+      - name: visit_end_date
+        dataType: STRING
+      - name: visit_source_value
+        dataType: STRING
+      - name: visit_source_concept_id
+        dataType: INT64
+  - name: observation_occurrence
+    attributes:
+      - name: observation_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: observation_concept_id
+        dataType: INT64
+      - name: observation_date
+        dataType: STRING
+      - name: value_as_string
+        dataType: STRING
+      - name: value_as_concept_id
+        dataType: INT64
+      - name: unit_concept_id
+        dataType: INT64
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: observation_source_value
+        dataType: STRING
+      - name: observation_source_concept_id
+        dataType: INT64
+  - name: device_occurrence
+    attributes:
+      - name: device_exposure_id
+        dataType: INT64
+      - name: person_id
+        dataType: INT64
+      - name: device_concept_id
+        dataType: INT64
+      - name: device_exposure_start_date
+        dataType: STRING
+      - name: device_exposure_end_date
+        dataType: STRING
+      - name: visit_occurrence_id
+        dataType: INT64
+      - name: device_source_value
+        dataType: STRING
+      - name: device_source_concept_id
+        dataType: INT64
+  - name: concept
+    attributes:
+      - name: concept_id
+        dataType: INT64
+      - name: concept_name
+        dataType: STRING
+      - name: domain_id
+        dataType: STRING
+      - name: vocabulary_id
+        dataType: STRING
+      - name: vocabulary_name
+        dataType: STRING
+      - name: standard_concept
+        dataType: STRING
+      - name: concept_code
+        dataType: STRING
+uiConfiguration: >-
+  {
+    "dataConfig": {
+      "primaryEntity": {
+        "displayName": "Person",
+        "entity": "person",
+        "key": "person_id"
+      },
+      "occurrences": [
+        {
+          "id": "condition_occurrence",
+          "displayName": "Condition Occurrences",
+          "entity": "condition_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "condition",
+              "attribute": "condition_concept_id",
+              "entity": "condition",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "condition"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "procedure_occurrence",
+          "displayName": "Procedure Occurrences",
+          "entity": "procedure_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "procedure",
+              "attribute": "procedure_concept_id",
+              "entity": "procedure",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "procedure"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "observation_occurrence",
+          "displayName": "Observation Occurrence",
+          "entity": "observation_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "observation",
+              "attribute": "observation_concept_id",
+              "entity": "observation",
+              "entityAttribute": "concept_id",
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "observation"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "ingredient_occurrence",
+          "displayName": "Drug Occurrence",
+          "entity": "ingredient_occurrence",
+          "key": "concept_id",
+          "classifications": [
+            {
+              "id": "ingredient",
+              "attribute": "ingredient_concept_id",
+              "entity": "ingredient",
+              "entityAttribute": "concept_id",
+              "hierarchical": true,
+              "defaultSort": {
+                "attribute": "person_count",
+                "direction": "DESC"
+              },
+              "filter": {
+                "binaryFilter": {
+                  "attributeVariable": {
+                    "name": "standard_concept",
+                    "variable": "ingredient"
+                  },
+                  "operator": "NOT_EQUALS"
+                }
+              },
+              "groupings": [
+                {
+                  "id": "brand",
+                  "entity": "brand",
+                  "defaultSort": {
+                    "attribute": "concept_name",
+                    "direction": "ASC"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "criteriaConfigs": [{
+      "type":"concept",
+      "title":"Conditions",
+      "defaultName":"Contains Conditions Codes",
+      "plugin": {
+        "columns":
+          [{"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Condition"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "condition_occurrence",
+        "classification": "condition"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Procedures",
+      "defaultName":"Contains Procedures Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},{"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Procedure"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "procedure_occurrence",
+        "classification": "procedure"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Observations",
+      "defaultName":"Contains Observations Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "occurrence": "observation_occurrence",
+        "classification": "observation"
+      }
+    },
+    {
+      "type":"concept",
+      "title":"Drugs",
+      "defaultName":"Contains Drugs Codes",
+      "plugin":{
+        "columns":[
+          {"key":"concept_name","width":"100%","title":"Concept Name"},
+          {"key":"concept_id","width":120,"title":"Concept ID"},
+          {"key":"standard_concept","width":180,"title":"SourceStandard"},
+          {"key":"vocabulary_id","width":120,"title":"Vocab"},
+          {"key":"concept_code","width":120,"title":"Code"}
+        ],
+        "hierarchyColumns": [
+          {"key": "concept_name", "width": "100%", "title": "Drug"},
+          {"key": "concept_id", "width": 120, "title": "Concept ID"}
+        ],
+        "occurrence": "ingredient_occurrence",
+        "classification": "ingredient"
+      }
+    },
+    {
+      "type":"attribute",
+      "title":"Ethnicity",
+      "defaultName":"Contains Ethnicity Codes",
+      "plugin":{"attribute":"ethnicity_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Gender Identity",
+      "defaultName":"Contains Gender Identity Codes",
+      "plugin":{"attribute":"gender_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Race",
+      "defaultName":"Contains Race Codes",
+      "plugin":{"attribute":"race_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Sex Assigned at Birth",
+      "defaultName":"Contains Sex Assigned at Birth Codes",
+      "plugin":{"attribute":"sex_at_birth_concept_id"}
+    },
+    {
+      "type":"attribute",
+      "title":"Year at Birth",
+      "defaultName":"Contains Year at Birth Values",
+      "plugin":{"attribute":"year_of_birth"}
+    }]
+  }
+relationships:
+  - name: brand_ingredient
+    entity1: brand
+    entity2: ingredient
+  - name: condition_occurrence_condition
+    entity1: condition_occurrence
+    entity2: condition
+  - name: condition_occurrence_person
+    entity1: condition_occurrence
+    entity2: person
+  - name: procedure_occurrence_procedure
+    entity1: procedure_occurrence
+    entity2: procedure
+  - name: procedure_occurrence_person
+    entity1: procedure_occurrence
+    entity2: person
+  - name: ingredient_occurrence_ingredient
+    entity1: ingredient_occurrence
+    entity2: ingredient
+  - name: ingredient_occurrence_person
+    entity1: ingredient_occurrence
+    entity2: person
+  - name: measurement_occurrence_measurement
+    entity1: measurement_occurrence
+    entity2: measurement
+  - name: measurement_occurrence_person
+    entity1: measurement_occurrence
+    entity2: person
+  - name: visit_occurrence_visit
+    entity1: visit_occurrence
+    entity2: visit
+  - name: visit_occurrence_person
+    entity1: visit_occurrence
+    entity2: person
+  - name: observation_occurrence_observation
+    entity1: observation_occurrence
+    entity2: observation
+  - name: observation_occurrence_person
+    entity1: observation_occurrence
+    entity2: person
+  - name: device_occurrence_device
+    entity1: device_occurrence
+    entity2: device
+  - name: device_occurrence_person
+    entity1: device_occurrence
+    entity2: person
+  - name: concept_id_person_gender
+    entity1: concept
+    entity2: person
+  - name: concept_id_person_race
+    entity1: concept
+    entity2: person
+  - name: concept_id_person_ethnicity
+    entity1: concept
+    entity2: person
+  - name: concept_id_person_sex_at_birth
+    entity1: concept
+    entity2: person
+  - name: concept_id_condition
+    entity1: concept
+    entity2: condition_occurrence
+datasets:
+  - name: aou_synthetic
+    bigQueryDataset:
+      projectId: verily-tanagra-test
+      datasetId: aou_synthetic_SR2019q4r4
+    tables:
+      - name: person
+        columns:
+          - name: person_id
+            dataType: INT64
+          - name: year_of_birth
+            dataType: INT64
+          - name: gender_concept_id
+            dataType: INT64
+          - name: race_concept_id
+            dataType: INT64
+          - name: ethnicity_concept_id
+            dataType: INT64
+          - name: sex_at_birth_concept_id
+            dataType: INT64
+      - name: condition_occurrence
+        columns:
+          - name: condition_occurrence_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: condition_concept_id
+            dataType: INT64
+          - name: condition_start_date
+            dataType: STRING
+          - name: condition_end_date
+            dataType: STRING
+          - name: stop_reason
+            dataType: STRING
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: condition_source_value
+            dataType: STRING
+          - name: condition_source_concept_id
+            dataType: INT64
+      - name: procedure_occurrence
+        columns:
+          - name: procedure_occurrence_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: procedure_concept_id
+            dataType: INT64
+          - name: procedure_date
+            dataType: STRING
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: procedure_source_value
+            dataType: STRING
+          - name: procedure_source_concept_id
+            dataType: INT64
+      - name: drug_exposure
+        columns:
+          - name: drug_exposure_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: drug_concept_id
+            dataType: INT64
+          - name: drug_exposure_start_date
+            dataType: STRING
+          - name: drug_exposure_end_date
+            dataType: STRING
+          - name: stop_reason
+            dataType: STRING
+          - name: refills
+            dataType: INT64
+          - name: days_supply
+            dataType: INT64
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: drug_source_value
+            dataType: STRING
+          - name: drug_source_concept_id
+            dataType: INT64
+      - name: measurement
+        columns:
+          - name: measurement_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: measurement_concept_id
+            dataType: INT64
+          - name: measurement_date
+            dataType: STRING
+          - name: value_as_concept_id
+            dataType: INT64
+          - name: unit_concept_id
+            dataType: INT64
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: measurement_source_value
+            dataType: STRING
+          - name: measurement_source_concept_id
+            dataType: INT64
+      - name: visit_occurrence
+        columns:
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: visit_concept_id
+            dataType: INT64
+          - name: visit_start_date
+            dataType: STRING
+          - name: visit_end_date
+            dataType: STRING
+          - name: visit_source_value
+            dataType: STRING
+          - name: visit_source_concept_id
+            dataType: INT64
+      - name: observation
+        columns:
+          - name: observation_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: observation_concept_id
+            dataType: INT64
+          - name: observation_date
+            dataType: STRING
+          - name: value_as_string
+            dataType: STRING
+          - name: value_as_concept_id
+            dataType: INT64
+          - name: unit_concept_id
+            dataType: INT64
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: observation_source_value
+            dataType: STRING
+          - name: observation_source_concept_id
+            dataType: INT64
+      - name: device_exposure
+        columns:
+          - name: device_exposure_id
+            dataType: INT64
+          - name: person_id
+            dataType: INT64
+          - name: device_concept_id
+            dataType: INT64
+          - name: device_exposure_start_date
+            dataType: STRING
+          - name: device_exposure_end_date
+            dataType: STRING
+          - name: visit_occurrence_id
+            dataType: INT64
+          - name: device_source_value
+            dataType: STRING
+          - name: device_source_concept_id
+            dataType: INT64
+      - name: concept
+        columns:
+          - name: concept_id
+            dataType: INT64
+          - name: concept_name
+            dataType: STRING
+          - name: domain_id
+            dataType: STRING
+          - name: standard_concept
+            dataType: STRING
+          - name: vocabulary_id
+            dataType: STRING
+          - name: concept_code
+            dataType: STRING
+          - name: concept_class_id
+            dataType: STRING
+          - name: valid_end_date
+            dataType: STRING
+          - name: invalid_reason
+            dataType: STRING
+      - name: vocabulary
+        columns:
+          - name: vocabulary_id
+            dataType: STRING
+          - name: vocabulary_name
+            dataType: STRING
+      - name: concept_relationship
+        columns:
+          - name: concept_id_1
+            dataType: INT64
+          - name: concept_id_2
+            dataType: INT64
+          - name: relationship_id
+            dataType: STRING
+      - name: concept_synonym
+        columns:
+          - name: concept_id
+            dataType: INT64
+          - name: concept_synonym_name
+            dataType: STRING
+  - name: omop_indexes
+    bigQueryDataset:
+      projectId: verily-tanagra-test
+      datasetId: aou_synthetic_SR2019q4r4_indexes
+    tables:
+      - name: flatten_snomed_conditions_0
+        columns:
+          - name: ancestor
+            dataType: INT64
+          - name: descendant
+            dataType: INT64
+      - name: concept_ancestor_descendant_2
+        columns:
+          - name: ancestor
+            dataType: INT64
+          - name: descendant
+            dataType: INT64
+      - name: concept_node_path_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: path
+            dataType: STRING
+      - name: condition_ancestor_descendant_2
+        columns:
+          - name: ancestor
+            dataType: INT64
+          - name: descendant
+            dataType: INT64
+      - name: procedure_ancestor_descendant_2
+        columns:
+          - name: ancestor
+            dataType: INT64
+          - name: descendant
+            dataType: INT64
+      - name: measurement_ancestor_descendant_2
+        columns:
+          - name: ancestor
+            dataType: INT64
+          - name: descendant
+            dataType: INT64
+      - name: ingredient_ancestor_descendant_2
+        columns:
+          - name: ancestor
+            dataType: INT64
+          - name: descendant
+            dataType: INT64
+      - name: condition_node_path_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: path
+            dataType: STRING
+          - name: numChildren
+            dataType: INT64
+      - name: procedure_node_path_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: path
+            dataType: STRING
+          - name: numChildren
+            dataType: INT64
+      - name: measurement_node_path_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: path
+            dataType: STRING
+          - name: numChildren
+            dataType: INT64
+      - name: ingredient_node_path_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: path
+            dataType: STRING
+          - name: numChildren
+            dataType: INT64
+      - name: condition_parent_child_2
+        columns:
+          - name: parent
+            dataType: INT64
+          - name: child
+            dataType: INT64
+      - name: procedure_parent_child_2
+        columns:
+          - name: parent
+            dataType: INT64
+          - name: child
+            dataType: INT64
+      - name: measurement_parent_child_2
+        columns:
+          - name: parent
+            dataType: INT64
+          - name: child
+            dataType: INT64
+      - name: ingredient_parent_child_2
+        columns:
+          - name: parent
+            dataType: INT64
+          - name: child
+            dataType: INT64
+      - name: condition_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: procedure_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: measurement_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: ingredient_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: brand_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: device_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: observation_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: visit_text_search_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: text
+            dataType: STRING
+      - name: condition_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+      - name: procedure_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+      - name: measurement_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+      - name: ingredient_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+      - name: device_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+      - name: observation_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+      - name: visit_person_counts_2
+        columns:
+          - name: node
+            dataType: INT64
+          - name: count
+            dataType: INT64
+entityMappings:
+  - entity: person
+    primaryKey:
+      dataset: aou_synthetic
+      table: person
+      column: person_id
+  - entity: condition
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Condition
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: valid_end_date
+            operator: GREATER_THAN
+            stringVal: 2022-01-01
+  - entity: procedure
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Procedure
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: valid_end_date
+            operator: GREATER_THAN
+            stringVal: 2022-01-01
+  - entity: ingredient
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        arrayColumnFilters:
+          - operator: OR
+            arrayColumnFilters:
+              - operator: AND
+                arrayColumnFilters:
+                  - operator: OR
+                    binaryColumnFilters:
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: vocabulary_id
+                        operator: EQUALS
+                        stringVal: RxNorm
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: vocabulary_id
+                        operator: EQUALS
+                        stringVal: RxNorm Extension
+                binaryColumnFilters:
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: concept_class_id
+                    operator: EQUALS
+                    stringVal: Ingredient
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: standard_concept
+                    operator: EQUALS
+                    stringVal: S
+              - operator: AND
+                binaryColumnFilters:
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: vocabulary_id
+                    operator: EQUALS
+                    stringVal: RxNorm
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: concept_class_id
+                    operator: EQUALS
+                    stringVal: Precise Ingredient
+              - operator: AND
+                arrayColumnFilters:
+                  - operator: OR
+                    binaryColumnFilters:
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: ATC 1st
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: ATC 2nd
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: ATC 3rd
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: ATC 4th
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: ATC 5th
+                binaryColumnFilters:
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: vocabulary_id
+                    operator: EQUALS
+                    stringVal: ATC
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: standard_concept
+                    operator: EQUALS
+                    stringVal: C
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Drug
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: valid_end_date
+            operator: GREATER_THAN
+            stringVal: 2022-01-01
+  - entity: brand
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        arrayColumnFilters:
+          - operator: OR
+            binaryColumnFilters:
+              - column:
+                  dataset: aou_synthetic
+                  table: concept
+                  column: vocabulary_id
+                operator: EQUALS
+                stringVal: RxNorm
+              - column:
+                  dataset: aou_synthetic
+                  table: concept
+                  column: vocabulary_id
+                operator: EQUALS
+                stringVal: RxNorm Extension
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Drug
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: concept_class_id
+            operator: EQUALS
+            stringVal: Brand Name
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: invalid_reason
+            operator: EQUALS
+  - entity: measurement
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        arrayColumnFilters:
+          - operator: OR
+            arrayColumnFilters:
+              - operator: AND
+                binaryColumnFilters:
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: domain_id
+                    operator: EQUALS
+                    stringVal: Measurement
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: vocabulary_id
+                    operator: EQUALS
+                    stringVal: SNOMED
+              - operator: AND
+                arrayColumnFilters:
+                  - operator: OR
+                    binaryColumnFilters:
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: LOINC Hierarchy
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: LOINC Component
+                      - column:
+                          dataset: aou_synthetic
+                          table: concept
+                          column: concept_class_id
+                        operator: EQUALS
+                        stringVal: Lab Test
+                binaryColumnFilters:
+                  - column:
+                      dataset: aou_synthetic
+                      table: concept
+                      column: vocabulary_id
+                    operator: EQUALS
+                    stringVal: LOINC
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: valid_end_date
+            operator: GREATER_THAN
+            stringVal: 2022-01-01
+  - entity: visit
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Visit
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: standard_concept
+            operator: EQUALS
+            stringVal: S
+  - entity: observation
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Observation
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: standard_concept
+            operator: EQUALS
+            stringVal: S
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: vocabulary_id
+            operator: NOT_EQUALS
+            stringVal: PPI
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: concept_class_id
+            operator: NOT_EQUALS
+            stringVal: Survey
+  - entity: device
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+    tableFilter:
+      arrayColumnFilter:
+        operator: AND
+        binaryColumnFilters:
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: domain_id
+            operator: EQUALS
+            stringVal: Device
+          - column:
+              dataset: aou_synthetic
+              table: concept
+              column: standard_concept
+            operator: EQUALS
+            stringVal: S
+  - entity: condition_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: condition_occurrence
+      column: condition_occurrence_id
+  - entity: procedure_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: procedure_occurrence
+      column: procedure_occurrence_id
+  - entity: ingredient_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: drug_exposure
+      column: drug_exposure_id
+  - entity: measurement_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: measurement
+      column: measurement_id
+  - entity: visit_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: visit_occurrence
+      column: visit_occurrence_id
+  - entity: observation_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: observation
+      column: observation_id
+  - entity: device_occurrence
+    primaryKey:
+      dataset: aou_synthetic
+      table: device_exposure
+      column: device_exposure_id
+  - entity: concept
+    primaryKey:
+      dataset: aou_synthetic
+      table: concept
+      column: concept_id
+attributeMappings:
+  - attribute:
+      entity: person
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - attribute:
+      entity: person
+      attribute: year_of_birth
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: person
+        column: year_of_birth
+  - attribute:
+      entity: person
+      attribute: gender_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: person
+        column: gender_concept_id
+  - attribute:
+      entity: person
+      attribute: gender
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: person
+        column: gender_concept_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: person
+      attribute: race_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: person
+        column: race_concept_id
+  - attribute:
+      entity: person
+      attribute: race
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: person
+        column: race_concept_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: person
+      attribute: ethnicity_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: person
+        column: ethnicity_concept_id
+  - attribute:
+      entity: person
+      attribute: ethnicity
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: person
+        column: ethnicity_concept_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: person
+      attribute: sex_at_birth_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: person
+        column: sex_at_birth_concept_id
+  - attribute:
+      entity: person
+      attribute: sex_at_birth
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: person
+        column: sex_at_birth_concept_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: condition
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: condition
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: condition
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: condition
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: condition
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: condition
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: condition
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: condition_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: condition_person_counts_2
+        column: count
+  - attribute:
+      entity: procedure
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: procedure
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: procedure
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: procedure
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: procedure
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: procedure
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: procedure
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: procedure_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: procedure_person_counts_2
+        column: count
+  - attribute:
+      entity: ingredient
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: ingredient
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: ingredient
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: ingredient
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: ingredient
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: ingredient
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: ingredient
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: ingredient_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: ingredient_person_counts_2
+        column: count
+  - attribute:
+      entity: brand
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: brand
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: brand
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: brand
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: measurement
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: measurement
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: measurement
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: measurement
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: measurement
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: measurement
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: measurement
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: measurement_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: measurement_person_counts_2
+        column: count
+  - attribute:
+      entity: visit
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: visit
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: visit
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: visit_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: visit_person_counts_2
+        column: count
+  - attribute:
+      entity: observation
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: observation
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: observation
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: observation
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: observation
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: observation
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: observation
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: observation_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: observation_person_counts_2
+        column: count
+  - attribute:
+      entity: device
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: device
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: device
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: device
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: device
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: device
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+  - attribute:
+      entity: device
+      attribute: person_count
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      lookupTableKey:
+        dataset: omop_indexes
+        table: device_person_counts_2
+        column: node
+      lookupColumn:
+        dataset: omop_indexes
+        table: device_person_counts_2
+        column: count
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_occurrence_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: person_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_concept_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_start_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_start_date
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_end_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_end_date
+  - attribute:
+      entity: condition_occurrence
+      attribute: stop_reason
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: stop_reason
+  - attribute:
+      entity: condition_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: visit_occurrence_id
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_source_value
+  - attribute:
+      entity: condition_occurrence
+      attribute: condition_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_source_concept_id
+  - attribute:
+      entity: procedure_occurrence
+      attribute: procedure_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: procedure_occurrence_id
+  - attribute:
+      entity: procedure_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: person_id
+  - attribute:
+      entity: procedure_occurrence
+      attribute: procedure_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: procedure_concept_id
+  - attribute:
+      entity: procedure_occurrence
+      attribute: procedure_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: procedure_date
+  - attribute:
+      entity: procedure_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: visit_occurrence_id
+  - attribute:
+      entity: procedure_occurrence
+      attribute: procedure_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: procedure_source_value
+  - attribute:
+      entity: procedure_occurrence
+      attribute: procedure_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: procedure_source_concept_id
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: drug_exposure_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_exposure_id
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: person_id
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: drug_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_concept_id
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: drug_exposure_start_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_exposure_start_date
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: drug_exposure_end_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_exposure_end_date
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: stop_reason
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: stop_reason
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: refills
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: refills
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: days_supply
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: days_supply
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: visit_occurrence_id
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: drug_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_source_value
+  - attribute:
+      entity: ingredient_occurrence
+      attribute: drug_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_source_concept_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: measurement_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: measurement_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: person_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: measurement_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: measurement_concept_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: measurement_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: measurement_date
+  - attribute:
+      entity: measurement_occurrence
+      attribute: value_as_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: value_as_concept_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: unit_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: unit_concept_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: visit_occurrence_id
+  - attribute:
+      entity: measurement_occurrence
+      attribute: measurement_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: measurement_source_value
+  - attribute:
+      entity: measurement_occurrence
+      attribute: measurement_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: measurement
+        column: measurement_source_concept_id
+  - attribute:
+      entity: visit_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_occurrence_id
+  - attribute:
+      entity: visit_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: person_id
+  - attribute:
+      entity: visit_occurrence
+      attribute: visit_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_concept_id
+  - attribute:
+      entity: visit_occurrence
+      attribute: visit_start_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_start_date
+  - attribute:
+      entity: visit_occurrence
+      attribute: visit_end_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_end_date
+  - attribute:
+      entity: visit_occurrence
+      attribute: visit_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_source_value
+  - attribute:
+      entity: visit_occurrence
+      attribute: visit_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_source_concept_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: observation_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: observation_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: person_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: observation_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: observation_concept_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: observation_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: observation_date
+  - attribute:
+      entity: observation_occurrence
+      attribute: value_as_string
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: value_as_string
+  - attribute:
+      entity: observation_occurrence
+      attribute: value_as_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: value_as_concept_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: unit_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: unit_concept_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: visit_occurrence_id
+  - attribute:
+      entity: observation_occurrence
+      attribute: observation_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: observation_source_value
+  - attribute:
+      entity: observation_occurrence
+      attribute: observation_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: observation
+        column: observation_source_concept_id
+  - attribute:
+      entity: device_occurrence
+      attribute: device_exposure_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_exposure_id
+  - attribute:
+      entity: device_occurrence
+      attribute: person_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: person_id
+  - attribute:
+      entity: device_occurrence
+      attribute: device_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_concept_id
+  - attribute:
+      entity: device_occurrence
+      attribute: device_exposure_start_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_exposure_start_date
+  - attribute:
+      entity: device_occurrence
+      attribute: device_exposure_end_date
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_exposure_end_date
+  - attribute:
+      entity: device_occurrence
+      attribute: visit_occurrence_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: visit_occurrence_id
+  - attribute:
+      entity: device_occurrence
+      attribute: device_source_value
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_source_value
+  - attribute:
+      entity: device_occurrence
+      attribute: device_source_concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_source_concept_id
+  - attribute:
+      entity: concept
+      attribute: concept_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - attribute:
+      entity: concept
+      attribute: concept_name
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_name
+  - attribute:
+      entity: concept
+      attribute: domain_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: domain_id
+  - attribute:
+      entity: concept
+      attribute: vocabulary_id
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+  - attribute:
+      entity: concept
+      attribute: vocabulary_name
+    lookupColumn:
+      primaryTableLookupKey:
+        dataset: aou_synthetic
+        table: concept
+        column: vocabulary_id
+      lookupTableKey:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_id
+      lookupColumn:
+        dataset: aou_synthetic
+        table: vocabulary
+        column: vocabulary_name
+  - attribute:
+      entity: concept
+      attribute: standard_concept
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: standard_concept
+  - attribute:
+      entity: concept
+      attribute: concept_code
+    simpleColumn:
+      columnId:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_code
+relationshipMappings:
+  - name: brand_ingredient
+    intermediateTable:
+      entity1EntityTableKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      entity1IntermediateTableKey:
+        dataset: aou_synthetic
+        table: concept_relationship
+        column: concept_id_1
+      entity2EntityTableKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      entity2IntermediateTableKey:
+        dataset: aou_synthetic
+        table: concept_relationship
+        column: concept_id_2
+  - name: condition_occurrence_condition
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: condition_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: procedure_occurrence_procedure
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: procedure_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: procedure_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: procedure_occurrence
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: ingredient_occurrence_ingredient
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: drug_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: ingredient_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: drug_exposure
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: measurement_occurrence_measurement
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: measurement
+        column: measurement_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: measurement_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: measurement
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: visit_occurrence_visit
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: visit_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: visit_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: visit_occurrence
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: observation_occurrence_observation
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: observation
+        column: observation_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: observation_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: observation
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: device_occurrence_device
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: device_concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+  - name: device_occurrence_person
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: device_exposure
+        column: person_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: person_id
+  - name: concept_id_person_gender
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: gender_concept_id
+  - name: concept_id_person_race
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: race_concept_id
+  - name: concept_id_person_ethnicity
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: ethnicity_concept_id
+  - name: concept_id_person_sex_at_birth
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: person
+        column: sex_at_birth_concept_id
+  - name: concept_id_condition
+    foreignKey:
+      primaryKey:
+        dataset: aou_synthetic
+        table: concept
+        column: concept_id
+      foreignKey:
+        dataset: aou_synthetic
+        table: condition_occurrence
+        column: condition_concept_id
+hierarchies:
+  - attribute:
+      entity: condition
+      attribute: concept_id
+    descendantsTable:
+      ancestor:
+        dataset: omop_indexes
+        table: condition_ancestor_descendant_2
+        column: ancestor
+      descendant:
+        dataset: omop_indexes
+        table: condition_ancestor_descendant_2
+        column: descendant
+    childrenTable:
+      parent:
+        dataset: omop_indexes
+        table: condition_parent_child_2
+        column: parent
+      child:
+        dataset: omop_indexes
+        table: condition_parent_child_2
+        column: child
+    pathsTable:
+      node:
+        dataset: omop_indexes
+        table: condition_node_path_2
+        column: node
+      path:
+        dataset: omop_indexes
+        table: condition_node_path_2
+        column: path
+      numChildren:
+        dataset: omop_indexes
+        table: condition_node_path_2
+        column: numChildren
+  - attribute:
+      entity: procedure
+      attribute: concept_id
+    descendantsTable:
+      ancestor:
+        dataset: omop_indexes
+        table: procedure_ancestor_descendant_2
+        column: ancestor
+      descendant:
+        dataset: omop_indexes
+        table: procedure_ancestor_descendant_2
+        column: descendant
+    childrenTable:
+      parent:
+        dataset: omop_indexes
+        table: procedure_parent_child_2
+        column: parent
+      child:
+        dataset: omop_indexes
+        table: procedure_parent_child_2
+        column: child
+    pathsTable:
+      node:
+        dataset: omop_indexes
+        table: procedure_node_path_2
+        column: node
+      path:
+        dataset: omop_indexes
+        table: procedure_node_path_2
+        column: path
+      numChildren:
+        dataset: omop_indexes
+        table: procedure_node_path_2
+        column: numChildren
+  - attribute:
+      entity: ingredient
+      attribute: concept_id
+    descendantsTable:
+      ancestor:
+        dataset: omop_indexes
+        table: ingredient_ancestor_descendant_2
+        column: ancestor
+      descendant:
+        dataset: omop_indexes
+        table: ingredient_ancestor_descendant_2
+        column: descendant
+    childrenTable:
+      parent:
+        dataset: omop_indexes
+        table: ingredient_parent_child_2
+        column: parent
+      child:
+        dataset: omop_indexes
+        table: ingredient_parent_child_2
+        column: child
+    pathsTable:
+      node:
+        dataset: omop_indexes
+        table: ingredient_node_path_2
+        column: node
+      path:
+        dataset: omop_indexes
+        table: ingredient_node_path_2
+        column: path
+      numChildren:
+        dataset: omop_indexes
+        table: ingredient_node_path_2
+        column: numChildren
+  - attribute:
+      entity: measurement
+      attribute: concept_id
+    descendantsTable:
+      ancestor:
+        dataset: omop_indexes
+        table: measurement_ancestor_descendant_2
+        column: ancestor
+      descendant:
+        dataset: omop_indexes
+        table: measurement_ancestor_descendant_2
+        column: descendant
+    childrenTable:
+      parent:
+        dataset: omop_indexes
+        table: measurement_parent_child_2
+        column: parent
+      child:
+        dataset: omop_indexes
+        table: measurement_parent_child_2
+        column: child
+    pathsTable:
+      node:
+        dataset: omop_indexes
+        table: measurement_node_path_2
+        column: node
+      path:
+        dataset: omop_indexes
+        table: measurement_node_path_2
+        column: path
+      numChildren:
+        dataset: omop_indexes
+        table: measurement_node_path_2
+        column: numChildren
+textSearchInformation:
+  - entity: condition
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: condition_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: condition_text_search_2
+        column: text
+  - entity: procedure
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: procedure_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: procedure_text_search_2
+        column: text
+  - entity: measurement
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: measurement_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: measurement_text_search_2
+        column: text
+  - entity: ingredient
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: ingredient_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: ingredient_text_search_2
+        column: text
+  - entity: brand
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: brand_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: brand_text_search_2
+        column: text
+  - entity: device
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: device_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: device_text_search_2
+        column: text
+  - entity: observation
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: observation_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: observation_text_search_2
+        column: text
+  - entity: visit
+    textTable:
+      lookupTableKey:
+        dataset: omop_indexes
+        table: visit_text_search_2
+        column: node
+      fullText:
+        dataset: omop_indexes
+        table: visit_text_search_2
+        column: text
+entityFiltersSchemas:
+  - entity: person
+    attributes:
+      - attributeName: year_of_birth
+        integerBoundsHint:
+          min: 1930
+          max: 2001
+      - attributeName: ethnicity_concept_id
+        enumHint:
+          enumHintValues:
+            - displayName: "Hispanic or Latino"
+              int64Val: 38003563
+            - displayName: "Race Ethnicity None Of These"
+              int64Val: 1586148
+            - displayName: "Not Hispanic or Latino"
+              int64Val: 38003564
+            - displayName: "Prefer Not To Answer"
+              int64Val: 903079
+            - displayName: "Skip"
+              int64Val: 903096
+      - attributeName: gender_concept_id
+        enumHint:
+          enumHintValues:
+            - displayName: "Not man only, not woman only, prefer not to answer, or skipped"
+              int64Val: 2000000002
+            - displayName: "Female"
+              int64Val: 45878463
+            - displayName: "Male"
+              int64Val: 45880669
+            - displayName: "Unknown"
+              int64Val: 0
+      - attributeName: race_concept_id
+        enumHint:
+          enumHintValues:
+            - displayName: "Another single population"
+              int64Val: 2000000001
+            - displayName: "White"
+              int64Val: 8527
+            - displayName: "I prefer not to answer"
+              int64Val: 1177221
+            - displayName: "More than one population"
+              int64Val: 2000000008
+            - displayName: "Asian"
+              int64Val: 8515
+            - displayName: "Black or African American"
+              int64Val: 8516
+            - displayName: "PMI: Skip"
+              int64Val: 903096
+            - displayName: "None of these"
+              int64Val: 45882607
+            - displayName: "Unknown"
+              int64Val: 0
+      - attributeName: sex_at_birth_concept_id
+        enumHint:
+          enumHintValues:
+            - displayName: "Female"
+              int64Val: 45878463
+            - displayName: "Male"
+              int64Val: 45880669
+            - displayName: "Not male, not female, prefer not to answer, or skipped"
+              int64Val: 2000000009
+            - displayName: "Unknown"
+              int64Val: 0
+entityIndexing:
+  - entity: condition
+    allNodesWorkflow:
+      outputTable: aou_synthetic_SR2019q4r4_indexes.condition_all_nodes
+      query: >-
+        SELECT c.concept_id AS node
+        FROM `verily-tanagra-test.aou_synthetic_SR2019q4r4.concept` c
+        WHERE c.domain_id = 'Condition'
+        AND c.valid_end_date > '2022-01-01';


### PR DESCRIPTION
Added a new underlay schema for a copy of the `aou_synthetic` dataset that lives in the `verily-tanagra-test` GCP project. Expect to primarily use this in the new `test` Plato deployment for Tanagra.

Note this new underlay schema is basically a copy of the existing `aou_synthetic` dataset that lives in the `verily-tanagra-dev` GCP project, just with the project name changed.