### PR TITLE
Underlays V2 endpoints.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/app/configuration/UnderlayConfiguration.java
+++ b/api/src/main/java/bio/terra/tanagra/app/configuration/UnderlayConfiguration.java
@@ -16,6 +16,10 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix = "tanagra.underlay")
 public class UnderlayConfiguration {
+  // The list of underlay config files in the resources/config directory. (e.g.
+  // 'broad/aou_synthetic/expanded/aou_synthetic.json')
+  private List<String> underlayFiles = new ArrayList<>();
+
   /** Paths to {@link Underlay} prototext files to load. */
   private List<String> underlayPrototextFiles = new ArrayList<>();
 
@@ -24,6 +28,14 @@ public class UnderlayConfiguration {
    * the standard protobuf json encoder.
    */
   private List<String> underlayYamlFiles = new ArrayList<>();
+
+  public List<String> getUnderlayFiles() {
+    return underlayFiles;
+  }
+
+  public void setUnderlayFiles(List<String> underlayFiles) {
+    this.underlayFiles = underlayFiles;
+  }
 
   public List<String> getUnderlayPrototextFiles() {
     return underlayPrototextFiles;

--- a/api/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
+++ b/api/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
@@ -1,0 +1,44 @@
+package bio.terra.tanagra.app.controller;
+
+import bio.terra.tanagra.generated.controller.UnderlaysV2Api;
+import bio.terra.tanagra.generated.model.ApiUnderlayListV2;
+import bio.terra.tanagra.generated.model.ApiUnderlayV2;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.UnderlaysService;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class UnderlaysV2ApiController implements UnderlaysV2Api {
+  private final UnderlaysService underlaysService;
+
+  @Autowired
+  public UnderlaysV2ApiController(UnderlaysService underlaysService) {
+    this.underlaysService = underlaysService;
+  }
+
+  @Override
+  public ResponseEntity<ApiUnderlayListV2> listUnderlaysV2() {
+    return ResponseEntity.ok(
+        new ApiUnderlayListV2()
+            .underlays(
+                underlaysService.getUnderlays().stream()
+                    .map(u -> toApiObject(u))
+                    .collect(Collectors.toList())));
+  }
+
+  @Override
+  public ResponseEntity<ApiUnderlayV2> getUnderlayV2(String underlayName) {
+    return ResponseEntity.ok(toApiObject(underlaysService.getUnderlay(underlayName)));
+  }
+
+  private ApiUnderlayV2 toApiObject(Underlay underlay) {
+    return new ApiUnderlayV2()
+        .name(underlay.getName())
+        // TODO: Add description and UI configuration to underlay config files.
+        .description("")
+        .uiConfiguration("");
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
+++ b/api/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
@@ -37,8 +37,7 @@ public class UnderlaysV2ApiController implements UnderlaysV2Api {
   private ApiUnderlayV2 toApiObject(Underlay underlay) {
     return new ApiUnderlayV2()
         .name(underlay.getName())
-        // TODO: Add description and UI configuration to underlay config files.
-        .description("")
-        .uiConfiguration("");
+        // TODO: Add display name to underlay config files.
+        .displayName(underlay.getName());
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/UnderlaysService.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/UnderlaysService.java
@@ -16,43 +16,35 @@ import org.springframework.stereotype.Component;
 /** Service to handle underlay operations. */
 @Component
 public class UnderlaysService {
-  private final UnderlayConfiguration underlayConfiguration;
-  private Map<String, Underlay> underlaysMap;
+  private final Map<String, Underlay> underlaysMap;
 
   @Autowired
   public UnderlaysService(UnderlayConfiguration underlayConfiguration) {
-    this.underlayConfiguration = underlayConfiguration;
+    // read in underlays from resource files
+    Map<String, Underlay> underlaysMapBuilder = new HashMap<>();
+    FileIO.setToReadResourceFiles();
+    for (String underlayFile : underlayConfiguration.getUnderlayFiles()) {
+      Path resourceConfigPath = Path.of("config").resolve(underlayFile);
+      FileIO.setInputParentDir(resourceConfigPath.getParent());
+      try {
+        Underlay underlay = Underlay.fromJSON(resourceConfigPath.getFileName().toString());
+        underlaysMapBuilder.put(underlay.getName(), underlay);
+      } catch (IOException ioEx) {
+        throw new SystemException(
+            "Error reading underlay file from resources: " + resourceConfigPath, ioEx);
+      }
+    }
+    this.underlaysMap = underlaysMapBuilder;
   }
 
   public List<Underlay> getUnderlays() {
-    return getUnderlaysMap().values().stream().collect(Collectors.toUnmodifiableList());
+    return underlaysMap.values().stream().collect(Collectors.toUnmodifiableList());
   }
 
   public Underlay getUnderlay(String name) {
-    if (!getUnderlaysMap().containsKey(name)) {
+    if (!underlaysMap.containsKey(name)) {
       throw new NotFoundException("Underlay not found: " + name);
     }
-    return getUnderlaysMap().get(name);
-  }
-
-  private Map<String, Underlay> getUnderlaysMap() {
-    // TODO: Only read in the underlay config files once at startup, instead of for every call.
-    if (underlaysMap == null) {
-      underlaysMap = new HashMap<>();
-      // read in underlays from resource files
-      FileIO.setToReadResourceFiles();
-      for (String underlayFile : underlayConfiguration.getUnderlayFiles()) {
-        Path resourceConfigPath = Path.of("config").resolve(underlayFile);
-        FileIO.setInputParentDir(resourceConfigPath.getParent());
-        try {
-          Underlay underlay = Underlay.fromJSON(resourceConfigPath.getFileName().toString());
-          underlaysMap.put(underlay.getName(), underlay);
-        } catch (IOException ioEx) {
-          throw new SystemException(
-              "Error reading underlay file from resources: " + resourceConfigPath, ioEx);
-        }
-      }
-    }
-    return underlaysMap;
+    return underlaysMap.get(name);
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/UnderlaysService.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/UnderlaysService.java
@@ -1,0 +1,58 @@
+package bio.terra.tanagra.underlay;
+
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.tanagra.app.configuration.UnderlayConfiguration;
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.indexing.FileIO;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/** Service to handle underlay operations. */
+@Component
+public class UnderlaysService {
+  private final UnderlayConfiguration underlayConfiguration;
+  private Map<String, Underlay> underlaysMap;
+
+  @Autowired
+  public UnderlaysService(UnderlayConfiguration underlayConfiguration) {
+    this.underlayConfiguration = underlayConfiguration;
+  }
+
+  public List<Underlay> getUnderlays() {
+    return getUnderlaysMap().values().stream().collect(Collectors.toUnmodifiableList());
+  }
+
+  public Underlay getUnderlay(String name) {
+    if (!getUnderlaysMap().containsKey(name)) {
+      throw new NotFoundException("Underlay not found: " + name);
+    }
+    return getUnderlaysMap().get(name);
+  }
+
+  private Map<String, Underlay> getUnderlaysMap() {
+    // TODO: Only read in the underlay config files once at startup, instead of for every call.
+    if (underlaysMap == null) {
+      underlaysMap = new HashMap<>();
+      // read in underlays from resource files
+      FileIO.setToReadResourceFiles();
+      for (String underlayFile : underlayConfiguration.getUnderlayFiles()) {
+        Path resourceConfigPath = Path.of("config").resolve(underlayFile);
+        FileIO.setInputParentDir(resourceConfigPath.getParent());
+        try {
+          Underlay underlay = Underlay.fromJSON(resourceConfigPath.getFileName().toString());
+          underlaysMap.put(underlay.getName(), underlay);
+        } catch (IOException ioEx) {
+          throw new SystemException(
+              "Error reading underlay file from resources: " + resourceConfigPath, ioEx);
+        }
+      }
+    }
+    return underlaysMap;
+  }
+}

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -950,11 +950,8 @@ components:
         name:
           description: Name
           type: string
-        description:
-          description: Description
-          type: string
-        uiConfiguration:
-          description: UI configuration
+        displayName:
+          description: Display name
           type: string
       required:
         - name

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -950,13 +950,14 @@ components:
         name:
           description: Name
           type: string
-          required: true
         description:
           description: Description
           type: string
         uiConfiguration:
           description: UI configuration
           type: string
+      required:
+        - name
 
     UnderlayListV2:
       type: object

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -180,6 +180,43 @@ paths:
         200:
           $ref: "#/components/responses/SearchEntityCountsResponse"
 
+  #########################UNDERLAY CONFIG V2 [START]#################################
+  "/v2/underlays":
+    get:
+      summary: List the underlays
+      operationId: listUnderlaysV2
+      tags: [UnderlaysV2]
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnderlayListV2"
+        500:
+          $ref: '#/components/responses/ServerError'
+
+  "/v2/underlays/{underlayName}":
+    parameters:
+      - $ref: "#/components/parameters/UnderlayNameV2"
+    get:
+      summary: Get an underlay
+      operationId: getUnderlayV2
+      tags: [UnderlaysV2]
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnderlayV2"
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/ServerError'
+
+  #########################UNDERLAY CONFIG V2 [END]###################################
+
 components:
   parameters:
     Underlay:
@@ -215,6 +252,17 @@ components:
       description: An opaque pagination token to retrieve a specific page of results
       schema:
         type: string
+
+  #########################UNDERLAY CONFIG V2 [START]#################################
+    UnderlayNameV2:
+      name: underlayName
+      in: path
+      description: Name of the underlay
+      required: true
+      schema:
+        type: string
+  #########################UNDERLAY CONFIG V2 [END]###################################
+
 
   responses:
     GetEntityResponse:
@@ -265,6 +313,23 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/SqlQuery"
+
+  #########################UNDERLAY CONFIG V2 [START]#################################
+    NotFound:
+      description: Not found (or unauthorized)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorReport'
+
+    ServerError:
+      description: Server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorReport'
+  #########################UNDERLAY CONFIG V2 [END]###################################
+
 
   schemas:
     Attribute:
@@ -876,3 +941,42 @@ components:
         - id
         - title
       additionalProperties: true
+
+    #########################UNDERLAY CONFIG V2 [START]#################################
+    UnderlayV2:
+      type: object
+      description: Underlay
+      properties:
+        name:
+          description: Name
+          type: string
+          required: true
+        description:
+          description: Description
+          type: string
+        uiConfiguration:
+          description: UI configuration
+          type: string
+
+    UnderlayListV2:
+      type: object
+      description: List of underlays
+      properties:
+        underlays:
+          type: array
+          items:
+            $ref: "#/components/schemas/UnderlayV2"
+
+    ErrorReportV2:
+      type: object
+      required: [message, statusCode, causes]
+      properties:
+        message:
+          type: string
+        statusCode:
+          type: integer
+        causes:
+          type: array
+          items:
+            type: string
+    #########################UNDERLAY CONFIG V2 [END]###################################

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -18,3 +18,4 @@ tanagra:
   underlay:
     # TODO(tjennison): Split these for different environments.
     underlay-yaml-files: ["underlays/aou_synthetic.yaml", "underlays/synpuf.yaml", "underlays/sd.yaml", "underlays/test/aou_synthetic.yaml"]
+    underlay-files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json" ]


### PR DESCRIPTION
New `/v2/underlays` endpoints to list and get an underlay. These endpoints use the new config files. I've left the existing `/underlays` endpoints as is, so as not to break the UI. Once the UI can be switched over to use all new endpoints, I'll go back and delete all the original ones.