### PR TITLE
Overhaul styling (fonts, colors, spacing, layout)

### DIFF
--- a/api/src/main/resources/underlays/aou_synthetic.yaml
+++ b/api/src/main/resources/underlays/aou_synthetic.yaml
@@ -430,8 +430,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -452,8 +452,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -474,8 +474,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -491,8 +491,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}

--- a/api/src/main/resources/underlays/sd.yaml
+++ b/api/src/main/resources/underlays/sd.yaml
@@ -417,8 +417,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -439,8 +439,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -461,8 +461,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -478,8 +478,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}

--- a/api/src/main/resources/underlays/synpuf.yaml
+++ b/api/src/main/resources/underlays/synpuf.yaml
@@ -193,8 +193,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -215,8 +215,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -237,8 +237,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}
@@ -254,8 +254,8 @@ uiConfiguration: >-
       "category": "Domains",
       "columns": [
         {"key":"concept_name","width":"100%","title":"Concept Name"},
-        {"key":"concept_id","width":120,"title":"Concept ID"},
-        {"key":"standard_concept","width":180,"title":"SourceStandard"},
+        {"key":"concept_id","width":100,"title":"Concept ID"},
+        {"key":"standard_concept","width":120,"title":"Source/Standard"},
         {"key":"vocabulary_id","width":120,"title":"Vocab"},
         {"key":"concept_code","width":120,"title":"Code"},
         {"key":"person_count","width":120,"title":"Roll-up Count"}

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="height: 100%">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Red+Hat+Display:wght@400;500;700&family=Red+Hat+Text:wght@500&display=swap"
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
     />
     <link
       rel="stylesheet"
@@ -34,8 +36,8 @@
     />
     <title>Tanagra</title>
   </head>
-  <body>
+  <body style="height: 100%">
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" style="height: 100%"></div>
   </body>
 </html>

--- a/ui/src/actionBar.tsx
+++ b/ui/src/actionBar.tsx
@@ -25,7 +25,12 @@ export default function ActionBar(props: ActionBarProps) {
     <Box className="action-bar">
       <AppBar
         position="fixed"
-        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+        sx={{
+          zIndex: (theme) => theme.zIndex.drawer + 1,
+          borderBottomColor: (theme) => theme.palette.divider,
+          borderBottomStyle: "solid",
+          borderBottomWidth: "1px",
+        }}
       >
         <Toolbar>
           <IconButton
@@ -39,12 +44,20 @@ export default function ActionBar(props: ActionBarProps) {
           >
             <ArrowBackIcon />
           </IconButton>
-          <Typography variant="h4" sx={{ flexGrow: 1 }}>
+          <Typography
+            variant="h1"
+            sx={{
+              flexGrow: 1,
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+            }}
+          >
             {props.title}
           </Typography>
           <UndoRedo />
           {underlay ? (
-            <Typography variant="h6" className="underlay-name">
+            <Typography variant="h4" className="underlay-name">
               Dataset: {underlay.name}
             </Typography>
           ) : null}

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -136,7 +136,15 @@ export function AddCriteria() {
   const searchState = useAsyncWithApi<void>(search);
 
   return (
-    <Box sx={{ m: 1 }}>
+    <Box
+      sx={{
+        p: 1,
+        minWidth: "900px",
+        height: "100%",
+        overflow: "auto",
+        backgroundColor: (theme) => theme.palette.background.paper,
+      }}
+    >
       <Search
         placeholder="Search criteria or select from the options below"
         onSearch={setQuery}
@@ -177,7 +185,7 @@ export function AddCriteria() {
               justifyContent="flex-start"
               sx={{ width: 180 }}
             >
-              <Typography key="" variant="h6">
+              <Typography key="" variant="subtitle1">
                 {category[0].category ?? "Uncategorized"}
               </Typography>
               {category.map((config) => (

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -26,11 +26,6 @@
   margin-bottom: 2em;
 }
 
-.outline .group-title {
-  background: #e2e6ea;
-  color: #262262;
-}
-
 .loading {
   margin: 2em 4em;
 }

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,3 +1,5 @@
+import CssBaseline from "@mui/material/CssBaseline";
+import { ThemeProvider } from "@mui/material/styles";
 import { EntitiesApiContext, UnderlaysApiContext } from "apiContext";
 import Loading from "components/loading";
 import { useAsyncWithApi } from "errors";
@@ -10,6 +12,7 @@ import { AppRouter } from "router";
 import { fetchUserData } from "storage/storage";
 import { setUnderlays } from "underlaysSlice";
 import "./app.css";
+import theme from "./theme";
 
 enableMapSet();
 
@@ -63,10 +66,13 @@ export default function App() {
   );
 
   return (
-    <Loading status={underlaysState}>
-      <HashRouter>
-        <AppRouter />
-      </HashRouter>
-    </Loading>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Loading status={underlaysState}>
+        <HashRouter>
+          <AppRouter />
+        </HashRouter>
+      </Loading>
+    </ThemeProvider>
   );
 }

--- a/ui/src/components/UndoRedo.tsx
+++ b/ui/src/components/UndoRedo.tsx
@@ -1,6 +1,7 @@
 import RedoIcon from "@mui/icons-material/Redo";
 import UndoIcon from "@mui/icons-material/Undo";
-import { Box, Button } from "@mui/material";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
 import { useAppDispatch, useAppSelector, useUndoRedoUrls } from "hooks";
 import { Link as RouterLink } from "react-router-dom";
 import { ActionCreators as UndoActionCreators } from "redux-undo";
@@ -12,30 +13,28 @@ function UndoRedo() {
   const [undoUrlPath, redoUrlPath] = useUndoRedoUrls();
 
   return (
-    <Box>
+    <Stack direction="row" spacing={1} sx={{ m: 1 }}>
       <Button
         onClick={() => dispatch(UndoActionCreators.undo())}
+        variant="outlined"
+        startIcon={<UndoIcon />}
         disabled={!canUndo}
         component={RouterLink}
         to={undoUrlPath}
       >
-        <UndoIcon
-          fontSize="medium"
-          sx={{ color: canUndo ? "white" : "gray" }}
-        />
+        Undo
       </Button>
       <Button
         onClick={() => dispatch(UndoActionCreators.redo())}
+        variant="outlined"
+        startIcon={<RedoIcon />}
         disabled={!canRedo}
         component={RouterLink}
         to={redoUrlPath}
       >
-        <RedoIcon
-          fontSize="medium"
-          sx={{ color: canRedo ? "white" : "gray" }}
-        />
+        Redo
       </Button>
-    </Box>
+    </Stack>
   );
 }
 

--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -36,12 +36,12 @@ Array [
               }
             }
           >
-            <h6
-              className="MuiTypography-root MuiTypography-h6 css-1to91m4-MuiTypography-root"
+            <span
+              className="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
               title="Column 1"
             >
               Column 1
-            </h6>
+            </span>
           </div>
         </td>
         <td
@@ -62,12 +62,12 @@ Array [
               }
             }
           >
-            <h6
-              className="MuiTypography-root MuiTypography-h6 css-1to91m4-MuiTypography-root"
+            <span
+              className="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
               title="Column 2"
             >
               Column 2
-            </h6>
+            </span>
           </div>
         </td>
         <td
@@ -88,8 +88,8 @@ Array [
               }
             }
           >
-            <h6
-              className="MuiTypography-root MuiTypography-h6 css-1to91m4-MuiTypography-root"
+            <span
+              className="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
               title="[object Object]"
             >
               <svg
@@ -103,12 +103,15 @@ Array [
                   d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
                 />
               </svg>
-            </h6>
+            </span>
           </div>
         </td>
       </tr>
     </thead>
   </table>,
+  <hr
+    className="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
+  />,
   <div
     style={
       Object {
@@ -141,48 +144,46 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
                   "paddingLeft": "0.2em",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
             >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                  data-testid="KeyboardArrowRightIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                  />
+                </svg>
+              </button>
               <p
                 className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="1-col1"
               >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                    data-testid="KeyboardArrowRightIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
-                    />
-                  </svg>
-                </button>
                 1-col1
               </p>
             </div>
@@ -199,47 +200,45 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
             >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                  data-testid="KeyboardArrowRightIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                  />
+                </svg>
+              </button>
               <p
                 className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="1-col2"
               >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                    data-testid="KeyboardArrowRightIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
-                    />
-                  </svg>
-                </button>
                 1-col2
               </p>
             </div>
@@ -256,47 +255,45 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
             >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                  data-testid="KeyboardArrowRightIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                  />
+                </svg>
+              </button>
               <p
                 className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title=""
               >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                    data-testid="KeyboardArrowRightIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
-                    />
-                  </svg>
-                </button>
                 
               </p>
             </div>
@@ -321,47 +318,45 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
                   "paddingLeft": "1.2em",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
             >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+                disabled={false}
+                onBlur={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                  data-testid="CheckBoxIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                  />
+                </svg>
+              </button>
               <p
                 className="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-q1lnya-MuiTypography-root"
                 title="2-col1"
               >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                    data-testid="CheckBoxIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                    />
-                  </svg>
-                </button>
                 2-col1
               </p>
             </div>
@@ -378,8 +373,6 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
@@ -404,8 +397,6 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
@@ -434,9 +425,7 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
                   "paddingLeft": "0.2em",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
@@ -461,8 +450,6 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }
@@ -487,8 +474,6 @@ Array [
             <div
               style={
                 Object {
-                  "overflow": "hidden",
-                  "textOverflow": "ellipsis",
                   "whiteSpace": "nowrap",
                 }
               }

--- a/ui/src/components/checkbox.tsx
+++ b/ui/src/components/checkbox.tsx
@@ -29,7 +29,7 @@ export default function Checkbox({
       }}
     >
       {checked ? (
-        <CheckBoxIcon fontSize={fontSize} />
+        <CheckBoxIcon fontSize={fontSize} color="primary" />
       ) : (
         <CheckBoxOutlineBlankIcon fontSize={fontSize} />
       )}

--- a/ui/src/components/search.tsx
+++ b/ui/src/components/search.tsx
@@ -12,7 +12,7 @@ export type SearchProps = {
 
 export function Search(props: SearchProps) {
   return (
-    <Box m={2}>
+    <Box m={1}>
       <Form
         initialValues={{ query: "" }}
         onSubmit={({ query }) => props.onSearch(query)}

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -2,6 +2,7 @@ import ErrorIcon from "@mui/icons-material/Error";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import CircularProgress from "@mui/material/CircularProgress";
+import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Typography from "@mui/material/Typography";
@@ -146,7 +147,7 @@ export function TreeGrid(props: TreeGridProps) {
                   }}
                 >
                   <Typography
-                    variant="h6"
+                    variant="overline"
                     title={String(col.title)}
                     sx={{
                       display: "inline",
@@ -160,6 +161,7 @@ export function TreeGrid(props: TreeGridProps) {
           </tr>
         </thead>
       </table>
+      <Divider />
       <div
         style={{
           overflowY: "auto",
@@ -208,7 +210,11 @@ function renderChildren(
     const childState = state.get(childId);
     const rowCustomization = props.rowCustomization?.(childId, child.data);
 
-    const renderColumn = (column: number, value: TreeGridValue) => {
+    const renderColumn = (
+      column: number,
+      value: TreeGridValue,
+      title: string
+    ) => {
       const columnCustomization = rowCustomization?.get(column);
       return (
         <>
@@ -231,12 +237,33 @@ function renderChildren(
               variant="body1"
               color="inherit"
               underline="hover"
+              title={title}
               onClick={columnCustomization.onClick}
+              sx={{
+                width: "100%",
+                textAlign: "initial",
+                ...(props.wrapBodyText
+                  ? { wordBreak: "break-all" }
+                  : {
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                    }),
+              }}
             >
               {value}
             </Link>
           ) : (
-            value
+            <Typography
+              variant="body1"
+              noWrap={!props.wrapBodyText}
+              title={title}
+              sx={{
+                display: "inline",
+              }}
+            >
+              {value}
+            </Typography>
           )}
         </>
       );
@@ -273,11 +300,7 @@ function renderChildren(
                 style={{
                   ...(props.wrapBodyText
                     ? { wordBreak: "break-all" }
-                    : {
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                      }),
+                    : { whiteSpace: "nowrap" }),
                   ...(i === 0 && {
                     // TODO(tjennison): The removal of checkboxes revealed that
                     // the inline-block style on the <thead> that's use to keep
@@ -288,16 +311,7 @@ function renderChildren(
                   }),
                 }}
               >
-                <Typography
-                  variant="body1"
-                  noWrap={!props.wrapBodyText}
-                  title={title}
-                  sx={{
-                    display: "inline",
-                  }}
-                >
-                  {renderColumn(i, value)}
-                </Typography>
+                {renderColumn(i, value, title)}
               </div>
             </td>
           );

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -190,7 +190,7 @@ function AttributeSlider(props: SliderProps) {
   };
 
   return (
-    <Box sx={{ width: "30%", minWidth: 500 }}>
+    <Box sx={{ width: "30%", minWidth: 400, mt: 0.5 }}>
       <Grid container spacing={1} direction="row">
         <Grid item>
           <Input

--- a/ui/src/criteria/concept.tsx
+++ b/ui/src/criteria/concept.tsx
@@ -1,8 +1,8 @@
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
 import { CriteriaPlugin, registerCriteriaPlugin } from "cohort";
 import Checkbox from "components/checkbox";
 import Loading from "components/loading";
@@ -92,7 +92,7 @@ class _ implements CriteriaPlugin<Data> {
   }
 
   renderInline() {
-    return <ConceptInline data={this.data} />;
+    return <ConceptInline />;
   }
 
   displayDetails() {
@@ -162,14 +162,16 @@ function ConceptEdit(props: ConceptEditProps) {
           const rowData: TreeGridRowData = { ...node.data };
           if (node.ancestors) {
             rowData.view_hierarchy = (
-              <IconButton
-                size="small"
-                onClick={() => {
-                  setHierarchy(node.ancestors);
-                }}
-              >
-                <AccountTreeIcon fontSize="inherit" />
-              </IconButton>
+              <Stack alignItems="center">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setHierarchy(node.ancestors);
+                  }}
+                >
+                  <AccountTreeIcon fontSize="inherit" />
+                </IconButton>
+              </Stack>
             );
           }
 
@@ -249,7 +251,7 @@ function ConceptEdit(props: ConceptEditProps) {
     () => [
       ...props.config.columns,
       ...(classification.hierarchical
-        ? [{ key: "view_hierarchy", width: 160, title: "View Hierarchy" }]
+        ? [{ key: "view_hierarchy", width: 70, title: "Hierarchy" }]
         : []),
     ],
     [props.config.columns]
@@ -258,7 +260,14 @@ function ConceptEdit(props: ConceptEditProps) {
   const nameColumnIndex = props.config.nameColumnIndex ?? 0;
 
   return (
-    <>
+    <Box
+      sx={{
+        minWidth: "900px",
+        height: "100%",
+        overflow: "auto",
+        backgroundColor: (theme) => theme.palette.background.paper,
+      }}
+    >
       {!hierarchy && (
         <Search
           placeholder="Search by code or description"
@@ -365,29 +374,12 @@ function ConceptEdit(props: ConceptEditProps) {
           }}
         />
       </Loading>
-    </>
+    </Box>
   );
 }
 
-type ConceptInlineProps = {
-  data: Data;
-};
-
-function ConceptInline(props: ConceptInlineProps) {
-  return (
-    <>
-      {props.data.selected.length === 0 ? (
-        <Typography variant="body1">None selected</Typography>
-      ) : (
-        props.data.selected.map(({ key, name }) => (
-          <Stack direction="row" alignItems="baseline" key={key}>
-            <Typography variant="body1">{key}</Typography>&nbsp;
-            <Typography variant="body2">{name}</Typography>
-          </Stack>
-        ))
-      )}
-    </>
-  );
+function ConceptInline() {
+  return null;
 }
 
 function search(

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -95,7 +95,7 @@ export function Datasets() {
         />
         {editable ? (
           <Link
-            variant="h6"
+            variant="body1"
             color="inherit"
             underline="hover"
             component={RouterLink}
@@ -104,7 +104,7 @@ export function Datasets() {
             {conceptSet.name}
           </Link>
         ) : (
-          <Typography variant="h6">{conceptSet.name}</Typography>
+          <Typography variant="body1">{conceptSet.name}</Typography>
         )}
       </Stack>
     ));
@@ -133,6 +133,10 @@ export function Datasets() {
   });
 
   const allAttributesChecked = () => {
+    if (conceptSetOccurrences.length === 0) {
+      return false;
+    }
+
     for (const occurrence of conceptSetOccurrences) {
       for (const attribute of occurrence.attributes) {
         if (excludedAttributes.get(occurrence.id)?.has(attribute)) {
@@ -159,7 +163,7 @@ export function Datasets() {
             {dialog}
           </Stack>
           <Paper
-            sx={{ overflowY: "auto", display: "block" }}
+            sx={{ p: 1, overflowY: "auto", display: "block" }}
             className="datasets-select-panel"
           >
             {cohorts
@@ -174,7 +178,7 @@ export function Datasets() {
                     onChange={() => onToggle(updateSelectedCohorts, cohort.id)}
                   />
                   <Link
-                    variant="h6"
+                    variant="body1"
                     color="inherit"
                     underline="hover"
                     component={RouterLink}
@@ -197,19 +201,19 @@ export function Datasets() {
             {menu}
           </Stack>
           <Paper
-            sx={{ overflowY: "auto", display: "block" }}
+            sx={{ p: 1, overflowY: "auto", display: "block" }}
             className="datasets-select-panel"
           >
             {underlay.uiConfiguration.prepackagedConceptSets && (
               <>
-                <Typography variant="h5">Prepackaged</Typography>
+                <Typography variant="h4">Prepackaged</Typography>
                 {listConceptSets(
                   false,
                   underlay.uiConfiguration.prepackagedConceptSets
                 )}
               </>
             )}
-            <Typography variant="h5">Workspace</Typography>
+            <Typography variant="h4">Workspace</Typography>
             {listConceptSets(
               true,
               workspaceConceptSets
@@ -227,13 +231,13 @@ export function Datasets() {
             alignItems="center"
             justifyContent="space-between"
           >
-            <Stack direction="row" alignItems="center">
+            <Stack direction="row" alignItems="baseline">
               <Typography variant="h4" mr={1}>
                 3. Values
               </Typography>
-              <Typography variant="h5">(Columns)</Typography>
+              <Typography variant="h4">(Columns)</Typography>
             </Stack>
-            <Stack direction="row">
+            <Stack direction="row" alignItems="center">
               <Checkbox
                 size="small"
                 fontSize="inherit"
@@ -259,12 +263,12 @@ export function Datasets() {
             </Stack>
           </Stack>
           <Paper
-            sx={{ overflowY: "auto", display: "block" }}
+            sx={{ p: 1, overflowY: "auto", display: "block" }}
             className="datasets-select-panel"
           >
             {conceptSetOccurrences.map((occurrence) => (
               <Fragment key={occurrence.id}>
-                <Typography variant="h5">{occurrence.name}</Typography>
+                <Typography variant="subtitle1">{occurrence.name}</Typography>
                 {occurrence.attributes.map((attribute) => (
                   <Stack key={attribute} direction="row" alignItems="center">
                     <Checkbox
@@ -289,7 +293,7 @@ export function Datasets() {
                         })
                       }
                     />
-                    <Typography variant="h6">{attribute}</Typography>
+                    <Typography variant="body1">{attribute}</Typography>
                   </Stack>
                 ))}
               </Fragment>
@@ -297,7 +301,7 @@ export function Datasets() {
           </Paper>
         </Grid>
         <Grid item xs={3}>
-          <Paper>
+          <Paper sx={{ p: 1 }}>
             {selectedCohorts.size > 0 && selectedConceptSets.size > 0 ? (
               <Preview
                 selectedCohorts={selectedCohorts}
@@ -306,7 +310,7 @@ export function Datasets() {
                 excludedAttributes={excludedAttributes}
               />
             ) : (
-              <Typography variant="h5">
+              <Typography variant="h4">
                 Select at least one cohort and concept set to preview the
                 dataset.
               </Typography>

--- a/ui/src/groupOverview.tsx
+++ b/ui/src/groupOverview.tsx
@@ -4,9 +4,9 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
@@ -53,10 +53,10 @@ export function GroupOverview() {
       <Stack
         direction="row"
         justifyContent="space-between"
-        alignItems="baseline"
+        alignItems="flex-start"
       >
         <Stack direction="row" alignItems="center">
-          <Typography variant="h5">{name}</Typography>
+          <Typography variant="h3">{name}</Typography>
           <IconButton onClick={showRenameGroup}>
             <EditIcon />
           </IconButton>
@@ -94,51 +94,50 @@ export function GroupOverview() {
           <Typography>Included</Typography>
         </Stack>
       </Stack>
-      <Divider />
-      <Stack spacing={0}>
+      <Stack spacing={1}>
         {group.criteria.map((criteria) => {
           const plugin = getCriteriaPlugin(criteria);
           const title = getCriteriaTitle(criteria, plugin);
 
           return (
             <Box key={criteria.id}>
-              <Stack
-                direction="row"
-                justifyContent="space-between"
-                alignItems="baseline"
-                sx={{ m: 1 }}
-              >
-                <Box>
-                  {!!plugin.renderEdit ? (
-                    <Link
-                      variant="h6"
-                      color="inherit"
-                      underline="hover"
-                      component={RouterLink}
-                      to={criteriaURL(criteria.id)}
-                    >
-                      {title}
-                    </Link>
-                  ) : (
-                    <Typography variant="h6">{title}</Typography>
-                  )}
-                  {plugin.renderInline(criteria.id)}
-                </Box>
-                <IconButton
-                  onClick={() => {
-                    dispatch(
-                      deleteCriteria({
-                        cohortId: cohort.id,
-                        groupId: group.id,
-                        criteriaId: criteria.id,
-                      })
-                    );
-                  }}
+              <Paper sx={{ p: 1 }}>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="flex-start"
                 >
-                  <DeleteIcon />
-                </IconButton>
-              </Stack>
-              <Divider />
+                  <Box>
+                    {!!plugin.renderEdit ? (
+                      <Link
+                        variant="h4"
+                        color="inherit"
+                        underline="hover"
+                        component={RouterLink}
+                        to={criteriaURL(criteria.id)}
+                      >
+                        {title}
+                      </Link>
+                    ) : (
+                      <Typography variant="h4">{title}</Typography>
+                    )}
+                    {plugin.renderInline(criteria.id)}
+                  </Box>
+                  <IconButton
+                    onClick={() => {
+                      dispatch(
+                        deleteCriteria({
+                          cohortId: cohort.id,
+                          groupId: group.id,
+                          criteriaId: criteria.id,
+                        })
+                      );
+                    }}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Stack>
+              </Paper>
             </Box>
           );
         })}

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -87,8 +87,12 @@ const MiniDrawer = styled(Drawer, {
 export function Overview() {
   const [showDemographics, setShowDemographics] = useState(false);
 
+  // TODO(tjennison): This overall layout is a mess and the built in components
+  // are only making it more difficult. Overhaul the main layout to use basic
+  // boxes and layout components, and confine scrolling to each of the
+  // approprite panels.
   return (
-    <Box sx={{ display: "flex" }}>
+    <Box sx={{ display: "flex", height: "calc(100% - 48px)" }}>
       <Drawer
         variant="permanent"
         anchor="left"
@@ -96,6 +100,7 @@ export function Overview() {
           width: outlineWidth,
           flexShrink: 0,
           [`& .MuiDrawer-paper`]: {
+            backgroundColor: (theme) => theme.palette.background.default,
             width: outlineWidth,
             boxSizing: "border-box",
           },
@@ -106,7 +111,12 @@ export function Overview() {
           <Outline />
         </Box>
       </Drawer>
-      <Box sx={{ flexGrow: 1 }}>
+      <Box
+        sx={{
+          flexGrow: 1,
+          height: "100%",
+        }}
+      >
         <Toolbar />
         <Outlet />
       </Box>
@@ -148,7 +158,7 @@ function Outline() {
             />
           </ListItemButton>
         ))}
-        <ListItem disableGutters key="">
+        <ListItem disableGutters key="" sx={{ p: 0 }}>
           <AddGroupButton />
         </ListItem>
       </List>
@@ -213,16 +223,31 @@ function ParticipantsGroup(props: {
   const groupCountState = useAsyncWithApi(fetchGroupCount);
 
   return (
-    <Paper elevation={props.selected ? 8 : 1} sx={{ width: "100%" }}>
+    <Paper
+      sx={{ p: 1, width: "100%", overflow: "hidden", position: "relative" }}
+    >
+      {props.selected && (
+        <Box
+          className="selected-group-highlight"
+          sx={{
+            position: "absolute",
+            top: "16px",
+            bottom: "16px",
+            left: "-4px",
+            width: "8px",
+            "border-radius": "4px",
+            backgroundColor: (theme) => theme.palette.primary.main,
+          }}
+        />
+      )}
       <Stack spacing={0}>
         <Stack
           direction="row"
           justifyContent="space-between"
           alignItems="center"
           className="group-title"
-          sx={{ px: 0.5 }}
         >
-          <Typography variant="h5">
+          <Typography variant="h3">
             {groupName(props.group, props.index)}
           </Typography>
           {props.group.kind === tanagra.GroupKindEnum.Included ? (
@@ -232,7 +257,7 @@ function ParticipantsGroup(props: {
           )}
         </Stack>
         {props.group.criteria.map((criteria) => (
-          <Box key={criteria.id} sx={{ px: 0.5 }}>
+          <Box key={criteria.id}>
             <ParticipantCriteria group={props.group} criteria={criteria} />
           </Box>
         ))}
@@ -243,10 +268,9 @@ function ParticipantsGroup(props: {
           justifyContent="right"
           alignItems="center"
           className="group-title"
-          sx={{ px: 0.5 }}
         >
           <Loading status={groupCountState} size="small">
-            <Typography variant="body1" fontWeight="bold">
+            <Typography variant="subtitle1">
               Group Count: {groupCountState.data?.toLocaleString()}
             </Typography>
           </Loading>
@@ -306,7 +330,7 @@ function ParticipantCriteria(props: {
         alignItems="center"
       >
         <Typography
-          variant="h6"
+          variant="body1"
           title={additionalText}
           sx={{
             textOverflow: "ellipsis",
@@ -317,7 +341,7 @@ function ParticipantCriteria(props: {
           {title}
         </Typography>
         <Loading status={criteriaCountState} size="small">
-          <Typography variant="body1">
+          <Typography variant="body2" sx={{ ml: 1 }}>
             {criteriaCountState.data?.toLocaleString()}
           </Typography>
         </Loading>

--- a/ui/src/theme.tsx
+++ b/ui/src/theme.tsx
@@ -1,0 +1,185 @@
+import { createTheme } from "@mui/material/styles";
+
+export const theme = createTheme({
+  typography: {
+    fontFamily: "Inter, sans-serif",
+    fontSize: 12,
+    h1: {
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 400,
+      fontSize: 32,
+      lineHeight: "40px",
+    },
+    h2: {
+      fontFamily: "'Red Hat Display', sans-serif",
+      fontWeight: 500,
+      fontSize: 24,
+      lineHeight: "32px",
+    },
+    h3: {
+      fontFamily: "'Red Hat Display', sans-serif",
+      fontWeight: 400,
+      fontSize: 20,
+      lineHeight: "26px",
+    },
+    h4: {
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 400,
+      fontSize: 16,
+      lineHeight: "20px",
+    },
+    subtitle1: {
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 500,
+      fontSize: 12,
+      lineHeight: "20px",
+    },
+    body1: {
+      fontFamily: "'Inter', sans-serif",
+      fontSize: 12,
+      lineHeight: "20px",
+    },
+    body2: {
+      fontFamily: "'Inter', sans-serif",
+      fontSize: 10,
+      lineHeight: "14px",
+    },
+    overline: {
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 500,
+      fontSize: 11,
+      lineHeight: "16px",
+    },
+    button: {
+      fontFamily: "'Red Hat Text', sans-serif",
+      fontSize: 14,
+      lineHeight: "16px",
+    },
+  },
+  palette: {
+    primary: {
+      main: "#0A96AA",
+      light: "#59c7dc",
+      dark: "#00687b",
+    },
+    info: {
+      main: "#EEEEEE",
+    },
+    background: {
+      default: "#F5F5F5",
+    },
+    text: {
+      primary: "#212121",
+    },
+    action: {
+      selected: "#34A853",
+      selectedOpacity: 0.2,
+    },
+  },
+  components: {
+    MuiButton: {
+      defaultProps: {
+        size: "small",
+        disableElevation: true,
+      },
+    },
+    MuiPaper: {
+      defaultProps: {
+        elevation: 0,
+      },
+    },
+    MuiAppBar: {
+      defaultProps: {
+        elevation: 0,
+        color: "transparent",
+      },
+      styleOverrides: {
+        root: {
+          backgroundColor: "white",
+        },
+      },
+    },
+    MuiToolbar: {
+      defaultProps: {
+        variant: "dense",
+      },
+    },
+    MuiChip: {
+      defaultProps: {
+        size: "small",
+        color: "info",
+      },
+      styleOverrides: {
+        root: {
+          "border-radius": "4px",
+          height: "16px",
+        },
+        label: {
+          "font-family": "'Inter', sans-serif",
+          "font-weight": "500",
+          "font-size": "11px",
+          "text-transform": "uppercase",
+          "letter-spacing": ".5px",
+          padding: "1px 8px 0px 8px",
+        },
+      },
+    },
+    MuiCheckbox: {
+      defaultProps: {
+        color: "primary",
+      },
+    },
+    MuiTextField: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiFilledInput: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiFormControl: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiFormHelperText: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiIconButton: {
+      defaultProps: {
+        size: "small",
+      },
+    },
+    MuiInputBase: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiInputLabel: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiListItem: {
+      defaultProps: {
+        dense: true,
+      },
+    },
+    MuiOutlinedInput: {
+      defaultProps: {
+        margin: "dense",
+      },
+    },
+    MuiTable: {
+      defaultProps: {
+        size: "small",
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
Some notable changes in the code:
* Added an MUI theme to control the overall style. This is a much cleaner interface for customizing the MUI components than using CSS. Future work will remove all built in style from app.css and set up a method for plugins to override the theme.
* Fixed ellipses in the TreeGrid.
* Tightened some of the column sizes to better accomodate longer concept names and reasonably support 1280 pixel width displays.
* Improve horizontal scrolling of tables by making the scroll bar stick to the bottom of the screen instead of the bottom of the table which might be way below the bottom of the screen.
* Removed existing inline concept editing. It was unnecessary with the change to single select. In the future, this is where modifier controls will go.