### PR TITLE
Start streamlining criteria names and condense outline layout

### DIFF
--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -49,10 +49,16 @@ export interface CriteriaPlugin<DataType> {
   id: string;
   data: DataType;
   renderEdit: (dispatchFn: (data: DataType) => void) => JSX.Element;
-  renderDetails: () => JSX.Element;
+  renderInline: () => JSX.Element;
+  displayDetails: () => DisplayDetails;
   generateFilter: () => Filter | null;
   occurrenceID: () => string;
 }
+
+export type DisplayDetails = {
+  title: string;
+  additionalText?: string[];
+};
 
 // registerCriteriaPlugin is a decorator that allows criteria to automatically
 // register with the app simply by importing them.

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -77,8 +77,30 @@ class _ implements CriteriaPlugin<Data> {
     );
   }
 
-  renderDetails() {
-    return <AttributeDetails data={this.data} config={this.config} />;
+  renderInline() {
+    return <AttributeInline data={this.data} config={this.config} />;
+  }
+
+  displayDetails() {
+    if (this.data.selected.length > 0) {
+      return {
+        title: this.config.title,
+        additionalText: this.data.selected.map((s) => s.name),
+      };
+    }
+
+    if (this.data.dataRanges.length > 0) {
+      return {
+        title: this.config.title,
+        additionalText: [
+          this.data.dataRanges.map((r) => `${r.min}-${r.max}`).join(", "),
+        ],
+      };
+    }
+
+    return {
+      title: `Any ${this.config.title}`,
+    };
   }
 
   generateFilter() {
@@ -317,12 +339,12 @@ function AttributeEdit(props: AttributeEditProps) {
   );
 }
 
-type AttributeDetailsProps = {
+type AttributeInlineProps = {
   config: Config;
   data: Data;
 };
 
-function AttributeDetails(props: AttributeDetailsProps) {
+function AttributeInline(props: AttributeInlineProps) {
   if (props.data.selected.length > 0) {
     return (
       <>

--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -77,8 +77,21 @@ class _ implements CriteriaPlugin<Data> {
     );
   }
 
-  renderDetails() {
-    return <ConceptDetails data={this.data} />;
+  renderInline() {
+    return <ConceptInline data={this.data} />;
+  }
+
+  displayDetails() {
+    if (this.data.selected.length > 0) {
+      return {
+        title: this.data.selected[0].name,
+        additionalText: this.data.selected.slice(1).map((s) => s.name),
+      };
+    }
+
+    return {
+      title: `Any ${this.config.title}`,
+    };
   }
 
   generateFilter() {
@@ -330,11 +343,11 @@ function ConceptEdit(props: ConceptEditProps) {
   );
 }
 
-type ConceptDetailsProps = {
+type ConceptInlineProps = {
   data: Data;
 };
 
-function ConceptDetails(props: ConceptDetailsProps) {
+function ConceptInline(props: ConceptInlineProps) {
   return (
     <>
       {props.data.selected.length === 0 ? (

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -769,22 +769,21 @@ function generateOccurrenceFilter(
       },
     }));
 
-    if (operands.length === 0) {
-      return [null, ""];
-    }
-
     return [
       {
         relationshipFilter: {
           outerVariable: entity.entity,
           newVariable: classification.entity,
           newEntity: classification.entity,
-          filter: {
-            arrayFilter: {
-              operands: operands,
-              operator: tanagra.ArrayFilterOperator.Or,
-            },
-          },
+          filter:
+            operands.length > 0
+              ? {
+                  arrayFilter: {
+                    operands: operands,
+                    operator: tanagra.ArrayFilterOperator.Or,
+                  },
+                }
+              : undefined,
         },
       },
       entity.entity,

--- a/ui/src/groupOverview.tsx
+++ b/ui/src/groupOverview.tsx
@@ -105,7 +105,7 @@ export function GroupOverview() {
               >
                 {criteria.name}
               </Link>
-              {getCriteriaPlugin(criteria).renderDetails()}
+              {getCriteriaPlugin(criteria).renderInline()}
             </Box>
             <Divider />
           </Box>

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -7,7 +7,6 @@ import Button from "@mui/material/Button";
 import Drawer from "@mui/material/Drawer";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
-import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
@@ -37,17 +36,18 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { cohortURL, criteriaURL } from "router";
+import { cohortURL } from "router";
 import * as tanagra from "tanagra-api";
 import { ChartConfigProperty } from "underlaysSlice";
 import { isValid } from "util/valid";
 import { generateCohortFilter, getCriteriaPlugin, groupName } from "./cohort";
 
-const drawerWidth = 400;
+const demographicsWidth = 400;
+const outlineWidth = 300;
 
 // This drawer customization is taken directly from the MUI docs.
 const openedMixin = (theme: Theme): CSSObject => ({
-  width: drawerWidth,
+  width: demographicsWidth,
   transition: theme.transitions.create("width", {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.enteringScreen,
@@ -70,7 +70,7 @@ const closedMixin = (theme: Theme): CSSObject => ({
 const MiniDrawer = styled(Drawer, {
   shouldForwardProp: (prop) => prop !== "open",
 })(({ theme, open }) => ({
-  width: drawerWidth,
+  width: demographicsWidth,
   flexShrink: 0,
   whiteSpace: "nowrap",
   boxSizing: "border-box",
@@ -93,10 +93,10 @@ export function Overview() {
         variant="permanent"
         anchor="left"
         sx={{
-          width: drawerWidth,
+          width: outlineWidth,
           flexShrink: 0,
           [`& .MuiDrawer-paper`]: {
-            width: drawerWidth,
+            width: outlineWidth,
             boxSizing: "border-box",
           },
         }}
@@ -288,6 +288,11 @@ function ParticipantCriteria(props: {
 
   const criteriaCountState = useAsyncWithApi(fetchCriteriaCount);
 
+  const displayDetails = getCriteriaPlugin(props.criteria).displayDetails();
+  const additionalText = displayDetails.additionalText?.length
+    ? displayDetails.additionalText.join("\n")
+    : displayDetails.title;
+
   return (
     <>
       <Box
@@ -296,23 +301,22 @@ function ParticipantCriteria(props: {
         justifyContent="space-between"
         alignItems="center"
       >
-        <Link
+        <Typography
           variant="h6"
-          color="inherit"
-          underline="hover"
-          component={RouterLink}
-          to={criteriaURL(props.criteria.id)}
+          title={additionalText}
+          sx={{
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+          }}
         >
-          {props.criteria.name}
-        </Link>
+          {displayDetails.title}
+        </Typography>
         <Loading status={criteriaCountState} size="small">
           <Typography variant="body1">
             {criteriaCountState.data?.toLocaleString()}
           </Typography>
         </Loading>
-      </Box>
-      <Box sx={{ pl: 1 }}>
-        {getCriteriaPlugin(props.criteria).renderDetails()}
       </Box>
     </>
   );


### PR DESCRIPTION
* Starts the process of deprioritizing concept ids and the verbose names associates with them (e.g. Contains Condition Codes).
* Using the single selection of criteria values to display the actual names of selected values in the outline.
* Moves detailed criteria information in the outline into tooltips to condense the outline display. The details are still in the group overview. There are a variety of options with slightly different layouts but I think this is the best compromise of space and information.