### PR TITLE
Separate criteria plugin config and data

### DIFF
--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -530,7 +530,6 @@ components:
       description: Enum for unary function operators
       type: string
       enum: ["NOT"]
-      
 
     BinaryFilter:
       type: object
@@ -840,8 +839,32 @@ components:
         data:
           type: object
           description: The plugin specific data that defines this criteria.
+        config:
+          type: object
+          description: The UI configuration used by this criteria.
+          $ref: "#/components/schemas/CriteriaConfig"
       required:
         - id
         - name
         - type
         - data
+        - config
+
+    CriteriaConfig:
+      type: object
+      description: The configuration for an instance of a cohort plugin. Fields related to individual plugins may also be present.
+      properties:
+        type:
+          type: string
+          description: The plugin type to use for this criteria.
+        id:
+          type: string
+          description: The unique id of this criteria config.
+        title:
+          type: string
+          description: The display title for this criteria.
+      required:
+        - type
+        - id
+        - title
+      additionalProperties: true

--- a/api/src/main/resources/underlays/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/aou_synthetic.yaml
@@ -424,116 +424,117 @@ uiConfiguration: >-
     },
     "criteriaConfigs": [{
       "type":"concept",
+      "id": "tanagra-conditions",
       "title":"Conditions",
       "defaultName":"Contains Conditions Codes",
-      "plugin": {
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Condition"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "condition_occurrence",
-        "classification": "condition"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Condition"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "condition_occurrence",
+      "classification": "condition"
     },
     {
       "type":"concept",
+      "id": "tanagra-procedures",
       "title":"Procedures",
       "defaultName":"Contains Procedures Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Procedure"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "procedure_occurrence",
-        "classification": "procedure"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Procedure"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "procedure_occurrence",
+      "classification": "procedure"
     },
     {
       "type":"concept",
+      "id": "tanagra-observations",
       "title":"Observations",
       "defaultName":"Contains Observations Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "observation_occurrence",
-        "classification": "observation"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "observation_occurrence",
+      "classification": "observation"
     },
     {
       "type":"concept",
+      "id": "tanagra-drugs",
       "title":"Drugs",
       "defaultName":"Contains Drugs Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Drug"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "ingredient_occurrence",
-        "classification": "ingredient"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Drug"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "ingredient_occurrence",
+      "classification": "ingredient"
     },
     {
       "type":"attribute",
+      "id": "tanagra-ethnicity",
       "title":"Ethnicity",
       "defaultName":"Contains Ethnicity Codes",
-      "plugin":{"attribute":"ethnicity_concept_id"}
+      "attribute":"ethnicity_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-gender",
       "title":"Gender Identity",
       "defaultName":"Contains Gender Identity Codes",
-      "plugin":{"attribute":"gender_concept_id"}
+      "attribute":"gender_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-race",
       "title":"Race",
       "defaultName":"Contains Race Codes",
-      "plugin":{"attribute":"race_concept_id"}
+      "attribute":"race_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-sex_at_birth",
       "title":"Sex Assigned at Birth",
       "defaultName":"Contains Sex Assigned at Birth Codes",
-      "plugin":{"attribute":"sex_at_birth_concept_id"}
+      "attribute":"sex_at_birth_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-year_of_birth",
       "title":"Year at Birth",
       "defaultName":"Contains Year at Birth Values",
-      "plugin":{"attribute":"year_of_birth"}
+      "attribute":"year_of_birth"
     }],
     "demographicChartConfigs": {
       "groupByAttributes": ["gender_concept_id", "race_concept_id", "year_of_birth"],

--- a/api/src/main/resources/underlays/sd.yaml
+++ b/api/src/main/resources/underlays/sd.yaml
@@ -411,110 +411,110 @@ uiConfiguration: >-
     },
     "criteriaConfigs": [{
       "type":"concept",
+      "id": "tanagra-conditions",
       "title":"Conditions",
       "defaultName":"Contains Conditions Codes",
-      "plugin": {
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Condition"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "condition_occurrence",
-        "classification": "condition"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Condition"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "condition_occurrence",
+      "classification": "condition"
     },
     {
       "type":"concept",
+      "id": "tanagra-procedures",
       "title":"Procedures",
       "defaultName":"Contains Procedures Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Procedure"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "procedure_occurrence",
-        "classification": "procedure"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Procedure"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "procedure_occurrence",
+      "classification": "procedure"
     },
     {
       "type":"concept",
+      "id": "tanagra-observations",
       "title":"Observations",
       "defaultName":"Contains Observations Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "observation_occurrence",
-        "classification": "observation"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "observation_occurrence",
+      "classification": "observation"
     },
     {
       "type":"concept",
+      "id": "tanagra-drugs",
       "title":"Drugs",
       "defaultName":"Contains Drugs Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Drug"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "ingredient_occurrence",
-        "classification": "ingredient"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Drug"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "ingredient_occurrence",
+      "classification": "ingredient"
     },
     {
       "type":"attribute",
+      "id": "tanagra-ethnicity",
       "title":"Ethnicity",
       "defaultName":"Contains Ethnicity Codes",
-      "plugin":{"attribute":"ethnicity_concept_id"}
+      "attribute":"ethnicity_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-gender",
       "title":"Gender Identity",
       "defaultName":"Contains Gender Identity Codes",
-      "plugin":{"attribute":"gender_concept_id"}
+      "attribute":"gender_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-race",
       "title":"Race",
       "defaultName":"Contains Race Codes",
-      "plugin":{"attribute":"race_concept_id"}
+      "attribute":"race_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-year_of_birth",
       "title":"Year at Birth",
       "defaultName":"Contains Year at Birth Values",
-      "plugin":{"attribute":"year_of_birth"}
+      "attribute":"year_of_birth"
     }],
     "demographicChartConfigs": {
       "groupByAttributes": ["gender_concept_id", "race_concept_id", "year_of_birth"],

--- a/api/src/main/resources/underlays/synpuf.yaml
+++ b/api/src/main/resources/underlays/synpuf.yaml
@@ -187,116 +187,117 @@ uiConfiguration: >-
     },
     "criteriaConfigs": [{
       "type":"concept",
+      "id": "tanagra-conditions",
       "title":"Conditions",
       "defaultName":"Contains Conditions Codes",
-      "plugin": {
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Condition"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "condition_occurrence",
-        "classification": "condition"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Condition"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "condition_occurrence",
+      "classification": "condition"
     },
     {
       "type":"concept",
+      "id": "tanagra-procedures",
       "title":"Procedures",
       "defaultName":"Contains Procedures Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Procedure"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "procedure_occurrence",
-        "classification": "procedure"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Procedure"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "procedure_occurrence",
+      "classification": "procedure"
     },
     {
       "type":"concept",
+      "id": "tanagra-observations",
       "title":"Observations",
       "defaultName":"Contains Observations Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "observation_occurrence",
-        "classification": "observation"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "observation_occurrence",
+      "classification": "observation"
     },
     {
       "type":"concept",
+      "id": "tanagra-drugs",
       "title":"Drugs",
       "defaultName":"Contains Drugs Codes",
-      "plugin":{
-        "columns": [
-          {"key":"concept_name","width":"100%","title":"Concept Name"},
-          {"key":"concept_id","width":120,"title":"Concept ID"},
-          {"key":"standard_concept","width":180,"title":"SourceStandard"},
-          {"key":"vocabulary_id","width":120,"title":"Vocab"},
-          {"key":"concept_code","width":120,"title":"Code"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "hierarchyColumns": [
-          {"key": "concept_name", "width": "100%", "title": "Drug"},
-          {"key": "concept_id", "width": 120, "title": "Concept ID"},
-          {"key":"person_count","width":120,"title":"Roll-up Count"}
-        ],
-        "occurrence": "ingredient_occurrence",
-        "classification": "ingredient"
-      }
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"concept_id","width":120,"title":"Concept ID"},
+        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "hierarchyColumns": [
+        {"key": "concept_name", "width": "100%", "title": "Drug"},
+        {"key": "concept_id", "width": 120, "title": "Concept ID"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ],
+      "occurrence": "ingredient_occurrence",
+      "classification": "ingredient"
     },
     {
       "type":"attribute",
+      "id": "tanagra-ethnicity",
       "title":"Ethnicity",
       "defaultName":"Contains Ethnicity Codes",
-      "plugin":{"attribute":"ethnicity_concept_id"}
+      "attribute":"ethnicity_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-gender",
       "title":"Gender Identity",
       "defaultName":"Contains Gender Identity Codes",
-      "plugin":{"attribute":"gender_concept_id"}
+      "attribute":"gender_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-race",
       "title":"Race",
       "defaultName":"Contains Race Codes",
-      "plugin":{"attribute":"race_concept_id"}
+      "attribute":"race_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-sex_at_birth",
       "title":"Sex Assigned at Birth",
       "defaultName":"Contains Sex Assigned at Birth Codes",
-      "plugin":{"attribute":"sex_at_birth_concept_id"}
+      "attribute":"sex_at_birth_concept_id"
     },
     {
       "type":"attribute",
+      "id": "tanagra-year_of_birth",
       "title":"Year at Birth",
       "defaultName":"Contains Year at Birth Values",
-      "plugin":{"attribute":"year_of_birth"}
+      "attribute":"year_of_birth"
     }],
     "demographicChartConfigs": {
       "groupByAttributes": ["gender_concept_id", "race_concept_id", "year_of_birth"],

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -49,37 +49,29 @@ class FakeUnderlaysApi {
           type: "concept",
           title: "Conditions",
           defaultName: "Contains Conditions Codes",
-          plugin: {
-            columns,
-            occurrence: "condition_occurrence",
-            classification: "condition",
-          },
+          columns,
+          occurrence: "condition_occurrence",
+          classification: "condition",
         },
         {
           type: "concept",
           title: "Observations",
           defaultName: "Contains Observations Codes",
-          plugin: {
-            columns,
-            occurrence: "observation_occurrence",
-            classification: "observation",
-          },
+          columns,
+          occurrence: "observation_occurrence",
+          classification: "observation",
         },
         {
           type: "attribute",
           title: "Race",
           defaultName: "Contains Race Codes",
-          plugin: {
-            attribute: "race_concept_id",
-          },
+          attribute: "race_concept_id",
         },
         {
           type: "attribute",
           title: "Year at Birth",
           defaultName: "Contains Year at Birth Values",
-          plugin: {
-            attribute: "year_of_birth",
-          },
+          attribute: "year_of_birth",
         },
       ],
     };

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -7,7 +7,7 @@ import "plugins";
 import { useCallback, useContext } from "react";
 import { HashRouter } from "react-router-dom";
 import { AppRouter } from "router";
-import { LoadingUserData } from "storage/storage";
+import { fetchUserData } from "storage/storage";
 import { setUnderlays } from "underlaysSlice";
 import "./app.css";
 
@@ -34,41 +34,39 @@ export default function App() {
         })
       );
 
-      dispatch(
-        setUnderlays(
-          entitiesResList.map((entitiesRes, i) => {
-            const name = res.underlays?.[i]?.name;
-            if (!name) {
-              throw new Error("Unnamed underlay.");
-            }
-            if (!entitiesRes.entities) {
-              throw new Error(`No entities in underlay ${name}`);
-            }
+      const underlays = entitiesResList.map((entitiesRes, i) => {
+        const name = res.underlays?.[i]?.name;
+        if (!name) {
+          throw new Error("Unnamed underlay.");
+        }
+        if (!entitiesRes.entities) {
+          throw new Error(`No entities in underlay ${name}`);
+        }
 
-            const uiConfiguration = res.underlays?.[i]?.uiConfiguration;
-            if (!uiConfiguration) {
-              throw new Error(`No UI configuration in underlay ${name}`);
-            }
+        const uiConfiguration = res.underlays?.[i]?.uiConfiguration;
+        if (!uiConfiguration) {
+          throw new Error(`No UI configuration in underlay ${name}`);
+        }
 
-            return {
-              name,
-              primaryEntity: "person",
-              entities: entitiesRes.entities,
-              uiConfiguration: JSON.parse(uiConfiguration),
-            };
-          })
-        )
-      );
+        return {
+          name,
+          primaryEntity: "person",
+          entities: entitiesRes.entities,
+          uiConfiguration: JSON.parse(uiConfiguration),
+        };
+      });
+
+      await fetchUserData(dispatch, underlays);
+
+      dispatch(setUnderlays(underlays));
     }, [])
   );
 
   return (
-    <LoadingUserData>
-      <Loading status={underlaysState}>
-        <HashRouter>
-          <AppRouter />
-        </HashRouter>
-      </Loading>
-    </LoadingUserData>
+    <Loading status={underlaysState}>
+      <HashRouter>
+        <AppRouter />
+      </HashRouter>
+    </Loading>
   );
 }

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -78,6 +78,7 @@ export function createCriteria(
     type: config.type,
     name: config.defaultName,
     data: entry.initializeData(source, config),
+    config: config,
   };
 }
 
@@ -86,6 +87,7 @@ export function getCriteriaPlugin(
 ): CriteriaPlugin<object> {
   return new (getCriteriaEntry(criteria.type).constructor)(
     criteria.id,
+    criteria.config as CriteriaConfig,
     criteria.data
   );
 }
@@ -99,7 +101,11 @@ function getCriteriaEntry(type: string): RegistryEntry {
 }
 
 interface CriteriaPluginConstructor {
-  new (id: string, data: object): CriteriaPlugin<object>;
+  new (
+    id: string,
+    config: CriteriaConfig,
+    data: object
+  ): CriteriaPlugin<object>;
 }
 
 type RegistryEntry = {

--- a/ui/src/storage/storage.tsx
+++ b/ui/src/storage/storage.tsx
@@ -1,12 +1,10 @@
-import Loading from "components/loading";
-import { useAppDispatch } from "hooks";
-import { useCallback } from "react";
-import { useAsync } from "react-async";
 import { AnyAction, Dispatch, Middleware, MiddlewareAPI } from "redux";
 import { loadUserData, RootState } from "rootReducer";
+import { AppDispatch } from "store";
 import * as tanagra from "tanagra-api";
+import { Underlay } from "underlaysSlice";
 
-const currentVersion = 4;
+const currentVersion = 5;
 
 export interface StoragePlugin {
   store(data: tanagra.UserData): Promise<void>;
@@ -32,45 +30,58 @@ export const storeUserData: Middleware<unknown, RootState> =
     return result;
   };
 
-export function LoadingUserData(props: { children?: React.ReactNode }) {
-  const dispatch = useAppDispatch();
-  const status = useAsync<tanagra.UserData>(
-    useCallback(() => {
-      if (!storagePlugin) {
-        throw new Error("No storage plugin configured.");
-      }
+export async function fetchUserData(
+  dispatch: AppDispatch,
+  underlays: Underlay[]
+) {
+  if (!storagePlugin) {
+    throw new Error("No storage plugin configured.");
+  }
 
-      return storagePlugin.load().then((data?: tanagra.UserData) => {
-        if (!data) {
-          return;
-        }
+  const data = await storagePlugin.load();
+  if (!data) {
+    return;
+  }
 
-        if (data.version > currentVersion) {
+  if (data.version > currentVersion) {
+    throw new Error(
+      `Unable to load newer data: verson ${data.version} > current version ${currentVersion}`
+    );
+  }
+
+  // TODO(tjennison): Handle backwards compatability when we're closer to
+  // launch.
+  if (data.version != currentVersion) {
+    data.cohorts = [];
+    data.conceptSets = [];
+  }
+
+  data.cohorts = data.cohorts || [];
+  data.conceptSets = data.conceptSets || [];
+
+  // TODO(tjennison): Add versioning to criteria.
+  for (const cohort of data.cohorts) {
+    const underlay = underlays.find((u) => u.name === cohort.underlayName);
+    if (!underlay) {
+      continue;
+    }
+
+    for (const group of cohort.groups) {
+      for (const criteria of group.criteria) {
+        const config = underlay.uiConfiguration.criteriaConfigs.find(
+          (config) => config.id === criteria.config.id
+        );
+        if (!config) {
           throw new Error(
-            `Unable to load newer data: verson ${data.version} > current version ${currentVersion}`
+            `Underlay has no support for criteria "${criteria.config.id}".`
           );
         }
+        criteria.config = config;
+      }
+    }
+  }
 
-        // TODO(tjennison): Handle backwards compatability when we're closer to
-        // launch.
-        if (data.version != currentVersion) {
-          data.cohorts = [];
-          data.conceptSets = [];
-        }
-
-        data.cohorts = data.cohorts || [];
-        data.conceptSets = data.conceptSets || [];
-
-        dispatch(loadUserData(data));
-      });
-    }, [])
-  );
-
-  return (
-    <Loading status={status}>
-      <>{props.children}</>
-    </Loading>
-  );
+  dispatch(loadUserData(data));
 }
 
 // registerStoragePlugin is a decorator that allows a storage plugin to be used

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -52,6 +52,7 @@ export type Bucket = {
 export interface CriteriaConfig {
   // The plugin type to use for this criteria.
   type: string;
+  id: string;
   title: string;
   defaultName: string;
 


### PR DESCRIPTION
Since the config was stored with the data, loading saved criteria would continue to used outdated config. This caused issues like not displaying new columns added to the config. Instead, only the id of the config is stored in the criteria and the current version is passed into the plugins.

This also merges the plugin specific config into the same structure as the rest of the config. The separation meant plugins that wanted base config and custom config either had to store them separately or cast the custom data at every use.