### PR TITLE
Show small loading spinner immediately

### DIFF
--- a/ui/src/components/loading.tsx
+++ b/ui/src/components/loading.tsx
@@ -27,6 +27,13 @@ export default function Loading(props: Props) {
       return;
     }
 
+    // Show the small spinner immediately since it's used inline and the delay
+    // causes extra shifting of the surrounding elements.
+    if (props.size === "small") {
+      setVisible(true);
+      return;
+    }
+
     timerRef.current = window.setTimeout(() => {
       setVisible(true);
     }, 800);


### PR DESCRIPTION
Since the small spinner is used inline unlike the normal one, delaying its appearance causes elements to shift around it until it appears.