### PR TITLE
Instances V2 endpoint: Hierarchy filters.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/api/QuerysService.java
+++ b/api/src/main/java/bio/terra/tanagra/api/QuerysService.java
@@ -17,6 +17,7 @@ import bio.terra.tanagra.underlay.AttributeMapping;
 import bio.terra.tanagra.underlay.DataPointer;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityMapping;
+import bio.terra.tanagra.underlay.HierarchyMapping;
 import bio.terra.tanagra.underlay.Literal;
 import bio.terra.tanagra.underlay.ValueDisplay;
 import com.google.common.collect.Lists;
@@ -131,5 +132,13 @@ public class QuerysService {
           "Attribute not found: " + entity.getName() + ", " + attributeName);
     }
     return attribute;
+  }
+
+  public HierarchyMapping getHierarchy(EntityMapping entityMapping, String hierarchyName) {
+    HierarchyMapping hierarchyMapping = entityMapping.getHierarchyMappings().get(hierarchyName);
+    if (hierarchyMapping == null) {
+      throw new NotFoundException("Hierarchy not found: " + hierarchyName);
+    }
+    return hierarchyMapping;
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyAncestorFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyAncestorFilter.java
@@ -1,0 +1,81 @@
+package bio.terra.tanagra.api.entityfilter;
+
+import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.ANCESTOR_COLUMN_NAME;
+import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.DESCENDANT_COLUMN_NAME;
+
+import bio.terra.tanagra.api.EntityFilter;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.FilterVariable;
+import bio.terra.tanagra.query.Query;
+import bio.terra.tanagra.query.TableVariable;
+import bio.terra.tanagra.query.filtervariable.ArrayFilterVariable;
+import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
+import bio.terra.tanagra.query.filtervariable.SubQueryFilterVariable;
+import bio.terra.tanagra.underlay.AuxiliaryDataMapping;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.EntityMapping;
+import bio.terra.tanagra.underlay.FieldPointer;
+import bio.terra.tanagra.underlay.HierarchyMapping;
+import bio.terra.tanagra.underlay.Literal;
+import java.util.List;
+
+public class HierarchyAncestorFilter extends EntityFilter {
+  private final HierarchyMapping hierarchyMapping;
+  private final Literal nodeId;
+
+  public HierarchyAncestorFilter(
+      Entity entity,
+      EntityMapping entityMapping,
+      HierarchyMapping hierarchyMapping,
+      Literal nodeId) {
+    super(entity, entityMapping);
+    this.hierarchyMapping = hierarchyMapping;
+    this.nodeId = nodeId;
+  }
+
+  @Override
+  public FilterVariable getFilterVariable(
+      TableVariable entityTableVar, List<TableVariable> tableVars) {
+    FieldPointer entityIdFieldPointer = getEntityMapping().getIdAttributeMapping().getValue();
+
+    // build a query to get a node's descendants:
+    //   SELECT descendant FROM ancestorDescendantTable WHERE ancestor=nodeId
+    AuxiliaryDataMapping ancestorDescendantAuxData = hierarchyMapping.getAncestorDescendant();
+    TableVariable ancestorDescendantTableVar =
+        TableVariable.forPrimary(ancestorDescendantAuxData.getTablePointer());
+    FieldVariable descendantFieldVar =
+        new FieldVariable(
+            ancestorDescendantAuxData.getFieldPointers().get(DESCENDANT_COLUMN_NAME),
+            ancestorDescendantTableVar);
+    FieldVariable ancestorFieldVar =
+        new FieldVariable(
+            ancestorDescendantAuxData.getFieldPointers().get(ANCESTOR_COLUMN_NAME),
+            ancestorDescendantTableVar);
+    BinaryFilterVariable ancestorEqualsNodeId =
+        new BinaryFilterVariable(
+            ancestorFieldVar, BinaryFilterVariable.BinaryOperator.EQUALS, nodeId);
+    Query justDescendants =
+        new Query.Builder()
+            .select(List.of(descendantFieldVar))
+            .tables(List.of(ancestorDescendantTableVar))
+            .where(ancestorEqualsNodeId)
+            .build();
+
+    // build a filter variable on the sub query
+    FieldVariable entityIdFieldVar = entityIdFieldPointer.buildVariable(entityTableVar, tableVars);
+    SubQueryFilterVariable justDescendantsFilterVar =
+        new SubQueryFilterVariable(
+            entityIdFieldVar, SubQueryFilterVariable.Operator.IN, justDescendants);
+
+    // build a filter variable on the exact node match: WHERE entityId=nodeId
+    BinaryFilterVariable itselfFilterVar =
+        new BinaryFilterVariable(
+            entityIdFieldVar, BinaryFilterVariable.BinaryOperator.EQUALS, nodeId);
+
+    // build an array filter variable with both:
+    //   WHERE entityId IN (SELECT descendant FROM ancestorDescendantTable WHERE ancestor=nodeId)
+    //   OR entityId=nodeId
+    return new ArrayFilterVariable(
+        ArrayFilterVariable.LogicalOperator.OR, List.of(justDescendantsFilterVar, itselfFilterVar));
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyParentFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyParentFilter.java
@@ -1,0 +1,66 @@
+package bio.terra.tanagra.api.entityfilter;
+
+import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.CHILD_COLUMN_NAME;
+import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.PARENT_COLUMN_NAME;
+
+import bio.terra.tanagra.api.EntityFilter;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.FilterVariable;
+import bio.terra.tanagra.query.Query;
+import bio.terra.tanagra.query.TableVariable;
+import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
+import bio.terra.tanagra.query.filtervariable.SubQueryFilterVariable;
+import bio.terra.tanagra.underlay.AuxiliaryDataMapping;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.EntityMapping;
+import bio.terra.tanagra.underlay.FieldPointer;
+import bio.terra.tanagra.underlay.HierarchyMapping;
+import bio.terra.tanagra.underlay.Literal;
+import java.util.List;
+
+public class HierarchyParentFilter extends EntityFilter {
+  private final HierarchyMapping hierarchyMapping;
+  private final Literal nodeId;
+
+  public HierarchyParentFilter(
+      Entity entity,
+      EntityMapping entityMapping,
+      HierarchyMapping hierarchyMapping,
+      Literal nodeId) {
+    super(entity, entityMapping);
+    this.hierarchyMapping = hierarchyMapping;
+    this.nodeId = nodeId;
+  }
+
+  @Override
+  public FilterVariable getFilterVariable(
+      TableVariable entityTableVar, List<TableVariable> tableVars) {
+    FieldPointer entityIdFieldPointer = getEntityMapping().getIdAttributeMapping().getValue();
+
+    // build a query to get a node's children:
+    //   SELECT child FROM childParentTable WHERE parent=nodeId
+    AuxiliaryDataMapping childParentAuxData = hierarchyMapping.getChildParent();
+    TableVariable childParentTableVar =
+        TableVariable.forPrimary(childParentAuxData.getTablePointer());
+    FieldVariable childFieldVar =
+        new FieldVariable(
+            childParentAuxData.getFieldPointers().get(CHILD_COLUMN_NAME), childParentTableVar);
+    FieldVariable parentFieldVar =
+        new FieldVariable(
+            childParentAuxData.getFieldPointers().get(PARENT_COLUMN_NAME), childParentTableVar);
+    BinaryFilterVariable parentEqualsNodeId =
+        new BinaryFilterVariable(
+            parentFieldVar, BinaryFilterVariable.BinaryOperator.EQUALS, nodeId);
+    Query subQuery =
+        new Query.Builder()
+            .select(List.of(childFieldVar))
+            .tables(List.of(childParentTableVar))
+            .where(parentEqualsNodeId)
+            .build();
+
+    // build a filter variable on the sub query
+    FieldVariable entityIdFieldVar = entityIdFieldPointer.buildVariable(entityTableVar, tableVars);
+    return new SubQueryFilterVariable(
+        entityIdFieldVar, SubQueryFilterVariable.Operator.IN, subQuery);
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyRootFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyRootFilter.java
@@ -1,0 +1,36 @@
+package bio.terra.tanagra.api.entityfilter;
+
+import bio.terra.tanagra.api.EntityFilter;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.FilterVariable;
+import bio.terra.tanagra.query.TableVariable;
+import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.EntityMapping;
+import bio.terra.tanagra.underlay.FieldPointer;
+import bio.terra.tanagra.underlay.HierarchyMapping;
+import bio.terra.tanagra.underlay.Literal;
+import java.util.List;
+
+public class HierarchyRootFilter extends EntityFilter {
+  private final HierarchyMapping hierarchyMapping;
+
+  public HierarchyRootFilter(
+      Entity entity, EntityMapping entityMapping, HierarchyMapping hierarchyMapping) {
+    super(entity, entityMapping);
+    this.hierarchyMapping = hierarchyMapping;
+  }
+
+  @Override
+  public FilterVariable getFilterVariable(
+      TableVariable entityTableVar, List<TableVariable> tableVars) {
+    FieldPointer entityIdFieldPointer = getEntityMapping().getIdAttributeMapping().getValue();
+    FieldPointer pathFieldPointer =
+        hierarchyMapping.buildPathFieldPointerFromEntityId(entityIdFieldPointer);
+    FieldVariable pathFieldVar = pathFieldPointer.buildVariable(entityTableVar, tableVars);
+
+    // IS_ROOT translates to path=""
+    return new BinaryFilterVariable(
+        pathFieldVar, BinaryFilterVariable.BinaryOperator.EQUALS, new Literal(""));
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
+++ b/api/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
@@ -4,13 +4,16 @@ import bio.terra.tanagra.api.EntityFilter;
 import bio.terra.tanagra.api.QuerysService;
 import bio.terra.tanagra.api.UnderlaysService;
 import bio.terra.tanagra.api.entityfilter.AttributeFilter;
+import bio.terra.tanagra.api.entityfilter.HierarchyAncestorFilter;
+import bio.terra.tanagra.api.entityfilter.HierarchyParentFilter;
+import bio.terra.tanagra.api.entityfilter.HierarchyRootFilter;
 import bio.terra.tanagra.api.entityfilter.TextFilter;
 import bio.terra.tanagra.api.utils.FromApiConversionUtils;
 import bio.terra.tanagra.api.utils.ToApiConversionUtils;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.controller.InstancesV2Api;
 import bio.terra.tanagra.generated.model.ApiAttributeFilterV2;
-import bio.terra.tanagra.generated.model.ApiFilterV2;
+import bio.terra.tanagra.generated.model.ApiHierarchyFilterV2;
 import bio.terra.tanagra.generated.model.ApiInstanceListV2;
 import bio.terra.tanagra.generated.model.ApiInstanceV2;
 import bio.terra.tanagra.generated.model.ApiQueryV2;
@@ -20,6 +23,7 @@ import bio.terra.tanagra.query.QueryRequest;
 import bio.terra.tanagra.underlay.Attribute;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityMapping;
+import bio.terra.tanagra.underlay.HierarchyMapping;
 import bio.terra.tanagra.underlay.ValueDisplay;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,32 +67,65 @@ public class InstancesV2ApiController implements InstancesV2Api {
 
     EntityFilter entityFilter = null;
     if (body.getFilter() != null) {
-      if (body.getFilter().getFilterType().equals(ApiFilterV2.FilterTypeEnum.ATTRIBUTE)) {
-        ApiAttributeFilterV2 apiAttributeFilter =
-            body.getFilter().getFilterUnion().getAttributeFilter();
-        entityFilter =
-            new AttributeFilter(
-                entity,
-                entityMapping,
-                querysService.getAttribute(entity, apiAttributeFilter.getAttribute()),
-                FromApiConversionUtils.fromApiObject(apiAttributeFilter.getOperator()),
-                FromApiConversionUtils.fromApiObject(apiAttributeFilter.getValue()));
-      } else if (body.getFilter().getFilterType().equals(ApiFilterV2.FilterTypeEnum.TEXT)) {
-        ApiTextFilterV2 apiTextFilter = body.getFilter().getFilterUnion().getTextFilter();
-        TextFilter.Builder textFilterBuilder =
-            new TextFilter.Builder()
-                .entity(entity)
-                .entityMapping(entityMapping)
-                .functionTemplate(
-                    FromApiConversionUtils.fromApiObject(apiTextFilter.getMatchType()))
-                .text(apiTextFilter.getText());
-        if (apiTextFilter.getAttribute() != null) {
-          textFilterBuilder.attribute(
-              querysService.getAttribute(entity, apiTextFilter.getAttribute()));
-        }
-        entityFilter = textFilterBuilder.build();
-      } else {
-        throw new SystemException("Unknown API filter type: " + body.getFilter().getFilterType());
+      switch (body.getFilter().getFilterType()) {
+        case ATTRIBUTE:
+          ApiAttributeFilterV2 apiAttributeFilter =
+              body.getFilter().getFilterUnion().getAttributeFilter();
+          entityFilter =
+              new AttributeFilter(
+                  entity,
+                  entityMapping,
+                  querysService.getAttribute(entity, apiAttributeFilter.getAttribute()),
+                  FromApiConversionUtils.fromApiObject(apiAttributeFilter.getOperator()),
+                  FromApiConversionUtils.fromApiObject(apiAttributeFilter.getValue()));
+          break;
+        case TEXT:
+          ApiTextFilterV2 apiTextFilter = body.getFilter().getFilterUnion().getTextFilter();
+          TextFilter.Builder textFilterBuilder =
+              new TextFilter.Builder()
+                  .entity(entity)
+                  .entityMapping(entityMapping)
+                  .functionTemplate(
+                      FromApiConversionUtils.fromApiObject(apiTextFilter.getMatchType()))
+                  .text(apiTextFilter.getText());
+          if (apiTextFilter.getAttribute() != null) {
+            textFilterBuilder.attribute(
+                querysService.getAttribute(entity, apiTextFilter.getAttribute()));
+          }
+          entityFilter = textFilterBuilder.build();
+          break;
+        case HIERARCHY:
+          ApiHierarchyFilterV2 apiHierarchyFilter =
+              body.getFilter().getFilterUnion().getHierarchyFilter();
+          HierarchyMapping hierarchyMapping =
+              querysService.getHierarchy(entityMapping, apiHierarchyFilter.getHierarchy());
+          switch (apiHierarchyFilter.getOperator()) {
+            case IS_ROOT:
+              entityFilter = new HierarchyRootFilter(entity, entityMapping, hierarchyMapping);
+              break;
+            case CHILD_OF:
+              entityFilter =
+                  new HierarchyParentFilter(
+                      entity,
+                      entityMapping,
+                      hierarchyMapping,
+                      FromApiConversionUtils.fromApiObject(apiHierarchyFilter.getValue()));
+              break;
+            case DESCENDANT_OF_INCLUSIVE:
+              entityFilter =
+                  new HierarchyAncestorFilter(
+                      entity,
+                      entityMapping,
+                      hierarchyMapping,
+                      FromApiConversionUtils.fromApiObject(apiHierarchyFilter.getValue()));
+              break;
+            default:
+              throw new SystemException(
+                  "Unknown API hierarchy filter operator: " + apiHierarchyFilter.getOperator());
+          }
+          break;
+        default:
+          throw new SystemException("Unknown API filter type: " + body.getFilter().getFilterType());
       }
     }
 

--- a/api/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
+++ b/api/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
@@ -1,0 +1,56 @@
+package bio.terra.tanagra.query.filtervariable;
+
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.FilterVariable;
+import bio.terra.tanagra.query.Query;
+import bio.terra.tanagra.query.SQLExpression;
+import bio.terra.tanagra.query.TableVariable;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.text.StringSubstitutor;
+
+public class SubQueryFilterVariable extends FilterVariable {
+  public enum Operator implements SQLExpression {
+    IN("IN"),
+    NOT_IN("NOT IN");
+
+    private String sql;
+
+    Operator(String sql) {
+      this.sql = sql;
+    }
+
+    @Override
+    public String renderSQL() {
+      return sql;
+    }
+  }
+
+  private final FieldVariable fieldVariable;
+  private final Operator operator;
+  private final Query subQuery;
+
+  public SubQueryFilterVariable(FieldVariable fieldVariable, Operator operator, Query subQuery) {
+    this.fieldVariable = fieldVariable;
+    this.operator = operator;
+    this.subQuery = subQuery;
+  }
+
+  @Override
+  public String renderSQL() {
+    String template = "${fieldSQL} ${operator} (${subQuerySQL})";
+    Map<String, String> params =
+        ImmutableMap.<String, String>builder()
+            .put("fieldSQL", fieldVariable.renderSQL())
+            .put("operator", operator.renderSQL())
+            .put("subQuerySQL", subQuery.renderSQL())
+            .build();
+    return StringSubstitutor.replace(template, params);
+  }
+
+  @Override
+  public List<TableVariable> getTableVariables() {
+    return null;
+  }
+}

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -1176,6 +1176,7 @@ components:
         limit:
           description: The maximum number of results to return. Defaults to 250.
           type: integer
+          default: 250
 
     FilterV2:
       type: object
@@ -1183,7 +1184,7 @@ components:
       properties:
         filterType:
           type: string
-          enum: ["ATTRIBUTE", "TEXT"]
+          enum: ["ATTRIBUTE", "TEXT", "HIERARCHY"]
         filterUnion:
           type: object
           properties:
@@ -1191,6 +1192,8 @@ components:
               $ref: "#/components/schemas/AttributeFilterV2"
             textFilter:
               $ref: "#/components/schemas/TextFilterV2"
+            hierarchyFilter:
+              $ref: "#/components/schemas/HierarchyFilterV2"
 
     AttributeFilterV2:
       type: object
@@ -1218,6 +1221,19 @@ components:
             Currently, fuzzy match only works on a single attribute (i.e. you must specify this field for fuzzy match).
         text:
           type: string
+
+    HierarchyFilterV2:
+      type: object
+      description: Filter on a hierarchy (e.g. descendant of id=12)
+      properties:
+        hierarchy:
+          description: Name of the hierarchy
+          type: string
+        operator:
+          type: string
+          enum: ["CHILD_OF", "DESCENDANT_OF_INCLUSIVE", "IS_ROOT"]
+        value:
+          $ref: "#/components/schemas/LiteralV2"
 
     InstanceV2:
       type: object


### PR DESCRIPTION
Added the hierarchy filter to the /v2/instances endpoint. This uses the new underlay config. The API specifies 3 possible operators: `IS_ROOT`, `CHILD_OF`, `DESCENDANT_OF_INCLUSIVE`. These map to 3 different `EntityFilter` sub-classes, because the `WHERE` clauses are pretty different for each one.