### PR TITLE
Instances V2 endpoint: Hierarchy fields.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/api/EntityInstance.java
+++ b/api/src/main/java/bio/terra/tanagra/api/EntityInstance.java
@@ -1,0 +1,81 @@
+package bio.terra.tanagra.api;
+
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.query.CellValue;
+import bio.terra.tanagra.query.RowResult;
+import bio.terra.tanagra.underlay.Attribute;
+import bio.terra.tanagra.underlay.AttributeMapping;
+import bio.terra.tanagra.underlay.HierarchyField;
+import bio.terra.tanagra.underlay.HierarchyMapping;
+import bio.terra.tanagra.underlay.Literal;
+import bio.terra.tanagra.underlay.ValueDisplay;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class EntityInstance {
+  private final Map<Attribute, ValueDisplay> attributeValues;
+  private final Map<HierarchyField, ValueDisplay> hierarchyFieldValues;
+
+  private EntityInstance(
+      Map<Attribute, ValueDisplay> attributeValues,
+      Map<HierarchyField, ValueDisplay> hierarchyFieldValues) {
+    this.attributeValues = attributeValues;
+    this.hierarchyFieldValues = hierarchyFieldValues;
+  }
+
+  public static EntityInstance fromRowResult(
+      RowResult rowResult,
+      List<Attribute> selectedAttributes,
+      List<HierarchyField> selectedHierarchyFields) {
+    Map<Attribute, ValueDisplay> attributeValues = new HashMap<>();
+    for (Attribute selectedAttribute : selectedAttributes) {
+      CellValue cellValue = rowResult.get(selectedAttribute.getName());
+      if (cellValue == null) {
+        throw new SystemException("Attribute column not found: " + selectedAttribute.getName());
+      }
+
+      Literal value = cellValue.getLiteral();
+      switch (selectedAttribute.getType()) {
+        case SIMPLE:
+          attributeValues.put(selectedAttribute, new ValueDisplay(value));
+          break;
+        case KEY_AND_DISPLAY:
+          String display =
+              rowResult
+                  .get(AttributeMapping.getDisplayMappingAlias(selectedAttribute.getName()))
+                  .getString()
+                  .get();
+          attributeValues.put(selectedAttribute, new ValueDisplay(value, display));
+          break;
+        default:
+          throw new SystemException("Unknown attribute type: " + selectedAttribute.getType());
+      }
+    }
+
+    Map<HierarchyField, ValueDisplay> hierarchyFieldValues = new HashMap<>();
+    for (HierarchyField selectedHierarchyField : selectedHierarchyFields) {
+      CellValue cellValue =
+          rowResult.get(HierarchyMapping.getHierarchyFieldAlias(selectedHierarchyField));
+      if (cellValue == null) {
+        throw new SystemException(
+            "Hierarchy field column not found: "
+                + selectedHierarchyField.getHierarchyName()
+                + ", "
+                + selectedHierarchyField.getFieldName());
+      }
+      hierarchyFieldValues.put(selectedHierarchyField, new ValueDisplay(cellValue.getLiteral()));
+    }
+
+    return new EntityInstance(attributeValues, hierarchyFieldValues);
+  }
+
+  public Map<Attribute, ValueDisplay> getAttributeValues() {
+    return Collections.unmodifiableMap(attributeValues);
+  }
+
+  public Map<HierarchyField, ValueDisplay> getHierarchyFieldValues() {
+    return Collections.unmodifiableMap(hierarchyFieldValues);
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyRootFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/api/entityfilter/HierarchyRootFilter.java
@@ -8,26 +8,35 @@ import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityMapping;
 import bio.terra.tanagra.underlay.FieldPointer;
+import bio.terra.tanagra.underlay.HierarchyField;
 import bio.terra.tanagra.underlay.HierarchyMapping;
 import bio.terra.tanagra.underlay.Literal;
 import java.util.List;
 
 public class HierarchyRootFilter extends EntityFilter {
   private final HierarchyMapping hierarchyMapping;
+  private final String hierarchyName;
 
   public HierarchyRootFilter(
-      Entity entity, EntityMapping entityMapping, HierarchyMapping hierarchyMapping) {
+      Entity entity,
+      EntityMapping entityMapping,
+      HierarchyMapping hierarchyMapping,
+      String hierarchyName) {
     super(entity, entityMapping);
     this.hierarchyMapping = hierarchyMapping;
+    this.hierarchyName = hierarchyName;
   }
 
   @Override
   public FilterVariable getFilterVariable(
       TableVariable entityTableVar, List<TableVariable> tableVars) {
     FieldPointer entityIdFieldPointer = getEntityMapping().getIdAttributeMapping().getValue();
-    FieldPointer pathFieldPointer =
-        hierarchyMapping.buildPathFieldPointerFromEntityId(entityIdFieldPointer);
-    FieldVariable pathFieldVar = pathFieldPointer.buildVariable(entityTableVar, tableVars);
+    FieldVariable pathFieldVar =
+        hierarchyMapping.buildFieldVariableFromEntityId(
+            new HierarchyField(hierarchyName, HierarchyField.FieldName.PATH),
+            entityIdFieldPointer,
+            entityTableVar,
+            tableVars);
 
     // IS_ROOT translates to path=""
     return new BinaryFilterVariable(

--- a/api/src/main/java/bio/terra/tanagra/api/utils/FromApiConversionUtils.java
+++ b/api/src/main/java/bio/terra/tanagra/api/utils/FromApiConversionUtils.java
@@ -3,9 +3,11 @@ package bio.terra.tanagra.api.utils;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.model.ApiAttributeFilterV2;
 import bio.terra.tanagra.generated.model.ApiLiteralV2;
+import bio.terra.tanagra.generated.model.ApiQueryV2IncludeHierarchyFields;
 import bio.terra.tanagra.generated.model.ApiTextFilterV2;
 import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
 import bio.terra.tanagra.query.filtervariable.FunctionFilterVariable;
+import bio.terra.tanagra.underlay.HierarchyField;
 import bio.terra.tanagra.underlay.Literal;
 
 public final class FromApiConversionUtils {
@@ -38,6 +40,20 @@ public final class FromApiConversionUtils {
         return FunctionFilterVariable.FunctionTemplate.TEXT_FUZZY_MATCH;
       default:
         throw new SystemException("Unknown API text match type: " + apiMatchType.name());
+    }
+  }
+
+  public static HierarchyField fromApiObject(
+      String hierarchyName, ApiQueryV2IncludeHierarchyFields.FieldsEnum apiHierarchyField) {
+    switch (apiHierarchyField) {
+      case IS_ROOT:
+        return new HierarchyField(hierarchyName, HierarchyField.FieldName.IS_ROOT);
+      case PATH:
+        return new HierarchyField(hierarchyName, HierarchyField.FieldName.PATH);
+      case NUM_CHILDREN:
+        return new HierarchyField(hierarchyName, HierarchyField.FieldName.NUM_CHILDREN);
+      default:
+        throw new SystemException("Unknown API hierarchy field: " + apiHierarchyField);
     }
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/query/Query.java
+++ b/api/src/main/java/bio/terra/tanagra/query/Query.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
 public class Query implements SQLExpression {
+  public static final String TANAGRA_FIELD_PREFIX = "t_";
+
   private final List<FieldVariable> select;
   private final List<TableVariable> tables;
   private final FilterVariable where;

--- a/api/src/main/java/bio/terra/tanagra/query/filtervariable/BinaryFilterVariable.java
+++ b/api/src/main/java/bio/terra/tanagra/query/filtervariable/BinaryFilterVariable.java
@@ -26,7 +26,7 @@ public class BinaryFilterVariable extends FilterVariable {
     String template = "${fieldSQL} ${operator} ${value}";
     Map<String, String> params =
         ImmutableMap.<String, String>builder()
-            .put("fieldSQL", fieldVariable.renderSQL())
+            .put("fieldSQL", fieldVariable.renderSqlForWhere())
             .put("operator", operator.renderSQL())
             .put("value", value.renderSQL())
             .build();

--- a/api/src/main/java/bio/terra/tanagra/query/filtervariable/FunctionFilterVariable.java
+++ b/api/src/main/java/bio/terra/tanagra/query/filtervariable/FunctionFilterVariable.java
@@ -25,7 +25,7 @@ public class FunctionFilterVariable extends FilterVariable {
   public String renderSQL() {
     Map<String, String> params =
         ImmutableMap.<String, String>builder()
-            .put("fieldVariable", fieldVariable.renderSQL())
+            .put("fieldVariable", fieldVariable.renderSqlForWhere())
             .put("value", value.renderSQL())
             .build();
     return StringSubstitutor.replace(functionTemplate.getSqlTemplate(), params);

--- a/api/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
+++ b/api/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
@@ -42,7 +42,7 @@ public class SubQueryFilterVariable extends FilterVariable {
     String template = "${fieldSQL} ${operator} (${subQuerySQL})";
     Map<String, String> params =
         ImmutableMap.<String, String>builder()
-            .put("fieldSQL", fieldVariable.renderSQL())
+            .put("fieldSQL", fieldVariable.renderSqlForWhere())
             .put("operator", operator.renderSQL())
             .put("subQuerySQL", subQuery.renderSQL())
             .build();

--- a/api/src/main/java/bio/terra/tanagra/underlay/FieldPointer.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/FieldPointer.java
@@ -84,7 +84,11 @@ public class FieldPointer {
                   foreignTablePointer, foreignKeyColumnName, primaryTableColumn);
       tableVariables.add(foreignTable);
       return new FieldVariable(
-          new Builder().tablePointer(foreignTablePointer).columnName(foreignColumnName).build(),
+          new Builder()
+              .tablePointer(foreignTablePointer)
+              .columnName(foreignColumnName)
+              .sqlFunctionWrapper(sqlFunctionWrapper)
+              .build(),
           foreignTable,
           alias);
     } else {

--- a/api/src/main/java/bio/terra/tanagra/underlay/HierarchyField.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/HierarchyField.java
@@ -1,0 +1,31 @@
+package bio.terra.tanagra.underlay;
+
+import static bio.terra.tanagra.query.Query.TANAGRA_FIELD_PREFIX;
+
+public class HierarchyField {
+  public enum FieldName {
+    PATH,
+    NUM_CHILDREN,
+    IS_ROOT
+  }
+
+  private final String hierarchyName;
+  private final FieldName fieldName;
+
+  public HierarchyField(String hierarchyName, FieldName fieldName) {
+    this.hierarchyName = hierarchyName;
+    this.fieldName = fieldName;
+  }
+
+  public String getColumnNamePrefix() {
+    return TANAGRA_FIELD_PREFIX + hierarchyName + "_";
+  }
+
+  public String getHierarchyName() {
+    return hierarchyName;
+  }
+
+  public FieldName getFieldName() {
+    return fieldName;
+  }
+}

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -1158,6 +1158,19 @@ components:
           type: array
           items:
             type: string
+        includeHierarchyFields:
+          description: Hierarchy fields to include in the returned instances
+          type: object
+          properties:
+            hierarchies:
+              type: array
+              items:
+                type: string
+            fields:
+              type: array
+              items:
+                type: string
+                enum: ["PATH", "NUM_CHILDREN", "IS_ROOT"]
         filter:
           $ref: "#/components/schemas/FilterV2"
         orderBy:
@@ -1237,11 +1250,25 @@ components:
 
     InstanceV2:
       type: object
-      description: A map of entity attribute names to their value for this instance
-      additionalProperties:
-        type: object
-        nullable: true
-        $ref: "#/components/schemas/ValueDisplayV2"
+      properties:
+        attributes:
+          description: A map of entity attribute names to their value for this instance
+          type: object
+          additionalProperties:
+            type: object
+            nullable: true
+            $ref: "#/components/schemas/ValueDisplayV2"
+        hierarchyFields:
+          description: Hierarchy field values for this instance
+          type: object
+          properties:
+            path:
+              type: string
+              nullable: true
+            numChildren:
+              type: integer
+            isRoot:
+              type: boolean
 
     InstanceListV2:
       type: object


### PR DESCRIPTION
Added the hierarchy fields to the `/v2/instances` endpoint. This uses the new underlay config. The API specifies 3 possible hierarchy fields: `IS_ROOT`, `PATH`, `NUM_CHILDREN`. Now you can request a list of attributes and hierarchy fields to be included for each entity instance that's returned.