### PR TITLE
Add CLEAN commands. Override default Dataflow job name.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/indexing/Indexer.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/Indexer.java
@@ -88,21 +88,45 @@ public final class Indexer {
   }
 
   public void runJobsForAllEntities(boolean isDryRun) {
-    underlay.getEntities().keySet().forEach(name -> runJobsForEntity(name, isDryRun));
+    underlay.getEntities().keySet().stream()
+        .sorted()
+        .forEach(name -> runJobsForEntity(name, isDryRun));
   }
 
   public void runJobsForEntity(String name, boolean isDryRun) {
-    LOGGER.info("Indexing entity: {}", name);
-    underlay.getEntity(name).getIndexingJobs().forEach(ij -> ij.runIfPending(isDryRun));
+    LOGGER.info("RUN entity: {}", name);
+    underlay.getEntity(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndRun(isDryRun));
   }
 
   public void runJobsForAllEntityGroups(boolean isDryRun) {
-    underlay.getEntityGroups().keySet().forEach(name -> runJobsForEntityGroup(name, isDryRun));
+    underlay.getEntityGroups().keySet().stream()
+        .sorted()
+        .forEach(name -> runJobsForEntityGroup(name, isDryRun));
   }
 
   public void runJobsForEntityGroup(String name, boolean isDryRun) {
-    LOGGER.info("Indexing entity group: {}", name);
-    underlay.getEntityGroup(name).getIndexingJobs().forEach(ij -> ij.runIfPending(isDryRun));
+    LOGGER.info("RUN entity group: {}", name);
+    underlay.getEntityGroup(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndRun(isDryRun));
+  }
+
+  public void cleanAllEntities(boolean isDryRun) {
+    underlay.getEntities().keySet().stream().sorted().forEach(name -> cleanEntity(name, isDryRun));
+  }
+
+  public void cleanEntity(String name, boolean isDryRun) {
+    LOGGER.info("CLEAN entity: {}", name);
+    underlay.getEntity(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndClean(isDryRun));
+  }
+
+  public void cleanAllEntityGroups(boolean isDryRun) {
+    underlay.getEntityGroups().keySet().stream()
+        .sorted()
+        .forEach(name -> cleanEntityGroup(name, isDryRun));
+  }
+
+  public void cleanEntityGroup(String name, boolean isDryRun) {
+    LOGGER.info("CLEAN entity group: {}", name);
+    underlay.getEntityGroup(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndClean(isDryRun));
   }
 
   public Underlay getUnderlay() {

--- a/api/src/main/java/bio/terra/tanagra/indexing/Main.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/Main.java
@@ -1,10 +1,24 @@
 package bio.terra.tanagra.indexing;
 
+import static bio.terra.tanagra.indexing.Main.Command.INDEX_ENTITY;
+import static bio.terra.tanagra.indexing.Main.Command.INDEX_ENTITY_GROUP;
+
+import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.utils.FileUtils;
 import java.nio.file.Path;
 
 public final class Main {
   private Main() {}
+
+  enum Command {
+    EXPAND_CONFIG,
+    INDEX_ENTITY,
+    INDEX_ENTITY_GROUP,
+    INDEX_ALL,
+    CLEAN_ENTITY,
+    CLEAN_ENTITY_GROUP,
+    CLEAN_ALL
+  }
 
   /**
    * Main entrypoint for running indexing.
@@ -23,7 +37,7 @@ public final class Main {
   public static void main(String... args) throws Exception {
     // TODO: Consider using the picocli library for command parsing and packaging this as an actual
     // CLI.
-    String cmd = args[0];
+    Command cmd = Command.valueOf(args[0]);
     String underlayFilePath = args[1];
 
     // TODO: Use singleton FileIO instance instead of setting a bunch of separate static properties.
@@ -32,64 +46,72 @@ public final class Main {
     Indexer indexer =
         Indexer.deserializeUnderlay(Path.of(underlayFilePath).getFileName().toString());
 
-    if ("EXPAND_CONFIG".equals(cmd)) {
-      String outputDirPath = args[2];
+    switch (cmd) {
+      case EXPAND_CONFIG:
+        String outputDirPath = args[2];
 
-      FileIO.setOutputParentDir(Path.of(outputDirPath));
-      FileUtils.createDirectoryIfNonexistent(FileIO.getOutputParentDir());
+        FileIO.setOutputParentDir(Path.of(outputDirPath));
+        FileUtils.createDirectoryIfNonexistent(FileIO.getOutputParentDir());
 
-      indexer.scanSourceData();
+        indexer.scanSourceData();
 
-      indexer.serializeUnderlay();
-      indexer.writeSerializedUnderlay();
-    } else if ("INDEX_ENTITY".equals(cmd) || "CLEAN_ENTITY".equals(cmd)) {
-      boolean isRun = "INDEX_ENTITY".equals(cmd);
-      String name = args[2];
-      boolean isDryRun = isDryRun(3, args);
+        indexer.serializeUnderlay();
+        indexer.writeSerializedUnderlay();
+        break;
+      case INDEX_ENTITY:
+      case CLEAN_ENTITY:
+        boolean isRunEntity = INDEX_ENTITY.equals(cmd);
+        String nameEntity = args[2];
+        boolean isDryRunEntity = isDryRun(3, args);
 
-      // Index/clean all the entities (*) or just one (entityName).
-      if ("*".equals(name)) {
-        if (isRun) {
-          indexer.runJobsForAllEntities(isDryRun);
+        // Index/clean all the entities (*) or just one (entityName).
+        if ("*".equals(nameEntity)) {
+          if (isRunEntity) {
+            indexer.runJobsForAllEntities(isDryRunEntity);
+          } else {
+            indexer.cleanAllEntities(isDryRunEntity);
+          }
         } else {
-          indexer.cleanAllEntities(isDryRun);
+          if (isRunEntity) {
+            indexer.runJobsForEntity(nameEntity, isDryRunEntity);
+          } else {
+            indexer.cleanEntity(nameEntity, isDryRunEntity);
+          }
         }
-      } else {
-        if (isRun) {
-          indexer.runJobsForEntity(name, isDryRun);
-        } else {
-          indexer.cleanEntity(name, isDryRun);
-        }
-      }
-    } else if ("INDEX_ENTITY_GROUP".equals(cmd) || "CLEAN_ENTITY_GROUP".equals(cmd)) {
-      boolean isRun = "INDEX_ENTITY_GROUP".equals(cmd);
-      String name = args[2];
-      boolean isDryRun = isDryRun(3, args);
+        break;
+      case INDEX_ENTITY_GROUP:
+      case CLEAN_ENTITY_GROUP:
+        boolean isRunEntityGroup = INDEX_ENTITY_GROUP.equals(cmd);
+        String nameEntityGroup = args[2];
+        boolean isDryRunEntityGroup = isDryRun(3, args);
 
-      // Index/clean all the entity groups (*) or just one (entityGroupName).
-      if ("*".equals(name)) {
-        if (isRun) {
-          indexer.runJobsForAllEntityGroups(isDryRun);
+        // Index/clean all the entity groups (*) or just one (entityGroupName).
+        if ("*".equals(nameEntityGroup)) {
+          if (isRunEntityGroup) {
+            indexer.runJobsForAllEntityGroups(isDryRunEntityGroup);
+          } else {
+            indexer.cleanAllEntityGroups(isDryRunEntityGroup);
+          }
         } else {
-          indexer.cleanAllEntityGroups(isDryRun);
+          if (isRunEntityGroup) {
+            indexer.runJobsForEntityGroup(nameEntityGroup, isDryRunEntityGroup);
+          } else {
+            indexer.cleanEntityGroup(nameEntityGroup, isDryRunEntityGroup);
+          }
         }
-      } else {
-        if (isRun) {
-          indexer.runJobsForEntityGroup(name, isDryRun);
-        } else {
-          indexer.cleanEntityGroup(name, isDryRun);
-        }
-      }
-    } else if ("INDEX_ALL".equals(cmd)) {
-      boolean isDryRun = isDryRun(2, args);
-      indexer.runJobsForAllEntities(isDryRun);
-      indexer.runJobsForAllEntityGroups(isDryRun);
-    } else if ("CLEAN_ALL".equals(cmd)) {
-      boolean isDryRun = isDryRun(2, args);
-      indexer.cleanAllEntities(isDryRun);
-      indexer.cleanAllEntityGroups(isDryRun);
-    } else {
-      throw new IllegalArgumentException("Unknown command: " + cmd);
+        break;
+      case INDEX_ALL:
+        boolean isDryRunIndexAll = isDryRun(2, args);
+        indexer.runJobsForAllEntities(isDryRunIndexAll);
+        indexer.runJobsForAllEntityGroups(isDryRunIndexAll);
+        break;
+      case CLEAN_ALL:
+        boolean isDryRunCleanAll = isDryRun(2, args);
+        indexer.cleanAllEntities(isDryRunCleanAll);
+        indexer.cleanAllEntityGroups(isDryRunCleanAll);
+        break;
+      default:
+        throw new SystemException("Unknown command: " + cmd);
     }
   }
 

--- a/api/src/main/java/bio/terra/tanagra/indexing/Main.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/Main.java
@@ -42,30 +42,52 @@ public final class Main {
 
       indexer.serializeUnderlay();
       indexer.writeSerializedUnderlay();
-    } else if ("INDEX_ENTITY".equals(cmd)) {
+    } else if ("INDEX_ENTITY".equals(cmd) || "CLEAN_ENTITY".equals(cmd)) {
+      boolean isRun = "INDEX_ENTITY".equals(cmd);
       String name = args[2];
       boolean isDryRun = isDryRun(3, args);
 
-      // Index all the entities (*) or just one (entityName).
+      // Index/clean all the entities (*) or just one (entityName).
       if ("*".equals(name)) {
-        indexer.runJobsForAllEntities(isDryRun);
+        if (isRun) {
+          indexer.runJobsForAllEntities(isDryRun);
+        } else {
+          indexer.cleanAllEntities(isDryRun);
+        }
       } else {
-        indexer.runJobsForEntity(name, isDryRun);
+        if (isRun) {
+          indexer.runJobsForEntity(name, isDryRun);
+        } else {
+          indexer.cleanEntity(name, isDryRun);
+        }
       }
-    } else if ("INDEX_ENTITY_GROUP".equals(cmd)) {
+    } else if ("INDEX_ENTITY_GROUP".equals(cmd) || "CLEAN_ENTITY_GROUP".equals(cmd)) {
+      boolean isRun = "INDEX_ENTITY_GROUP".equals(cmd);
       String name = args[2];
       boolean isDryRun = isDryRun(3, args);
 
-      // Index all the entity groups (*) or just one (entityGroupName).
+      // Index/clean all the entity groups (*) or just one (entityGroupName).
       if ("*".equals(name)) {
-        indexer.runJobsForAllEntityGroups(isDryRun);
+        if (isRun) {
+          indexer.runJobsForAllEntityGroups(isDryRun);
+        } else {
+          indexer.cleanAllEntityGroups(isDryRun);
+        }
       } else {
-        indexer.runJobsForEntityGroup(name, isDryRun);
+        if (isRun) {
+          indexer.runJobsForEntityGroup(name, isDryRun);
+        } else {
+          indexer.cleanEntityGroup(name, isDryRun);
+        }
       }
     } else if ("INDEX_ALL".equals(cmd)) {
       boolean isDryRun = isDryRun(2, args);
       indexer.runJobsForAllEntities(isDryRun);
       indexer.runJobsForAllEntityGroups(isDryRun);
+    } else if ("CLEAN_ALL".equals(cmd)) {
+      boolean isDryRun = isDryRun(2, args);
+      indexer.cleanAllEntities(isDryRun);
+      indexer.cleanAllEntityGroups(isDryRun);
     } else {
       throw new IllegalArgumentException("Unknown command: " + cmd);
     }

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/BuildNumChildrenAndPaths.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/BuildNumChildrenAndPaths.java
@@ -76,7 +76,7 @@ public class BuildNumChildrenAndPaths extends BigQueryIndexingJob {
   }
 
   @Override
-  protected void run(boolean isDryRun) {
+  public void run(boolean isDryRun) {
     String selectAllIdsSql =
         getEntity()
             .getSourceDataMapping()

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/BuildTextSearchStrings.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/BuildTextSearchStrings.java
@@ -21,7 +21,7 @@ public class BuildTextSearchStrings extends BigQueryIndexingJob {
   }
 
   @Override
-  protected void run(boolean isDryRun) {
+  public void run(boolean isDryRun) {
     Query selectIdTextPairs = getEntity().getSourceDataMapping().queryTextSearchStrings();
     String sql = selectIdTextPairs.renderSQL();
     LOGGER.info("select id-text pairs SQL: {}", sql);

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/ComputeRollupCounts.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/ComputeRollupCounts.java
@@ -68,7 +68,7 @@ public class ComputeRollupCounts extends BigQueryIndexingJob {
   }
 
   @Override
-  protected void run(boolean isDryRun) {
+  public void run(boolean isDryRun) {
     CriteriaOccurrence entityGroup = (CriteriaOccurrence) getEntityGroup();
 
     String selectAllCriteriaIdsSql =

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/DenormalizeEntityInstances.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/DenormalizeEntityInstances.java
@@ -21,7 +21,7 @@ public class DenormalizeEntityInstances extends BigQueryIndexingJob {
   }
 
   @Override
-  protected void run(boolean isDryRun) {
+  public void run(boolean isDryRun) {
     Query selectAllAttributes =
         getEntity().getSourceDataMapping().queryAttributes(getEntity().getAttributes());
     String sql = selectAllAttributes.renderSQL();

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/WriteAncestorDescendantIdPairs.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/WriteAncestorDescendantIdPairs.java
@@ -65,7 +65,7 @@ public class WriteAncestorDescendantIdPairs extends BigQueryIndexingJob {
   }
 
   @Override
-  protected void run(boolean isDryRun) {
+  public void run(boolean isDryRun) {
     SQLExpression selectChildParentIdPairs =
         getEntity()
             .getSourceDataMapping()

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/WriteParentChildIdPairs.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/WriteParentChildIdPairs.java
@@ -24,7 +24,7 @@ public class WriteParentChildIdPairs extends BigQueryIndexingJob {
   }
 
   @Override
-  protected void run(boolean isDryRun) {
+  public void run(boolean isDryRun) {
     SQLExpression selectChildParentIdPairs =
         getEntity()
             .getSourceDataMapping()

--- a/api/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/api/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -18,11 +18,8 @@ import com.google.cloud.bigquery.TableResult;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/api/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/api/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -164,6 +164,25 @@ public final class GoogleBigQuery {
   }
 
   /**
+   * Delete a table. Do nothing if the table is not found (i.e. assume that means it's already
+   * deleted).
+   */
+  public void deleteTable(String projectId, String datasetId, String tableId) {
+    try {
+      TableId tablePointer = TableId.of(projectId, datasetId, tableId);
+      boolean deleteSuccessful =
+          callWithRetries(() -> bigQuery.delete(tablePointer), "Retryable error deleting table");
+      if (deleteSuccessful) {
+        LOGGER.info("Table deleted: {}, {}, {}", projectId, datasetId, tableId);
+      } else {
+        LOGGER.info("Table not found: {}, {}, {}", projectId, datasetId, tableId);
+      }
+    } catch (Exception ex) {
+      throw new SystemException("Error deleting table", ex);
+    }
+  }
+
+  /**
    * Utility method that checks if an exception thrown by the BQ client is retryable.
    *
    * @param ex exception to test

--- a/api/src/main/java/bio/terra/tanagra/utils/HttpUtils.java
+++ b/api/src/main/java/bio/terra/tanagra/utils/HttpUtils.java
@@ -144,7 +144,7 @@ public class HttpUtils {
     do {
       numTries++;
       try {
-        LOGGER.info("Request attempt #{}/{}", numTries - 1, maxCalls);
+        LOGGER.debug("Request attempt #{}/{}", numTries - 1, maxCalls);
 
         T result = makeRequest.makeRequest();
         LOGGER.debug("Result: {}", result);
@@ -167,7 +167,7 @@ public class HttpUtils {
           // keep track of the last retryable exception so we can re-throw it in case of a timeout
           lastRetryableException = ex;
         }
-        LOGGER.info("Caught retryable exception: {}", ex);
+        LOGGER.debug("Caught retryable exception: {}", ex);
       }
 
       // sleep before retrying, unless this is the last try


### PR DESCRIPTION
- Added commands to cleanup the outputs of indexing jobs: `CLEAN_ENTITY`, `CLEAN_ENTITY_GROUP`, `CLEAN_ALL`. This is useful for debugging and testing.
- Run the indexing jobs in alphabetical order.
- Override the default Dataflow job name so the indexing job name and entity/group name are visible in the Cloud Console.