### PR TITLE
Improve group filtering UI

### DIFF
--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -787,10 +787,8 @@ components:
         name:
           type: string
           description: The name of this group if customized.
-        kind:
-          type: string
-          description: The kind of this group.
-          enum: ["INCLUDED", "EXCLUDED"]
+        filter:
+          $ref: "#/components/schemas/GroupFilter"
         criteria:
           type: array
           description: The criteria that make of this group.
@@ -799,8 +797,26 @@ components:
       required:
         - id
         - kind
+        - filter
         - underlayName
         - criteria
+
+    GroupFilter:
+      type: object
+      description: |
+        A filter for a list of criteria that indicates how to combine the states
+        of the individual criteria.
+      properties:
+        kind:
+          type: string
+          description: The kind of this group.
+          enum: ["ANY", "ALL"]
+        excluded:
+          type: boolean
+          description: This group should be excluded instead of included.
+      required:
+        - kind
+        - excluded
 
     ConceptSet:
       type: object

--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -14,7 +14,7 @@ describe("Basic tests", () => {
 
     cy.get("button:Contains(Add Criteria)").first().click();
     cy.get("button:Contains(Race)").click();
-    cy.get(".MuiSelect-select").click();
+    cy.get(".MuiSelect-select:Contains(None selected)").click();
     cy.get("li:Contains(Asian)").click();
     cy.get(".MuiBackdrop-root").click();
 

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -24,13 +24,13 @@ export function generateCohortFilter(cohort: tanagra.Cohort): Filter | null {
 
 function generateFilter(group: tanagra.Group): Filter | null {
   const filter = makeArrayFilter(
-    { min: 1 },
+    group.filter.kind === tanagra.GroupFilterKindEnum.Any ? { min: 1 } : {},
     group.criteria
       .map((criteria) => getCriteriaPlugin(criteria).generateFilter())
       .filter(isValid)
   );
 
-  if (!filter || group.kind === tanagra.GroupKindEnum.Included) {
+  if (!filter || !group.filter.excluded) {
     return filter;
   }
   return {
@@ -41,7 +41,18 @@ function generateFilter(group: tanagra.Group): Filter | null {
 }
 
 export function groupName(group: tanagra.Group, index: number) {
-  return group.name ?? "Group " + String(index + 1);
+  return group.name ?? "Requirement " + String(index + 1);
+}
+
+export function groupFilterKindLabel(kind: tanagra.GroupFilterKindEnum) {
+  switch (kind) {
+    case tanagra.GroupFilterKindEnum.Any:
+      return "Any";
+    case tanagra.GroupFilterKindEnum.All:
+      return "All";
+  }
+
+  throw new Error(`Unknown group filter kind "${kind}".`);
 }
 
 // Having typed data here allows the registry to treat all data generically

--- a/ui/src/cohortsSlice.ts
+++ b/ui/src/cohortsSlice.ts
@@ -4,6 +4,11 @@ import * as tanagra from "tanagra-api";
 
 const initialState: tanagra.Cohort[] = [];
 
+export const defaultFilter: tanagra.GroupFilter = {
+  kind: tanagra.GroupFilterKindEnum.Any,
+  excluded: false,
+};
+
 // TODO(tjennison): Normalize groups and criteria to simplify a lot of this
 // nested code. This may require changing how the slices are arranged though,
 // since having cohorts, groups, and criteria in separate slices may end up
@@ -24,7 +29,7 @@ const cohortsSlice = createSlice({
           groups: [
             {
               id: generateId(),
-              kind: tanagra.GroupKindEnum.Included,
+              filter: defaultFilter,
               criteria: [],
             },
           ],
@@ -42,16 +47,12 @@ const cohortsSlice = createSlice({
           cohort.groups.push(action.payload.group);
         }
       },
-      prepare: (
-        cohortId: string,
-        kind: tanagra.GroupKindEnum,
-        criteria?: tanagra.Criteria
-      ) => ({
+      prepare: (cohortId: string, criteria?: tanagra.Criteria) => ({
         payload: {
           cohortId,
           group: {
             id: generateId(),
-            kind,
+            filter: defaultFilter,
             criteria: criteria ? [criteria] : [],
           },
         },
@@ -96,7 +97,7 @@ const cohortsSlice = createSlice({
             cohort.groups = [
               {
                 id: cohort.groups[0].id,
-                kind: tanagra.GroupKindEnum.Included,
+                filter: defaultFilter,
                 criteria: [],
               },
             ];
@@ -134,13 +135,13 @@ const cohortsSlice = createSlice({
       },
     },
 
-    setGroupKind: {
+    setGroupFilter: {
       reducer: (
         state,
         action: PayloadAction<{
           cohortId: string;
           groupId: string;
-          kind: tanagra.GroupKindEnum;
+          filter: tanagra.GroupFilter;
         }>
       ) => {
         const cohort = state.find((c) => c.id === action.payload.cohortId);
@@ -149,19 +150,19 @@ const cohortsSlice = createSlice({
             (g) => g.id === action.payload.groupId
           );
           if (group) {
-            group.kind = action.payload.kind;
+            group.filter = action.payload.filter;
           }
         }
       },
       prepare: (
         cohortId: string,
         groupId: string,
-        kind: tanagra.GroupKindEnum
+        filter: tanagra.GroupFilter
       ) => ({
         payload: {
           cohortId,
           groupId,
-          kind,
+          filter,
         },
       }),
     },
@@ -237,7 +238,7 @@ export const {
   insertGroup,
   renameGroup,
   deleteGroup,
-  setGroupKind,
+  setGroupFilter,
   insertCriteria,
   updateCriteriaData,
   deleteCriteria,

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -368,7 +368,7 @@ function AttributeInline(props: AttributeInlineProps) {
       </Box>
 
       {!!hintDataState.data?.enumHintOptions && (
-        <FormControl size="small" sx={{ maxWidth: 500 }}>
+        <FormControl sx={{ maxWidth: 500 }}>
           <Select
             multiple
             displayEmpty

--- a/ui/src/groupOverview.tsx
+++ b/ui/src/groupOverview.tsx
@@ -1,12 +1,14 @@
-import CheckIcon from "@mui/icons-material/Check";
-import ClearIcon from "@mui/icons-material/Clear";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import FormControl from "@mui/material/FormControl";
 import IconButton from "@mui/material/IconButton";
+import InputLabel from "@mui/material/InputLabel";
 import Link from "@mui/material/Link";
+import MenuItem from "@mui/material/MenuItem";
 import Paper from "@mui/material/Paper";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
@@ -15,14 +17,19 @@ import {
   deleteCriteria,
   deleteGroup,
   renameGroup,
-  setGroupKind,
+  setGroupFilter,
 } from "cohortsSlice";
 import { useTextInputDialog } from "components/textInputDialog";
 import { useAppDispatch, useCohortAndGroup } from "hooks";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { cohortURL, criteriaURL } from "router";
 import * as tanagra from "tanagra-api";
-import { getCriteriaPlugin, getCriteriaTitle, groupName } from "./cohort";
+import {
+  getCriteriaPlugin,
+  getCriteriaTitle,
+  groupFilterKindLabel,
+  groupName,
+} from "./cohort";
 
 export function GroupOverview() {
   const { cohort, group, groupIndex } = useCohortAndGroup();
@@ -73,25 +80,40 @@ export function GroupOverview() {
           {renameGroupDialog}
         </Stack>
         <Stack direction="row" alignItems="center">
-          <ClearIcon />
-          <Typography>Excluded</Typography>
+          <FormControl>
+            <InputLabel id="group-kind-label">Require</InputLabel>
+            <Select
+              value={group.filter.kind}
+              label="Require"
+              onChange={(event: SelectChangeEvent<string>) => {
+                dispatch(
+                  setGroupFilter(cohort.id, group.id, {
+                    ...group.filter,
+                    kind: event.target.value as tanagra.GroupFilterKindEnum,
+                  })
+                );
+              }}
+            >
+              {Object.values(tanagra.GroupFilterKindEnum).map((value) => (
+                <MenuItem key={value} value={value}>
+                  {groupFilterKindLabel(value)}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
           <Switch
-            checked={group.kind === tanagra.GroupKindEnum.Included}
-            onChange={(event, checked) =>
+            checked={group.filter.excluded}
+            onChange={() =>
               dispatch(
-                setGroupKind(
-                  cohort.id,
-                  group.id,
-                  checked
-                    ? tanagra.GroupKindEnum.Included
-                    : tanagra.GroupKindEnum.Excluded
-                )
+                setGroupFilter(cohort.id, group.id, {
+                  ...group.filter,
+                  excluded: !group.filter.excluded,
+                })
               )
             }
             inputProps={{ "aria-label": "controlled" }}
           />
-          <CheckIcon />
-          <Typography>Included</Typography>
+          <Typography>Excluded</Typography>
         </Stack>
       </Stack>
       <Stack spacing={1}>

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -1,9 +1,8 @@
 import BarChartIcon from "@mui/icons-material/BarChart";
-import CheckIcon from "@mui/icons-material/Check";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import ClearIcon from "@mui/icons-material/Clear";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
 import Drawer from "@mui/material/Drawer";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
@@ -15,7 +14,7 @@ import Stack from "@mui/material/Stack";
 import { CSSObject, styled, Theme } from "@mui/material/styles";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
-import { insertGroup } from "cohortsSlice";
+import { defaultFilter, insertGroup } from "cohortsSlice";
 import Loading from "components/loading";
 import { FilterCountValue, useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
@@ -40,7 +39,12 @@ import { cohortURL } from "router";
 import * as tanagra from "tanagra-api";
 import { ChartConfigProperty } from "underlaysSlice";
 import { isValid } from "util/valid";
-import { generateCohortFilter, getCriteriaPlugin, groupName } from "./cohort";
+import {
+  generateCohortFilter,
+  getCriteriaPlugin,
+  groupFilterKindLabel,
+  groupName,
+} from "./cohort";
 
 const demographicsWidth = 400;
 const outlineWidth = 300;
@@ -172,9 +176,7 @@ function AddGroupButton() {
   const dispatch = useAppDispatch();
 
   const onAddGroup = () => {
-    const action = dispatch(
-      insertGroup(cohort.id, tanagra.GroupKindEnum.Included)
-    );
+    const action = dispatch(insertGroup(cohort.id));
     const groupId = action.payload.group.id;
     if (groupId) {
       navigate("../" + cohortURL(cohort.id, groupId));
@@ -184,7 +186,7 @@ function AddGroupButton() {
   return (
     <>
       <Button onClick={onAddGroup} variant="contained" className="add-group">
-        Add Group
+        Add requirement
       </Button>
     </>
   );
@@ -207,7 +209,10 @@ function ParticipantsGroup(props: {
       groups: [
         {
           ...props.group,
-          kind: tanagra.GroupKindEnum.Included,
+          filter: {
+            kind: props.group.filter.kind,
+            excluded: false,
+          },
         },
       ],
     };
@@ -250,11 +255,10 @@ function ParticipantsGroup(props: {
           <Typography variant="h3">
             {groupName(props.group, props.index)}
           </Typography>
-          {props.group.kind === tanagra.GroupKindEnum.Included ? (
-            <CheckIcon />
-          ) : (
-            <ClearIcon />
-          )}
+          <Stack direction="row" spacing={1}>
+            {props.group.filter.excluded && <Chip label="Not" />}
+            <Chip label={groupFilterKindLabel(props.group.filter.kind)} />
+          </Stack>
         </Stack>
         {props.group.criteria.map((criteria) => (
           <Box key={criteria.id}>
@@ -296,7 +300,7 @@ function ParticipantCriteria(props: {
       groups: [
         {
           id: props.group.id,
-          kind: tanagra.GroupKindEnum.Included,
+          filter: defaultFilter,
           criteria: [props.criteria],
         },
       ],

--- a/ui/src/storage/storage.tsx
+++ b/ui/src/storage/storage.tsx
@@ -4,7 +4,7 @@ import { AppDispatch } from "store";
 import * as tanagra from "tanagra-api";
 import { Underlay } from "underlaysSlice";
 
-const currentVersion = 5;
+const currentVersion = 6;
 
 export interface StoragePlugin {
   store(data: tanagra.UserData): Promise<void>;

--- a/ui/src/theme.tsx
+++ b/ui/src/theme.tsx
@@ -142,6 +142,7 @@ export const theme = createTheme({
     MuiFormControl: {
       defaultProps: {
         margin: "dense",
+        size: "small",
       },
     },
     MuiFormHelperText: {


### PR DESCRIPTION
* Reorganize the group filter definition. The filter is moved into a separate object to group its parameters. Repurpose the "kind" field to indicate the overall kind (any, all, in future temporal, x-of-y, etc.) and move the existing exclusion logic to a boolean.
* Change UI to use badges instead of icons. This also clarifies the relationship between individual criteria.
* Rename groups to requirements to indicate that they're all required to match.