### PR TITLE
Add separate page for creating criteria

### DIFF
--- a/api/src/main/resources/underlays/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/aou_synthetic.yaml
@@ -427,6 +427,7 @@ uiConfiguration: >-
       "id": "tanagra-conditions",
       "title":"Conditions",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -448,6 +449,7 @@ uiConfiguration: >-
       "id": "tanagra-procedures",
       "title":"Procedures",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -469,6 +471,7 @@ uiConfiguration: >-
       "id": "tanagra-observations",
       "title":"Observations",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -485,6 +488,7 @@ uiConfiguration: >-
       "id": "tanagra-drugs",
       "title":"Drugs",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -505,30 +509,35 @@ uiConfiguration: >-
       "type":"attribute",
       "id": "tanagra-ethnicity",
       "title":"Ethnicity",
+      "category": "Program data",
       "attribute":"ethnicity_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-gender",
       "title":"Gender Identity",
+      "category": "Program data",
       "attribute":"gender_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-race",
       "title":"Race",
+      "category": "Program data",
       "attribute":"race_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-sex_at_birth",
       "title":"Sex Assigned at Birth",
+      "category": "Program data",
       "attribute":"sex_at_birth_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-year_of_birth",
       "title":"Year of Birth",
+      "category": "Program data",
       "attribute":"year_of_birth"
     }],
     "demographicChartConfigs": {
@@ -580,7 +589,16 @@ uiConfiguration: >-
           "keys": [21604253]
         }
       }
-    ]
+    ],
+    "criteriaSearchConfig": {
+      "criteriaTypeWidth": 120,
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ]
+    }
   }
 relationships:
   - name: brand_ingredient

--- a/api/src/main/resources/underlays/sd.yaml
+++ b/api/src/main/resources/underlays/sd.yaml
@@ -414,6 +414,7 @@ uiConfiguration: >-
       "id": "tanagra-conditions",
       "title":"Conditions",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -435,6 +436,7 @@ uiConfiguration: >-
       "id": "tanagra-procedures",
       "title":"Procedures",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -456,6 +458,7 @@ uiConfiguration: >-
       "id": "tanagra-observations",
       "title":"Observations",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -472,6 +475,7 @@ uiConfiguration: >-
       "id": "tanagra-drugs",
       "title":"Drugs",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -492,24 +496,28 @@ uiConfiguration: >-
       "type":"attribute",
       "id": "tanagra-ethnicity",
       "title":"Ethnicity",
+      "category": "Program data",
       "attribute":"ethnicity_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-gender",
       "title":"Gender Identity",
+      "category": "Program data",
       "attribute":"gender_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-race",
       "title":"Race",
+      "category": "Program data",
       "attribute":"race_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-year_of_birth",
       "title":"Year of Birth",
+      "category": "Program data",
       "attribute":"year_of_birth"
     }],
     "demographicChartConfigs": {
@@ -561,7 +569,16 @@ uiConfiguration: >-
           "keys": [21604253]
         }
       }
-    ]
+    ],
+    "criteriaSearchConfig": {
+      "criteriaTypeWidth": 120,
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ]
+    }
   }
 relationships:
   - name: brand_ingredient

--- a/api/src/main/resources/underlays/synpuf.yaml
+++ b/api/src/main/resources/underlays/synpuf.yaml
@@ -190,6 +190,7 @@ uiConfiguration: >-
       "id": "tanagra-conditions",
       "title":"Conditions",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -211,6 +212,7 @@ uiConfiguration: >-
       "id": "tanagra-procedures",
       "title":"Procedures",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -232,6 +234,7 @@ uiConfiguration: >-
       "id": "tanagra-observations",
       "title":"Observations",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -248,6 +251,7 @@ uiConfiguration: >-
       "id": "tanagra-drugs",
       "title":"Drugs",
       "conceptSet": true,
+      "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
         {"key":"concept_id","width":120,"title":"Concept ID"},
@@ -268,30 +272,35 @@ uiConfiguration: >-
       "type":"attribute",
       "id": "tanagra-ethnicity",
       "title":"Ethnicity",
+      "category": "Program data",
       "attribute":"ethnicity_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-gender",
       "title":"Gender Identity",
+      "category": "Program data",
       "attribute":"gender_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-race",
       "title":"Race",
+      "category": "Program data",
       "attribute":"race_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-sex_at_birth",
       "title":"Sex Assigned at Birth",
+      "category": "Program data",
       "attribute":"sex_at_birth_concept_id"
     },
     {
       "type":"attribute",
       "id": "tanagra-year_of_birth",
       "title":"Year of Birth",
+      "category": "Program data",
       "attribute":"year_of_birth"
     }],
     "demographicChartConfigs": {
@@ -343,7 +352,16 @@ uiConfiguration: >-
           "keys": [21604253]
         }
       }
-    ]
+    ],
+    "criteriaSearchConfig": {
+      "criteriaTypeWidth": 120,
+      "columns": [
+        {"key":"concept_name","width":"100%","title":"Concept Name"},
+        {"key":"vocabulary_id","width":120,"title":"Vocab"},
+        {"key":"concept_code","width":120,"title":"Code"},
+        {"key":"person_count","width":120,"title":"Roll-up Count"}
+      ]
+    }
   }
 relationships:
   - name: person_condition_occurrence

--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -9,22 +9,26 @@ describe("Basic tests", () => {
     cy.get("#text").type("New Cohort");
     cy.get("button:Contains(Create)").click();
     cy.get("button:Contains(Add Criteria)").first().click();
-    cy.get("li:Contains(Conditions)").click();
+    cy.get("button:Contains(Conditions)").click();
     cy.get("button:Contains(test concept)").click();
 
     cy.get("button:Contains(Add Criteria)").first().click();
-    cy.get("li:Contains(Race)").click();
+    cy.get("button:Contains(Race)").click();
     cy.get(".MuiSelect-select").click();
     cy.get("li:Contains(Asian)").click();
     cy.get(".MuiBackdrop-root").click();
 
     cy.get("button:Contains(Add Criteria)").first().click();
-    cy.get("li:Contains(Year at Birth)").click();
+    cy.get("button:Contains(Year at Birth)").click();
     cy.get(".MuiInput-input").first().type("{selectall}30");
 
     cy.get("button:Contains(Add Criteria)").last().click();
-    cy.get("li:Contains(Observations)").click();
+    cy.get("button:Contains(Observations)").click();
     cy.get("button:Contains(test concept)").click();
+
+    cy.get("button:Contains(Add Criteria)").last().click();
+    cy.get("input").type("test{enter}");
+    cy.get("button:Contains(test concept)").first().click();
 
     cy.get("a[aria-label=back]").click();
 

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -1,0 +1,202 @@
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import ActionBar from "actionBar";
+import { insertCriteria } from "cohortsSlice";
+import Loading from "components/loading";
+import { Search } from "components/search";
+import {
+  TreeGrid,
+  TreeGridData,
+  TreeGridId,
+  TreeGridItem,
+} from "components/treegrid";
+import { DataEntry, DataKey } from "data/configuration";
+import { MergedDataEntry, useSource } from "data/source";
+import { useAsyncWithApi } from "errors";
+import { useAppDispatch, useCohortAndGroup, useUnderlay } from "hooks";
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { cohortURL, criteriaURL } from "router";
+import { CriteriaConfig } from "underlaysSlice";
+import { createCriteria, getCriteriaPlugin, searchCriteria } from "./cohort";
+
+export function AddCriteria() {
+  const underlay = useUnderlay();
+  const source = useSource();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { cohort, group } = useCohortAndGroup();
+
+  const [query, setQuery] = useState<string>("");
+  const [showResults, setShowResults] = useState<boolean>(false);
+  const [data, setData] = useState<TreeGridData>({});
+
+  const criteriaConfigs = underlay.uiConfiguration.criteriaConfigs;
+  const searchConfig = underlay.uiConfiguration.criteriaSearchConfig;
+
+  const categories = useMemo(() => {
+    const categories: CriteriaConfig[][] = [];
+
+    for (const config of criteriaConfigs) {
+      let category: CriteriaConfig[] | undefined;
+      for (const c of categories) {
+        if (c[0].category === config.category) {
+          category = c;
+          break;
+        }
+      }
+
+      if (category) {
+        category.push(config);
+      } else {
+        categories.push([config]);
+      }
+    }
+
+    return categories;
+  }, [underlay]);
+
+  const columns = useMemo(
+    () => [
+      {
+        key: "t_criteria_type",
+        width: searchConfig.criteriaTypeWidth,
+        title: "Criteria type",
+      },
+      ...searchConfig.columns,
+    ],
+    [underlay]
+  );
+
+  const onClick = useCallback(
+    (config: CriteriaConfig, dataEntry?: DataEntry) => {
+      const criteria = createCriteria(source, config, dataEntry);
+      dispatch(
+        insertCriteria({
+          cohortId: cohort.id,
+          groupId: group.id,
+          criteria,
+        })
+      );
+      navigate(
+        !!getCriteriaPlugin(criteria).renderEdit && !dataEntry
+          ? "../" + criteriaURL(criteria.id)
+          : "../../" + cohortURL(cohort.id, group.id)
+      );
+    },
+    [source, cohort.id, group.id]
+  );
+
+  const criteriaConfigMap = useMemo(
+    () => new Map(criteriaConfigs.map((cc) => [cc.id, cc])),
+    [criteriaConfigs]
+  );
+
+  const search = useCallback(async () => {
+    // This prevents briefly showing the empty results from the empty query
+    // inbetween when a new query has been set but before searchState is
+    // retriggered.
+    setShowResults(!!query);
+
+    const children: DataKey[] = [];
+    const data: TreeGridData = {
+      root: { data: {}, children },
+    };
+
+    if (query) {
+      const res = await searchCriteria(source, criteriaConfigs, query);
+
+      res.data.forEach((entry) => {
+        const key = `${entry.source}~${entry.data.key}`;
+        children.push(key);
+
+        const item: CriteriaItem = {
+          data: {
+            ...entry.data,
+            t_criteria_type: (
+              <Stack direction="row" justifyContent="center">
+                <Chip
+                  label={criteriaConfigMap.get(entry.source)?.title}
+                  size="small"
+                />
+              </Stack>
+            ),
+          },
+          entry: entry,
+        };
+        data[key] = item;
+      });
+    }
+
+    setData(data);
+  }, [source, query, criteriaConfigs]);
+  const searchState = useAsyncWithApi<void>(search);
+
+  return (
+    <Box sx={{ m: 1 }}>
+      <Search
+        placeholder="Search criteria or select from the options below"
+        onSearch={setQuery}
+      />
+      <ActionBar title={"Add criteria"} />
+      {showResults ? (
+        <Loading status={searchState}>
+          <TreeGrid
+            columns={columns}
+            data={data}
+            rowCustomization={(id: TreeGridId) => {
+              const item = data[id] as CriteriaItem;
+              const config = criteriaConfigMap.get(item.entry.source);
+              if (!config) {
+                throw new Error(
+                  `Item source "${item.entry.source}" doesn't match any criteria config ID.`
+                );
+              }
+
+              return new Map([
+                [
+                  1,
+                  {
+                    onClick: () => onClick(config, item.entry.data),
+                  },
+                ],
+              ]);
+            }}
+          />
+        </Loading>
+      ) : (
+        <Stack direction="row" justifyContent="center">
+          {categories.map((category) => (
+            <Stack
+              key={category[0].category}
+              spacing={1}
+              alignItems="center"
+              justifyContent="flex-start"
+              sx={{ width: 180 }}
+            >
+              <Typography key="" variant="h6">
+                {category[0].category ?? "Uncategorized"}
+              </Typography>
+              {category.map((config) => (
+                <Button
+                  key={config.id}
+                  onClick={() => onClick(config)}
+                  variant="contained"
+                >
+                  {config.title}
+                </Button>
+              ))}
+            </Stack>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+type CriteriaItem = TreeGridItem & {
+  entry: MergedDataEntry;
+};

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -79,6 +79,13 @@ class FakeUnderlaysApi {
           attribute: "year_of_birth",
         },
       ],
+      criteriaSearchConfig: {
+        criteriaTypeWidth: 120,
+        columns: [
+          { key: "concept_name", width: "100%", title: "Concept Name" },
+          { key: "person_count", width: 120, title: "Roll-up Count" },
+        ],
+      },
     };
 
     return new Promise<tanagra.ListUnderlaysResponse>((resolve) => {

--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -209,6 +209,37 @@ Array [
                 className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="1-col2"
               >
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                    />
+                  </svg>
+                </button>
                 1-col2
               </p>
             </div>
@@ -235,6 +266,37 @@ Array [
                 className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title=""
               >
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowRightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                    />
+                  </svg>
+                </button>
                 
               </p>
             </div>

--- a/ui/src/components/treegrid.test.tsx
+++ b/ui/src/components/treegrid.test.tsx
@@ -56,13 +56,18 @@ test("Table renders correctly", () => {
     if (id !== 2) {
       return undefined;
     }
-    return {
-      prefixElements: (
-        <IconButton size="small">
-          <CheckBoxIcon fontSize="inherit" />
-        </IconButton>
-      ),
-    };
+    return new Map([
+      [
+        0,
+        {
+          prefixElements: (
+            <IconButton size="small">
+              <CheckBoxIcon fontSize="inherit" />
+            </IconButton>
+          ),
+        },
+      ],
+    ]);
   };
 
   const tree = renderer

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -30,7 +30,7 @@ export type TreeGridColumn = {
   title?: string | JSX.Element;
 };
 
-export type RowCustomization = {
+export type ColumnCustomization = {
   prefixElements?: ReactNode;
   onClick?: () => void;
 };
@@ -42,7 +42,7 @@ export type TreeGridProps = {
   rowCustomization?: (
     id: TreeGridId,
     data: TreeGridRowData
-  ) => RowCustomization | undefined;
+  ) => Map<number, ColumnCustomization> | undefined;
   loadChildren?: (id: TreeGridId) => Promise<void>;
   variableWidth?: boolean;
   wrapBodyText?: boolean;
@@ -204,10 +204,12 @@ function renderChildren(
     if (!child) {
       return;
     }
-    const childState = state.get(childId);
 
-    const renderFirstColumn = (value: TreeGridValue) => {
-      const rowCustomization = props.rowCustomization?.(childId, child.data);
+    const childState = state.get(childId);
+    const rowCustomization = props.rowCustomization?.(childId, child.data);
+
+    const renderColumn = (column: number, value: TreeGridValue) => {
+      const columnCustomization = rowCustomization?.get(column);
       return (
         <>
           {(!!child.children?.length ||
@@ -222,14 +224,14 @@ function renderChildren(
               <ItemIcon state={childState} />
             </IconButton>
           )}
-          {rowCustomization?.prefixElements}
-          {rowCustomization?.onClick ? (
+          {columnCustomization?.prefixElements}
+          {columnCustomization?.onClick ? (
             <Link
               component="button"
               variant="body1"
               color="inherit"
               underline="hover"
-              onClick={rowCustomization.onClick}
+              onClick={columnCustomization.onClick}
             >
               {value}
             </Link>
@@ -294,7 +296,7 @@ function renderChildren(
                     display: "inline",
                   }}
                 >
-                  {i === 0 ? renderFirstColumn(value) : value}
+                  {renderColumn(i, value)}
                 </Typography>
               </div>
             </td>

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -1,13 +1,15 @@
 import DeleteIcon from "@mui/icons-material/Delete";
-import { Button, IconButton, Slider } from "@mui/material";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import FormControl from "@mui/material/FormControl";
 import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
 import Input from "@mui/material/Input";
 import MenuItem from "@mui/material/MenuItem";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
+import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { CriteriaPlugin, generateId, registerCriteriaPlugin } from "cohort";

--- a/ui/src/groupOverview.tsx
+++ b/ui/src/groupOverview.tsx
@@ -7,7 +7,6 @@ import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
-import MenuItem from "@mui/material/MenuItem";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
@@ -15,28 +14,15 @@ import ActionBar from "actionBar";
 import {
   deleteCriteria,
   deleteGroup,
-  insertCriteria,
   renameGroup,
   setGroupKind,
 } from "cohortsSlice";
-import { useMenu } from "components/menu";
 import { useTextInputDialog } from "components/textInputDialog";
-import { useSource } from "data/source";
-import {
-  useAppDispatch,
-  useCohort,
-  useCohortAndGroup,
-  useUnderlay,
-} from "hooks";
+import { useAppDispatch, useCohortAndGroup } from "hooks";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { cohortURL, criteriaURL } from "router";
 import * as tanagra from "tanagra-api";
-import {
-  createCriteria,
-  getCriteriaPlugin,
-  getCriteriaTitle,
-  groupName,
-} from "./cohort";
+import { getCriteriaPlugin, getCriteriaTitle, groupName } from "./cohort";
 
 export function GroupOverview() {
   const { cohort, group, groupIndex } = useCohortAndGroup();
@@ -163,51 +149,14 @@ export function GroupOverview() {
         alignItems="baseline"
         sx={{ mt: 1 }}
       >
-        <AddCriteriaButton group={group.id} />
+        <Button
+          onClick={() => navigate("add")}
+          variant="contained"
+          className="add-criteria"
+        >
+          Add Criteria
+        </Button>
       </Stack>
     </Box>
-  );
-}
-
-function AddCriteriaButton(props: { group: string }) {
-  const underlay = useUnderlay();
-  const source = useSource();
-  const cohort = useCohort();
-  const navigate = useNavigate();
-  const dispatch = useAppDispatch();
-
-  const configs = underlay.uiConfiguration.criteriaConfigs;
-
-  const onAddCriteria = (criteria: tanagra.Criteria) => {
-    dispatch(
-      insertCriteria({ cohortId: cohort.id, groupId: props.group, criteria })
-    );
-    navigate(
-      !!getCriteriaPlugin(criteria).renderEdit
-        ? criteriaURL(criteria.id)
-        : "../" + cohortURL(cohort.id, props.group)
-    );
-  };
-
-  const [menu, show] = useMenu({
-    children: configs.map((config) => (
-      <MenuItem
-        key={config.title}
-        onClick={() => {
-          onAddCriteria(createCriteria(source, config));
-        }}
-      >
-        {config.title}
-      </MenuItem>
-    )),
-  });
-
-  return (
-    <>
-      <Button onClick={show} variant="contained" className="add-criteria">
-        Add Criteria
-      </Button>
-      {menu}
-    </>
   );
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,4 +1,5 @@
 import Button from "@mui/material/Button";
+import { AddCriteria } from "addCriteria";
 import ConceptSetEdit from "conceptSetEdit";
 import Edit from "edit";
 import { GroupOverview } from "groupOverview";
@@ -18,6 +19,7 @@ export function AppRouter() {
           <Route index element={<Datasets />} />
           <Route path="cohorts/:cohortId/:groupId" element={<Overview />}>
             <Route index element={<GroupOverview />} />
+            <Route path="add" element={<AddCriteria />} />
             <Route path="edit/:criteriaId" element={<Edit />} />
           </Route>
           <Route

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { TreeGridColumn } from "components/treegrid";
 import { Configuration } from "data/configuration";
 import { Filter } from "data/filter";
 import * as tanagra from "tanagra-api";
@@ -22,6 +23,7 @@ export type UIConfiguration = {
   criteriaConfigs: CriteriaConfig[];
   demographicChartConfigs: DemographicChartConfig;
   prepackagedConceptSets: PrepackagedConceptSet[];
+  criteriaSearchConfig: CriteriaSearchConfig;
 };
 
 export type DemographicChartConfig = {
@@ -47,6 +49,11 @@ export type Bucket = {
   displayName: string;
 };
 
+export type CriteriaSearchConfig = {
+  criteriaTypeWidth: string;
+  columns: TreeGridColumn[];
+};
+
 // CriteriaConfigs are used to initialize CriteriaPlugins and provide a list of
 // possible criteria.
 export interface CriteriaConfig {
@@ -55,6 +62,7 @@ export interface CriteriaConfig {
   id: string;
   title: string;
   conceptSet?: boolean;
+  category?: string;
 
   // Plugin specific config.
   plugin: unknown;


### PR DESCRIPTION
* Instead of the "Add Criteria" button opening a menu, it navigates to a separate page. The options from the menu are present on the new page along with a search bar.
* Support searching across criteria types and display the returned criteria merged together and sorted by roll up count. Criteria can be added directly from the search results.
* Allow customization of individual columns of a TreeGrid to allow the criteria type column to be before the name.