### PR TITLE
Allow overriding the Dataflow SA and GCS temp location.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/serialization/datapointer/UFBigQueryDataset.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/datapointer/UFBigQueryDataset.java
@@ -2,6 +2,7 @@ package bio.terra.tanagra.serialization.datapointer;
 
 import bio.terra.tanagra.serialization.UFDataPointer;
 import bio.terra.tanagra.underlay.datapointer.BigQueryDataset;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -11,16 +12,21 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  * <p>This is a POJO class intended for serialization. This JSON format is user-facing.
  */
 @JsonDeserialize(builder = UFBigQueryDataset.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UFBigQueryDataset extends UFDataPointer {
   private final String projectId;
   private final String datasetId;
   private final String queryProjectId;
+  private final String dataflowServiceAccountEmail;
+  private final String dataflowTempLocation;
 
   public UFBigQueryDataset(BigQueryDataset dataPointer) {
     super(dataPointer);
     this.projectId = dataPointer.getProjectId();
     this.datasetId = dataPointer.getDatasetId();
     this.queryProjectId = dataPointer.getQueryProjectId();
+    this.dataflowServiceAccountEmail = dataPointer.getDataflowServiceAccountEmail();
+    this.dataflowTempLocation = dataPointer.getDataflowTempLocation();
   }
 
   private UFBigQueryDataset(Builder builder) {
@@ -28,6 +34,8 @@ public class UFBigQueryDataset extends UFDataPointer {
     this.projectId = builder.projectId;
     this.datasetId = builder.datasetId;
     this.queryProjectId = builder.queryProjectId;
+    this.dataflowServiceAccountEmail = builder.dataflowServiceAccountEmail;
+    this.dataflowTempLocation = builder.dataflowTempLocation;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -35,6 +43,8 @@ public class UFBigQueryDataset extends UFDataPointer {
     private String projectId;
     private String datasetId;
     private String queryProjectId;
+    private String dataflowServiceAccountEmail;
+    private String dataflowTempLocation;
 
     public Builder projectId(String projectId) {
       this.projectId = projectId;
@@ -48,6 +58,16 @@ public class UFBigQueryDataset extends UFDataPointer {
 
     public Builder queryProjectId(String queryProjectId) {
       this.queryProjectId = queryProjectId;
+      return this;
+    }
+
+    public Builder dataflowServiceAccountEmail(String dataflowServiceAccountEmail) {
+      this.dataflowServiceAccountEmail = dataflowServiceAccountEmail;
+      return this;
+    }
+
+    public Builder dataflowTempLocation(String dataflowTempLocation) {
+      this.dataflowTempLocation = dataflowTempLocation;
       return this;
     }
 
@@ -74,5 +94,13 @@ public class UFBigQueryDataset extends UFDataPointer {
 
   public String getQueryProjectId() {
     return queryProjectId;
+  }
+
+  public String getDataflowServiceAccountEmail() {
+    return dataflowServiceAccountEmail;
+  }
+
+  public String getDataflowTempLocation() {
+    return dataflowTempLocation;
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/datapointer/BigQueryDataset.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/datapointer/BigQueryDataset.java
@@ -26,14 +26,25 @@ public final class BigQueryDataset extends DataPointer {
   private final String projectId;
   private final String datasetId;
   private final String queryProjectId;
+  private final String dataflowServiceAccountEmail;
+  private final String dataflowTempLocation;
+
   private GoogleBigQuery bigQueryService;
   private BigQueryExecutor queryExecutor;
 
-  private BigQueryDataset(String name, String projectId, String datasetId, String queryProjectId) {
+  private BigQueryDataset(
+      String name,
+      String projectId,
+      String datasetId,
+      String queryProjectId,
+      String dataflowServiceAccountEmail,
+      String dataflowTempLocation) {
     super(name);
     this.projectId = projectId;
     this.datasetId = datasetId;
     this.queryProjectId = queryProjectId;
+    this.dataflowServiceAccountEmail = dataflowServiceAccountEmail;
+    this.dataflowTempLocation = dataflowTempLocation;
   }
 
   public static BigQueryDataset fromSerialized(UFBigQueryDataset serialized) {
@@ -51,8 +62,15 @@ public final class BigQueryDataset extends DataPointer {
     if (queryProjectId == null || queryProjectId.isEmpty()) {
       queryProjectId = serialized.getProjectId();
     }
+
+    // TODO: Check if the Dataflow temp location is a valid GCS path, if specified.
     return new BigQueryDataset(
-        serialized.getName(), serialized.getProjectId(), serialized.getDatasetId(), queryProjectId);
+        serialized.getName(),
+        serialized.getProjectId(),
+        serialized.getDatasetId(),
+        queryProjectId,
+        serialized.getDataflowServiceAccountEmail(),
+        serialized.getDataflowTempLocation());
   }
 
   @Override
@@ -158,5 +176,13 @@ public final class BigQueryDataset extends DataPointer {
 
   public String getQueryProjectId() {
     return queryProjectId;
+  }
+
+  public String getDataflowServiceAccountEmail() {
+    return dataflowServiceAccountEmail;
+  }
+
+  public String getDataflowTempLocation() {
+    return dataflowTempLocation;
   }
 }

--- a/api/src/main/resources/config/vumc/sdd/expanded/sdd.json
+++ b/api/src/main/resources/config/vumc/sdd/expanded/sdd.json
@@ -5,7 +5,9 @@
     "name" : "index_dataset",
     "projectId" : "victr-tanagra-test",
     "datasetId" : "sdstatic_index",
-    "queryProjectId" : "victr-tanagra-test"
+    "queryProjectId" : "victr-tanagra-test",
+    "dataflowServiceAccountEmail" : "tanagra-indexing-runner@victr-tanagra-test.iam.gserviceaccount.com",
+    "dataflowTempLocation" : "gs://dataflow-indexing-victr-tanagra-test/temp/"
   }, {
     "type" : "BQ_DATASET",
     "name" : "omop_dataset",

--- a/api/src/main/resources/config/vumc/sdd/original/sdd.json
+++ b/api/src/main/resources/config/vumc/sdd/original/sdd.json
@@ -8,7 +8,9 @@
     { "type": "BQ_DATASET",
       "name": "index_dataset",
       "projectId": "victr-tanagra-test",
-      "datasetId": "sdstatic_index" } ],
+      "datasetId": "sdstatic_index",
+      "dataflowServiceAccountEmail": "tanagra-indexing-runner@victr-tanagra-test.iam.gserviceaccount.com",
+      "dataflowTempLocation": "gs://dataflow-indexing-victr-tanagra-test/temp/" } ],
   "entities": [
     "brand.json",
     "condition.json",


### PR DESCRIPTION
- Determine the SA to use for Dataflow jobs:
  - If the `dataflowServiceAccountEmail` property is set, then use that.
  - If the default application credentials are set, then try to pull a service account email from that.
  - Otherwise, don't set a SA and let Dataflow use the default Compute Engine service account.
- Determine the GCS location where Dataflow can write temporary files:
  - If the `dataflowTempLocation` property is set, then use that.
  - Otherwise, don't set a location and let Dataflow create a default bucket.
- Update the SDD config files to specify both of these properties.