### PR TITLE
Migrate filtering and data requests into business logic layer

### DIFF
--- a/api/src/main/resources/underlays/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/aou_synthetic.yaml
@@ -303,7 +303,7 @@ uiConfiguration: >-
           "id": "condition_occurrence",
           "displayName": "Condition Occurrences",
           "entity": "condition_occurrence",
-          "key": "concept_id",
+          "key": "condition_concept_id",
           "classifications": [
             {
               "id": "condition",
@@ -331,7 +331,7 @@ uiConfiguration: >-
           "id": "procedure_occurrence",
           "displayName": "Procedure Occurrences",
           "entity": "procedure_occurrence",
-          "key": "concept_id",
+          "key": "procedure_concept_id",
           "classifications": [
             {
               "id": "procedure",
@@ -359,7 +359,7 @@ uiConfiguration: >-
           "id": "observation_occurrence",
           "displayName": "Observation Occurrence",
           "entity": "observation_occurrence",
-          "key": "concept_id",
+          "key": "observation_concept_id",
           "classifications": [
             {
               "id": "observation",
@@ -386,11 +386,11 @@ uiConfiguration: >-
           "id": "ingredient_occurrence",
           "displayName": "Drug Occurrence",
           "entity": "ingredient_occurrence",
-          "key": "concept_id",
+          "key": "drug_concept_id",
           "classifications": [
             {
               "id": "ingredient",
-              "attribute": "ingredient_concept_id",
+              "attribute": "drug_concept_id",
               "entity": "ingredient",
               "entityAttribute": "concept_id",
               "hierarchical": true,

--- a/api/src/main/resources/underlays/sd.yaml
+++ b/api/src/main/resources/underlays/sd.yaml
@@ -285,7 +285,7 @@ uiConfiguration: >-
           "id": "condition_occurrence",
           "displayName": "Condition Occurrences",
           "entity": "condition_occurrence",
-          "key": "concept_id",
+          "key": "condition_concept_id",
           "classifications": [
             {
               "id": "condition",
@@ -314,7 +314,7 @@ uiConfiguration: >-
           "id": "procedure_occurrence",
           "displayName": "Procedure Occurrences",
           "entity": "procedure_occurrence",
-          "key": "concept_id",
+          "key": "procedure_concept_id",
           "classifications": [
             {
               "id": "procedure",
@@ -343,7 +343,7 @@ uiConfiguration: >-
           "id": "observation_occurrence",
           "displayName": "Observation Occurrence",
           "entity": "observation_occurrence",
-          "key": "concept_id",
+          "key": "observation_concept_id",
           "classifications": [
             {
               "id": "observation",
@@ -371,12 +371,12 @@ uiConfiguration: >-
           "id": "ingredient_occurrence",
           "displayName": "Drug Occurrence",
           "entity": "ingredient_occurrence",
-          "key": "concept_id",
+          "key": "drug_concept_id",
           "classifications": [
             {
               "id": "ingredient",
               "name": "Ingredient",
-              "attribute": "ingredient_concept_id",
+              "attribute": "drug_concept_id",
               "entity": "ingredient",
               "entityAttribute": "concept_id",
               "hierarchical": true,

--- a/api/src/main/resources/underlays/synpuf.yaml
+++ b/api/src/main/resources/underlays/synpuf.yaml
@@ -61,7 +61,7 @@ uiConfiguration: >-
           "id": "condition_occurrence",
           "displayName": "Condition Occurrences",
           "entity": "condition_occurrence",
-          "key": "concept_id",
+          "key": "condition_concept_id",
           "classifications": [
             {
               "id": "condition",
@@ -90,7 +90,7 @@ uiConfiguration: >-
           "id": "procedure_occurrence",
           "displayName": "Procedure Occurrences",
           "entity": "procedure_occurrence",
-          "key": "concept_id",
+          "key": "procedure_concept_id",
           "classifications": [
             {
               "id": "procedure",
@@ -119,7 +119,7 @@ uiConfiguration: >-
           "id": "observation_occurrence",
           "displayName": "Observation Occurrence",
           "entity": "observation_occurrence",
-          "key": "concept_id",
+          "key": "observation_concept_id",
           "classifications": [
             {
               "id": "observation",
@@ -147,12 +147,12 @@ uiConfiguration: >-
           "id": "ingredient_occurrence",
           "displayName": "Drug Occurrence",
           "entity": "ingredient_occurrence",
-          "key": "concept_id",
+          "key": "drug_concept_id",
           "classifications": [
             {
               "id": "ingredient",
               "name": "Ingredient",
-              "attribute": "ingredient_concept_id",
+              "attribute": "drug_concept_id",
               "entity": "ingredient",
               "entityAttribute": "concept_id",
               "hierarchical": true,

--- a/api/src/main/resources/underlays/test/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/test/aou_synthetic.yaml
@@ -303,7 +303,7 @@ uiConfiguration: >-
           "id": "condition_occurrence",
           "displayName": "Condition Occurrences",
           "entity": "condition_occurrence",
-          "key": "concept_id",
+          "key": "condition_concept_id",
           "classifications": [
             {
               "id": "condition",
@@ -331,7 +331,7 @@ uiConfiguration: >-
           "id": "procedure_occurrence",
           "displayName": "Procedure Occurrences",
           "entity": "procedure_occurrence",
-          "key": "concept_id",
+          "key": "procedure_concept_id",
           "classifications": [
             {
               "id": "procedure",
@@ -359,7 +359,7 @@ uiConfiguration: >-
           "id": "observation_occurrence",
           "displayName": "Observation Occurrence",
           "entity": "observation_occurrence",
-          "key": "concept_id",
+          "key": "observation_concept_id",
           "classifications": [
             {
               "id": "observation",
@@ -386,11 +386,11 @@ uiConfiguration: >-
           "id": "ingredient_occurrence",
           "displayName": "Drug Occurrence",
           "entity": "ingredient_occurrence",
-          "key": "concept_id",
+          "key": "drug_concept_id",
           "classifications": [
             {
               "id": "ingredient",
-              "attribute": "ingredient_concept_id",
+              "attribute": "drug_concept_id",
               "entity": "ingredient",
               "entityAttribute": "concept_id",
               "hierarchical": true,

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,5 +1,6 @@
 import { EntitiesApiContext, UnderlaysApiContext } from "apiContext";
 import Loading from "components/loading";
+import { FilterType } from "data/filter";
 import { useAsyncWithApi } from "errors";
 import { useAppDispatch } from "hooks";
 import { enableMapSet } from "immer";
@@ -8,7 +9,6 @@ import { useCallback, useContext } from "react";
 import { HashRouter } from "react-router-dom";
 import { AppRouter } from "router";
 import { LoadingUserData } from "storage/storage";
-import * as tanagra from "tanagra-api";
 import { setUnderlays } from "underlaysSlice";
 import "./app.css";
 
@@ -20,30 +20,17 @@ const prepackagedConceptSets = [
   {
     id: "_demographics",
     name: "Demographics",
-    entity: "person",
+    occurrence: "",
   },
   {
     id: "_analgesics",
     name: "Analgesics",
-    entity: "ingredient_occurrence",
+    occurrence: "ingredient_occurrence",
     filter: {
-      relationshipFilter: {
-        outerVariable: "ingredient_occurrence",
-        newVariable: "concept",
-        newEntity: "ingredient",
-        filter: {
-          binaryFilter: {
-            attributeVariable: {
-              variable: "concept",
-              name: "concept_id",
-            },
-            operator: tanagra.BinaryFilterOperator.DescendantOfInclusive,
-            attributeValue: {
-              int64Val: 21604253,
-            },
-          },
-        },
-      },
+      type: FilterType.Classification,
+      occurrenceID: "ingredient_occurrence",
+      classificationID: "ingredient",
+      keys: [21604253],
     },
   },
 ];

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -15,17 +15,11 @@ import Typography from "@mui/material/Typography";
 import { CriteriaPlugin, generateId, registerCriteriaPlugin } from "cohort";
 import Loading from "components/loading";
 import { DataValue } from "data/configuration";
-import {
-  attributeValueFromDataValue,
-  EnumHintOption,
-  IntegerHint,
-  Source,
-  useSource,
-} from "data/source";
+import { FilterType } from "data/filter";
+import { EnumHintOption, IntegerHint, Source, useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
 import produce from "immer";
 import React, { useCallback, useState } from "react";
-import * as tanagra from "tanagra-api";
 import { CriteriaConfig } from "underlaysSlice";
 
 type Selection = {
@@ -84,75 +78,18 @@ class _ implements CriteriaPlugin<Data> {
     return <AttributeDetails data={this.data} />;
   }
 
-  generateFilter(source: Source, entityVar: string) {
-    if (this.data.dataRanges.length > 0) {
-      return {
-        arrayFilter: {
-          operands: this.data.dataRanges.map((range) => ({
-            arrayFilter: {
-              operands: [
-                {
-                  binaryFilter: {
-                    attributeVariable: {
-                      variable: entityVar,
-                      name: this.data.attribute,
-                    },
-                    operator: tanagra.BinaryFilterOperator.LessThan,
-                    attributeValue: {
-                      int64Val: range.max,
-                    },
-                  },
-                },
-                {
-                  binaryFilter: {
-                    attributeVariable: {
-                      variable: entityVar,
-                      name: this.data.attribute,
-                    },
-                    operator: tanagra.BinaryFilterOperator.GreaterThan,
-                    attributeValue: {
-                      int64Val: range.min,
-                    },
-                  },
-                },
-              ],
-              operator: tanagra.ArrayFilterOperator.And,
-            },
-          })),
-          operator: tanagra.ArrayFilterOperator.Or,
-        },
-      };
-    } else if (this.data.selected.length > 0) {
-      return {
-        arrayFilter: {
-          operands: this.data.selected.map(({ value }) => ({
-            binaryFilter: {
-              attributeVariable: {
-                variable: entityVar,
-                name: this.data.attribute,
-              },
-              operator: tanagra.BinaryFilterOperator.Equals,
-              attributeValue: attributeValueFromDataValue(value),
-            },
-          })),
-          operator: tanagra.ArrayFilterOperator.Or,
-        },
-      };
-    }
-
+  generateFilter() {
     return {
-      binaryFilter: {
-        attributeVariable: {
-          variable: entityVar,
-          name: this.data.attribute,
-        },
-        operator: tanagra.BinaryFilterOperator.NotEquals,
-      },
+      type: FilterType.Attribute,
+      occurrenceID: "",
+      attribute: this.data.attribute,
+      values: this.data.selected?.map(({ value }) => value),
+      ranges: this.data.dataRanges,
     };
   }
 
-  occurrenceEntities() {
-    return [];
+  occurrenceID() {
+    return "";
   }
 }
 

--- a/ui/src/criteria/concept.test.tsx
+++ b/ui/src/criteria/concept.test.tsx
@@ -54,15 +54,6 @@ const testCases: TestCase[] = [
     },
     matches: ["test-concept", "1234", "Standard"],
   },
-  {
-    name: "missing concept_id",
-    instance: {
-      concept_name: {
-        stringVal: "test-concept",
-      },
-    },
-    notMatches: ["test-concept"],
-  },
 ];
 
 test.each(testCases)(

--- a/ui/src/data/configuration.ts
+++ b/ui/src/data/configuration.ts
@@ -18,6 +18,10 @@ export type SortOrder = {
   direction: SortDirection;
 };
 
+// Classifications allow occurrences to be filtered using an attribute that
+// refers to another table. An example of this is how OMOP data stores the
+// condition associated with a condition occurrence as a concept_id that
+// references a concept table.
 export type Classification = {
   id: string;
   attribute: string;
@@ -43,17 +47,17 @@ export type Grouping = {
   defaultSort?: SortOrder;
 };
 
-export type PrimaryEntity = {
-  entity: string;
-  key: string;
-};
-
-export type Occurrence = {
-  id: string;
+export type Entity = {
   entity: string;
   key: string;
 
   classifications?: Classification[];
+};
+
+export type PrimaryEntity = Entity;
+
+export type Occurrence = Entity & {
+  id: string;
 };
 
 export type Configuration = {
@@ -67,4 +71,14 @@ export function findByID<T extends { id: string }>(id: string, list?: T[]): T {
     throw new Error(`Unknown item "${id}" in ${JSON.stringify(list)}.`);
   }
   return item;
+}
+
+export function findEntity(
+  occurrenceID: string,
+  config: Configuration
+): Entity {
+  if (occurrenceID) {
+    return findByID(occurrenceID, config.occurrences);
+  }
+  return config.primaryEntity;
 }

--- a/ui/src/data/filter.ts
+++ b/ui/src/data/filter.ts
@@ -1,0 +1,87 @@
+import { isValid } from "util/valid";
+import { DataKey, DataValue } from "./configuration";
+
+export enum FilterType {
+  Unary = "UNARY",
+  Array = "ARRAY",
+  Classification = "CLASSIFICATION",
+  Attribute = "ATTRIBUTE",
+}
+
+type BaseFilter = {
+  type: FilterType;
+};
+
+export enum UnaryFilterOperator {
+  Not,
+}
+
+export type UnaryFilter = BaseFilter & {
+  operator: UnaryFilterOperator;
+  operand: Filter;
+};
+
+export function isUnaryFilter(filter: Filter): filter is UnaryFilter {
+  return filter.type == FilterType.Unary;
+}
+
+export type ArrayFilterOperator = {
+  // Currently only AND (all) and OR (1+) equivalent values are supported but
+  // this could allow for various XOR and x-of-y type operations in the future.
+  // As a convenience, both min and max being undefined is equivalent to an AND.
+  min?: number;
+  max?: number;
+};
+
+export function isArrayFilter(filter: Filter): filter is ArrayFilter {
+  return filter.type == FilterType.Array;
+}
+
+export type ArrayFilter = BaseFilter & {
+  operator: ArrayFilterOperator;
+  operands: Filter[];
+};
+
+export function makeArrayFilter(
+  operator: ArrayFilterOperator,
+  filters: (Filter | null)[]
+): ArrayFilter | null {
+  const operands = filters.filter(isValid);
+  if (operands.length === 0) {
+    return null;
+  }
+  return {
+    type: FilterType.Array,
+    operator,
+    operands,
+  };
+}
+
+export type AttributeFilter = BaseFilter & {
+  occurrenceID: string;
+  attribute: string;
+  values?: DataValue[];
+  ranges?: { min: number; max: number }[];
+};
+
+export function isAttributeFilter(filter: Filter): filter is AttributeFilter {
+  return filter.type == FilterType.Attribute;
+}
+
+export type ClassificationFilter = BaseFilter & {
+  occurrenceID: string;
+  classificationID: string;
+  keys: DataKey[];
+};
+
+export function isClassificationFilter(
+  filter: Filter
+): filter is ClassificationFilter {
+  return filter.type == FilterType.Classification;
+}
+
+export type Filter =
+  | UnaryFilter
+  | ArrayFilter
+  | AttributeFilter
+  | ClassificationFilter;

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -10,30 +10,28 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
-import { EntityInstancesApiContext } from "apiContext";
-import { createCriteria, generateQueryFilter, getCriteriaPlugin } from "cohort";
+import {
+  createCriteria,
+  generateCohortFilter,
+  getCriteriaPlugin,
+} from "cohort";
 import { insertCohort } from "cohortsSlice";
 import Checkbox from "components/checkbox";
 import Loading from "components/loading";
 import { useMenu } from "components/menu";
 import { useTextInputDialog } from "components/textInputDialog";
-import { TreeGrid, TreeGridData, TreeGridRowData } from "components/treegrid";
+import { TreeGrid, TreeGridData } from "components/treegrid";
 import { insertConceptSet } from "conceptSetsSlice";
+import { findEntity } from "data/configuration";
+import { Filter, makeArrayFilter } from "data/filter";
 import { useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
 import { useAppDispatch, useAppSelector, useUnderlay } from "hooks";
-import React, {
-  Fragment,
-  SyntheticEvent,
-  useCallback,
-  useContext,
-  useState,
-} from "react";
+import React, { Fragment, SyntheticEvent, useCallback, useState } from "react";
 import { Link as RouterLink, useHistory } from "react-router-dom";
 import { createUrl } from "router";
 import * as tanagra from "tanagra-api";
 import { useImmer } from "use-immer";
-import { isValid } from "util/valid";
 
 export function Datasets() {
   const dispatch = useAppDispatch();
@@ -54,7 +52,7 @@ export function Datasets() {
     new Map<string, Set<string>>()
   );
 
-  const conceptSetEntities = useConceptSetEntities(selectedConceptSets);
+  const conceptSetOccurrences = useConceptSetOccurrences(selectedConceptSets);
 
   const [dialog, showNewCohort] = useTextInputDialog({
     title: "New Cohort",
@@ -144,9 +142,9 @@ export function Datasets() {
   });
 
   const allAttributesChecked = () => {
-    for (const entity of conceptSetEntities) {
-      for (const attribute of entity.attributes) {
-        if (excludedAttributes.get(entity.name)?.has(attribute)) {
+    for (const occurrence of conceptSetOccurrences) {
+      for (const attribute of occurrence.attributes) {
+        if (excludedAttributes.get(occurrence.id)?.has(attribute)) {
           return false;
         }
       }
@@ -249,10 +247,10 @@ export function Datasets() {
                   updateExcludedAttributes((selection) => {
                     selection.clear();
                     if (allAttributesChecked()) {
-                      conceptSetEntities.forEach((entity) => {
+                      conceptSetOccurrences.forEach((occurrence) => {
                         selection.set(
-                          entity.name,
-                          new Set<string>(entity.attributes)
+                          occurrence.id,
+                          new Set<string>(occurrence.attributes)
                         );
                       });
                     }
@@ -268,25 +266,25 @@ export function Datasets() {
             sx={{ overflowY: "auto", display: "block" }}
             className="datasets-select-panel"
           >
-            {conceptSetEntities.map((entity) => (
-              <Fragment key={entity.name}>
-                <Typography variant="h5">{entity.name}</Typography>
-                {entity.attributes.map((attribute) => (
+            {conceptSetOccurrences.map((occurrence) => (
+              <Fragment key={occurrence.id}>
+                <Typography variant="h5">{occurrence.name}</Typography>
+                {occurrence.attributes.map((attribute) => (
                   <Stack key={attribute} direction="row" alignItems="center">
                     <Checkbox
                       size="small"
                       fontSize="inherit"
-                      name={entity + "-" + attribute}
+                      name={occurrence.id + "-" + attribute}
                       checked={
-                        !excludedAttributes.get(entity.name)?.has(attribute)
+                        !excludedAttributes.get(occurrence.id)?.has(attribute)
                       }
                       onChange={() =>
                         updateExcludedAttributes((selection) => {
-                          if (!selection?.get(entity.name)) {
-                            selection?.set(entity.name, new Set<string>());
+                          if (!selection?.get(occurrence.id)) {
+                            selection?.set(occurrence.id, new Set<string>());
                           }
 
-                          const attributes = selection?.get(entity.name);
+                          const attributes = selection?.get(occurrence.id);
                           if (attributes?.has(attribute)) {
                             attributes?.delete(attribute);
                           } else {
@@ -308,7 +306,8 @@ export function Datasets() {
               <Preview
                 selectedCohorts={selectedCohorts}
                 selectedConceptSets={selectedConceptSets}
-                conceptSetEntities={conceptSetEntities}
+                conceptSetOccurrences={conceptSetOccurrences}
+                excludedAttributes={excludedAttributes}
               />
             ) : (
               <Typography variant="h5">
@@ -323,31 +322,32 @@ export function Datasets() {
   );
 }
 
-type ConceptSetEntity = {
+type ConceptSetOccurrence = {
+  id: string;
   name: string;
   attributes: string[];
-  filters: tanagra.Filter[];
+  filters: Filter[];
 };
 
-function useConceptSetEntities(
+function useConceptSetOccurrences(
   selectedConceptSets: Set<string>
-): ConceptSetEntity[] {
+): ConceptSetOccurrence[] {
   const underlay = useUnderlay();
   const source = useSource();
 
-  const entities = new Map<string, tanagra.Filter[]>();
-  const addFilter = (entity: string, filter?: tanagra.Filter | null) => {
-    if (!entities.has(entity)) {
-      entities.set(entity, []);
+  const occurrences = new Map<string, Filter[]>();
+  const addFilter = (occurrence: string, filter?: Filter | null) => {
+    if (!occurrences.has(occurrence)) {
+      occurrences.set(occurrence, []);
     }
     if (filter) {
-      entities.get(entity)?.push(filter);
+      occurrences.get(occurrence)?.push(filter);
     }
   };
 
   underlay.prepackagedConceptSets.forEach((conceptSet) => {
     if (selectedConceptSets.has(conceptSet.id)) {
-      addFilter(conceptSet.entity, conceptSet.filter);
+      addFilter(conceptSet.occurrence, conceptSet.filter);
     }
   });
 
@@ -356,24 +356,16 @@ function useConceptSetEntities(
   );
   workspaceConceptSets.forEach((conceptSet) => {
     const plugin = getCriteriaPlugin(conceptSet.criteria);
-    if (plugin.occurrenceEntities(source).length != 1) {
-      throw new Error("Only one entity per concept set is supported.");
-    }
-
-    const entity = plugin.occurrenceEntities(source)[0];
-    addFilter(entity, plugin.generateFilter(source, entity, true));
+    addFilter(plugin.occurrenceID(), plugin.generateFilter());
   });
 
-  return Array.from(entities)
+  return Array.from(occurrences)
     .sort()
-    .map(([entityName, filters]) => {
-      const attributes = underlay.entities
-        .find((entity) => entity.name === entityName)
-        ?.attributes?.map((attribute) => attribute.name || "unknown")
-        ?.filter((attribute) => !attribute.startsWith("t_"));
+    .map(([id, filters]) => {
       return {
-        name: entityName,
-        attributes: attributes || [],
+        id,
+        name: findEntity(id, source.config).entity,
+        attributes: source.listAttributes(id),
         filters,
       };
     });
@@ -382,18 +374,17 @@ function useConceptSetEntities(
 type PreviewProps = {
   selectedCohorts: Set<string>;
   selectedConceptSets: Set<string>;
-  conceptSetEntities: ConceptSetEntity[];
+  conceptSetOccurrences: ConceptSetOccurrence[];
+  excludedAttributes: Map<string, Set<string>>;
 };
 
 function Preview(props: PreviewProps) {
-  const underlay = useUnderlay();
   const source = useSource();
   const cohorts = useAppSelector((state) =>
     state.present.cohorts.filter((cohort) =>
       props.selectedCohorts.has(cohort.id)
     )
   );
-  const api = useContext(EntityInstancesApiContext);
 
   const [tab, setTab] = useState(0);
   const [queriesMode, setQueriesMode] = useState(false);
@@ -401,104 +392,55 @@ function Preview(props: PreviewProps) {
   const tabDataState = useAsyncWithApi<PreviewTabData[]>(
     useCallback(async () => {
       return Promise.all(
-        props.conceptSetEntities.map(async (entity) => {
-          let filter: tanagra.Filter = {
-            arrayFilter: {
-              operands: cohorts
-                .map((cohort) =>
-                  generateQueryFilter(source, cohort, underlay.primaryEntity)
-                )
-                .filter((filter): filter is tanagra.Filter => !!filter),
-              operator: tanagra.ArrayFilterOperator.Or,
-            },
-          };
-
-          if (entity.name !== underlay.primaryEntity) {
-            filter = {
-              arrayFilter: {
-                operator: tanagra.ArrayFilterOperator.And,
-                operands: [
-                  {
-                    relationshipFilter: {
-                      outerVariable: entity.name,
-                      newVariable: underlay.primaryEntity,
-                      newEntity: underlay.primaryEntity,
-                      filter: filter,
-                    },
-                  },
-                  ...(entity.filters.length > 0
-                    ? [
-                        {
-                          arrayFilter: {
-                            operator: tanagra.ArrayFilterOperator.Or,
-                            operands: entity.filters,
-                          },
-                        },
-                      ]
-                    : []),
-                ],
-              },
-            };
+        props.conceptSetOccurrences.map(async (occurrence) => {
+          const cohortsFilter = makeArrayFilter(
+            { min: 1 },
+            cohorts.map((cohort) => generateCohortFilter(cohort))
+          );
+          if (!cohortsFilter) {
+            throw new Error("All selected cohorts are empty.");
           }
 
-          const entityDataset = {
-            entityVariable: entity.name,
-            selectedAttributes: entity.attributes,
-            filter: filter,
-            limit: 50,
-          };
+          const conceptSetsFilter = makeArrayFilter(
+            { min: 1 },
+            occurrence.filters
+          );
+
+          const filteredAttributes = occurrence.attributes.filter(
+            (a) => !props.excludedAttributes.get(occurrence.id)?.has(a)
+          );
 
           const dataParts = await Promise.all([
             (async () => {
-              const res = await api.generateDatasetSqlQuery({
-                entityName: entity.name,
-                underlayName: underlay.name,
-                generateDatasetSqlQueryRequest: {
-                  entityDataset,
-                },
-              });
-
-              if (!res?.query) {
-                throw new Error("Service returned an empty query.");
-              }
-              return res.query;
+              return await source.generateSQLQuery(
+                filteredAttributes,
+                occurrence.id,
+                cohortsFilter,
+                conceptSetsFilter
+              );
             })(),
             (async () => {
-              const res = await api.searchEntityInstances({
-                entityName: entity.name,
-                underlayName: underlay.name,
-                searchEntityInstancesRequest: {
-                  entityDataset,
-                },
-              });
+              const res = await source.listData(
+                occurrence.attributes,
+                occurrence.id,
+                cohortsFilter,
+                conceptSetsFilter
+              );
 
               const data: TreeGridData = {
                 root: { data: {}, children: [] },
               };
 
-              res?.instances?.forEach((instance, i) => {
-                const row: TreeGridRowData = {};
-                for (const k in instance) {
-                  const v = instance[k];
-                  if (!v) {
-                    row[k] = "";
-                  } else if (isValid(v.int64Val)) {
-                    row[k] = v.int64Val;
-                  } else if (isValid(v.boolVal)) {
-                    row[k] = v.boolVal;
-                  } else {
-                    row[k] = v.stringVal;
-                  }
-                }
-
-                data[i] = { data: row };
+              res.data.forEach((entry, i) => {
+                data[i] = { data: entry };
                 data.root?.children?.push(i);
               });
               return data;
             })(),
           ]);
+
           return {
-            entity: entity.name,
+            name: occurrence.name,
             sql: dataParts[0],
             data: dataParts[1],
           };
@@ -525,7 +467,7 @@ function Preview(props: PreviewProps) {
         >
           <Tabs value={tab} onChange={onTabChange} sx={{ flexGrow: 1 }}>
             {tabDataState.data?.map((data) => (
-              <Tab key={data.entity} label={data.entity} />
+              <Tab key={data.name} label={data.name} />
             ))}
           </Tabs>
           <Typography variant="button">Data</Typography>
@@ -545,13 +487,18 @@ function Preview(props: PreviewProps) {
           >
             <TreeGrid
               data={tabDataState.data?.[tab]?.data}
-              columns={props.conceptSetEntities[tab]?.attributes.map(
-                (attribute) => ({
+              columns={props.conceptSetOccurrences[tab]?.attributes
+                .filter(
+                  (a) =>
+                    !props.excludedAttributes
+                      .get(props.conceptSetOccurrences[tab]?.id)
+                      ?.has(a)
+                )
+                .map((attribute) => ({
                   key: attribute,
                   width: 120,
                   title: attribute,
-                })
-              )}
+                }))}
               variableWidth
               wrapBodyText
             />
@@ -563,7 +510,7 @@ function Preview(props: PreviewProps) {
 }
 
 type PreviewTabData = {
-  entity: string;
+  name: string;
   sql: string;
   data: TreeGridData;
 };

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -27,7 +27,7 @@ import {
 import Loading from "components/loading";
 import { useMenu } from "components/menu";
 import { useTextInputDialog } from "components/textInputDialog";
-import { useSource } from "data/source";
+import { generateFilter, useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
 import { useAppDispatch, useCohort, useUnderlay } from "hooks";
 import { useCallback, useContext } from "react";
@@ -47,7 +47,7 @@ import { ChartConfigProperty } from "underlaysSlice";
 import { isValid } from "util/valid";
 import {
   createCriteria,
-  generateQueryFilter,
+  generateCohortFilter,
   getCriteriaPlugin,
 } from "./cohort";
 
@@ -209,10 +209,15 @@ function ParticipantsGroup(props: { group: tanagra.Group; index: number }) {
       ],
     };
 
+    const filter = generateCohortFilter(cohortForFilter);
+    if (!filter) {
+      throw new Error("Group is empty.");
+    }
+
     const searchEntityCountsRequest: tanagra.SearchEntityCountsRequest = {
       entityCounts: {
-        entityVariable: "p",
-        filter: generateQueryFilter(source, cohortForFilter, "p"),
+        entityVariable: "person",
+        filter: generateFilter(source, filter, true),
       },
     };
 
@@ -331,12 +336,17 @@ function ParticipantCriteria(props: {
       ],
     };
 
+    const filter = generateCohortFilter(cohortForFilter);
+    if (!filter) {
+      throw new Error("Criteria is empty.");
+    }
+
     const searchEntityCountsRequest: tanagra.SearchEntityCountsRequest = {
       entityCounts: {
-        entityVariable: "p",
+        entityVariable: "person",
         additionalSelectedAttributes: [],
         groupByAttributes: [],
-        filter: generateQueryFilter(source, cohortForFilter, "p"),
+        filter: generateFilter(source, filter, true),
       },
     };
 
@@ -562,12 +572,18 @@ function DemographicCharts({ cohort }: DemographicChartsProps) {
       }
     }
 
+    const filter = generateCohortFilter(cohort);
+    if (!filter) {
+      // TODO(tjennison): Add non-error UI for this case.
+      throw new Error("Cohort is empty.");
+    }
+
     const searchEntityCountsRequest: tanagra.SearchEntityCountsRequest = {
       entityCounts: {
-        entityVariable: "p",
+        entityVariable: "person",
         additionalSelectedAttributes: Array.from(additionalSelectedAttributes),
         groupByAttributes: groupByAttributes,
-        filter: generateQueryFilter(source, cohort, "p"),
+        filter: generateFilter(source, filter, true),
       },
     };
 

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -1,12 +1,13 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Configuration } from "data/configuration";
+import { Filter } from "data/filter";
 import * as tanagra from "tanagra-api";
 
 export type PrepackagedConceptSet = {
   id: string;
   name: string;
-  entity: string;
-  filter?: tanagra.Filter;
+  occurrence: string;
+  filter?: Filter;
 };
 
 export type Underlay = {


### PR DESCRIPTION
This migrates the core filtering and data (entity instance) request
functionality into the business logic layer. This is the last (and
largest) major piece of work required to untagle the UI from the API.
This entails:
* Creating a local filter abstraction that operates in UI logical terms.
  These are converted to underlying backend types when making requests.
  Handling of empty/null filters has been streamlined.
* Adding methods to fetch entity instances and SQL queries from the
  backend, refactoring some of the existing code to be shared.
* Updating the datasets page to work in terms of the new filters,
  centralizing the last bespoke entity instance handling.
* Changing the criteria plugins to use the new filters.
* Updating the prepackaged concept sets to use the new filters.
* Enabling the primary entity and occurrences to be handled
  interchangeably in some cases.
* Fixing incorrect key names in the underlay defintions.

The overview pages are in a temporary state pending the addition of the
count API to the layer.