### PR TITLE
Indexing job for writing text search string.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/indexing/job/BuildTextSearchStrings.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/BuildTextSearchStrings.java
@@ -1,0 +1,84 @@
+package bio.terra.tanagra.indexing.job;
+
+import bio.terra.tanagra.exception.InvalidConfigException;
+import bio.terra.tanagra.indexing.EntityJob;
+import bio.terra.tanagra.query.Query;
+import bio.terra.tanagra.underlay.DataPointer;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.TablePointer;
+import bio.terra.tanagra.underlay.datapointer.BigQueryDataset;
+import bio.terra.tanagra.utils.GoogleBigQuery;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BuildTextSearchStrings extends EntityJob {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WriteParentChildIdPairs.class);
+
+  public BuildTextSearchStrings(Entity entity) {
+    super(entity);
+  }
+
+  @Override
+  public String getName() {
+    return "BUILD TEXT SEARCH (" + getEntity().getName() + ")";
+  }
+
+  @Override
+  public void dryRun() {
+    run(true);
+  }
+
+  @Override
+  public void run() {
+    run(false);
+  }
+
+  private void run(boolean isDryRun) {
+    Query selectIdTextPairs = getEntity().getSourceDataMapping().queryTextSearchString();
+    String sql = selectIdTextPairs.renderSQL();
+    LOGGER.info("select id-text pairs SQL: {}", sql);
+
+    BigQueryDataset outputBQDataset = getOutputDataPointer();
+    TablePointer outputTable = getEntity().getIndexDataMapping().getTextSearchTablePointer();
+    LOGGER.info(
+        "output BQ table: project={}, dataset={}, table={}",
+        outputBQDataset.getProjectId(),
+        outputBQDataset.getDatasetId(),
+        outputTable.getTableName());
+
+    TableId destinationTable =
+        TableId.of(
+            outputBQDataset.getProjectId(),
+            outputBQDataset.getDatasetId(),
+            outputTable.getTableName());
+    outputBQDataset.getBigQueryService().createTableFromQuery(destinationTable, sql, isDryRun);
+  }
+
+  @Override
+  public JobStatus checkStatus() {
+    // Check if the table already exists. We don't expect this to be a long-running operation, so
+    // there is no IN_PROGRESS state for this job.
+    BigQueryDataset outputBQDataset = getOutputDataPointer();
+    TablePointer outputTable = getEntity().getIndexDataMapping().getTextSearchTablePointer();
+    GoogleBigQuery googleBigQuery = outputBQDataset.getBigQueryService();
+    Optional<Table> tableOpt =
+        googleBigQuery.getTable(
+            outputBQDataset.getProjectId(),
+            outputBQDataset.getDatasetId(),
+            outputTable.getTableName());
+    return tableOpt.isPresent() ? JobStatus.COMPLETE : JobStatus.NOT_STARTED;
+  }
+
+  private BigQueryDataset getOutputDataPointer() {
+    TablePointer outputTable = getEntity().getIndexDataMapping().getTablePointer();
+    DataPointer outputDataPointer = outputTable.getDataPointer();
+    if (!(outputDataPointer instanceof BigQueryDataset)) {
+      throw new InvalidConfigException(
+          "BuildTextSearchStrings indexing job only supports BigQuery");
+    }
+    return (BigQueryDataset) outputDataPointer;
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/underlay/EntityMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/EntityMapping.java
@@ -83,7 +83,7 @@ public final class EntityMapping {
         serialized.getTextSearchMapping() == null
             ? null
             : TextSearchMapping.fromSerialized(
-                serialized.getTextSearchMapping(), tablePointer, attributes);
+                serialized.getTextSearchMapping(), tablePointer, attributes, idAttributeName);
 
     Map<String, HierarchyMapping> hierarchyMappings =
         serialized.getHierarchyMappings() == null
@@ -178,6 +178,14 @@ public final class EntityMapping {
     } else {
       throw new SystemException("Unknown text search mapping type");
     }
+  }
+
+  public Query queryTextSearchString() {
+    return textSearchMapping.queryTextSearchString(this);
+  }
+
+  public TablePointer getTextSearchTablePointer() {
+    return textSearchMapping.getTablePointer(this);
   }
 
   public TablePointer getTablePointer() {

--- a/api/src/main/java/bio/terra/tanagra/underlay/TextSearchMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/TextSearchMapping.java
@@ -1,6 +1,12 @@
 package bio.terra.tanagra.underlay;
 
 import bio.terra.tanagra.exception.InvalidConfigException;
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.Query;
+import bio.terra.tanagra.query.SQLExpression;
+import bio.terra.tanagra.query.TableVariable;
+import bio.terra.tanagra.query.UnionQuery;
 import bio.terra.tanagra.serialization.UFTextSearchMapping;
 import java.util.Collections;
 import java.util.List;
@@ -8,28 +14,35 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class TextSearchMapping {
-  private static final String TEXT_SEARCH_COLUMN_ALIAS = "t_text";
+  private static final String TEXT_SEARCH_TABLE = "textsearch";
+  private static final String TEXT_SEARCH_STRING_COLUMN_ALIAS = "t_text";
+  private static final String TEXT_SEARCH_ID_COLUMN_ALIAS = "id";
 
   private List<Attribute> attributes;
   private FieldPointer searchString;
+  private final Attribute idAttribute;
 
-  private TextSearchMapping(List<Attribute> attributes) {
+  private TextSearchMapping(List<Attribute> attributes, Attribute idAttribute) {
     this.attributes = attributes;
+    this.idAttribute = idAttribute;
   }
 
-  private TextSearchMapping(FieldPointer searchString) {
+  private TextSearchMapping(FieldPointer searchString, Attribute idAttribute) {
     this.searchString = searchString;
+    this.idAttribute = idAttribute;
   }
 
   public static TextSearchMapping fromSerialized(
       UFTextSearchMapping serialized,
       TablePointer tablePointer,
-      Map<String, Attribute> entityAttributes) {
+      Map<String, Attribute> entityAttributes,
+      String idAttributeName) {
     if (serialized.getAttributes() != null && serialized.getSearchString() != null) {
       throw new InvalidConfigException(
           "Text search mapping can be defined by either attributes or a search string, not both");
     }
 
+    Attribute idAttribute = entityAttributes.get(idAttributeName);
     if (serialized.getAttributes() != null) {
       if (serialized.getAttributes().size() == 0) {
         throw new InvalidConfigException("Text search mapping list of attributes is empty");
@@ -38,28 +51,99 @@ public final class TextSearchMapping {
           serialized.getAttributes().stream()
               .map(a -> entityAttributes.get(a))
               .collect(Collectors.toList());
-      return new TextSearchMapping(attributesForTextSearch);
+      return new TextSearchMapping(attributesForTextSearch, idAttribute);
     }
 
     if (serialized.getSearchString() != null) {
       FieldPointer searchStringField =
           FieldPointer.fromSerialized(serialized.getSearchString(), tablePointer);
-      return new TextSearchMapping(searchStringField);
+      return new TextSearchMapping(searchStringField, idAttribute);
     }
 
     throw new InvalidConfigException("Text search mapping is empty");
   }
 
-  public static TextSearchMapping defaultIndexMapping(TablePointer tablePointer) {
+  public static TextSearchMapping defaultIndexMapping(
+      String entityName, TablePointer tablePointer, Attribute idAttribute) {
+    // TODO: Change default index mapping to be a field in the same table as the denormalized entity
+    // instances.
+    String tablePrefix = entityName + "_";
+    TablePointer idTextStringTable =
+        TablePointer.fromTableName(tablePrefix + TEXT_SEARCH_TABLE, tablePointer.getDataPointer());
+
     return new TextSearchMapping(
         new FieldPointer.Builder()
             .tablePointer(tablePointer)
-            .columnName(TEXT_SEARCH_COLUMN_ALIAS)
-            .build());
+            .columnName(idAttribute.getName())
+            .foreignTablePointer(idTextStringTable)
+            .foreignKeyColumnName(TEXT_SEARCH_ID_COLUMN_ALIAS)
+            .foreignColumnName(TEXT_SEARCH_STRING_COLUMN_ALIAS)
+            .build(),
+        idAttribute);
   }
 
   public boolean definedByAttributes() {
     return attributes != null;
+  }
+
+  public Query queryTextSearchString(EntityMapping entityMapping) {
+    SQLExpression idAllTextPairs;
+    if (definedByAttributes()) {
+      idAllTextPairs =
+          new UnionQuery(
+              getAttributes().stream()
+                  .map(
+                      attr ->
+                          entityMapping.queryAttributes(
+                              Map.of(
+                                  TEXT_SEARCH_ID_COLUMN_ALIAS,
+                                  idAttribute,
+                                  TEXT_SEARCH_STRING_COLUMN_ALIAS,
+                                  attr)))
+                  .collect(Collectors.toList()));
+    } else if (definedBySearchString()) {
+      idAllTextPairs =
+          entityMapping.queryAttributesAndFields(
+              Map.of(TEXT_SEARCH_ID_COLUMN_ALIAS, idAttribute),
+              Map.of(TEXT_SEARCH_STRING_COLUMN_ALIAS, getSearchString()));
+    } else {
+      throw new SystemException("Unknown text search mapping type");
+    }
+
+    TablePointer idTextPairsTable =
+        TablePointer.fromRawSql(
+            idAllTextPairs.renderSQL(), entityMapping.getTablePointer().getDataPointer());
+    FieldPointer idField =
+        new FieldPointer.Builder()
+            .tablePointer(idTextPairsTable)
+            .columnName(TEXT_SEARCH_ID_COLUMN_ALIAS)
+            .build();
+    FieldPointer concatenatedTextField =
+        new FieldPointer.Builder()
+            .tablePointer(idTextPairsTable)
+            .columnName(TEXT_SEARCH_STRING_COLUMN_ALIAS)
+            .sqlFunctionWrapper("STRING_AGG")
+            .build();
+
+    TableVariable idTextPairsTableVar = TableVariable.forPrimary(idTextPairsTable);
+    FieldVariable idFieldVar = new FieldVariable(idField, idTextPairsTableVar);
+    FieldVariable concatenatedTextFieldVar =
+        new FieldVariable(concatenatedTextField, idTextPairsTableVar);
+    return new Query.Builder()
+        .select(List.of(idFieldVar, concatenatedTextFieldVar))
+        .tables(List.of(idTextPairsTableVar))
+        .groupBy(List.of(idFieldVar))
+        .build();
+  }
+
+  public TablePointer getTablePointer(EntityMapping entityMapping) {
+    if (definedByAttributes()) {
+      return entityMapping.getTablePointer();
+    } else if (definedBySearchString()) {
+      return searchString.getForeignTablePointer();
+    } else {
+      throw new SystemException("Unknown text search mapping type");
+    }
   }
 
   public boolean definedBySearchString() {

--- a/api/src/test/resources/query/condition_index_textSearch.sql
+++ b/api/src/test/resources/query/condition_index_textSearch.sql
@@ -1,1 +1,1 @@
-SELECT c.id AS node, c.t_text AS text FROM `broad-tanagra-dev.aou_synthetic_SR2019q4r4_indexes`.condition AS c
+SELECT c.id AS node, c0.t_text AS text FROM `broad-tanagra-dev.aou_synthetic_SR2019q4r4_indexes`.condition AS c JOIN `broad-tanagra-dev.aou_synthetic_SR2019q4r4_indexes`.condition_textsearch AS c0 ON c0.id = c.id


### PR DESCRIPTION
- Added the indexing job for writing text search string - id pairs for entities with a text search mapping defined.
- A future improvement is to write this string to a new field in the denormalized entity instances index table.