### PR TITLE
[PF-1731] Replace Java setup action

### DIFF
--- a/.github/workflows/api-publish-maven.yaml
+++ b/.github/workflows/api-publish-maven.yaml
@@ -15,9 +15,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -28,9 +28,10 @@ jobs:
       - name: Auth Docker for gcloud
         run: gcloud auth configure-docker --quiet
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/api-test.yaml
+++ b/.github/workflows/api-test.yaml
@@ -26,9 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Initialize Postgres DB
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/workflow-test.yaml
+++ b/.github/workflows/workflow-test.yaml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up AdoptOpenJDK 11
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
The `joschi/setup-jdk@v2` Github action is deprecated and the recommendation is to move to the official github setup-java action with the `temurin` distribution: see https://github.com/joschi/setup-jdk#-notice