### PR TITLE
Override query project id. Config files for CMS SynPUF dataset.

### DIFF
--- a/api/docs/INDEXING.md
+++ b/api/docs/INDEXING.md
@@ -117,17 +117,21 @@ All the entities in a group should be indexed before the group. The `INDEX_ALL` 
 this in  mind if you're running the jobs for each entity or entity group separately.
 
 ## OMOP Example
-The `aou_synthetic` dataset uses the standard OMOP schema. You can see the underlay config files defined for this
-dataset in [`api/src/main/resources/config/broad/aou_synthetic/`](../src/main/resources/config/broad/aou_synthetic/).
+The `cms_synpuf` is a [public dataset](https://console.cloud.google.com/marketplace/product/hhs/synpuf) that uses the 
+standard OMOP schema.
+
+You can see the underlay config files defined for this dataset in 
+[`api/src/main/resources/config/broad/cms_synpuf/`](../src/main/resources/config/broad/cms_synpuf/).
+Note that while the source dataset is public, the index dataset that Tanagra generates is not.
 
 ```
-export INPUT_DIR=$HOME/tanagra/api/src/main/resources/config/broad/aou_synthetic/original
-export OUTPUT_DIR=$HOME/tanagra/api/src/main/resources/config/broad/aou_synthetic/expanded
+export INPUT_DIR=$HOME/tanagra/api/src/main/resources/config/broad/cms_synpuf/original
+export OUTPUT_DIR=$HOME/tanagra/api/src/main/resources/config/broad/cms_synpuf/expanded
 
-./gradlew api:index -Dexec.args="EXPAND_CONFIG $INPUT_DIR/omop.json $OUTPUT_DIR/"
+./gradlew api:index -Dexec.args="EXPAND_CONFIG $INPUT_DIR/cms_synpuf.json $OUTPUT_DIR/"
 
-bq mk --location=US broad-tanagra-dev:aousynthetic_index
+bq mk --location=US broad-tanagra-dev:cmssynpuf_index
 
-./gradlew api:index -Dexec.args="INDEX_ALL $OUTPUT_DIR/omop.json DRY_RUN"
-./gradlew api:index -Dexec.args="INDEX_ALL $OUTPUT_DIR/omop.json"
+./gradlew api:index -Dexec.args="INDEX_ALL $OUTPUT_DIR/cms_synpuf.json DRY_RUN"
+./gradlew api:index -Dexec.args="INDEX_ALL $OUTPUT_DIR/cms_synpuf.json"
 ```

--- a/api/src/main/java/bio/terra/tanagra/serialization/datapointer/UFBigQueryDataset.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/datapointer/UFBigQueryDataset.java
@@ -14,23 +14,27 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 public class UFBigQueryDataset extends UFDataPointer {
   private final String projectId;
   private final String datasetId;
+  private final String queryProjectId;
 
   public UFBigQueryDataset(BigQueryDataset dataPointer) {
     super(dataPointer);
     this.projectId = dataPointer.getProjectId();
     this.datasetId = dataPointer.getDatasetId();
+    this.queryProjectId = dataPointer.getQueryProjectId();
   }
 
   private UFBigQueryDataset(Builder builder) {
     super(builder);
     this.projectId = builder.projectId;
     this.datasetId = builder.datasetId;
+    this.queryProjectId = builder.queryProjectId;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder extends UFDataPointer.Builder {
     private String projectId;
     private String datasetId;
+    private String queryProjectId;
 
     public Builder projectId(String projectId) {
       this.projectId = projectId;
@@ -39,6 +43,11 @@ public class UFBigQueryDataset extends UFDataPointer {
 
     public Builder datasetId(String datasetId) {
       this.datasetId = datasetId;
+      return this;
+    }
+
+    public Builder queryProjectId(String queryProjectId) {
+      this.queryProjectId = queryProjectId;
       return this;
     }
 
@@ -61,5 +70,9 @@ public class UFBigQueryDataset extends UFDataPointer {
 
   public String getDatasetId() {
     return datasetId;
+  }
+
+  public String getQueryProjectId() {
+    return queryProjectId;
   }
 }

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/cms_synpuf.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/cms_synpuf.json
@@ -1,0 +1,19 @@
+{
+  "name" : "cms_synpuf",
+  "dataPointers" : [ {
+    "type" : "BQ_DATASET",
+    "name" : "index_dataset",
+    "projectId" : "broad-tanagra-dev",
+    "datasetId" : "cmssynpuf_index",
+    "queryProjectId" : "broad-tanagra-dev"
+  }, {
+    "type" : "BQ_DATASET",
+    "name" : "omop_dataset",
+    "projectId" : "bigquery-public-data",
+    "datasetId" : "cms_synthetic_patient_data_omop",
+    "queryProjectId" : "broad-tanagra-dev"
+  } ],
+  "entities" : [ "ingredient_occurrence.json", "condition.json", "condition_occurrence.json", "ingredient.json", "device_occurrence.json", "observation.json", "person.json", "observation_occurrence.json", "procedure.json", "procedure_occurrence.json", "brand.json", "device.json" ],
+  "entityGroups" : [ "device_person_occurrence.json", "condition_person_occurrence.json", "ingredient_person_occurrence.json", "observation_person_occurrence.json", "brand_ingredient.json", "procedure_person_occurrence.json" ],
+  "primaryEntity" : "person"
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/brand.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/brand.json
@@ -1,0 +1,156 @@
+{
+  "name" : "brand",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "standard_concept",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : "Source"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "name",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "concept_code",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "concept",
+      "filter" : {
+        "type" : "ARRAY",
+        "operator" : "AND",
+        "subfilters" : [ {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "domain_id"
+          },
+          "operator" : "EQUALS",
+          "value" : {
+            "stringVal" : "Drug"
+          }
+        }, {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "concept_class_id"
+          },
+          "operator" : "EQUALS",
+          "value" : {
+            "stringVal" : "Brand Name"
+          }
+        }, {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "invalid_reason"
+          },
+          "operator" : "IS",
+          "value" : { }
+        }, {
+          "type" : "ARRAY",
+          "operator" : "OR",
+          "subfilters" : [ {
+            "type" : "BINARY",
+            "field" : {
+              "column" : "vocabulary_id"
+            },
+            "operator" : "EQUALS",
+            "value" : {
+              "stringVal" : "RxNorm"
+            }
+          }, {
+            "type" : "BINARY",
+            "field" : {
+              "column" : "vocabulary_id"
+            },
+            "operator" : "EQUALS",
+            "value" : {
+              "stringVal" : "RxNorm Extension"
+            }
+          } ]
+        } ]
+      }
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "standard_concept",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "concept_name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "concept_id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "attributes" : [ "name", "concept_code" ]
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "brand"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "t_display_standard_concept"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "searchString" : {
+        "column" : "id",
+        "foreignTable" : "brand_textsearch",
+        "foreignKey" : "id",
+        "foreignColumn" : "text"
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/condition.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/condition.json
@@ -1,0 +1,247 @@
+{
+  "name" : "condition",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "standard_concept",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : "Source"
+      }, {
+        "value" : {
+          "stringVal" : "S"
+        },
+        "display" : "Standard"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "vocabulary",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "HCPCS"
+        },
+        "display" : "Healthcare Common Procedure Coding System (CMS)"
+      }, {
+        "value" : {
+          "stringVal" : "ICD9CM"
+        },
+        "display" : "International Classification of Diseases, Ninth Revision, Clinical Modification, Volume 1 and 2 (NCHS)"
+      }, {
+        "value" : {
+          "stringVal" : "ICD10CM"
+        },
+        "display" : "International Classification of Diseases, Tenth Revision, Clinical Modification (NCHS)"
+      }, {
+        "value" : {
+          "stringVal" : "SNOMED"
+        },
+        "display" : "Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "name",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "concept_code",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "concept",
+      "filter" : {
+        "type" : "BINARY",
+        "field" : {
+          "column" : "domain_id"
+        },
+        "operator" : "EQUALS",
+        "value" : {
+          "stringVal" : "Condition"
+        }
+      }
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "standard_concept",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary_id"
+        },
+        "display" : {
+          "column" : "vocabulary_id",
+          "foreignTable" : "vocabulary",
+          "foreignKey" : "vocabulary_id",
+          "foreignColumn" : "vocabulary_name"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "concept_name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "concept_id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "attributes" : [ "name", "concept_code" ]
+    },
+    "hierarchyMappings" : {
+      "standard" : {
+        "childParent" : {
+          "tablePointer" : {
+            "rawSql" : "SELECT   cr.concept_id_1 AS parent,   cr.concept_id_2 AS child, FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_relationship` cr JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = cr.concept_id_1 JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = cr.concept_id_2 WHERE   cr.relationship_id = 'Subsumes'   AND c1.domain_id = c2.domain_id   AND c2.domain_id = 'Condition'   AND c1.vocabulary_id = c2.vocabulary_id   AND c2.vocabulary_id = 'SNOMED'"
+          },
+          "fieldPointers" : {
+            "parent" : {
+              "column" : "parent"
+            },
+            "child" : {
+              "column" : "child"
+            }
+          }
+        },
+        "rootNodesFilter" : {
+          "tablePointer" : {
+            "table" : "concept",
+            "filter" : {
+              "type" : "BINARY",
+              "field" : {
+                "column" : "concept_id"
+              },
+              "operator" : "EQUALS",
+              "value" : {
+                "int64Val" : 441840
+              }
+            }
+          },
+          "fieldPointers" : {
+            "id" : {
+              "column" : "concept_id"
+            }
+          }
+        }
+      }
+    }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "condition"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "t_display_standard_concept"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary"
+        },
+        "display" : {
+          "column" : "t_display_vocabulary"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "searchString" : {
+        "column" : "id",
+        "foreignTable" : "condition_textsearch",
+        "foreignKey" : "id",
+        "foreignColumn" : "text"
+      }
+    },
+    "hierarchyMappings" : {
+      "standard" : {
+        "childParent" : {
+          "tablePointer" : {
+            "table" : "condition_standard_childParent"
+          },
+          "fieldPointers" : {
+            "parent" : {
+              "column" : "parent"
+            },
+            "child" : {
+              "column" : "child"
+            }
+          }
+        },
+        "ancestorDescendant" : {
+          "tablePointer" : {
+            "table" : "condition_standard_ancestorDescendant"
+          },
+          "fieldPointers" : {
+            "ancestor" : {
+              "column" : "ancestor"
+            },
+            "descendant" : {
+              "column" : "descendant"
+            }
+          }
+        },
+        "pathNumChildren" : {
+          "tablePointer" : {
+            "table" : "condition_standard_pathNumChildren"
+          },
+          "fieldPointers" : {
+            "path" : {
+              "column" : "path"
+            },
+            "num_children" : {
+              "column" : "num_children"
+            },
+            "id" : {
+              "column" : "id"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/condition_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/condition_occurrence.json
@@ -1,0 +1,180 @@
+{
+  "name" : "condition_occurrence",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "SIMPLE",
+    "name" : "end_date",
+    "dataType" : "STRING"
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "condition",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_criteria_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 2617496,
+      "maxVal" : 45890988
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "stop_reason",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : null
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "visit_occurrence_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 111638270
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_value",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "person_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 2326856
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "start_date",
+    "dataType" : "STRING"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "condition_occurrence"
+    },
+    "attributeMappings" : {
+      "end_date" : {
+        "value" : {
+          "column" : "condition_end_date"
+        }
+      },
+      "condition" : {
+        "value" : {
+          "column" : "condition_concept_id"
+        },
+        "display" : {
+          "column" : "condition_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "condition_source_concept_id"
+        }
+      },
+      "stop_reason" : {
+        "value" : {
+          "column" : "stop_reason"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "condition_occurrence_id"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "condition_source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "start_date" : {
+        "value" : {
+          "column" : "condition_start_date"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "condition_occurrence"
+    },
+    "attributeMappings" : {
+      "end_date" : {
+        "value" : {
+          "column" : "end_date"
+        }
+      },
+      "condition" : {
+        "value" : {
+          "column" : "condition"
+        },
+        "display" : {
+          "column" : "t_display_condition"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "source_criteria_id"
+        }
+      },
+      "stop_reason" : {
+        "value" : {
+          "column" : "stop_reason"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "start_date" : {
+        "value" : {
+          "column" : "start_date"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/device.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/device.json
@@ -1,0 +1,166 @@
+{
+  "name" : "device",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "standard_concept",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "S"
+        },
+        "display" : "Standard"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "vocabulary",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "HCPCS"
+        },
+        "display" : "Healthcare Common Procedure Coding System (CMS)"
+      }, {
+        "value" : {
+          "stringVal" : "SNOMED"
+        },
+        "display" : "Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "name",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "concept_code",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "concept",
+      "filter" : {
+        "type" : "ARRAY",
+        "operator" : "AND",
+        "subfilters" : [ {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "domain_id"
+          },
+          "operator" : "EQUALS",
+          "value" : {
+            "stringVal" : "Device"
+          }
+        }, {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "standard_concept"
+          },
+          "operator" : "EQUALS",
+          "value" : {
+            "stringVal" : "S"
+          }
+        } ]
+      }
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "standard_concept",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary_id"
+        },
+        "display" : {
+          "column" : "vocabulary_id",
+          "foreignTable" : "vocabulary",
+          "foreignKey" : "vocabulary_id",
+          "foreignColumn" : "vocabulary_name"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "concept_name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "concept_id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "attributes" : [ "name", "concept_code" ]
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "device"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "t_display_standard_concept"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary"
+        },
+        "display" : {
+          "column" : "t_display_vocabulary"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "searchString" : {
+        "column" : "id",
+        "foreignTable" : "device_textsearch",
+        "foreignKey" : "id",
+        "foreignColumn" : "text"
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/device_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/device_occurrence.json
@@ -1,0 +1,159 @@
+{
+  "name" : "device_occurrence",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "SIMPLE",
+    "name" : "end_date",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_criteria_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 2614686,
+      "maxVal" : 44786357
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "visit_occurrence_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 105,
+      "maxVal" : 111638213
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "device",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_value",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "person_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 7,
+      "maxVal" : 2326856
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "start_date",
+    "dataType" : "STRING"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "device_exposure"
+    },
+    "attributeMappings" : {
+      "end_date" : {
+        "value" : {
+          "column" : "device_exposure_end_date"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "device_source_concept_id"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "device_exposure_id"
+        }
+      },
+      "device" : {
+        "value" : {
+          "column" : "device_concept_id"
+        },
+        "display" : {
+          "column" : "device_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "device_source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "start_date" : {
+        "value" : {
+          "column" : "device_exposure_start_date"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "device_occurrence"
+    },
+    "attributeMappings" : {
+      "end_date" : {
+        "value" : {
+          "column" : "end_date"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "source_criteria_id"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      },
+      "device" : {
+        "value" : {
+          "column" : "device"
+        },
+        "display" : {
+          "column" : "t_display_device"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "start_date" : {
+        "value" : {
+          "column" : "start_date"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/ingredient.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/ingredient.json
@@ -1,0 +1,259 @@
+{
+  "name" : "ingredient",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "standard_concept",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : "Source"
+      }, {
+        "value" : {
+          "stringVal" : "C"
+        },
+        "display" : "Unknown"
+      }, {
+        "value" : {
+          "stringVal" : "S"
+        },
+        "display" : "Standard"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "vocabulary",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "RxNorm"
+        },
+        "display" : "RxNorm (NLM)"
+      }, {
+        "value" : {
+          "stringVal" : "RxNorm Extension"
+        },
+        "display" : "RxNorm Extension (OMOP)"
+      }, {
+        "value" : {
+          "stringVal" : "ATC"
+        },
+        "display" : "WHO Anatomic Therapeutic Chemical Classification"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "name",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "concept_code",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "rawSql" : "SELECT   c.concept_id AS id, c.concept_name AS name, c.vocabulary_id, c.standard_concept, c.concept_code FROM  `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c WHERE c.domain_id = 'Drug' AND ((c.vocabulary_id IN ('RxNorm', 'RxNorm Extension')         AND c.concept_class_id = 'Ingredient'         AND c.standard_concept = 'S')     OR (c.vocabulary_id = 'RxNorm'         AND c.concept_class_id = 'Precise Ingredient')     OR (c.vocabulary_id = 'ATC'         AND c.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')         AND c.standard_concept = 'C'))"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "standard_concept",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary_id"
+        },
+        "display" : {
+          "column" : "vocabulary_id",
+          "foreignTable" : "vocabulary",
+          "foreignKey" : "vocabulary_id",
+          "foreignColumn" : "vocabulary_name"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "attributes" : [ "name", "concept_code" ]
+    },
+    "hierarchyMappings" : {
+      "standard" : {
+        "childParent" : {
+          "tablePointer" : {
+            "rawSql" : "SELECT   cr.concept_id_1 AS parent,   cr.concept_id_2 AS child, FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_relationship` cr JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = cr.concept_id_1 JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = cr.concept_id_2 WHERE   cr.relationship_id IN ('Has form', 'RxNorm - ATC', 'RxNorm - ATC name', 'Mapped from', 'Subsumes')   AND c1.concept_id != c2.concept_id    AND ((c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')           AND c1.concept_class_id = 'Ingredient'           AND c1.standard_concept = 'S')       OR (c1.vocabulary_id = 'RxNorm'           AND c1.concept_class_id = 'Precise Ingredient')       OR (c1.vocabulary_id = 'ATC'           AND c1.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')           AND c1.standard_concept = 'C'))    AND ((c2.vocabulary_id IN ('RxNorm', 'RxNorm Extension')           AND c2.concept_class_id = 'Ingredient'           AND c2.standard_concept = 'S')       OR (c2.vocabulary_id = 'RxNorm'           AND c2.concept_class_id = 'Precise Ingredient')       OR (c2.vocabulary_id = 'ATC'           AND c2.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')           AND c2.standard_concept = 'C'))  UNION ALL  SELECT   ca.ancestor_concept_id AS parent,   ca.descendant_concept_id AS child, FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_ancestor` ca JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = ca.ancestor_concept_id JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = ca.descendant_concept_id WHERE   ca.min_levels_of_separation = 1   AND ca.max_levels_of_separation = 1    AND ((c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')           AND c1.concept_class_id = 'Ingredient'           AND c1.standard_concept = 'S')       OR (c1.vocabulary_id = 'RxNorm'           AND c1.concept_class_id = 'Precise Ingredient')       OR (c1.vocabulary_id = 'ATC'           AND c1.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')           AND c1.standard_concept = 'C'))    AND ((c2.vocabulary_id IN ('RxNorm', 'RxNorm Extension')           AND c2.concept_class_id = 'Ingredient'           AND c2.standard_concept = 'S')       OR (c2.vocabulary_id = 'RxNorm'           AND c2.concept_class_id = 'Precise Ingredient')       OR (c2.vocabulary_id = 'ATC'           AND c2.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')           AND c2.standard_concept = 'C'))"
+          },
+          "fieldPointers" : {
+            "parent" : {
+              "column" : "parent"
+            },
+            "child" : {
+              "column" : "child"
+            }
+          }
+        },
+        "rootNodesFilter" : {
+          "tablePointer" : {
+            "table" : "concept",
+            "filter" : {
+              "type" : "ARRAY",
+              "operator" : "AND",
+              "subfilters" : [ {
+                "type" : "BINARY",
+                "field" : {
+                  "column" : "vocabulary_id"
+                },
+                "operator" : "EQUALS",
+                "value" : {
+                  "stringVal" : "ATC"
+                }
+              }, {
+                "type" : "BINARY",
+                "field" : {
+                  "column" : "concept_class_id"
+                },
+                "operator" : "EQUALS",
+                "value" : {
+                  "stringVal" : "ATC 1st"
+                }
+              }, {
+                "type" : "BINARY",
+                "field" : {
+                  "column" : "standard_concept"
+                },
+                "operator" : "EQUALS",
+                "value" : {
+                  "stringVal" : "C"
+                }
+              } ]
+            }
+          },
+          "fieldPointers" : {
+            "id" : {
+              "column" : "concept_id"
+            }
+          }
+        }
+      }
+    }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "ingredient"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "t_display_standard_concept"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary"
+        },
+        "display" : {
+          "column" : "t_display_vocabulary"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "searchString" : {
+        "column" : "id",
+        "foreignTable" : "ingredient_textsearch",
+        "foreignKey" : "id",
+        "foreignColumn" : "text"
+      }
+    },
+    "hierarchyMappings" : {
+      "standard" : {
+        "childParent" : {
+          "tablePointer" : {
+            "table" : "ingredient_standard_childParent"
+          },
+          "fieldPointers" : {
+            "parent" : {
+              "column" : "parent"
+            },
+            "child" : {
+              "column" : "child"
+            }
+          }
+        },
+        "ancestorDescendant" : {
+          "tablePointer" : {
+            "table" : "ingredient_standard_ancestorDescendant"
+          },
+          "fieldPointers" : {
+            "ancestor" : {
+              "column" : "ancestor"
+            },
+            "descendant" : {
+              "column" : "descendant"
+            }
+          }
+        },
+        "pathNumChildren" : {
+          "tablePointer" : {
+            "table" : "ingredient_standard_pathNumChildren"
+          },
+          "fieldPointers" : {
+            "path" : {
+              "column" : "path"
+            },
+            "num_children" : {
+              "column" : "num_children"
+            },
+            "id" : {
+              "column" : "id"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/ingredient_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/ingredient_occurrence.json
@@ -1,0 +1,199 @@
+{
+  "name" : "ingredient_occurrence",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "SIMPLE",
+    "name" : "end_date",
+    "dataType" : "STRING"
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "ingredient",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_criteria_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 0,
+      "maxVal" : 45383587
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "stop_reason",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : null
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "visit_occurrence_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 43,
+      "maxVal" : 111638243
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "days_supply",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 0,
+      "maxVal" : 90
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_value",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "person_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 2326856
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "start_date",
+    "dataType" : "STRING"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "drug_exposure"
+    },
+    "attributeMappings" : {
+      "end_date" : {
+        "value" : {
+          "column" : "drug_exposure_end_date"
+        }
+      },
+      "ingredient" : {
+        "value" : {
+          "column" : "drug_concept_id"
+        },
+        "display" : {
+          "column" : "drug_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "drug_source_concept_id"
+        }
+      },
+      "stop_reason" : {
+        "value" : {
+          "column" : "stop_reason"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "drug_exposure_id"
+        }
+      },
+      "days_supply" : {
+        "value" : {
+          "column" : "days_supply"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "drug_source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "start_date" : {
+        "value" : {
+          "column" : "drug_exposure_start_date"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "ingredient_occurrence"
+    },
+    "attributeMappings" : {
+      "end_date" : {
+        "value" : {
+          "column" : "end_date"
+        }
+      },
+      "ingredient" : {
+        "value" : {
+          "column" : "ingredient"
+        },
+        "display" : {
+          "column" : "t_display_ingredient"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "source_criteria_id"
+        }
+      },
+      "stop_reason" : {
+        "value" : {
+          "column" : "stop_reason"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      },
+      "days_supply" : {
+        "value" : {
+          "column" : "days_supply"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "start_date" : {
+        "value" : {
+          "column" : "start_date"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/observation.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/observation.json
@@ -1,0 +1,194 @@
+{
+  "name" : "observation",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "standard_concept",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "S"
+        },
+        "display" : "Standard"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "vocabulary",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "CPT4"
+        },
+        "display" : "Current Procedural Terminology version 4 (AMA)"
+      }, {
+        "value" : {
+          "stringVal" : "HCPCS"
+        },
+        "display" : "Healthcare Common Procedure Coding System (CMS)"
+      }, {
+        "value" : {
+          "stringVal" : "LOINC"
+        },
+        "display" : "Logical Observation Identifiers Names and Codes (Regenstrief Institute)"
+      }, {
+        "value" : {
+          "stringVal" : "SNOMED"
+        },
+        "display" : "Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "name",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "concept_code",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "concept",
+      "filter" : {
+        "type" : "ARRAY",
+        "operator" : "AND",
+        "subfilters" : [ {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "domain_id"
+          },
+          "operator" : "EQUALS",
+          "value" : {
+            "stringVal" : "Observation"
+          }
+        }, {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "standard_concept"
+          },
+          "operator" : "EQUALS",
+          "value" : {
+            "stringVal" : "S"
+          }
+        }, {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "vocabulary_id"
+          },
+          "operator" : "NOT_EQUALS",
+          "value" : {
+            "stringVal" : "PPI"
+          }
+        }, {
+          "type" : "BINARY",
+          "field" : {
+            "column" : "concept_class_id"
+          },
+          "operator" : "NOT_EQUALS",
+          "value" : {
+            "stringVal" : "Survey"
+          }
+        } ]
+      }
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "standard_concept",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary_id"
+        },
+        "display" : {
+          "column" : "vocabulary_id",
+          "foreignTable" : "vocabulary",
+          "foreignKey" : "vocabulary_id",
+          "foreignColumn" : "vocabulary_name"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "concept_name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "concept_id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "attributes" : [ "name", "concept_code" ]
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "observation"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "t_display_standard_concept"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary"
+        },
+        "display" : {
+          "column" : "t_display_vocabulary"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "searchString" : {
+        "column" : "id",
+        "foreignTable" : "observation_textsearch",
+        "foreignKey" : "id",
+        "foreignColumn" : "text"
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/observation_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/observation_occurrence.json
@@ -1,0 +1,225 @@
+{
+  "name" : "observation_occurrence",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "SIMPLE",
+    "name" : "date",
+    "dataType" : "STRING"
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "unit",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_criteria_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 2101829,
+      "maxVal" : 45890981
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "observation",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "value_as_string",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : null
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "visit_occurrence_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 111638269
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "value",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "int64Val" : 0
+        },
+        "display" : "No matching concept"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_value",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "person_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 2326856
+    }
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "observation"
+    },
+    "attributeMappings" : {
+      "date" : {
+        "value" : {
+          "column" : "observation_date"
+        }
+      },
+      "unit" : {
+        "value" : {
+          "column" : "unit_concept_id"
+        },
+        "display" : {
+          "column" : "unit_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "observation_source_concept_id"
+        }
+      },
+      "observation" : {
+        "value" : {
+          "column" : "observation_concept_id"
+        },
+        "display" : {
+          "column" : "observation_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "value_as_string" : {
+        "value" : {
+          "column" : "value_as_string"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "observation_id"
+        }
+      },
+      "value" : {
+        "value" : {
+          "column" : "value_as_concept_id"
+        },
+        "display" : {
+          "column" : "value_as_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "observation_source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "observation_occurrence"
+    },
+    "attributeMappings" : {
+      "date" : {
+        "value" : {
+          "column" : "date"
+        }
+      },
+      "unit" : {
+        "value" : {
+          "column" : "unit"
+        },
+        "display" : {
+          "column" : "t_display_unit"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "source_criteria_id"
+        }
+      },
+      "observation" : {
+        "value" : {
+          "column" : "observation"
+        },
+        "display" : {
+          "column" : "t_display_observation"
+        }
+      },
+      "value_as_string" : {
+        "value" : {
+          "column" : "value_as_string"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      },
+      "value" : {
+        "value" : {
+          "column" : "value"
+        },
+        "display" : {
+          "column" : "t_display_value"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/person.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/person.json
@@ -1,0 +1,172 @@
+{
+  "name" : "person",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "gender",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "int64Val" : 8532
+        },
+        "display" : "FEMALE"
+      }, {
+        "value" : {
+          "int64Val" : 8507
+        },
+        "display" : "MALE"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "race",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "int64Val" : 8516
+        },
+        "display" : "Black or African American"
+      }, {
+        "value" : {
+          "int64Val" : 0
+        },
+        "display" : "No matching concept"
+      }, {
+        "value" : {
+          "int64Val" : 8527
+        },
+        "display" : "White"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "ethnicity",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "int64Val" : 38003563
+        },
+        "display" : "Hispanic or Latino"
+      }, {
+        "value" : {
+          "int64Val" : 38003564
+        },
+        "display" : "Not Hispanic or Latino"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "year_of_birth",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1909,
+      "maxVal" : 1983
+    }
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "person"
+    },
+    "attributeMappings" : {
+      "gender" : {
+        "value" : {
+          "column" : "gender_concept_id"
+        },
+        "display" : {
+          "column" : "gender_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "race" : {
+        "value" : {
+          "column" : "race_concept_id"
+        },
+        "display" : {
+          "column" : "race_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "ethnicity" : {
+        "value" : {
+          "column" : "ethnicity_concept_id"
+        },
+        "display" : {
+          "column" : "ethnicity_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      },
+      "year_of_birth" : {
+        "value" : {
+          "column" : "year_of_birth"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "person"
+    },
+    "attributeMappings" : {
+      "gender" : {
+        "value" : {
+          "column" : "gender"
+        },
+        "display" : {
+          "column" : "t_display_gender"
+        }
+      },
+      "race" : {
+        "value" : {
+          "column" : "race"
+        },
+        "display" : {
+          "column" : "t_display_race"
+        }
+      },
+      "ethnicity" : {
+        "value" : {
+          "column" : "ethnicity"
+        },
+        "display" : {
+          "column" : "t_display_ethnicity"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      },
+      "year_of_birth" : {
+        "value" : {
+          "column" : "year_of_birth"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/procedure.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/procedure.json
@@ -1,0 +1,262 @@
+{
+  "name" : "procedure",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "standard_concept",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : { },
+        "display" : "Source"
+      }, {
+        "value" : {
+          "stringVal" : "C"
+        },
+        "display" : "Unknown"
+      }, {
+        "value" : {
+          "stringVal" : "S"
+        },
+        "display" : "Standard"
+      } ]
+    }
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "vocabulary",
+    "dataType" : "STRING",
+    "displayHint" : {
+      "type" : "ENUM",
+      "valueDisplays" : [ {
+        "value" : {
+          "stringVal" : "CPT4"
+        },
+        "display" : "Current Procedural Terminology version 4 (AMA)"
+      }, {
+        "value" : {
+          "stringVal" : "HCPCS"
+        },
+        "display" : "Healthcare Common Procedure Coding System (CMS)"
+      }, {
+        "value" : {
+          "stringVal" : "ICD9CM"
+        },
+        "display" : "International Classification of Diseases, Ninth Revision, Clinical Modification, Volume 1 and 2 (NCHS)"
+      }, {
+        "value" : {
+          "stringVal" : "ICD9Proc"
+        },
+        "display" : "International Classification of Diseases, Ninth Revision, Clinical Modification, Volume 3 (NCHS)"
+      }, {
+        "value" : {
+          "stringVal" : "ICD10CM"
+        },
+        "display" : "International Classification of Diseases, Tenth Revision, Clinical Modification (NCHS)"
+      }, {
+        "value" : {
+          "stringVal" : "SNOMED"
+        },
+        "display" : "Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO)"
+      } ]
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "name",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "concept_code",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "concept",
+      "filter" : {
+        "type" : "BINARY",
+        "field" : {
+          "column" : "domain_id"
+        },
+        "operator" : "EQUALS",
+        "value" : {
+          "stringVal" : "Procedure"
+        }
+      }
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "standard_concept",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary_id"
+        },
+        "display" : {
+          "column" : "vocabulary_id",
+          "foreignTable" : "vocabulary",
+          "foreignKey" : "vocabulary_id",
+          "foreignColumn" : "vocabulary_name"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "concept_name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "concept_id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "attributes" : [ "name", "concept_code" ]
+    },
+    "hierarchyMappings" : {
+      "standard" : {
+        "childParent" : {
+          "tablePointer" : {
+            "rawSql" : "SELECT   cr.concept_id_1 AS parent,   cr.concept_id_2 AS child, FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_relationship` cr JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = cr.concept_id_1 JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = cr.concept_id_2 WHERE   cr.relationship_id = 'Subsumes'   AND c1.domain_id = c2.domain_id   AND c2.domain_id = 'Procedure'   AND c1.vocabulary_id = c2.vocabulary_id   AND c2.vocabulary_id = 'SNOMED'"
+          },
+          "fieldPointers" : {
+            "parent" : {
+              "column" : "parent"
+            },
+            "child" : {
+              "column" : "child"
+            }
+          }
+        },
+        "rootNodesFilter" : {
+          "tablePointer" : {
+            "table" : "concept",
+            "filter" : {
+              "type" : "BINARY",
+              "field" : {
+                "column" : "concept_id"
+              },
+              "operator" : "EQUALS",
+              "value" : {
+                "int64Val" : 4322976
+              }
+            }
+          },
+          "fieldPointers" : {
+            "id" : {
+              "column" : "concept_id"
+            }
+          }
+        }
+      }
+    }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "procedure"
+    },
+    "attributeMappings" : {
+      "standard_concept" : {
+        "value" : {
+          "column" : "standard_concept"
+        },
+        "display" : {
+          "column" : "t_display_standard_concept"
+        }
+      },
+      "vocabulary" : {
+        "value" : {
+          "column" : "vocabulary"
+        },
+        "display" : {
+          "column" : "t_display_vocabulary"
+        }
+      },
+      "name" : {
+        "value" : {
+          "column" : "name"
+        }
+      },
+      "concept_code" : {
+        "value" : {
+          "column" : "concept_code"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      }
+    },
+    "textSearchMapping" : {
+      "searchString" : {
+        "column" : "id",
+        "foreignTable" : "procedure_textsearch",
+        "foreignKey" : "id",
+        "foreignColumn" : "text"
+      }
+    },
+    "hierarchyMappings" : {
+      "standard" : {
+        "childParent" : {
+          "tablePointer" : {
+            "table" : "procedure_standard_childParent"
+          },
+          "fieldPointers" : {
+            "parent" : {
+              "column" : "parent"
+            },
+            "child" : {
+              "column" : "child"
+            }
+          }
+        },
+        "ancestorDescendant" : {
+          "tablePointer" : {
+            "table" : "procedure_standard_ancestorDescendant"
+          },
+          "fieldPointers" : {
+            "ancestor" : {
+              "column" : "ancestor"
+            },
+            "descendant" : {
+              "column" : "descendant"
+            }
+          }
+        },
+        "pathNumChildren" : {
+          "tablePointer" : {
+            "table" : "procedure_standard_pathNumChildren"
+          },
+          "fieldPointers" : {
+            "path" : {
+              "column" : "path"
+            },
+            "num_children" : {
+              "column" : "num_children"
+            },
+            "id" : {
+              "column" : "id"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/procedure_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entity/procedure_occurrence.json
@@ -1,0 +1,145 @@
+{
+  "name" : "procedure_occurrence",
+  "idAttribute" : "id",
+  "attributes" : [ {
+    "type" : "SIMPLE",
+    "name" : "date",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_criteria_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 2000002,
+      "maxVal" : 46257453
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "visit_occurrence_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 111638270
+    }
+  }, {
+    "type" : "SIMPLE",
+    "name" : "id",
+    "dataType" : "INT64"
+  }, {
+    "type" : "KEY_AND_DISPLAY",
+    "name" : "procedure",
+    "dataType" : "INT64"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "source_value",
+    "dataType" : "STRING"
+  }, {
+    "type" : "SIMPLE",
+    "name" : "person_id",
+    "dataType" : "INT64",
+    "displayHint" : {
+      "type" : "RANGE",
+      "minVal" : 1,
+      "maxVal" : 2326856
+    }
+  } ],
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "tablePointer" : {
+      "table" : "procedure_occurrence"
+    },
+    "attributeMappings" : {
+      "date" : {
+        "value" : {
+          "column" : "procedure_dat"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "procedure_source_concept_id"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "procedure_occurrence_id"
+        }
+      },
+      "procedure" : {
+        "value" : {
+          "column" : "procedure_concept_id"
+        },
+        "display" : {
+          "column" : "procedure_concept_id",
+          "foreignTable" : "concept",
+          "foreignKey" : "concept_id",
+          "foreignColumn" : "concept_name"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "procedure_source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "tablePointer" : {
+      "table" : "procedure_occurrence"
+    },
+    "attributeMappings" : {
+      "date" : {
+        "value" : {
+          "column" : "date"
+        }
+      },
+      "source_criteria_id" : {
+        "value" : {
+          "column" : "source_criteria_id"
+        }
+      },
+      "visit_occurrence_id" : {
+        "value" : {
+          "column" : "visit_occurrence_id"
+        }
+      },
+      "id" : {
+        "value" : {
+          "column" : "id"
+        }
+      },
+      "procedure" : {
+        "value" : {
+          "column" : "procedure"
+        },
+        "display" : {
+          "column" : "t_display_procedure"
+        }
+      },
+      "source_value" : {
+        "value" : {
+          "column" : "source_value"
+        }
+      },
+      "person_id" : {
+        "value" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "hierarchyMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/brand_ingredient.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/brand_ingredient.json
@@ -1,0 +1,30 @@
+{
+  "type" : "GROUP_ITEMS",
+  "name" : "brand_ingredient",
+  "entities" : {
+    "items" : "ingredient",
+    "group" : "brand"
+  },
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "relationshipMappings" : {
+      "groupToItems" : {
+        "tablePointer" : {
+          "table" : "concept_relationship"
+        },
+        "fromEntityId" : {
+          "column" : "concept_id_1"
+        },
+        "toEntityId" : {
+          "column" : "concept_id_2"
+        }
+      }
+    },
+    "auxiliaryDataMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "relationshipMappings" : { },
+    "auxiliaryDataMappings" : { }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/condition_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/condition_person_occurrence.json
@@ -1,0 +1,55 @@
+{
+  "type" : "CRITERIA_OCCURRENCE",
+  "name" : "condition_person_occurrence",
+  "entities" : {
+    "criteria" : "condition",
+    "occurrence" : "condition_occurrence"
+  },
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "relationshipMappings" : {
+      "occurrenceToCriteria" : {
+        "tablePointer" : {
+          "table" : "condition_occurrence"
+        },
+        "fromEntityId" : {
+          "column" : "condition_occurrence_id"
+        },
+        "toEntityId" : {
+          "column" : "condition_concept_id"
+        }
+      },
+      "occurrenceToPrimary" : {
+        "tablePointer" : {
+          "table" : "condition_occurrence"
+        },
+        "fromEntityId" : {
+          "column" : "condition_occurrence_id"
+        },
+        "toEntityId" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "auxiliaryDataMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "relationshipMappings" : { },
+    "auxiliaryDataMappings" : {
+      "criteriaPrimaryRollupCount" : {
+        "tablePointer" : {
+          "table" : "condition_person_occurrence_criteriaPrimaryRollupCount"
+        },
+        "fieldPointers" : {
+          "id" : {
+            "column" : "id"
+          },
+          "rollup_count" : {
+            "column" : "rollup_count"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/device_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/device_person_occurrence.json
@@ -1,0 +1,55 @@
+{
+  "type" : "CRITERIA_OCCURRENCE",
+  "name" : "device_person_occurrence",
+  "entities" : {
+    "criteria" : "device",
+    "occurrence" : "device_occurrence"
+  },
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "relationshipMappings" : {
+      "occurrenceToCriteria" : {
+        "tablePointer" : {
+          "table" : "device_exposure"
+        },
+        "fromEntityId" : {
+          "column" : "device_exposure_id"
+        },
+        "toEntityId" : {
+          "column" : "device_concept_id"
+        }
+      },
+      "occurrenceToPrimary" : {
+        "tablePointer" : {
+          "table" : "device_exposure"
+        },
+        "fromEntityId" : {
+          "column" : "device_exposure_id"
+        },
+        "toEntityId" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "auxiliaryDataMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "relationshipMappings" : { },
+    "auxiliaryDataMappings" : {
+      "criteriaPrimaryRollupCount" : {
+        "tablePointer" : {
+          "table" : "device_person_occurrence_criteriaPrimaryRollupCount"
+        },
+        "fieldPointers" : {
+          "id" : {
+            "column" : "id"
+          },
+          "rollup_count" : {
+            "column" : "rollup_count"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/ingredient_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/ingredient_person_occurrence.json
@@ -1,0 +1,55 @@
+{
+  "type" : "CRITERIA_OCCURRENCE",
+  "name" : "ingredient_person_occurrence",
+  "entities" : {
+    "criteria" : "ingredient",
+    "occurrence" : "ingredient_occurrence"
+  },
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "relationshipMappings" : {
+      "occurrenceToCriteria" : {
+        "tablePointer" : {
+          "table" : "drug_exposure"
+        },
+        "fromEntityId" : {
+          "column" : "drug_exposure_id"
+        },
+        "toEntityId" : {
+          "column" : "drug_concept_id"
+        }
+      },
+      "occurrenceToPrimary" : {
+        "tablePointer" : {
+          "table" : "drug_exposure"
+        },
+        "fromEntityId" : {
+          "column" : "drug_exposure_id"
+        },
+        "toEntityId" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "auxiliaryDataMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "relationshipMappings" : { },
+    "auxiliaryDataMappings" : {
+      "criteriaPrimaryRollupCount" : {
+        "tablePointer" : {
+          "table" : "ingredient_person_occurrence_criteriaPrimaryRollupCount"
+        },
+        "fieldPointers" : {
+          "id" : {
+            "column" : "id"
+          },
+          "rollup_count" : {
+            "column" : "rollup_count"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/observation_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/observation_person_occurrence.json
@@ -1,0 +1,55 @@
+{
+  "type" : "CRITERIA_OCCURRENCE",
+  "name" : "observation_person_occurrence",
+  "entities" : {
+    "criteria" : "observation",
+    "occurrence" : "observation_occurrence"
+  },
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "relationshipMappings" : {
+      "occurrenceToCriteria" : {
+        "tablePointer" : {
+          "table" : "observation"
+        },
+        "fromEntityId" : {
+          "column" : "observation_id"
+        },
+        "toEntityId" : {
+          "column" : "observation_concept_id"
+        }
+      },
+      "occurrenceToPrimary" : {
+        "tablePointer" : {
+          "table" : "observation"
+        },
+        "fromEntityId" : {
+          "column" : "observation_id"
+        },
+        "toEntityId" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "auxiliaryDataMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "relationshipMappings" : { },
+    "auxiliaryDataMappings" : {
+      "criteriaPrimaryRollupCount" : {
+        "tablePointer" : {
+          "table" : "observation_person_occurrence_criteriaPrimaryRollupCount"
+        },
+        "fieldPointers" : {
+          "id" : {
+            "column" : "id"
+          },
+          "rollup_count" : {
+            "column" : "rollup_count"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/procedure_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/procedure_person_occurrence.json
@@ -1,0 +1,55 @@
+{
+  "type" : "CRITERIA_OCCURRENCE",
+  "name" : "procedure_person_occurrence",
+  "entities" : {
+    "criteria" : "procedure",
+    "occurrence" : "procedure_occurrence"
+  },
+  "sourceDataMapping" : {
+    "dataPointer" : "omop_dataset",
+    "relationshipMappings" : {
+      "occurrenceToCriteria" : {
+        "tablePointer" : {
+          "table" : "procedure_occurrence"
+        },
+        "fromEntityId" : {
+          "column" : "procedure_occurrence_id"
+        },
+        "toEntityId" : {
+          "column" : "procedure_concept_id"
+        }
+      },
+      "occurrenceToPrimary" : {
+        "tablePointer" : {
+          "table" : "procedure_occurrence"
+        },
+        "fromEntityId" : {
+          "column" : "procedure_occurrence_id"
+        },
+        "toEntityId" : {
+          "column" : "person_id"
+        }
+      }
+    },
+    "auxiliaryDataMappings" : { }
+  },
+  "indexDataMapping" : {
+    "dataPointer" : "index_dataset",
+    "relationshipMappings" : { },
+    "auxiliaryDataMappings" : {
+      "criteriaPrimaryRollupCount" : {
+        "tablePointer" : {
+          "table" : "procedure_person_occurrence_criteriaPrimaryRollupCount"
+        },
+        "fieldPointers" : {
+          "id" : {
+            "column" : "id"
+          },
+          "rollup_count" : {
+            "column" : "rollup_count"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/cms_synpuf.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/cms_synpuf.json
@@ -1,0 +1,35 @@
+{
+  "name": "cms_synpuf",
+  "dataPointers": [
+    { "type": "BQ_DATASET",
+      "name": "omop_dataset",
+      "projectId": "bigquery-public-data",
+      "datasetId": "cms_synthetic_patient_data_omop",
+      "queryProjectId": "broad-tanagra-dev" },
+    { "type": "BQ_DATASET",
+      "name": "index_dataset",
+      "projectId": "broad-tanagra-dev",
+      "datasetId": "cmssynpuf_index" } ],
+  "entities": [
+    "brand.json",
+    "condition.json",
+    "condition_occurrence.json",
+    "device.json",
+    "device_occurrence.json",
+    "ingredient.json",
+    "ingredient_occurrence.json",
+    "observation.json",
+    "observation_occurrence.json",
+    "person.json",
+    "procedure.json",
+    "procedure_occurrence.json" ],
+  "primaryEntity": "person",
+  "entityGroups": [
+    "brand_ingredient.json",
+    "condition_person_occurrence.json",
+    "device_person_occurrence.json",
+    "ingredient_person_occurrence.json",
+    "observation_person_occurrence.json",
+    "procedure_person_occurrence.json"
+  ]
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/brand.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/brand.json
@@ -1,0 +1,56 @@
+{
+  "name": "brand",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "name" },
+    { "type": "KEY_AND_DISPLAY", "name": "standard_concept" },
+    { "type": "SIMPLE", "name": "concept_code" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": {
+      "table": "concept",
+      "filter": {
+        "type": "ARRAY",
+        "operator": "AND",
+        "subfilters": [
+          { "type": "BINARY",
+            "field": { "column": "domain_id" },
+            "operator": "EQUALS",
+            "value": { "stringVal": "Drug" } },
+          { "type": "BINARY",
+            "field": { "column": "concept_class_id" },
+            "operator": "EQUALS",
+            "value": { "stringVal": "Brand Name" } },
+          { "type": "BINARY",
+            "field": { "column": "invalid_reason" },
+            "operator": "IS",
+            "value": { "stringVal": null } },
+          { "type": "ARRAY",
+            "operator": "OR",
+            "subfilters": [
+              { "type": "BINARY",
+                "field": { "column": "vocabulary_id" },
+                "operator": "EQUALS",
+                "value": { "stringVal": "RxNorm" } },
+              { "type": "BINARY",
+                "field": { "column": "vocabulary_id" },
+                "operator": "EQUALS",
+                "value": { "stringVal": "RxNorm Extension" } }
+            ] } ] } },
+    "attributeMappings": {
+      "id": { "value": { "column": "concept_id" } },
+      "name": { "value": { "column": "concept_name" } },
+      "standard_concept": {
+        "value": { "column": "standard_concept" },
+        "display": {
+          "column": "standard_concept",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)" } } },
+    "textSearchMapping": { "attributes": [ "name", "concept_code" ] }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/condition.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/condition.json
@@ -1,0 +1,56 @@
+{
+  "name": "condition",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "name" },
+    { "type": "KEY_AND_DISPLAY", "name": "vocabulary" },
+    { "type": "KEY_AND_DISPLAY", "name": "standard_concept" },
+    { "type": "SIMPLE", "name": "concept_code" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": {
+      "table": "concept",
+      "filter": {
+        "type": "BINARY",
+        "field": { "column": "domain_id" },
+        "operator": "EQUALS",
+        "value": { "stringVal": "Condition" } } },
+    "attributeMappings": {
+      "id": { "value": { "column": "concept_id" } },
+      "name": { "value": { "column": "concept_name" } },
+      "vocabulary": {
+        "value": { "column": "vocabulary_id" },
+        "display": {
+          "column": "vocabulary_id",
+          "foreignTable": "vocabulary",
+          "foreignKey": "vocabulary_id",
+          "foreignColumn": "vocabulary_name" } },
+      "standard_concept": {
+        "value": { "column": "standard_concept" },
+        "display": {
+          "column": "standard_concept",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)" } } },
+    "textSearchMapping": { "attributes": [ "name", "concept_code" ] },
+    "hierarchyMappings": {
+      "standard": {
+        "childParent": {
+          "tablePointer": { "rawSqlFile": "condition_parentChild.sql" }
+        },
+        "rootNodesFilter": {
+          "tablePointer": {
+            "table": "concept",
+            "filter": { "type": "BINARY",  "field": { "column": "concept_id" }, "operator": "EQUALS", "value": { "int64Val": 441840 } } },
+          "fieldPointers": {
+            "id": { "column": "concept_id" }
+          }
+        }
+      }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/condition_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/condition_occurrence.json
@@ -1,0 +1,37 @@
+{
+  "name": "condition_occurrence",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "person_id" },
+    { "type": "KEY_AND_DISPLAY", "name": "condition" },
+    { "type": "SIMPLE", "name": "start_date" },
+    { "type": "SIMPLE", "name": "end_date" },
+    { "type": "SIMPLE", "name": "stop_reason" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id" },
+    { "type": "SIMPLE", "name": "source_value" },
+    { "type": "SIMPLE", "name": "source_criteria_id" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "table": "condition_occurrence" },
+    "attributeMappings": {
+      "id": { "value": { "column": "condition_occurrence_id" } },
+      "condition": {
+        "value": { "column": "condition_concept_id" },
+        "display": {
+          "column": "condition_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "start_date": { "value": { "column": "condition_start_date" } },
+      "end_date": { "value": { "column": "condition_end_date" } },
+      "source_value": { "value": { "column": "condition_source_value" } },
+      "source_criteria_id": { "value": { "column": "condition_source_concept_id" } }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/device.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/device.json
@@ -1,0 +1,49 @@
+{
+  "name": "device",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "name" },
+    { "type": "KEY_AND_DISPLAY", "name": "vocabulary" },
+    { "type": "KEY_AND_DISPLAY", "name": "standard_concept" },
+    { "type": "SIMPLE", "name": "concept_code" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": {
+      "table": "concept",
+      "filter": {
+        "type": "ARRAY",
+        "operator": "AND",
+        "subfilters": [
+          { "type": "BINARY",
+            "field": { "column": "domain_id" },
+            "operator": "EQUALS",
+            "value": { "stringVal": "Device" } },
+          { "type": "BINARY",
+            "field": { "column": "standard_concept" },
+            "operator": "EQUALS",
+            "value": { "stringVal": "S" } }
+        ] } },
+    "attributeMappings": {
+      "id": { "value": { "column": "concept_id" } },
+      "name": { "value": { "column": "concept_name" } },
+      "vocabulary": {
+        "value": { "column": "vocabulary_id" },
+        "display": {
+          "column": "vocabulary_id",
+          "foreignTable": "vocabulary",
+          "foreignKey": "vocabulary_id",
+          "foreignColumn": "vocabulary_name" } },
+      "standard_concept": {
+        "value": { "column": "standard_concept" },
+        "display": {
+          "column": "standard_concept",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)" } } },
+    "textSearchMapping": { "attributes": [ "name", "concept_code" ] }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/device_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/device_occurrence.json
@@ -1,0 +1,36 @@
+{
+  "name": "device_occurrence",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "person_id" },
+    { "type": "KEY_AND_DISPLAY", "name": "device" },
+    { "type": "SIMPLE", "name": "start_date" },
+    { "type": "SIMPLE", "name": "end_date" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id" },
+    { "type": "SIMPLE", "name": "source_value" },
+    { "type": "SIMPLE", "name": "source_criteria_id" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "table": "device_exposure" },
+    "attributeMappings": {
+      "id": { "value": { "column": "device_exposure_id" } },
+      "device": {
+        "value": { "column": "device_concept_id" },
+        "display": {
+          "column": "device_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "start_date": { "value": { "column": "device_exposure_start_date" } },
+      "end_date": { "value": { "column": "device_exposure_end_date" } },
+      "source_value": { "value": { "column": "device_source_value" } },
+      "source_criteria_id": { "value": { "column": "device_source_concept_id" } }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/ingredient.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/ingredient.json
@@ -1,0 +1,63 @@
+{
+  "name": "ingredient",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "name" },
+    { "type": "KEY_AND_DISPLAY", "name": "vocabulary" },
+    { "type": "KEY_AND_DISPLAY", "name": "standard_concept" },
+    { "type": "SIMPLE", "name": "concept_code" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "rawSqlFile": "ingredient_all.sql" },
+    "attributeMappings": {
+      "vocabulary": {
+        "value": { "column": "vocabulary_id" },
+        "display": {
+          "column": "vocabulary_id",
+          "foreignTable": "vocabulary",
+          "foreignKey": "vocabulary_id",
+          "foreignColumn": "vocabulary_name" } },
+      "standard_concept": {
+        "value": { "column": "standard_concept" },
+        "display": {
+          "column": "standard_concept",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)" } } },
+    "textSearchMapping": { "attributes": [ "name", "concept_code" ] },
+    "hierarchyMappings": {
+      "standard": {
+        "childParent": {
+          "tablePointer": { "rawSqlFile": "ingredient_parentChild.sql" }
+        },
+        "rootNodesFilter": {
+          "tablePointer": {
+            "table": "concept",
+            "filter": {
+              "type": "ARRAY",
+              "operator": "AND",
+              "subfilters": [
+                { "type": "BINARY",
+                  "field": { "column": "vocabulary_id" },
+                  "operator": "EQUALS",
+                  "value": { "stringVal": "ATC" } },
+                { "type": "BINARY",
+                  "field": { "column": "concept_class_id" },
+                  "operator": "EQUALS",
+                  "value": { "stringVal": "ATC 1st" } },
+                { "type": "BINARY",
+                  "field": { "column": "standard_concept" },
+                  "operator": "EQUALS",
+                  "value": { "stringVal": "C" } } ] } },
+          "fieldPointers": {
+            "id": { "column": "concept_id" }
+          }
+        }
+      }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/ingredient_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/ingredient_occurrence.json
@@ -1,0 +1,38 @@
+{
+  "name": "ingredient_occurrence",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "person_id" },
+    { "type": "KEY_AND_DISPLAY", "name": "ingredient" },
+    { "type": "SIMPLE", "name": "start_date" },
+    { "type": "SIMPLE", "name": "end_date" },
+    { "type": "SIMPLE", "name": "stop_reason" },
+    { "type": "SIMPLE", "name": "days_supply" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id" },
+    { "type": "SIMPLE", "name": "source_value" },
+    { "type": "SIMPLE", "name": "source_criteria_id" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "table": "drug_exposure" },
+    "attributeMappings": {
+      "id": { "value": { "column": "drug_exposure_id" } },
+      "ingredient": {
+        "value": { "column": "drug_concept_id" },
+        "display": {
+          "column": "drug_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "start_date": { "value": { "column": "drug_exposure_start_date" } },
+      "end_date": { "value": { "column": "drug_exposure_end_date" } },
+      "source_value": { "value": { "column": "drug_source_value" } },
+      "source_criteria_id": { "value": { "column": "drug_source_concept_id" } }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/observation.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/observation.json
@@ -1,0 +1,57 @@
+{
+  "name": "observation",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "name" },
+    { "type": "KEY_AND_DISPLAY", "name": "vocabulary" },
+    { "type": "KEY_AND_DISPLAY", "name": "standard_concept" },
+    { "type": "SIMPLE", "name": "concept_code" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": {
+      "table": "concept",
+      "filter": {
+        "type": "ARRAY",
+        "operator": "AND",
+        "subfilters": [
+          { "type": "BINARY",
+            "field": { "column": "domain_id" },
+            "operator": "EQUALS",
+            "value": { "stringVal": "Observation" } },
+          { "type": "BINARY",
+            "field": { "column": "standard_concept" },
+            "operator": "EQUALS",
+            "value": { "stringVal": "S" } },
+          { "type": "BINARY",
+            "field": { "column": "vocabulary_id" },
+            "operator": "NOT_EQUALS",
+            "value": { "stringVal": "PPI" } },
+          { "type": "BINARY",
+            "field": { "column": "concept_class_id" },
+            "operator": "NOT_EQUALS",
+            "value": { "stringVal": "Survey" } }
+        ] } },
+    "attributeMappings": {
+      "id": { "value": { "column": "concept_id" } },
+      "name": { "value": { "column": "concept_name" } },
+      "vocabulary": {
+        "value": { "column": "vocabulary_id" },
+        "display": {
+          "column": "vocabulary_id",
+          "foreignTable": "vocabulary",
+          "foreignKey": "vocabulary_id",
+          "foreignColumn": "vocabulary_name" } },
+      "standard_concept": {
+        "value": { "column": "standard_concept" },
+        "display": {
+          "column": "standard_concept",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)" } } },
+    "textSearchMapping": { "attributes": [ "name", "concept_code" ] }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/observation_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/observation_occurrence.json
@@ -1,0 +1,51 @@
+{
+  "name": "observation_occurrence",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "person_id" },
+    { "type": "KEY_AND_DISPLAY", "name": "observation" },
+    { "type": "SIMPLE", "name": "date" },
+    { "type": "SIMPLE", "name": "value_as_string" },
+    { "type": "KEY_AND_DISPLAY", "name": "value" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id" },
+    { "type": "SIMPLE", "name": "source_value" },
+    { "type": "SIMPLE", "name": "source_criteria_id" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "table": "observation" },
+    "attributeMappings": {
+      "id": { "value": { "column": "observation_id" } },
+      "observation": {
+        "value": { "column": "observation_concept_id" },
+        "display": {
+          "column": "observation_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "date": { "value": { "column": "observation_date" } },
+      "value": {
+        "value": { "column": "value_as_concept_id" },
+        "display": {
+          "column": "value_as_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "unit": {
+        "value": { "column": "unit_concept_id" },
+        "display": {
+          "column": "unit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "source_value": { "value": { "column": "observation_source_value" } },
+      "source_criteria_id": { "value": { "column": "observation_source_concept_id" } }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/person.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/person.json
@@ -1,0 +1,42 @@
+{
+  "name": "person",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "year_of_birth" },
+    { "type": "KEY_AND_DISPLAY", "name": "gender" },
+    { "type": "KEY_AND_DISPLAY", "name": "race" },
+    { "type": "KEY_AND_DISPLAY", "name": "ethnicity" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "table": "person" },
+    "attributeMappings": {
+      "id": { "value": { "column": "person_id" } },
+      "gender": {
+        "value": { "column": "gender_concept_id" },
+        "display": {
+          "column": "gender_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "race": {
+        "value": { "column": "race_concept_id" },
+        "display": {
+          "column": "race_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "ethnicity": {
+        "value": { "column": "ethnicity_concept_id" },
+        "display": {
+          "column": "ethnicity_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
+    } },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/procedure.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/procedure.json
@@ -1,0 +1,56 @@
+{
+  "name": "procedure",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "name" },
+    { "type": "KEY_AND_DISPLAY", "name": "vocabulary" },
+    { "type": "KEY_AND_DISPLAY", "name": "standard_concept" },
+    { "type": "SIMPLE", "name": "concept_code" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": {
+      "table": "concept",
+      "filter": {
+        "type": "BINARY",
+        "field": { "column": "domain_id" },
+        "operator": "EQUALS",
+        "value": { "stringVal": "Procedure" } } },
+    "attributeMappings": {
+      "id": { "value": { "column": "concept_id" } },
+      "name": { "value": { "column": "concept_name" } },
+      "vocabulary": {
+        "value": { "column": "vocabulary_id" },
+        "display": {
+          "column": "vocabulary_id",
+          "foreignTable": "vocabulary",
+          "foreignKey": "vocabulary_id",
+          "foreignColumn": "vocabulary_name" } },
+      "standard_concept": {
+        "value": { "column": "standard_concept" },
+        "display": {
+          "column": "standard_concept",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 'Source' WHEN ${fieldSql} = 'S' THEN 'Standard' ELSE 'Unknown' END)" } } },
+    "textSearchMapping": { "attributes": [ "name", "concept_code" ] },
+    "hierarchyMappings": {
+      "standard": {
+        "childParent": {
+          "tablePointer": { "rawSqlFile": "procedure_parentChild.sql" }
+        },
+        "rootNodesFilter": {
+          "tablePointer": {
+            "table": "concept",
+            "filter": { "type": "BINARY",  "field": { "column": "concept_id" }, "operator": "EQUALS", "value": { "int64Val": 4322976 } } },
+          "fieldPointers": {
+            "id": { "column": "concept_id" }
+          }
+        }
+      }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entity/procedure_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entity/procedure_occurrence.json
@@ -1,0 +1,34 @@
+{
+  "name": "procedure_occurrence",
+  "idAttribute": "id",
+  "attributes": [
+    { "type": "SIMPLE", "name": "id" },
+    { "type": "SIMPLE", "name": "person_id" },
+    { "type": "KEY_AND_DISPLAY", "name": "procedure" },
+    { "type": "SIMPLE", "name": "date" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id" },
+    { "type": "SIMPLE", "name": "source_value" },
+    { "type": "SIMPLE", "name": "source_criteria_id" } ],
+
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "tablePointer": { "table": "procedure_occurrence" },
+    "attributeMappings": {
+      "id": { "value": { "column": "procedure_occurrence_id" } },
+      "procedure": {
+        "value": { "column": "procedure_concept_id" },
+        "display": {
+          "column": "procedure_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } },
+      "date": { "value": { "column": "procedure_dat" } },
+      "source_value": { "value": { "column": "procedure_source_value" } },
+      "source_criteria_id": { "value": { "column": "procedure_source_concept_id" } }
+    }
+  },
+
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/brand_ingredient.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/brand_ingredient.json
@@ -1,0 +1,21 @@
+{
+  "name": "brand_ingredient",
+  "type": "GROUP_ITEMS",
+  "entities": {
+    "group": "brand",
+    "items": "ingredient"
+  },
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "relationshipMappings": {
+      "groupToItems": {
+        "tablePointer": { "table": "concept_relationship" },
+        "fromEntityId": { "column": "concept_id_1" },
+        "toEntityId":  { "column": "concept_id_2" }
+      }
+    }
+  },
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/condition_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/condition_person_occurrence.json
@@ -1,0 +1,26 @@
+{
+  "name": "condition_person_occurrence",
+  "type": "CRITERIA_OCCURRENCE",
+  "entities": {
+    "criteria": "condition",
+    "occurrence": "condition_occurrence"
+  },
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "relationshipMappings": {
+      "occurrenceToCriteria": {
+        "tablePointer": { "table": "condition_occurrence" },
+        "fromEntityId": { "column": "condition_occurrence_id" },
+        "toEntityId":  { "column": "condition_concept_id" }
+      },
+      "occurrenceToPrimary": {
+        "tablePointer": { "table": "condition_occurrence" },
+        "fromEntityId": { "column": "condition_occurrence_id" },
+        "toEntityId":  { "column": "person_id" }
+      }
+    }
+  },
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/device_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/device_person_occurrence.json
@@ -1,0 +1,26 @@
+{
+  "name": "device_person_occurrence",
+  "type": "CRITERIA_OCCURRENCE",
+  "entities": {
+    "criteria": "device",
+    "occurrence": "device_occurrence"
+  },
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "relationshipMappings": {
+      "occurrenceToCriteria": {
+        "tablePointer": { "table": "device_exposure" },
+        "fromEntityId": { "column": "device_exposure_id" },
+        "toEntityId":  { "column": "device_concept_id" }
+      },
+      "occurrenceToPrimary": {
+        "tablePointer": { "table": "device_exposure" },
+        "fromEntityId": { "column": "device_exposure_id" },
+        "toEntityId":  { "column": "person_id" }
+      }
+    }
+  },
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/ingredient_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/ingredient_person_occurrence.json
@@ -1,0 +1,26 @@
+{
+  "name": "ingredient_person_occurrence",
+  "type": "CRITERIA_OCCURRENCE",
+  "entities": {
+    "criteria": "ingredient",
+    "occurrence": "ingredient_occurrence"
+  },
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "relationshipMappings": {
+      "occurrenceToCriteria": {
+        "tablePointer": { "table": "drug_exposure" },
+        "fromEntityId": { "column": "drug_exposure_id" },
+        "toEntityId":  { "column": "drug_concept_id" }
+      },
+      "occurrenceToPrimary": {
+        "tablePointer": { "table": "drug_exposure" },
+        "fromEntityId": { "column": "drug_exposure_id" },
+        "toEntityId":  { "column": "person_id" }
+      }
+    }
+  },
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/observation_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/observation_person_occurrence.json
@@ -1,0 +1,26 @@
+{
+  "name": "observation_person_occurrence",
+  "type": "CRITERIA_OCCURRENCE",
+  "entities": {
+    "criteria": "observation",
+    "occurrence": "observation_occurrence"
+  },
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "relationshipMappings": {
+      "occurrenceToCriteria": {
+        "tablePointer": { "table": "observation" },
+        "fromEntityId": { "column": "observation_id" },
+        "toEntityId":  { "column": "observation_concept_id" }
+      },
+      "occurrenceToPrimary": {
+        "tablePointer": { "table": "observation" },
+        "fromEntityId": { "column": "observation_id" },
+        "toEntityId":  { "column": "person_id" }
+      }
+    }
+  },
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/procedure_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/procedure_person_occurrence.json
@@ -1,0 +1,26 @@
+{
+  "name": "procedure_person_occurrence",
+  "type": "CRITERIA_OCCURRENCE",
+  "entities": {
+    "criteria": "procedure",
+    "occurrence": "procedure_occurrence"
+  },
+  "sourceDataMapping": {
+    "dataPointer": "omop_dataset",
+    "relationshipMappings": {
+      "occurrenceToCriteria": {
+        "tablePointer": { "table": "procedure_occurrence" },
+        "fromEntityId": { "column": "procedure_occurrence_id" },
+        "toEntityId":  { "column": "procedure_concept_id" }
+      },
+      "occurrenceToPrimary": {
+        "tablePointer": { "table": "procedure_occurrence" },
+        "fromEntityId": { "column": "procedure_occurrence_id" },
+        "toEntityId":  { "column": "person_id" }
+      }
+    }
+  },
+  "indexDataMapping": {
+    "dataPointer": "index_dataset"
+  }
+}

--- a/api/src/main/resources/config/broad/cms_synpuf/original/sql/condition_parentChild.sql
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/sql/condition_parentChild.sql
@@ -1,0 +1,12 @@
+SELECT
+  cr.concept_id_1 AS parent,
+  cr.concept_id_2 AS child,
+FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_relationship` cr
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = cr.concept_id_2
+WHERE
+  cr.relationship_id = 'Subsumes'
+  AND c1.domain_id = c2.domain_id
+  AND c2.domain_id = 'Condition'
+  AND c1.vocabulary_id = c2.vocabulary_id
+  AND c2.vocabulary_id = 'SNOMED'

--- a/api/src/main/resources/config/broad/cms_synpuf/original/sql/ingredient_all.sql
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/sql/ingredient_all.sql
@@ -1,0 +1,12 @@
+SELECT
+  c.concept_id AS id, c.concept_name AS name, c.vocabulary_id, c.standard_concept, c.concept_code
+FROM  `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c
+WHERE c.domain_id = 'Drug'
+AND ((c.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+        AND c.concept_class_id = 'Ingredient'
+        AND c.standard_concept = 'S')
+    OR (c.vocabulary_id = 'RxNorm'
+        AND c.concept_class_id = 'Precise Ingredient')
+    OR (c.vocabulary_id = 'ATC'
+        AND c.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')
+        AND c.standard_concept = 'C'))

--- a/api/src/main/resources/config/broad/cms_synpuf/original/sql/ingredient_parentChild.sql
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/sql/ingredient_parentChild.sql
@@ -1,0 +1,57 @@
+SELECT
+  cr.concept_id_1 AS parent,
+  cr.concept_id_2 AS child,
+FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_relationship` cr
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = cr.concept_id_2
+WHERE
+  cr.relationship_id IN ('Has form', 'RxNorm - ATC', 'RxNorm - ATC name', 'Mapped from', 'Subsumes')
+  AND c1.concept_id != c2.concept_id
+
+  AND ((c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+          AND c1.concept_class_id = 'Ingredient'
+          AND c1.standard_concept = 'S')
+      OR (c1.vocabulary_id = 'RxNorm'
+          AND c1.concept_class_id = 'Precise Ingredient')
+      OR (c1.vocabulary_id = 'ATC'
+          AND c1.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')
+          AND c1.standard_concept = 'C'))
+
+  AND ((c2.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+          AND c2.concept_class_id = 'Ingredient'
+          AND c2.standard_concept = 'S')
+      OR (c2.vocabulary_id = 'RxNorm'
+          AND c2.concept_class_id = 'Precise Ingredient')
+      OR (c2.vocabulary_id = 'ATC'
+          AND c2.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')
+          AND c2.standard_concept = 'C'))
+
+UNION ALL
+
+SELECT
+  ca.ancestor_concept_id AS parent,
+  ca.descendant_concept_id AS child,
+FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_ancestor` ca
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = ca.ancestor_concept_id
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = ca.descendant_concept_id
+WHERE
+  ca.min_levels_of_separation = 1
+  AND ca.max_levels_of_separation = 1
+
+  AND ((c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+          AND c1.concept_class_id = 'Ingredient'
+          AND c1.standard_concept = 'S')
+      OR (c1.vocabulary_id = 'RxNorm'
+          AND c1.concept_class_id = 'Precise Ingredient')
+      OR (c1.vocabulary_id = 'ATC'
+          AND c1.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')
+          AND c1.standard_concept = 'C'))
+
+  AND ((c2.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+          AND c2.concept_class_id = 'Ingredient'
+          AND c2.standard_concept = 'S')
+      OR (c2.vocabulary_id = 'RxNorm'
+          AND c2.concept_class_id = 'Precise Ingredient')
+      OR (c2.vocabulary_id = 'ATC'
+          AND c2.concept_class_id IN ('ATC 1st', 'ATC 2nd', 'ATC 3rd', 'ATC 4th', 'ATC 5th')
+          AND c2.standard_concept = 'C'))

--- a/api/src/main/resources/config/broad/cms_synpuf/original/sql/procedure_parentChild.sql
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/sql/procedure_parentChild.sql
@@ -1,0 +1,12 @@
+SELECT
+  cr.concept_id_1 AS parent,
+  cr.concept_id_2 AS child,
+FROM `bigquery-public-data.cms_synthetic_patient_data_omop.concept_relationship` cr
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `bigquery-public-data.cms_synthetic_patient_data_omop.concept` c2  ON c2.concept_id = cr.concept_id_2
+WHERE
+  cr.relationship_id = 'Subsumes'
+  AND c1.domain_id = c2.domain_id
+  AND c2.domain_id = 'Procedure'
+  AND c1.vocabulary_id = c2.vocabulary_id
+  AND c2.vocabulary_id = 'SNOMED'


### PR DESCRIPTION
- Added an optional `queryProjectId` property to a dataset definition. By default, we run queries in the same project as the data is in. But sometimes that's not possible (e.g. for a public dataset), so this allows users to override this and specify a different project to run queries in.
- Defined config files for the [publicly available](https://console.cloud.google.com/marketplace/product/hhs/synpuf) CMS SynPUF dataset. I also generated the index tables for this dataset in the `broad-tanagra-dev` project.