### PR TITLE
Eliminate "(any)" states from criteria

### DIFF
--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -19,7 +19,7 @@ describe("Basic tests", () => {
     cy.get(".MuiBackdrop-root").click();
 
     cy.get("button:Contains(Add criteria)").first().click();
-    cy.get("button:Contains(Year at birth)").click();
+    cy.get("button:Contains(Year of birth)").click();
     cy.get(".MuiInput-input").first().type("{selectall}30");
 
     cy.get("button:Contains(Add criteria)").last().click();

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -20,7 +20,7 @@ import { useAsyncWithApi } from "errors";
 import { useAppDispatch, useCohortAndGroup, useUnderlay } from "hooks";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { cohortURL, criteriaURL } from "router";
+import { cohortURL, newCriteriaURL } from "router";
 import { CriteriaConfig } from "underlaysSlice";
 import { createCriteria, getCriteriaPlugin, searchCriteria } from "./cohort";
 
@@ -75,18 +75,18 @@ export function AddCriteria() {
   const onClick = useCallback(
     (config: CriteriaConfig, dataEntry?: DataEntry) => {
       const criteria = createCriteria(source, config, dataEntry);
-      dispatch(
-        insertCriteria({
-          cohortId: cohort.id,
-          groupId: group.id,
-          criteria,
-        })
-      );
-      navigate(
-        !!getCriteriaPlugin(criteria).renderEdit && !dataEntry
-          ? "../" + criteriaURL(criteria.id)
-          : "../../" + cohortURL(cohort.id, group.id)
-      );
+      if (!!getCriteriaPlugin(criteria).renderEdit && !dataEntry) {
+        navigate("../" + newCriteriaURL(config.id));
+      } else {
+        dispatch(
+          insertCriteria({
+            cohortId: cohort.id,
+            groupId: group.id,
+            criteria,
+          })
+        );
+        navigate("../../" + cohortURL(cohort.id, group.id));
+      }
     },
     [source, cohort.id, group.id]
   );

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -71,7 +71,8 @@ class FakeUnderlaysApi {
         },
         {
           type: "attribute",
-          title: "Year at birth",
+          id: "tanagra-year_of_birth",
+          title: "Year of birth",
           attribute: "year_of_birth",
         },
       ],

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -24,7 +24,6 @@ import Loading from "components/loading";
 import { useMenu } from "components/menu";
 import { useTextInputDialog } from "components/textInputDialog";
 import { TreeGrid, TreeGridData } from "components/treegrid";
-import { insertConceptSet } from "conceptSetsSlice";
 import { findEntity } from "data/configuration";
 import { Filter, makeArrayFilter } from "data/filter";
 import { useSource } from "data/source";
@@ -38,7 +37,7 @@ import React, {
   useState,
 } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
-import { cohortURL, conceptSetURL } from "router";
+import { cohortURL, conceptSetURL, newConceptSetURL } from "router";
 import * as tanagra from "tanagra-api";
 import { useImmer } from "use-immer";
 
@@ -118,10 +117,7 @@ export function Datasets() {
   };
 
   const onInsertConceptSet = (criteria: tanagra.Criteria) => {
-    const {
-      payload: { id },
-    } = dispatch(insertConceptSet(underlay.name, criteria));
-    navigate(conceptSetURL(id));
+    navigate(newConceptSetURL(criteria.config.id));
   };
 
   const [menu, showInsertConceptSet] = useMenu({

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,6 +1,8 @@
-import { updateCriteriaData } from "cohortsSlice";
-import { updateConceptSetData } from "conceptSetsSlice";
-import { useCallback } from "react";
+import { createCriteria } from "cohort";
+import { insertCriteria, updateCriteriaData } from "cohortsSlice";
+import { insertConceptSet, updateConceptSetData } from "conceptSetsSlice";
+import { useSource } from "data/source";
+import { useCallback, useMemo } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import { RootState } from "rootReducer";
@@ -64,6 +66,32 @@ function useOptionalGroupAndCriteria(throwOnUnknown: boolean) {
   return { group, criteria };
 }
 
+function useOptionalNewCriteria(throwOnUnknown: boolean) {
+  const source = useSource();
+  const underlay = useUnderlay();
+  const { configId } = useParams<{ configId: string }>();
+
+  const criteria = useMemo(() => {
+    for (const config of underlay.uiConfiguration.criteriaConfigs) {
+      if (config.id !== configId) {
+        continue;
+      }
+
+      return createCriteria(source, config);
+    }
+    return undefined;
+  }, [underlay, configId]);
+
+  if (throwOnUnknown && !criteria) {
+    throw new PathError("Unknown new criteria config.");
+  }
+  return criteria;
+}
+
+export function useNewCriteria() {
+  return useOptionalNewCriteria(true) as NonNullable<tanagra.Criteria>;
+}
+
 export function useGroupAndCriteria() {
   const { group, criteria } = useOptionalGroupAndCriteria(true);
   return {
@@ -90,25 +118,55 @@ export function useConceptSet() {
 }
 
 export function useUpdateCriteria(criteriaId?: string) {
+  const underlay = useUnderlay();
   const cohort = useOptionalCohort(false);
   const { group, criteria } = useOptionalGroupAndCriteria(false);
+  const newCriteria = useOptionalNewCriteria(false);
   const conceptSet = useOptionalConceptSet(false);
   const dispatch = useAppDispatch();
 
-  const cId = criteriaId ?? criteria?.id;
-  if (cohort && group && cId) {
+  if (cohort && group) {
+    if (newCriteria) {
+      return useCallback(
+        (data: object) => {
+          dispatch(
+            insertCriteria({
+              cohortId: cohort.id,
+              groupId: group.id,
+              criteria: { ...newCriteria, data: data },
+            })
+          );
+        },
+        [cohort.id, group.id, newCriteria]
+      );
+    }
+
+    const cId = criteriaId ?? criteria?.id;
+    if (cId) {
+      return useCallback(
+        (data: object) => {
+          dispatch(
+            updateCriteriaData({
+              cohortId: cohort.id,
+              groupId: group.id,
+              criteriaId: cId,
+              data: data,
+            })
+          );
+        },
+        [cohort.id, group?.id, cId]
+      );
+    }
+  }
+
+  if (newCriteria) {
     return useCallback(
       (data: object) => {
         dispatch(
-          updateCriteriaData({
-            cohortId: cohort.id,
-            groupId: group.id,
-            criteriaId: cId,
-            data: data,
-          })
+          insertConceptSet(underlay.name, { ...newCriteria, data: data })
         );
       },
-      [cohort.id, group?.id, cId]
+      [underlay, newCriteria]
     );
   }
 

--- a/ui/src/newConceptSet.tsx
+++ b/ui/src/newConceptSet.tsx
@@ -1,0 +1,17 @@
+import Toolbar from "@mui/material/Toolbar";
+import ActionBar from "actionBar";
+import { useNewCriteria } from "hooks";
+import React from "react";
+import { getCriteriaPlugin } from "./cohort";
+
+export default function NewCriteria() {
+  const criteria = useNewCriteria();
+
+  return (
+    <>
+      <ActionBar title={`New ${criteria.config.title} Concept Set`} />
+      <Toolbar />
+      {getCriteriaPlugin(criteria).renderEdit?.()}
+    </>
+  );
+}

--- a/ui/src/newCriteria.tsx
+++ b/ui/src/newCriteria.tsx
@@ -1,0 +1,15 @@
+import ActionBar from "actionBar";
+import { useNewCriteria } from "hooks";
+import React from "react";
+import { getCriteriaPlugin } from "./cohort";
+
+export default function NewCriteria() {
+  const criteria = useNewCriteria();
+
+  return (
+    <>
+      <ActionBar title={`New ${criteria.config.title} Criteria`} />
+      {getCriteriaPlugin(criteria).renderEdit?.()}
+    </>
+  );
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -4,6 +4,8 @@ import ConceptSetEdit from "conceptSetEdit";
 import Edit from "edit";
 import { GroupOverview } from "groupOverview";
 import { PathError } from "hooks";
+import NewConceptSet from "newConceptSet";
+import NewCriteria from "newCriteria";
 import { Overview } from "overview";
 import { ErrorBoundary } from "react-error-boundary";
 import { Route, Routes, useNavigate } from "react-router-dom";
@@ -20,10 +22,12 @@ export function AppRouter() {
           <Route path="cohorts/:cohortId/:groupId" element={<Overview />}>
             <Route index element={<GroupOverview />} />
             <Route path="add" element={<AddCriteria />} />
+            <Route path="new/:configId" element={<NewCriteria />} />
             <Route path="edit/:criteriaId" element={<Edit />} />
           </Route>
+          <Route path="conceptSets/new/:configId" element={<NewConceptSet />} />
           <Route
-            path="conceptSets/:conceptSetId"
+            path="conceptSets/edit/:conceptSetId"
             element={<ConceptSetEdit />}
           />
         </Route>
@@ -48,8 +52,16 @@ export function conceptSetURL(conceptSetId: string) {
   return "conceptSets/" + conceptSetId;
 }
 
+export function newConceptSetURL(configId: string) {
+  return `conceptSets/new/${configId}`;
+}
+
 export function criteriaURL(criteriaId: string) {
   return `edit/${criteriaId}`;
+}
+
+export function newCriteriaURL(configId: string) {
+  return `new/${configId}`;
 }
 
 // TODO(tjennison): Make a prettier 404 page.


### PR DESCRIPTION
Instead of defaulting to "(any)" states, criteria aren't actually added to the cohort until a selection is made.