### PR TITLE
Relationship fields: COUNT, DISPLAY_HINTS.

### DIFF
--- a/api/src/main/java/bio/terra/tanagra/api/EntityQueryRequest.java
+++ b/api/src/main/java/bio/terra/tanagra/api/EntityQueryRequest.java
@@ -4,6 +4,7 @@ import bio.terra.tanagra.query.OrderByDirection;
 import bio.terra.tanagra.underlay.Attribute;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.HierarchyField;
+import bio.terra.tanagra.underlay.RelationshipField;
 import bio.terra.tanagra.underlay.Underlay;
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +14,7 @@ public class EntityQueryRequest {
   private final Underlay.MappingType mappingType;
   private final List<Attribute> selectAttributes;
   private final List<HierarchyField> selectHierarchyFields;
+  private final List<RelationshipField> selectRelationshipFields;
   private final EntityFilter filter;
   private final List<Attribute> orderByAttributes;
   private final OrderByDirection orderByDirection;
@@ -23,6 +25,7 @@ public class EntityQueryRequest {
     this.mappingType = builder.mappingType;
     this.selectAttributes = builder.selectAttributes;
     this.selectHierarchyFields = builder.selectHierarchyFields;
+    this.selectRelationshipFields = builder.selectRelationshipFields;
     this.filter = builder.filter;
     this.orderByAttributes = builder.orderByAttributes;
     this.orderByDirection = builder.orderByDirection;
@@ -43,6 +46,10 @@ public class EntityQueryRequest {
 
   public List<HierarchyField> getSelectHierarchyFields() {
     return Collections.unmodifiableList(selectHierarchyFields);
+  }
+
+  public List<RelationshipField> getSelectRelationshipFields() {
+    return Collections.unmodifiableList(selectRelationshipFields);
   }
 
   public EntityFilter getFilter() {
@@ -66,6 +73,7 @@ public class EntityQueryRequest {
     private Underlay.MappingType mappingType;
     private List<Attribute> selectAttributes;
     private List<HierarchyField> selectHierarchyFields;
+    private List<RelationshipField> selectRelationshipFields;
     private EntityFilter filter;
     private List<Attribute> orderByAttributes;
     private OrderByDirection orderByDirection;
@@ -88,6 +96,11 @@ public class EntityQueryRequest {
 
     public Builder selectHierarchyFields(List<HierarchyField> selectHierarchyFields) {
       this.selectHierarchyFields = selectHierarchyFields;
+      return this;
+    }
+
+    public Builder selectRelationshipFields(List<RelationshipField> selectRelationshipFields) {
+      this.selectRelationshipFields = selectRelationshipFields;
       return this;
     }
 

--- a/api/src/main/java/bio/terra/tanagra/api/FromApiConversionService.java
+++ b/api/src/main/java/bio/terra/tanagra/api/FromApiConversionService.java
@@ -97,7 +97,7 @@ public final class FromApiConversionService {
         Collection<EntityGroup> entityGroups =
             underlaysService.getUnderlay(underlayName).getEntityGroups().values();
         return new RelationshipFilter(
-            querysService.getRelationship(entityGroups, entity, relatedEntity), subFilter);
+            entity, querysService.getRelationship(entityGroups, entity, relatedEntity), subFilter);
       case BOOLEAN_LOGIC:
         ApiBooleanLogicFilterV2 apiBooleanLogicFilter =
             apiFilter.getFilterUnion().getBooleanLogicFilter();

--- a/api/src/main/java/bio/terra/tanagra/api/entityfilter/RelationshipFilter.java
+++ b/api/src/main/java/bio/terra/tanagra/api/entityfilter/RelationshipFilter.java
@@ -73,10 +73,7 @@ public class RelationshipFilter extends EntityFilter {
       // build a filter variable for the entity table on the sub query
       //  WHERE relatedEntityId IN (SELECT relatedEntityId FROM relatedEntityTable WHERE subFilter)
       FieldVariable filterEntityIdFieldVar =
-          relationship
-              .getMapping(Underlay.MappingType.SOURCE)
-              .getIdPairsId(filterEntity)
-              .buildVariable(entityTableVar, tableVars);
+          indexMapping.getIdPairsId(filterEntity).buildVariable(entityTableVar, tableVars);
       return new SubQueryFilterVariable(
           filterEntityIdFieldVar, SubQueryFilterVariable.Operator.IN, relatedEntityQuery);
     } else {

--- a/api/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
+++ b/api/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
@@ -16,6 +16,7 @@ import bio.terra.tanagra.generated.model.ApiInstanceCountV2;
 import bio.terra.tanagra.generated.model.ApiInstanceListV2;
 import bio.terra.tanagra.generated.model.ApiInstanceV2;
 import bio.terra.tanagra.generated.model.ApiInstanceV2HierarchyFields;
+import bio.terra.tanagra.generated.model.ApiInstanceV2RelationshipFields;
 import bio.terra.tanagra.generated.model.ApiQueryV2;
 import bio.terra.tanagra.generated.model.ApiValueDisplayV2;
 import bio.terra.tanagra.query.OrderByDirection;
@@ -25,6 +26,8 @@ import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityMapping;
 import bio.terra.tanagra.underlay.Hierarchy;
 import bio.terra.tanagra.underlay.HierarchyField;
+import bio.terra.tanagra.underlay.Relationship;
+import bio.terra.tanagra.underlay.RelationshipField;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.ValueDisplay;
 import java.util.ArrayList;
@@ -81,6 +84,30 @@ public class InstancesV2ApiController implements InstancesV2Api {
                                     HierarchyField.Type.valueOf(hierarchyFieldName.name()))));
               });
     }
+    List<RelationshipField> selectRelationshipFields = new ArrayList<>();
+    if (body.getIncludeRelationshipFields() != null) {
+      // for each related entity, return all the fields specified
+      body.getIncludeRelationshipFields().stream()
+          .forEach(
+              includeRelationshipField -> {
+                Entity relatedEntity =
+                    underlaysService.getEntity(
+                        underlayName, includeRelationshipField.getRelatedEntity());
+                Hierarchy hierarchy =
+                    includeRelationshipField.getHierarchy() == null
+                        ? null
+                        : entity.getHierarchy(includeRelationshipField.getHierarchy());
+                Relationship relationship = entity.getRelationship(relatedEntity);
+                includeRelationshipField.getFields().stream()
+                    .forEach(
+                        relationshipFieldName ->
+                            selectRelationshipFields.add(
+                                relationship.getField(
+                                    RelationshipField.Type.valueOf(relationshipFieldName.name()),
+                                    entity,
+                                    hierarchy)));
+              });
+    }
 
     List<Attribute> orderByAttributes = new ArrayList<>();
     OrderByDirection orderByDirection = OrderByDirection.ASCENDING;
@@ -106,6 +133,7 @@ public class InstancesV2ApiController implements InstancesV2Api {
                 .mappingType(Underlay.MappingType.INDEX)
                 .selectAttributes(selectAttributes)
                 .selectHierarchyFields(selectHierarchyFields)
+                .selectRelationshipFields(selectRelationshipFields)
                 .filter(entityFilter)
                 .orderByAttributes(orderByAttributes)
                 .orderByDirection(orderByDirection)
@@ -113,7 +141,11 @@ public class InstancesV2ApiController implements InstancesV2Api {
                 .build());
     List<EntityInstance> entityInstances =
         querysService.runInstancesQuery(
-            entityMapping, selectAttributes, selectHierarchyFields, queryRequest);
+            entityMapping,
+            selectAttributes,
+            selectHierarchyFields,
+            selectRelationshipFields,
+            queryRequest);
 
     return ResponseEntity.ok(
         new ApiInstanceListV2()
@@ -165,9 +197,42 @@ public class InstancesV2ApiController implements InstancesV2Api {
       }
     }
 
+    Map<String, ApiInstanceV2RelationshipFields> relationshipFieldSets = new HashMap<>();
+    for (Map.Entry<RelationshipField, ValueDisplay> relationshipFieldValue :
+        entityInstance.getRelationshipFieldValues().entrySet()) {
+      RelationshipField relationshipField = relationshipFieldValue.getKey();
+      ValueDisplay valueDisplay = relationshipFieldValue.getValue();
+
+      ApiInstanceV2RelationshipFields relationshipFieldSet =
+          relationshipFieldSets.get(relationshipField.getName());
+      if (relationshipFieldSet == null) {
+        relationshipFieldSet =
+            new ApiInstanceV2RelationshipFields()
+                .relatedEntity(
+                    relationshipField
+                        .getRelationship()
+                        .getRelatedEntity(relationshipField.getEntity())
+                        .getName())
+                .hierarchy(relationshipField.getHierarchyName());
+        relationshipFieldSets.put(relationshipField.getName(), relationshipFieldSet);
+      }
+      switch (relationshipField.getType()) {
+        case COUNT:
+          relationshipFieldSet.count(Math.toIntExact(valueDisplay.getValue().getInt64Val()));
+          break;
+        case DISPLAY_HINTS:
+          relationshipFieldSet.displayHints(valueDisplay.getValue().getStringVal());
+          break;
+        default:
+          throw new SystemException(
+              "Unknown relationship field type: " + relationshipField.getType());
+      }
+    }
+
     return instance
         .attributes(attributes)
-        .hierarchyFields(hierarchyFieldSets.values().stream().collect(Collectors.toList()));
+        .hierarchyFields(hierarchyFieldSets.values().stream().collect(Collectors.toList()))
+        .relationshipFields(relationshipFieldSets.values().stream().collect(Collectors.toList()));
   }
 
   @Override

--- a/api/src/main/java/bio/terra/tanagra/indexing/BigQueryIndexingJob.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/BigQueryIndexingJob.java
@@ -17,7 +17,6 @@ import bio.terra.tanagra.query.UpdateFromSelect;
 import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
 import bio.terra.tanagra.underlay.DataPointer;
 import bio.terra.tanagra.underlay.Entity;
-import bio.terra.tanagra.underlay.EntityGroup;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.datapointer.BigQueryDataset;
 import bio.terra.tanagra.utils.GoogleBigQuery;
@@ -55,16 +54,9 @@ public abstract class BigQueryIndexingJob implements IndexingJob {
   protected static final int DEFAULT_MAX_HIERARCHY_DEPTH = 64;
 
   private final Entity entity;
-  private final EntityGroup entityGroup;
 
   protected BigQueryIndexingJob(Entity entity) {
     this.entity = entity;
-    this.entityGroup = null;
-  }
-
-  protected BigQueryIndexingJob(EntityGroup entityGroup) {
-    this.entity = null;
-    this.entityGroup = entityGroup;
   }
 
   @Override
@@ -75,10 +67,6 @@ public abstract class BigQueryIndexingJob implements IndexingJob {
 
   protected Entity getEntity() {
     return entity;
-  }
-
-  protected EntityGroup getEntityGroup() {
-    return entityGroup;
   }
 
   @VisibleForTesting

--- a/api/src/main/java/bio/terra/tanagra/indexing/Indexer.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/Indexer.java
@@ -95,7 +95,18 @@ public final class Indexer {
 
   public void runJobsForEntity(String name, boolean isDryRun) {
     LOGGER.info("RUN entity: {}", name);
-    underlay.getEntity(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndRun(isDryRun));
+    underlay
+        .getEntity(name)
+        .getIndexingJobs()
+        .forEach(
+            ij -> {
+              try {
+                ij.checkStatusAndRun(isDryRun);
+              } catch (Exception ex) {
+                LOGGER.error("Error running indexing job for entity: {}", ij.getName());
+                LOGGER.error("Exception thrown: {}", ex);
+              }
+            });
   }
 
   public void runJobsForAllEntityGroups(boolean isDryRun) {
@@ -106,7 +117,18 @@ public final class Indexer {
 
   public void runJobsForEntityGroup(String name, boolean isDryRun) {
     LOGGER.info("RUN entity group: {}", name);
-    underlay.getEntityGroup(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndRun(isDryRun));
+    underlay
+        .getEntityGroup(name)
+        .getIndexingJobs()
+        .forEach(
+            ij -> {
+              try {
+                ij.checkStatusAndRun(isDryRun);
+              } catch (Exception ex) {
+                LOGGER.error("Error running indexing job for entity group: {}", ij.getName());
+                LOGGER.error("Exception thrown: {}", ex);
+              }
+            });
   }
 
   public void cleanAllEntities(boolean isDryRun) {
@@ -115,7 +137,18 @@ public final class Indexer {
 
   public void cleanEntity(String name, boolean isDryRun) {
     LOGGER.info("CLEAN entity: {}", name);
-    underlay.getEntity(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndClean(isDryRun));
+    underlay
+        .getEntity(name)
+        .getIndexingJobs()
+        .forEach(
+            ij -> {
+              try {
+                ij.checkStatusAndClean(isDryRun);
+              } catch (Exception ex) {
+                LOGGER.error("Error running clean job for entity: {}", ij.getName());
+                LOGGER.error("Exception thrown: {}", ex);
+              }
+            });
   }
 
   public void cleanAllEntityGroups(boolean isDryRun) {
@@ -126,7 +159,18 @@ public final class Indexer {
 
   public void cleanEntityGroup(String name, boolean isDryRun) {
     LOGGER.info("CLEAN entity group: {}", name);
-    underlay.getEntityGroup(name).getIndexingJobs().forEach(ij -> ij.checkStatusAndClean(isDryRun));
+    underlay
+        .getEntityGroup(name)
+        .getIndexingJobs()
+        .forEach(
+            ij -> {
+              try {
+                ij.checkStatusAndClean(isDryRun);
+              } catch (Exception ex) {
+                LOGGER.error("Error running clean job for entity group: {}", ij.getName());
+                LOGGER.error("Exception thrown: {}", ex);
+              }
+            });
   }
 
   public Underlay getUnderlay() {

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/ComputeRollupCounts.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/ComputeRollupCounts.java
@@ -67,7 +67,7 @@ public class ComputeRollupCounts extends BigQueryIndexingJob {
                   new TableFieldSchema()
                       .setName(ROLLUP_DISPLAY_HINTS_COLUMN_NAME)
                       .setType("STRING")
-                      .setMode("REQUIRED")));
+                      .setMode("NULLABLE")));
 
   private final Relationship relationship;
   private final Hierarchy hierarchy;

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/ComputeRollupCounts.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/ComputeRollupCounts.java
@@ -6,17 +6,32 @@ import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.DESCENDANT_COLUM
 import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.ID_COLUMN_NAME;
 import static bio.terra.tanagra.indexing.job.beam.BigQueryUtils.ROLLUP_COUNT_COLUMN_NAME;
 
+import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.indexing.BigQueryIndexingJob;
 import bio.terra.tanagra.indexing.job.beam.BigQueryUtils;
 import bio.terra.tanagra.indexing.job.beam.CountUtils;
+import bio.terra.tanagra.query.ColumnSchema;
+import bio.terra.tanagra.query.FieldPointer;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.Query;
+import bio.terra.tanagra.query.SQLExpression;
 import bio.terra.tanagra.query.TablePointer;
+import bio.terra.tanagra.query.TableVariable;
+import bio.terra.tanagra.underlay.DataPointer;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.Hierarchy;
+import bio.terra.tanagra.underlay.Relationship;
+import bio.terra.tanagra.underlay.RelationshipField;
+import bio.terra.tanagra.underlay.RelationshipMapping;
 import bio.terra.tanagra.underlay.Underlay;
-import bio.terra.tanagra.underlay.entitygroup.CriteriaOccurrence;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -33,6 +48,8 @@ import org.slf4j.LoggerFactory;
 public class ComputeRollupCounts extends BigQueryIndexingJob {
   private static final Logger LOGGER = LoggerFactory.getLogger(ComputeRollupCounts.class);
 
+  private static final String TEMP_TABLE_PREFIX = "rollup_";
+
   // The default table schema for the id-rollupCount output table.
   private static final TableSchema ROLLUP_COUNT_TABLE_SCHEMA =
       new TableSchema()
@@ -47,89 +64,36 @@ public class ComputeRollupCounts extends BigQueryIndexingJob {
                       .setType("INTEGER")
                       .setMode("REQUIRED")));
 
-  private final String hierarchyName;
+  private final Relationship relationship;
+  private final Hierarchy hierarchy;
 
-  public ComputeRollupCounts(CriteriaOccurrence entityGroup) {
-    this(entityGroup, null);
-  }
-
-  public ComputeRollupCounts(CriteriaOccurrence entityGroup, String hierarchyName) {
-    super(entityGroup);
-    this.hierarchyName = hierarchyName;
+  public ComputeRollupCounts(Entity rollupEntity, Relationship relationship, Hierarchy hierarchy) {
+    super(rollupEntity);
+    this.relationship = relationship;
+    this.hierarchy = hierarchy;
   }
 
   @Override
   public String getName() {
-    return "COMPUTE ROLLUP COUNTS ("
-        + getEntityGroup().getName()
+    return "COMPUTE ROLLUPS ("
+        + getRollupEntity().getName()
         + ", "
-        + (hierarchyName == null ? "NO HIERARCHY" : hierarchyName)
+        + (hierarchy == null ? "NO HIERARCHY" : hierarchy.getName())
         + ")";
   }
 
   @Override
   public void run(boolean isDryRun) {
-    CriteriaOccurrence entityGroup = (CriteriaOccurrence) getEntityGroup();
-
-    String selectAllCriteriaIdsSql =
-        entityGroup
-            .getCriteriaEntity()
-            .getMapping(Underlay.MappingType.SOURCE)
-            .queryIds(ID_COLUMN_NAME)
-            .renderSQL();
-    LOGGER.info("select all criteria ids SQL: {}", selectAllCriteriaIdsSql);
-
-    String selectAllCriteriaPrimaryIdPairsSql =
-        entityGroup.queryCriteriaPrimaryPairs(ID_COLUMN_NAME, COUNT_ID_COLUMN_NAME).renderSQL();
-    LOGGER.info(
-        "select all criteria id - primary id pairs SQL: {}", selectAllCriteriaPrimaryIdPairsSql);
-
-    String selectCriteriaAncestorDescendantIdPairsSql = null;
-    if (hierarchyName != null) {
-      selectCriteriaAncestorDescendantIdPairsSql =
-          entityGroup
-              .getCriteriaEntity()
-              .getHierarchy(hierarchyName)
-              .getMapping(Underlay.MappingType.INDEX)
-              .queryAncestorDescendantPairs(ANCESTOR_COLUMN_NAME, DESCENDANT_COLUMN_NAME)
-              .renderSQL();
-    }
-    LOGGER.info(
-        "select all criteria ancestor - descendant id pairs SQL: {}",
-        selectCriteriaAncestorDescendantIdPairsSql);
-
-    Pipeline pipeline =
-        Pipeline.create(buildDataflowPipelineOptions(getBQDataPointer(getTempTable())));
-
-    // read in the criteria ids and the criteria-primary id pairs from BQ
-    PCollection<Long> criteriaIdsPC =
-        BigQueryUtils.readNodesFromBQ(pipeline, selectAllCriteriaIdsSql, "criteriaIds");
-    PCollection<KV<Long, Long>> occurrenceCriteriaIdPairsPC =
-        BigQueryUtils.readOccurrencesFromBQ(pipeline, selectAllCriteriaPrimaryIdPairsSql);
-
-    // optionally handle a hierarchy for the criteria entity
-    if (hierarchyName != null) {
-      // read in the ancestor-descendant relationships from BQ. build (descendant, ancestor) pairs
-      PCollection<KV<Long, Long>> descendantAncestorKVsPC =
-          BigQueryUtils.readAncestorDescendantRelationshipsFromBQ(
-              pipeline, selectCriteriaAncestorDescendantIdPairsSql);
-
-      // expand the set of occurrences to include a repeat for each ancestor
-      occurrenceCriteriaIdPairsPC =
-          CountUtils.repeatOccurrencesForHierarchy(
-              occurrenceCriteriaIdPairsPC, descendantAncestorKVsPC);
+    // If the temp table hasn't been written yet, run the Dataflow job.
+    if (!checkTableExists(getTempTable())) {
+      writeFieldsToTempTable(isDryRun);
+    } else {
+      LOGGER.info("Temp table has already been written.");
     }
 
-    // count the number of distinct occurrences per primary node
-    PCollection<KV<Long, Long>> nodeCountKVsPC =
-        CountUtils.countDistinct(criteriaIdsPC, occurrenceCriteriaIdPairsPC);
-
-    // write the (id, count) rows to BQ
-    writeCountsToBQ(nodeCountKVsPC, getTempTable());
-
-    if (!isDryRun) {
-      pipeline.run().waitUntilFinish();
-    }
+    // Dataflow jobs can only write new rows to BigQuery, so in this second step, copy over the
+    // rollup counts to the corresponding columns in the entity table.
+    copyFieldsToEntityTable(isDryRun);
   }
 
   @Override
@@ -137,21 +101,101 @@ public class ComputeRollupCounts extends BigQueryIndexingJob {
     if (checkTableExists(getTempTable())) {
       deleteTable(getTempTable(), isDryRun);
     }
+    // CreateEntityTable will delete the entity table, which includes all the rows updated by this
+    // job.
   }
 
   @Override
   public JobStatus checkStatus() {
-    // Check if the table already exists. We don't expect this to be a long-running operation, so
-    // there is no IN_PROGRESS state for this job.
-    return checkTableExists(getTempTable()) ? JobStatus.COMPLETE : JobStatus.NOT_STARTED;
+    // Check if the temp table already exists.
+    if (!checkTableExists(getTempTable())) {
+      return JobStatus.NOT_STARTED;
+    }
+
+    // Check if the entity table already exists.
+    if (!checkTableExists(getEntityIndexTable())) {
+      return JobStatus.NOT_STARTED;
+    }
+
+    // Check if the table has at least 1 row where path IS NOT NULL.
+    RelationshipMapping indexMapping = relationship.getMapping(Underlay.MappingType.INDEX);
+    ColumnSchema countColumnSchema =
+        relationship.getField(RelationshipField.Type.COUNT, getRollupEntity()).buildColumnSchema();
+    return checkOneNotNullRowExists(
+            indexMapping.getRollupCount(getRollupEntity()), countColumnSchema)
+        ? JobStatus.COMPLETE
+        : JobStatus.NOT_STARTED;
   }
 
   @VisibleForTesting
   public TablePointer getTempTable() {
-    return ((CriteriaOccurrence) getEntityGroup())
-        .getCriteriaPrimaryRollupAuxiliaryData()
-        .getMapping(Underlay.MappingType.INDEX)
-        .getTablePointer();
+    // Name the temporary table rollup_[rollup entity]_[counted entity].
+    DataPointer dataPointer =
+        getRollupEntity().getMapping(Underlay.MappingType.INDEX).getTablePointer().getDataPointer();
+    return TablePointer.fromTableName(
+        TEMP_TABLE_PREFIX
+            + getRollupEntity().getName()
+            + "_"
+            + getCountedEntity().getName()
+            + (hierarchy == null ? "" : "_" + hierarchy.getName()),
+        dataPointer);
+  }
+
+  private void writeFieldsToTempTable(boolean isDryRun) {
+    Pipeline pipeline =
+        Pipeline.create(buildDataflowPipelineOptions(getBQDataPointer(getTempTable())));
+
+    // Read in the rollup ids from BQ.
+    Query rollupIds =
+        getRollupEntity().getMapping(Underlay.MappingType.SOURCE).queryIds(ID_COLUMN_NAME);
+    LOGGER.info("select all rollup entity ids SQL: {}", rollupIds.renderSQL());
+    PCollection<Long> rollupIdsPC =
+        BigQueryUtils.readNodesFromBQ(pipeline, rollupIds.renderSQL(), "rollupIds");
+
+    // Read in the rollup-counted id pairs from BQ.
+    boolean rollupEntityIsA = relationship.getEntityA().equals(getEntity());
+    String rollupEntityIdAlias = rollupEntityIsA ? ID_COLUMN_NAME : COUNT_ID_COLUMN_NAME;
+    String countedEntityIdAlias = rollupEntityIsA ? COUNT_ID_COLUMN_NAME : ID_COLUMN_NAME;
+    Query rollupCountedIdPairs =
+        relationship
+            .getMapping(Underlay.MappingType.SOURCE)
+            .queryIdPairs(rollupEntityIdAlias, countedEntityIdAlias);
+    LOGGER.info("select all rollup-counted id pairs SQL: {}", rollupCountedIdPairs.renderSQL());
+    PCollection<KV<Long, Long>> rollupCountedIdPairsPC =
+        BigQueryUtils.readOccurrencesFromBQ(pipeline, rollupCountedIdPairs.renderSQL());
+
+    // Optionally handle a hierarchy for the rollup entity.
+    if (hierarchy != null) {
+      SQLExpression rollupAncestorDescendantPairs =
+          hierarchy
+              .getMapping(Underlay.MappingType.INDEX)
+              .queryAncestorDescendantPairs(ANCESTOR_COLUMN_NAME, DESCENDANT_COLUMN_NAME);
+      LOGGER.info(
+          "select all rollup entity ancestor-descendant id pairs SQL: {}",
+          rollupAncestorDescendantPairs.renderSQL());
+
+      // Read in the ancestor-descendant relationships from BQ and build (descendant, ancestor) KV
+      // pairs.
+      PCollection<KV<Long, Long>> rollupAncestorDescendantKVsPC =
+          BigQueryUtils.readAncestorDescendantRelationshipsFromBQ(
+              pipeline, rollupAncestorDescendantPairs.renderSQL());
+
+      // Expand the set of occurrences to include a repeat for each ancestor.
+      rollupCountedIdPairsPC =
+          CountUtils.repeatOccurrencesForHierarchy(
+              rollupCountedIdPairsPC, rollupAncestorDescendantKVsPC);
+    }
+
+    // Count the number of distinct occurrences per primary node.
+    PCollection<KV<Long, Long>> nodeCountKVsPC =
+        CountUtils.countDistinct(rollupIdsPC, rollupCountedIdPairsPC);
+
+    // Write the (id, count) rows to BQ.
+    writeCountsToBQ(nodeCountKVsPC, getTempTable());
+
+    if (!isDryRun) {
+      pipeline.run().waitUntilFinish();
+    }
   }
 
   /** Write the {@link KV} pairs (id, rollup_count) to BQ. */
@@ -180,5 +224,66 @@ public class ComputeRollupCounts extends BigQueryIndexingJob {
             .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
             .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_EMPTY)
             .withMethod(BigQueryIO.Write.Method.FILE_LOADS));
+  }
+
+  private void copyFieldsToEntityTable(boolean isDryRun) {
+    // Build a query for the id-rollup_count pairs that we want to select.
+    Query idCountPairs = queryIdRollupPairs(getTempTable());
+    LOGGER.info("select all id-count pairs SQL: {}", idCountPairs.renderSQL());
+
+    // Build a map of (output) update field name -> (input) selected FieldVariable.
+    // This map only contains one item, because we're only updating the count field.
+    RelationshipMapping indexMapping = relationship.getMapping(Underlay.MappingType.INDEX);
+    Map<String, FieldVariable> updateFields = new HashMap<>();
+    String updateCountFieldName = indexMapping.getRollupCount(getRollupEntity()).getColumnName();
+    FieldVariable selectCountField =
+        idCountPairs.getSelect().stream()
+            .filter(fv -> fv.getAliasOrColumnName().equals(ROLLUP_COUNT_COLUMN_NAME))
+            .findFirst()
+            .get();
+    updateFields.put(updateCountFieldName, selectCountField);
+
+    // Check that the count field is not in a different table from the entity table.
+    if (indexMapping.getRollupCount(getRollupEntity()).isForeignKey()
+        || !indexMapping
+            .getRollupCount(getRollupEntity())
+            .getTablePointer()
+            .equals(getEntity().getMapping(Underlay.MappingType.INDEX).getTablePointer())) {
+      throw new SystemException(
+          "Indexing rollup count information only supports an index mapping to a column in the entity table");
+    }
+
+    updateEntityTableFromSelect(idCountPairs, updateFields, ID_COLUMN_NAME, isDryRun);
+  }
+
+  public static Query queryIdRollupPairs(TablePointer tablePointer) {
+    TableVariable tempTableVar = TableVariable.forPrimary(tablePointer);
+    List<TableVariable> inputTables = Lists.newArrayList(tempTableVar);
+    FieldVariable selectIdFieldVar =
+        new FieldPointer.Builder()
+            .tablePointer(tablePointer)
+            .columnName(ID_COLUMN_NAME)
+            .build()
+            .buildVariable(tempTableVar, inputTables);
+    FieldVariable selectCountFieldVar =
+        new FieldPointer.Builder()
+            .tablePointer(tablePointer)
+            .columnName(ROLLUP_COUNT_COLUMN_NAME)
+            .build()
+            .buildVariable(tempTableVar, inputTables);
+    return new Query.Builder()
+        .select(List.of(selectIdFieldVar, selectCountFieldVar))
+        .tables(inputTables)
+        .build();
+  }
+
+  private Entity getRollupEntity() {
+    return getEntity();
+  }
+
+  private Entity getCountedEntity() {
+    return relationship.getEntityA().equals(getRollupEntity())
+        ? relationship.getEntityB()
+        : relationship.getEntityA();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/CreateEntityTable.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/CreateEntityTable.java
@@ -61,7 +61,17 @@ public class CreateEntityTable extends BigQueryIndexingJob {
                       hierarchy.getField(HierarchyField.Type.NUM_CHILDREN).buildColumnSchema()));
             });
 
-    // create an empty table with this schema
+    // Build field schemas for relationship fields: count, display_hints.
+    getEntity().getRelationships().stream()
+        .forEach(
+            relationship ->
+                relationship.getFields().stream()
+                    .filter(relationshipField -> relationshipField.getEntity().equals(getEntity()))
+                    .forEach(
+                        relationshipField ->
+                            fields.add(fromColumnSchema(relationshipField.buildColumnSchema()))));
+
+    // Create an empty table with this schema.
     BigQueryDataset outputBQDataset = getBQDataPointer(getEntityIndexTable());
     TableId destinationTable =
         TableId.of(

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/WriteRelationshipIdPairs.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/WriteRelationshipIdPairs.java
@@ -1,0 +1,64 @@
+package bio.terra.tanagra.indexing.job;
+
+import bio.terra.tanagra.indexing.BigQueryIndexingJob;
+import bio.terra.tanagra.query.SQLExpression;
+import bio.terra.tanagra.query.TablePointer;
+import bio.terra.tanagra.underlay.Relationship;
+import bio.terra.tanagra.underlay.Underlay;
+import com.google.cloud.bigquery.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WriteRelationshipIdPairs extends BigQueryIndexingJob {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WriteRelationshipIdPairs.class);
+
+  private final Relationship relationship;
+
+  public WriteRelationshipIdPairs(Relationship relationship) {
+    super(relationship.getEntityA());
+    this.relationship = relationship;
+  }
+
+  @Override
+  public String getName() {
+    return "WRITE RELATIONSHIP ID PAIRS ("
+        + relationship.getEntityA().getName()
+        + ", "
+        + relationship.getEntityB().getName()
+        + ")";
+  }
+
+  @Override
+  public void run(boolean isDryRun) {
+    SQLExpression selectRelationshipIdPairs =
+        relationship.getMapping(Underlay.MappingType.SOURCE).queryIdPairs("idA", "idB");
+    String sql = selectRelationshipIdPairs.renderSQL();
+    LOGGER.info("select all relationship id pairs SQL: {}", sql);
+
+    TableId destinationTable =
+        TableId.of(
+            getBQDataPointer(getAuxiliaryTable()).getProjectId(),
+            getBQDataPointer(getAuxiliaryTable()).getDatasetId(),
+            getAuxiliaryTable().getTableName());
+    getBQDataPointer(getAuxiliaryTable())
+        .getBigQueryService()
+        .createTableFromQuery(destinationTable, sql, isDryRun);
+  }
+
+  @Override
+  public void clean(boolean isDryRun) {
+    if (checkTableExists(getAuxiliaryTable())) {
+      deleteTable(getAuxiliaryTable(), isDryRun);
+    }
+  }
+
+  @Override
+  public JobStatus checkStatus() {
+    // Check if the table already exists.
+    return checkTableExists(getAuxiliaryTable()) ? JobStatus.COMPLETE : JobStatus.NOT_STARTED;
+  }
+
+  public TablePointer getAuxiliaryTable() {
+    return relationship.getMapping(Underlay.MappingType.INDEX).getIdPairsTable();
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/WriteRelationshipIdPairs.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/WriteRelationshipIdPairs.java
@@ -30,8 +30,12 @@ public class WriteRelationshipIdPairs extends BigQueryIndexingJob {
 
   @Override
   public void run(boolean isDryRun) {
+    String idAAlias =
+        relationship.getMapping(Underlay.MappingType.INDEX).getIdPairsIdA().getColumnName();
+    String idBAlias =
+        relationship.getMapping(Underlay.MappingType.INDEX).getIdPairsIdB().getColumnName();
     SQLExpression selectRelationshipIdPairs =
-        relationship.getMapping(Underlay.MappingType.SOURCE).queryIdPairs("idA", "idB");
+        relationship.getMapping(Underlay.MappingType.SOURCE).queryIdPairs(idAAlias, idBAlias);
     String sql = selectRelationshipIdPairs.renderSQL();
     LOGGER.info("select all relationship id pairs SQL: {}", sql);
 

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/beam/BigQueryUtils.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/beam/BigQueryUtils.java
@@ -22,6 +22,7 @@ public final class BigQueryUtils {
   public static final String NUMCHILDREN_COLUMN_NAME = "num_children";
   public static final String COUNT_ID_COLUMN_NAME = "count_id";
   public static final String ROLLUP_COUNT_COLUMN_NAME = "rollup_count";
+  public static final String ROLLUP_DISPLAY_HINTS_COLUMN_NAME = "rollup_displayhints";
 
   private BigQueryUtils() {}
 

--- a/api/src/main/java/bio/terra/tanagra/indexing/job/beam/CountUtils.java
+++ b/api/src/main/java/bio/terra/tanagra/indexing/job/beam/CountUtils.java
@@ -33,12 +33,10 @@ public final class CountUtils {
       PCollection<Long> primaryNodes, PCollection<KV<Long, Long>> occurrences) {
     // remove duplicate occurrences
     // do this because there could be duplicate occurrences (i.e. 2 occurrences of diabetes for
-    // personA)
-    // in the original data. or, for concepts that include a hierarchy, there would be duplicates if
-    // e.g. a parent
-    // condition had two children, each with an occurrence for the same person. this distinct step
-    // is so we only
-    // count occurrences of a condition for each person once.
+    // personA) in the original data. or, for concepts that include a hierarchy, there would be
+    // duplicates if e.g. a parent condition had two children, each with an occurrence for the same
+    // person. this distinct step is so we only count occurrences of a condition for each person
+    // once.
     PCollection<KV<Long, Long>> distinctOccurrences =
         occurrences.apply("remove duplicate occurrences before counting", Distinct.create());
 
@@ -50,11 +48,9 @@ public final class CountUtils {
             "count the number of distinct occurrences per primary node", Count.perKey());
 
     // build a collection of KV<node,[placeholder 0L]>. this is just a collection of the primary
-    // nodes,
-    // but here we expand it to a map where each primary node is mapped to 0L, just so we can do an
-    // outer join with the countKVs above. the 0L is just a placeholder value in the map, the actual
-    // count
-    // will be set in the join result
+    // nodes, but here we expand it to a map where each primary node is mapped to 0L, just so we can
+    // do an outer join with the countKVs above. the 0L is just a placeholder value in the map, the
+    // actual count will be set in the join result
     PCollection<KV<Long, Long>> primaryNodeInitialKVs =
         primaryNodes.apply(
             "build initial (node,[placeholder 0L]) KV pairs",

--- a/api/src/main/java/bio/terra/tanagra/serialization/UFEntityGroup.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/UFEntityGroup.java
@@ -24,7 +24,7 @@ public class UFEntityGroup {
     this.type = entityGroup.getType();
     this.name = entityGroup.getName();
     Map<String, String> entities = new HashMap<>();
-    entityGroup.getEntities().entrySet().stream()
+    entityGroup.getEntityMap().entrySet().stream()
         .forEach(e -> entities.put(e.getKey(), e.getValue().getName()));
     this.entities = entities;
     this.sourceDataMapping =

--- a/api/src/main/java/bio/terra/tanagra/serialization/UFEntityGroupMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/UFEntityGroupMapping.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.serialization;
 
 import bio.terra.tanagra.underlay.EntityGroupMapping;
-import bio.terra.tanagra.underlay.Underlay;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -18,7 +17,6 @@ import java.util.Map;
 public class UFEntityGroupMapping {
   private final String dataPointer;
   private final Map<String, UFRelationshipMapping> relationshipMappings;
-  private final Map<String, UFAuxiliaryDataMapping> auxiliaryDataMappings;
 
   public UFEntityGroupMapping(EntityGroupMapping entityGroupMapping) {
     this.dataPointer = entityGroupMapping.getDataPointer().getName();
@@ -29,32 +27,21 @@ public class UFEntityGroupMapping {
             relationship -> {
               relationshipMappings.put(
                   relationship.getName(),
-                  new UFRelationshipMapping(relationship.getMapping(Underlay.MappingType.SOURCE)));
+                  new UFRelationshipMapping(
+                      relationship.getMapping(entityGroupMapping.getMappingType())));
             });
     this.relationshipMappings = relationshipMappings;
-
-    Map<String, UFAuxiliaryDataMapping> auxiliaryDataMappings = new HashMap<>();
-    entityGroupMapping.getEntityGroup().getAuxiliaryData().values().stream()
-        .forEach(
-            auxiliaryData -> {
-              auxiliaryDataMappings.put(
-                  auxiliaryData.getName(),
-                  new UFAuxiliaryDataMapping(auxiliaryData.getMapping(Underlay.MappingType.INDEX)));
-            });
-    this.auxiliaryDataMappings = auxiliaryDataMappings;
   }
 
   private UFEntityGroupMapping(Builder builder) {
     this.dataPointer = builder.dataPointer;
     this.relationshipMappings = builder.relationshipMappings;
-    this.auxiliaryDataMappings = builder.auxiliaryDataMappings;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
     private String dataPointer;
     private Map<String, UFRelationshipMapping> relationshipMappings;
-    private Map<String, UFAuxiliaryDataMapping> auxiliaryDataMappings;
 
     public Builder dataPointer(String dataPointer) {
       this.dataPointer = dataPointer;
@@ -63,12 +50,6 @@ public class UFEntityGroupMapping {
 
     public Builder relationshipMappings(Map<String, UFRelationshipMapping> relationshipMappings) {
       this.relationshipMappings = relationshipMappings;
-      return this;
-    }
-
-    public Builder auxiliaryDataMappings(
-        Map<String, UFAuxiliaryDataMapping> auxiliaryDataMappings) {
-      this.auxiliaryDataMappings = auxiliaryDataMappings;
       return this;
     }
 
@@ -84,9 +65,5 @@ public class UFEntityGroupMapping {
 
   public Map<String, UFRelationshipMapping> getRelationshipMappings() {
     return relationshipMappings;
-  }
-
-  public Map<String, UFAuxiliaryDataMapping> getAuxiliaryDataMappings() {
-    return auxiliaryDataMappings;
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/serialization/UFRelationshipMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/UFRelationshipMapping.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.serialization;
 
 import bio.terra.tanagra.underlay.RelationshipMapping;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -10,41 +11,136 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  * <p>This is a POJO class intended for serialization. This JSON format is user-facing.
  */
 @JsonDeserialize(builder = UFRelationshipMapping.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UFRelationshipMapping {
-  private final UFTablePointer tablePointer;
-  private final UFFieldPointer fromEntityId;
-  private final UFFieldPointer toEntityId;
+  private final UFTablePointer idPairsTable;
+  private final UFFieldPointer idPairsIdA;
+  private final UFFieldPointer idPairsIdB;
+
+  private final UFTablePointer rollupTableA;
+  private final UFFieldPointer rollupIdA;
+  private final UFFieldPointer rollupCountA;
+  private final UFFieldPointer rollupDisplayHintsA;
+
+  private final UFTablePointer rollupTableB;
+  private final UFFieldPointer rollupIdB;
+  private final UFFieldPointer rollupCountB;
+  private final UFFieldPointer rollupDisplayHintsB;
 
   public UFRelationshipMapping(RelationshipMapping relationshipMapping) {
-    this.tablePointer = new UFTablePointer(relationshipMapping.getTablePointer());
-    this.fromEntityId = new UFFieldPointer(relationshipMapping.getFromEntityId());
-    this.toEntityId = new UFFieldPointer(relationshipMapping.getToEntityId());
+    this.idPairsTable = new UFTablePointer(relationshipMapping.getIdPairsTable());
+    this.idPairsIdA = new UFFieldPointer(relationshipMapping.getIdPairsIdA());
+    this.idPairsIdB = new UFFieldPointer(relationshipMapping.getIdPairsIdB());
+
+    if (relationshipMapping.getRollupTableA() != null) {
+      this.rollupTableA = new UFTablePointer(relationshipMapping.getRollupTableA());
+      this.rollupIdA = new UFFieldPointer(relationshipMapping.getRollupIdA());
+      this.rollupCountA = new UFFieldPointer(relationshipMapping.getRollupCountA());
+      this.rollupDisplayHintsA = new UFFieldPointer(relationshipMapping.getRollupDisplayHintsA());
+    } else {
+      this.rollupTableA = null;
+      this.rollupIdA = null;
+      this.rollupCountA = null;
+      this.rollupDisplayHintsA = null;
+    }
+
+    if (relationshipMapping.getRollupTableB() != null) {
+      this.rollupTableB = new UFTablePointer(relationshipMapping.getRollupTableB());
+      this.rollupIdB = new UFFieldPointer(relationshipMapping.getRollupIdB());
+      this.rollupCountB = new UFFieldPointer(relationshipMapping.getRollupCountB());
+      this.rollupDisplayHintsB = new UFFieldPointer(relationshipMapping.getRollupDisplayHintsB());
+    } else {
+      this.rollupTableB = null;
+      this.rollupIdB = null;
+      this.rollupCountB = null;
+      this.rollupDisplayHintsB = null;
+    }
   }
 
   private UFRelationshipMapping(Builder builder) {
-    this.tablePointer = builder.tablePointer;
-    this.fromEntityId = builder.fromEntityId;
-    this.toEntityId = builder.toEntityId;
+    this.idPairsTable = builder.idPairsTable;
+    this.idPairsIdA = builder.idPairsIdA;
+    this.idPairsIdB = builder.idPairsIdB;
+
+    this.rollupTableA = builder.rollupTableA;
+    this.rollupIdA = builder.rollupIdA;
+    this.rollupCountA = builder.rollupCountA;
+    this.rollupDisplayHintsA = builder.rollupDisplayHintsA;
+
+    this.rollupTableB = builder.rollupTableB;
+    this.rollupIdB = builder.rollupIdB;
+    this.rollupCountB = builder.rollupCountB;
+    this.rollupDisplayHintsB = builder.rollupDisplayHintsB;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
-    private UFTablePointer tablePointer;
-    private UFFieldPointer fromEntityId;
-    private UFFieldPointer toEntityId;
+    private UFTablePointer idPairsTable;
+    private UFFieldPointer idPairsIdA;
+    private UFFieldPointer idPairsIdB;
 
-    public Builder tablePointer(UFTablePointer tablePointer) {
-      this.tablePointer = tablePointer;
+    private UFTablePointer rollupTableA;
+    private UFFieldPointer rollupIdA;
+    private UFFieldPointer rollupCountA;
+    private UFFieldPointer rollupDisplayHintsA;
+
+    private UFTablePointer rollupTableB;
+    private UFFieldPointer rollupIdB;
+    private UFFieldPointer rollupCountB;
+    private UFFieldPointer rollupDisplayHintsB;
+
+    public Builder idPairsTable(UFTablePointer idPairsTable) {
+      this.idPairsTable = idPairsTable;
       return this;
     }
 
-    public Builder fromEntityId(UFFieldPointer fromEntityId) {
-      this.fromEntityId = fromEntityId;
+    public Builder idPairsIdA(UFFieldPointer idPairsIdA) {
+      this.idPairsIdA = idPairsIdA;
       return this;
     }
 
-    public Builder toEntityId(UFFieldPointer toEntityId) {
-      this.toEntityId = toEntityId;
+    public Builder idPairsIdB(UFFieldPointer idPairsIdB) {
+      this.idPairsIdB = idPairsIdB;
+      return this;
+    }
+
+    public Builder rollupTableA(UFTablePointer rollupTableA) {
+      this.rollupTableA = rollupTableA;
+      return this;
+    }
+
+    public Builder rollupIdA(UFFieldPointer rollupIdA) {
+      this.rollupIdA = rollupIdA;
+      return this;
+    }
+
+    public Builder rollupCountA(UFFieldPointer rollupCountA) {
+      this.rollupCountA = rollupCountA;
+      return this;
+    }
+
+    public Builder rollupDisplayHintsA(UFFieldPointer rollupDisplayHintsA) {
+      this.rollupDisplayHintsA = rollupDisplayHintsA;
+      return this;
+    }
+
+    public Builder rollupTableB(UFTablePointer rollupTableB) {
+      this.rollupTableB = rollupTableB;
+      return this;
+    }
+
+    public Builder rollupIdB(UFFieldPointer rollupIdB) {
+      this.rollupIdB = rollupIdB;
+      return this;
+    }
+
+    public Builder rollupCountB(UFFieldPointer rollupCountB) {
+      this.rollupCountB = rollupCountB;
+      return this;
+    }
+
+    public Builder rollupDisplayHintsB(UFFieldPointer rollupDisplayHintsB) {
+      this.rollupDisplayHintsB = rollupDisplayHintsB;
       return this;
     }
 
@@ -54,15 +150,47 @@ public class UFRelationshipMapping {
     }
   }
 
-  public UFTablePointer getTablePointer() {
-    return tablePointer;
+  public UFTablePointer getIdPairsTable() {
+    return idPairsTable;
   }
 
-  public UFFieldPointer getFromEntityId() {
-    return fromEntityId;
+  public UFFieldPointer getIdPairsIdA() {
+    return idPairsIdA;
   }
 
-  public UFFieldPointer getToEntityId() {
-    return toEntityId;
+  public UFFieldPointer getIdPairsIdB() {
+    return idPairsIdB;
+  }
+
+  public UFTablePointer getRollupTableA() {
+    return rollupTableA;
+  }
+
+  public UFFieldPointer getRollupIdA() {
+    return rollupIdA;
+  }
+
+  public UFFieldPointer getRollupCountA() {
+    return rollupCountA;
+  }
+
+  public UFFieldPointer getRollupDisplayHintsA() {
+    return rollupDisplayHintsA;
+  }
+
+  public UFTablePointer getRollupTableB() {
+    return rollupTableB;
+  }
+
+  public UFFieldPointer getRollupIdB() {
+    return rollupIdB;
+  }
+
+  public UFFieldPointer getRollupCountB() {
+    return rollupCountB;
+  }
+
+  public UFFieldPointer getRollupDisplayHintsB() {
+    return rollupDisplayHintsB;
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/serialization/UFRelationshipMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/UFRelationshipMapping.java
@@ -4,6 +4,8 @@ import bio.terra.tanagra.underlay.RelationshipMapping;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * External representation of a relationship mapping.
@@ -16,61 +18,41 @@ public class UFRelationshipMapping {
   private final UFTablePointer idPairsTable;
   private final UFFieldPointer idPairsIdA;
   private final UFFieldPointer idPairsIdB;
-
-  private final UFTablePointer rollupTableA;
-  private final UFFieldPointer rollupIdA;
-  private final UFFieldPointer rollupCountA;
-  private final UFFieldPointer rollupDisplayHintsA;
-
-  private final UFTablePointer rollupTableB;
-  private final UFFieldPointer rollupIdB;
-  private final UFFieldPointer rollupCountB;
-  private final UFFieldPointer rollupDisplayHintsB;
+  private final Map<String, UFRollupInformation> rollupInformationMapA;
+  private final Map<String, UFRollupInformation> rollupInformationMapB;
 
   public UFRelationshipMapping(RelationshipMapping relationshipMapping) {
     this.idPairsTable = new UFTablePointer(relationshipMapping.getIdPairsTable());
     this.idPairsIdA = new UFFieldPointer(relationshipMapping.getIdPairsIdA());
     this.idPairsIdB = new UFFieldPointer(relationshipMapping.getIdPairsIdB());
 
-    if (relationshipMapping.getRollupTableA() != null) {
-      this.rollupTableA = new UFTablePointer(relationshipMapping.getRollupTableA());
-      this.rollupIdA = new UFFieldPointer(relationshipMapping.getRollupIdA());
-      this.rollupCountA = new UFFieldPointer(relationshipMapping.getRollupCountA());
-      this.rollupDisplayHintsA = new UFFieldPointer(relationshipMapping.getRollupDisplayHintsA());
-    } else {
-      this.rollupTableA = null;
-      this.rollupIdA = null;
-      this.rollupCountA = null;
-      this.rollupDisplayHintsA = null;
+    Map<String, UFRollupInformation> rollupInformationMapA = new HashMap<>();
+    if (relationshipMapping.getRollupInformationMapA() != null) {
+      relationshipMapping.getRollupInformationMapA().entrySet().stream()
+          .forEach(
+              entry ->
+                  rollupInformationMapA.put(
+                      entry.getKey(), new UFRollupInformation(entry.getValue())));
     }
+    this.rollupInformationMapA = rollupInformationMapA;
 
-    if (relationshipMapping.getRollupTableB() != null) {
-      this.rollupTableB = new UFTablePointer(relationshipMapping.getRollupTableB());
-      this.rollupIdB = new UFFieldPointer(relationshipMapping.getRollupIdB());
-      this.rollupCountB = new UFFieldPointer(relationshipMapping.getRollupCountB());
-      this.rollupDisplayHintsB = new UFFieldPointer(relationshipMapping.getRollupDisplayHintsB());
-    } else {
-      this.rollupTableB = null;
-      this.rollupIdB = null;
-      this.rollupCountB = null;
-      this.rollupDisplayHintsB = null;
+    Map<String, UFRollupInformation> rollupInformationMapB = new HashMap<>();
+    if (relationshipMapping.getRollupInformationMapB() != null) {
+      relationshipMapping.getRollupInformationMapB().entrySet().stream()
+          .forEach(
+              entry ->
+                  rollupInformationMapB.put(
+                      entry.getKey(), new UFRollupInformation(entry.getValue())));
     }
+    this.rollupInformationMapB = rollupInformationMapB;
   }
 
   private UFRelationshipMapping(Builder builder) {
     this.idPairsTable = builder.idPairsTable;
     this.idPairsIdA = builder.idPairsIdA;
     this.idPairsIdB = builder.idPairsIdB;
-
-    this.rollupTableA = builder.rollupTableA;
-    this.rollupIdA = builder.rollupIdA;
-    this.rollupCountA = builder.rollupCountA;
-    this.rollupDisplayHintsA = builder.rollupDisplayHintsA;
-
-    this.rollupTableB = builder.rollupTableB;
-    this.rollupIdB = builder.rollupIdB;
-    this.rollupCountB = builder.rollupCountB;
-    this.rollupDisplayHintsB = builder.rollupDisplayHintsB;
+    this.rollupInformationMapA = builder.rollupInformationMapA;
+    this.rollupInformationMapB = builder.rollupInformationMapB;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -78,16 +60,8 @@ public class UFRelationshipMapping {
     private UFTablePointer idPairsTable;
     private UFFieldPointer idPairsIdA;
     private UFFieldPointer idPairsIdB;
-
-    private UFTablePointer rollupTableA;
-    private UFFieldPointer rollupIdA;
-    private UFFieldPointer rollupCountA;
-    private UFFieldPointer rollupDisplayHintsA;
-
-    private UFTablePointer rollupTableB;
-    private UFFieldPointer rollupIdB;
-    private UFFieldPointer rollupCountB;
-    private UFFieldPointer rollupDisplayHintsB;
+    private Map<String, UFRollupInformation> rollupInformationMapA;
+    private Map<String, UFRollupInformation> rollupInformationMapB;
 
     public Builder idPairsTable(UFTablePointer idPairsTable) {
       this.idPairsTable = idPairsTable;
@@ -104,47 +78,16 @@ public class UFRelationshipMapping {
       return this;
     }
 
-    public Builder rollupTableA(UFTablePointer rollupTableA) {
-      this.rollupTableA = rollupTableA;
+    public Builder rollupInformationMapA(Map<String, UFRollupInformation> rollupInformationMapA) {
+      this.rollupInformationMapA = rollupInformationMapA;
       return this;
     }
 
-    public Builder rollupIdA(UFFieldPointer rollupIdA) {
-      this.rollupIdA = rollupIdA;
+    public Builder rollupInformationMapB(Map<String, UFRollupInformation> rollupInformationMapB) {
+      this.rollupInformationMapB = rollupInformationMapB;
       return this;
     }
 
-    public Builder rollupCountA(UFFieldPointer rollupCountA) {
-      this.rollupCountA = rollupCountA;
-      return this;
-    }
-
-    public Builder rollupDisplayHintsA(UFFieldPointer rollupDisplayHintsA) {
-      this.rollupDisplayHintsA = rollupDisplayHintsA;
-      return this;
-    }
-
-    public Builder rollupTableB(UFTablePointer rollupTableB) {
-      this.rollupTableB = rollupTableB;
-      return this;
-    }
-
-    public Builder rollupIdB(UFFieldPointer rollupIdB) {
-      this.rollupIdB = rollupIdB;
-      return this;
-    }
-
-    public Builder rollupCountB(UFFieldPointer rollupCountB) {
-      this.rollupCountB = rollupCountB;
-      return this;
-    }
-
-    public Builder rollupDisplayHintsB(UFFieldPointer rollupDisplayHintsB) {
-      this.rollupDisplayHintsB = rollupDisplayHintsB;
-      return this;
-    }
-
-    /** Call the private constructor. */
     public UFRelationshipMapping build() {
       return new UFRelationshipMapping(this);
     }
@@ -162,35 +105,11 @@ public class UFRelationshipMapping {
     return idPairsIdB;
   }
 
-  public UFTablePointer getRollupTableA() {
-    return rollupTableA;
+  public Map<String, UFRollupInformation> getRollupInformationMapA() {
+    return rollupInformationMapA;
   }
 
-  public UFFieldPointer getRollupIdA() {
-    return rollupIdA;
-  }
-
-  public UFFieldPointer getRollupCountA() {
-    return rollupCountA;
-  }
-
-  public UFFieldPointer getRollupDisplayHintsA() {
-    return rollupDisplayHintsA;
-  }
-
-  public UFTablePointer getRollupTableB() {
-    return rollupTableB;
-  }
-
-  public UFFieldPointer getRollupIdB() {
-    return rollupIdB;
-  }
-
-  public UFFieldPointer getRollupCountB() {
-    return rollupCountB;
-  }
-
-  public UFFieldPointer getRollupDisplayHintsB() {
-    return rollupDisplayHintsB;
+  public Map<String, UFRollupInformation> getRollupInformationMapB() {
+    return rollupInformationMapB;
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/serialization/UFRollupInformation.java
+++ b/api/src/main/java/bio/terra/tanagra/serialization/UFRollupInformation.java
@@ -1,0 +1,82 @@
+package bio.terra.tanagra.serialization;
+
+import bio.terra.tanagra.underlay.RollupInformation;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * External representation of rollup information.
+ *
+ * <p>This is a POJO class intended for serialization. This JSON format is user-facing.
+ */
+@JsonDeserialize(builder = UFRollupInformation.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UFRollupInformation {
+  private final UFTablePointer table;
+  private final UFFieldPointer id;
+  private final UFFieldPointer count;
+  private final UFFieldPointer displayHints;
+
+  public UFRollupInformation(RollupInformation rollupInformation) {
+    this.table = new UFTablePointer(rollupInformation.getTable());
+    this.id = new UFFieldPointer(rollupInformation.getId());
+    this.count = new UFFieldPointer(rollupInformation.getCount());
+    this.displayHints = new UFFieldPointer(rollupInformation.getDisplayHints());
+  }
+
+  private UFRollupInformation(Builder builder) {
+    this.table = builder.table;
+    this.id = builder.id;
+    this.count = builder.count;
+    this.displayHints = builder.displayHints;
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class Builder {
+    private UFTablePointer table;
+    private UFFieldPointer id;
+    private UFFieldPointer count;
+    private UFFieldPointer displayHints;
+
+    public Builder table(UFTablePointer table) {
+      this.table = table;
+      return this;
+    }
+
+    public Builder id(UFFieldPointer id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder count(UFFieldPointer count) {
+      this.count = count;
+      return this;
+    }
+
+    public Builder displayHints(UFFieldPointer displayHints) {
+      this.displayHints = displayHints;
+      return this;
+    }
+
+    public UFRollupInformation build() {
+      return new UFRollupInformation(this);
+    }
+  }
+
+  public UFTablePointer getTable() {
+    return table;
+  }
+
+  public UFFieldPointer getId() {
+    return id;
+  }
+
+  public UFFieldPointer getCount() {
+    return count;
+  }
+
+  public UFFieldPointer getDisplayHints() {
+    return displayHints;
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
@@ -106,7 +106,7 @@ public final class AttributeMapping {
     return dataPointer.lookupDatatype(value);
   }
 
-  public DisplayHint computeDisplayHint(Attribute attribute) {
+  public DisplayHint computeDisplayHint() {
     if (attribute.getType().equals(Attribute.Type.KEY_AND_DISPLAY)) {
       return EnumVals.computeForField(attribute.getDataType(), value, display);
     }

--- a/api/src/main/java/bio/terra/tanagra/underlay/Entity.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/Entity.java
@@ -242,7 +242,7 @@ public final class Entity {
 
               // generate the display hint
               if (!isIdAttribute(attribute)) {
-                // attribute.setDisplayHint(attributeMapping.computeDisplayHint());
+                attribute.setDisplayHint(attributeMapping.computeDisplayHint());
               }
             });
   }
@@ -309,6 +309,13 @@ public final class Entity {
                     .filter(relationship -> relationship.includesEntity(this))
                     .forEach(relationship -> relationships.add(relationship)));
     return relationships;
+  }
+
+  public Relationship getRelationship(Entity relatedEntity) {
+    return getRelationships().stream()
+        .filter(relationship -> relationship.includesEntity(relatedEntity))
+        .findFirst()
+        .get();
   }
 
   public EntityMapping getMapping(Underlay.MappingType mappingType) {

--- a/api/src/main/java/bio/terra/tanagra/underlay/Entity.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/Entity.java
@@ -31,6 +31,7 @@ public final class Entity {
   private final TextSearch textSearch;
   private final EntityMapping sourceDataMapping;
   private final EntityMapping indexDataMapping;
+  private Underlay underlay;
 
   private Entity(
       String name,
@@ -47,6 +48,10 @@ public final class Entity {
     this.textSearch = textSearch;
     this.sourceDataMapping = sourceDataMapping;
     this.indexDataMapping = indexDataMapping;
+  }
+
+  public void initialize(Underlay underlay) {
+    this.underlay = underlay;
   }
 
   public static Entity fromJSON(String entityFileName, Map<String, DataPointer> dataPointers)
@@ -237,7 +242,7 @@ public final class Entity {
 
               // generate the display hint
               if (!isIdAttribute(attribute)) {
-                attribute.setDisplayHint(attributeMapping.computeDisplayHint(attribute));
+                // attribute.setDisplayHint(attributeMapping.computeDisplayHint());
               }
             });
   }
@@ -293,6 +298,17 @@ public final class Entity {
 
   public TextSearch getTextSearch() {
     return textSearch;
+  }
+
+  public List<Relationship> getRelationships() {
+    List<Relationship> relationships = new ArrayList<>();
+    underlay.getEntityGroups().values().stream()
+        .forEach(
+            entityGroup ->
+                entityGroup.getRelationships().values().stream()
+                    .filter(relationship -> relationship.includesEntity(this))
+                    .forEach(relationship -> relationships.add(relationship)));
+    return relationships;
   }
 
   public EntityMapping getMapping(Underlay.MappingType mappingType) {

--- a/api/src/main/java/bio/terra/tanagra/underlay/EntityGroupMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/EntityGroupMapping.java
@@ -6,10 +6,12 @@ import java.util.Map;
 
 public final class EntityGroupMapping {
   private final DataPointer dataPointer;
+  private final Underlay.MappingType mappingType;
   private EntityGroup entityGroup;
 
-  private EntityGroupMapping(DataPointer dataPointer) {
+  private EntityGroupMapping(DataPointer dataPointer, Underlay.MappingType mappingType) {
     this.dataPointer = dataPointer;
+    this.mappingType = mappingType;
   }
 
   public void initialize(EntityGroup entityGroup) {
@@ -17,7 +19,9 @@ public final class EntityGroupMapping {
   }
 
   public static EntityGroupMapping fromSerialized(
-      UFEntityGroupMapping serialized, Map<String, DataPointer> dataPointers) {
+      UFEntityGroupMapping serialized,
+      Map<String, DataPointer> dataPointers,
+      Underlay.MappingType mappingType) {
     if (serialized.getDataPointer() == null || serialized.getDataPointer().isEmpty()) {
       throw new InvalidConfigException("No Data Pointer defined");
     }
@@ -26,11 +30,15 @@ public final class EntityGroupMapping {
     }
     DataPointer dataPointer = dataPointers.get(serialized.getDataPointer());
 
-    return new EntityGroupMapping(dataPointer);
+    return new EntityGroupMapping(dataPointer, mappingType);
   }
 
   public DataPointer getDataPointer() {
     return dataPointer;
+  }
+
+  public Underlay.MappingType getMappingType() {
+    return mappingType;
   }
 
   public EntityGroup getEntityGroup() {

--- a/api/src/main/java/bio/terra/tanagra/underlay/Relationship.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/Relationship.java
@@ -2,13 +2,15 @@ package bio.terra.tanagra.underlay;
 
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Relationship {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(Relationship.class);
   private final String name;
   private final Entity entityA;
   private final Entity entityB;
-  private List<RelationshipField> fields;
+  private final List<RelationshipField> fields;
 
   private RelationshipMapping sourceMapping;
   private RelationshipMapping indexMapping;
@@ -37,6 +39,10 @@ public class Relationship {
     return name;
   }
 
+  public Entity getRelatedEntity(Entity entity) {
+    return entityA.equals(entity) ? entityB : entityA;
+  }
+
   public Entity getEntityA() {
     return entityA;
   }
@@ -49,9 +55,20 @@ public class Relationship {
     return Collections.unmodifiableList(fields);
   }
 
-  public RelationshipField getField(RelationshipField.Type type, Entity entity) {
+  public RelationshipField getField(
+      RelationshipField.Type type, Entity entity, Hierarchy hierarchy) {
+    LOGGER.info(
+        "get relationship field: {}, {}, {}",
+        type,
+        entity.getName(),
+        hierarchy == null ? "null" : hierarchy.getName());
     return fields.stream()
-        .filter(field -> field.getEntity().equals(entity) && field.getType().equals(type))
+        .filter(
+            field ->
+                field.getType().equals(type)
+                    && field.getEntity().equals(entity)
+                    && ((hierarchy == null && field.getHierarchy() == null)
+                        || (hierarchy != null && hierarchy.equals(field.getHierarchy()))))
         .findFirst()
         .get();
   }

--- a/api/src/main/java/bio/terra/tanagra/underlay/Relationship.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/Relationship.java
@@ -1,18 +1,24 @@
 package bio.terra.tanagra.underlay;
 
+import java.util.Collections;
+import java.util.List;
+
 public class Relationship {
+
   private final String name;
   private final Entity entityA;
   private final Entity entityB;
+  private List<RelationshipField> fields;
 
   private RelationshipMapping sourceMapping;
   private RelationshipMapping indexMapping;
   private EntityGroup entityGroup;
 
-  public Relationship(String name, Entity entityA, Entity entityB) {
+  public Relationship(String name, Entity entityA, Entity entityB, List<RelationshipField> fields) {
     this.name = name;
     this.entityA = entityA;
     this.entityB = entityB;
+    this.fields = fields;
   }
 
   public void initialize(
@@ -22,6 +28,9 @@ public class Relationship {
     this.sourceMapping = sourceMapping;
     this.indexMapping = indexMapping;
     this.entityGroup = entityGroup;
+    sourceMapping.initialize(this);
+    indexMapping.initialize(this);
+    fields.stream().forEach(field -> field.initialize(this));
   }
 
   public String getName() {
@@ -36,8 +45,23 @@ public class Relationship {
     return entityB;
   }
 
+  public List<RelationshipField> getFields() {
+    return Collections.unmodifiableList(fields);
+  }
+
+  public RelationshipField getField(RelationshipField.Type type, Entity entity) {
+    return fields.stream()
+        .filter(field -> field.getEntity().equals(entity) && field.getType().equals(type))
+        .findFirst()
+        .get();
+  }
+
   public EntityGroup getEntityGroup() {
     return entityGroup;
+  }
+
+  public boolean includesEntity(Entity entity) {
+    return entityA.equals(entity) || entityB.equals(entity);
   }
 
   public RelationshipMapping getMapping(Underlay.MappingType mappingType) {

--- a/api/src/main/java/bio/terra/tanagra/underlay/RelationshipField.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/RelationshipField.java
@@ -83,12 +83,6 @@ public abstract class RelationshipField {
   }
 
   public String getName() {
-    return getType()
-        + "_"
-        + relationship.getName()
-        + "_"
-        + entity.getName()
-        + "_"
-        + getHierarchyName();
+    return relationship.getName() + "_" + entity.getName() + "_" + getHierarchyName();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/RelationshipField.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/RelationshipField.java
@@ -1,0 +1,61 @@
+package bio.terra.tanagra.underlay;
+
+import static bio.terra.tanagra.query.Query.TANAGRA_FIELD_PREFIX;
+import static bio.terra.tanagra.underlay.RelationshipMapping.COUNT_FIELD_PREFIX;
+import static bio.terra.tanagra.underlay.RelationshipMapping.DISPLAY_HINTS_FIELD_PREFIX;
+
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.query.ColumnSchema;
+
+public abstract class RelationshipField {
+  public enum Type {
+    COUNT,
+    DISPLAY_HINTS
+  }
+
+  private final Entity entity;
+  private Relationship relationship;
+
+  public RelationshipField(Entity entity) {
+    this.entity = entity;
+  }
+
+  public void initialize(Relationship relationship) {
+    this.relationship = relationship;
+  }
+
+  public abstract Type getType();
+
+  public abstract ColumnSchema buildColumnSchema();
+
+  public String getFieldAlias(Entity entity) {
+    String relatedEntityName =
+        relationship.getEntityA().equals(entity)
+            ? relationship.getEntityB().getName()
+            : relationship.getEntityA().getName();
+    return getFieldAlias(relatedEntityName, getType());
+  }
+
+  public static String getFieldAlias(String relatedEntityName, Type fieldType) {
+    String fieldName;
+    switch (fieldType) {
+      case COUNT:
+        fieldName = COUNT_FIELD_PREFIX;
+        break;
+      case DISPLAY_HINTS:
+        fieldName = DISPLAY_HINTS_FIELD_PREFIX;
+        break;
+      default:
+        throw new SystemException("Unknown relationship field type: " + fieldType);
+    }
+    return TANAGRA_FIELD_PREFIX + fieldName + relatedEntityName;
+  }
+
+  public Relationship getRelationship() {
+    return relationship;
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/underlay/RelationshipField.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/RelationshipField.java
@@ -3,9 +3,13 @@ package bio.terra.tanagra.underlay;
 import static bio.terra.tanagra.query.Query.TANAGRA_FIELD_PREFIX;
 import static bio.terra.tanagra.underlay.RelationshipMapping.COUNT_FIELD_PREFIX;
 import static bio.terra.tanagra.underlay.RelationshipMapping.DISPLAY_HINTS_FIELD_PREFIX;
+import static bio.terra.tanagra.underlay.RelationshipMapping.NO_HIERARCHY_KEY;
 
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.query.ColumnSchema;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.TableVariable;
+import java.util.List;
 
 public abstract class RelationshipField {
   public enum Type {
@@ -14,10 +18,17 @@ public abstract class RelationshipField {
   }
 
   private final Entity entity;
+  private final Hierarchy hierarchy;
   private Relationship relationship;
 
-  public RelationshipField(Entity entity) {
+  protected RelationshipField(Entity entity) {
     this.entity = entity;
+    this.hierarchy = null;
+  }
+
+  protected RelationshipField(Entity entity, Hierarchy hierarchy) {
+    this.entity = entity;
+    this.hierarchy = hierarchy;
   }
 
   public void initialize(Relationship relationship) {
@@ -28,34 +39,56 @@ public abstract class RelationshipField {
 
   public abstract ColumnSchema buildColumnSchema();
 
-  public String getFieldAlias(Entity entity) {
-    String relatedEntityName =
-        relationship.getEntityA().equals(entity)
-            ? relationship.getEntityB().getName()
-            : relationship.getEntityA().getName();
-    return getFieldAlias(relatedEntityName, getType());
+  public abstract FieldVariable buildFieldVariableFromEntityId(
+      RelationshipMapping relationshipMapping,
+      TableVariable entityTableVar,
+      List<TableVariable> tableVars);
+
+  public String getFieldAlias() {
+    return getFieldAlias(getType(), relationship.getRelatedEntity(entity), hierarchy);
   }
 
-  public static String getFieldAlias(String relatedEntityName, Type fieldType) {
-    String fieldName;
+  public static String getFieldAlias(Type fieldType, Entity relatedEntity, Hierarchy hierarchy) {
+    String fieldNamePrefix;
     switch (fieldType) {
       case COUNT:
-        fieldName = COUNT_FIELD_PREFIX;
+        fieldNamePrefix = COUNT_FIELD_PREFIX;
         break;
       case DISPLAY_HINTS:
-        fieldName = DISPLAY_HINTS_FIELD_PREFIX;
+        fieldNamePrefix = DISPLAY_HINTS_FIELD_PREFIX;
         break;
       default:
         throw new SystemException("Unknown relationship field type: " + fieldType);
     }
-    return TANAGRA_FIELD_PREFIX + fieldName + relatedEntityName;
+    return TANAGRA_FIELD_PREFIX
+        + fieldNamePrefix
+        + relatedEntity.getName()
+        + (hierarchy == null ? "" : ("_" + hierarchy.getName()));
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+
+  public Hierarchy getHierarchy() {
+    return hierarchy;
+  }
+
+  public String getHierarchyName() {
+    return hierarchy == null ? NO_HIERARCHY_KEY : hierarchy.getName();
   }
 
   public Relationship getRelationship() {
     return relationship;
   }
 
-  public Entity getEntity() {
-    return entity;
+  public String getName() {
+    return getType()
+        + "_"
+        + relationship.getName()
+        + "_"
+        + entity.getName()
+        + "_"
+        + getHierarchyName();
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/RelationshipMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/RelationshipMapping.java
@@ -7,50 +7,330 @@ import bio.terra.tanagra.query.TablePointer;
 import bio.terra.tanagra.query.TableVariable;
 import bio.terra.tanagra.serialization.UFRelationshipMapping;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RelationshipMapping {
-  private final TablePointer tablePointer;
-  private final FieldPointer fromEntityId;
-  private final FieldPointer toEntityId;
+  private static final Logger LOGGER = LoggerFactory.getLogger(RelationshipMapping.class);
 
-  private RelationshipMapping(
-      TablePointer tablePointer, FieldPointer fromEntityId, FieldPointer toEntityId) {
-    this.tablePointer = tablePointer;
-    this.fromEntityId = fromEntityId;
-    this.toEntityId = toEntityId;
+  public static final String COUNT_FIELD_PREFIX = "count_";
+  public static final String DISPLAY_HINTS_FIELD_PREFIX = "displayhints_";
+  private static final String ID_PAIRS_TABLE_PREFIX = "idpairs_";
+  private static final String ID_FIELD_NAME_PREFIX = "id_";
+
+  private final TablePointer idPairsTable;
+  private final FieldPointer idPairsIdA;
+  private final FieldPointer idPairsIdB;
+
+  private final TablePointer rollupTableA;
+  private final FieldPointer rollupIdA;
+  private final FieldPointer rollupCountA;
+  private final FieldPointer rollupDisplayHintsA;
+
+  private final TablePointer rollupTableB;
+  private final FieldPointer rollupIdB;
+  private final FieldPointer rollupCountB;
+  private final FieldPointer rollupDisplayHintsB;
+
+  private Relationship relationship;
+
+  private RelationshipMapping(Builder builder) {
+    this.idPairsTable = builder.idPairsTable;
+    this.idPairsIdA = builder.idPairsIdA;
+    this.idPairsIdB = builder.idPairsIdB;
+
+    this.rollupTableA = builder.rollupTableA;
+    this.rollupIdA = builder.rollupIdA;
+    this.rollupCountA = builder.rollupCountA;
+    this.rollupDisplayHintsA = builder.rollupDisplayHintsA;
+
+    this.rollupTableB = builder.rollupTableB;
+    this.rollupIdB = builder.rollupIdB;
+    this.rollupCountB = builder.rollupCountB;
+    this.rollupDisplayHintsB = builder.rollupDisplayHintsB;
+  }
+
+  public void initialize(Relationship relationship) {
+    this.relationship = relationship;
   }
 
   public static RelationshipMapping fromSerialized(
       UFRelationshipMapping serialized, DataPointer dataPointer) {
-    TablePointer tablePointer =
-        TablePointer.fromSerialized(serialized.getTablePointer(), dataPointer);
-    FieldPointer fromEntityId =
-        FieldPointer.fromSerialized(serialized.getFromEntityId(), tablePointer);
-    FieldPointer toEntityId = FieldPointer.fromSerialized(serialized.getToEntityId(), tablePointer);
-    return new RelationshipMapping(tablePointer, fromEntityId, toEntityId);
+    // ID pairs table.
+    TablePointer idPairsTable =
+        TablePointer.fromSerialized(serialized.getIdPairsTable(), dataPointer);
+    FieldPointer idPairsIdA = FieldPointer.fromSerialized(serialized.getIdPairsIdA(), idPairsTable);
+    FieldPointer idPairsIdB = FieldPointer.fromSerialized(serialized.getIdPairsIdB(), idPairsTable);
+    Builder builder =
+        new Builder().idPairsTable(idPairsTable).idPairsIdA(idPairsIdA).idPairsIdB(idPairsIdB);
+
+    // Rollup columns for entity A.
+    if (serialized.getRollupTableA() != null) {
+      TablePointer rollupTableA =
+          TablePointer.fromSerialized(serialized.getRollupTableA(), dataPointer);
+      FieldPointer rollupIdA = FieldPointer.fromSerialized(serialized.getRollupIdA(), rollupTableA);
+      FieldPointer rollupCountA =
+          FieldPointer.fromSerialized(serialized.getRollupCountA(), rollupTableA);
+      FieldPointer rollupDisplayHintsA =
+          FieldPointer.fromSerialized(serialized.getRollupDisplayHintsA(), rollupTableA);
+      builder
+          .rollupTableA(rollupTableA)
+          .rollupIdA(rollupIdA)
+          .rollupCountA(rollupCountA)
+          .rollupDisplayHintsA(rollupDisplayHintsA);
+    }
+
+    // Rollup columns for entity B.
+    if (serialized.getRollupTableB() != null) {
+      TablePointer rollupTableB =
+          TablePointer.fromSerialized(serialized.getRollupTableB(), dataPointer);
+      FieldPointer rollupIdB = FieldPointer.fromSerialized(serialized.getRollupIdB(), rollupTableB);
+      FieldPointer rollupCountB =
+          FieldPointer.fromSerialized(serialized.getRollupCountB(), rollupTableB);
+      FieldPointer rollupDisplayHintsB =
+          FieldPointer.fromSerialized(serialized.getRollupDisplayHintsB(), rollupTableB);
+      builder
+          .rollupTableB(rollupTableB)
+          .rollupIdB(rollupIdB)
+          .rollupCountB(rollupCountB)
+          .rollupDisplayHintsB(rollupDisplayHintsB);
+    }
+
+    return builder.build();
   }
 
-  public Query queryIdPairs(String fromEntityAlias, String toEntityAlias) {
-    TableVariable tableVariable = TableVariable.forPrimary(tablePointer);
-    FieldVariable fromEntityIdFieldVariable =
-        new FieldVariable(fromEntityId, tableVariable, fromEntityAlias);
-    FieldVariable toEntityIdFieldVariable =
-        new FieldVariable(toEntityId, tableVariable, toEntityAlias);
+  public static RelationshipMapping defaultIndexMapping(
+      DataPointer dataPointer, Relationship relationship) {
+    // ID pairs table.
+    TablePointer idPairsTable =
+        TablePointer.fromTableName(
+            ID_PAIRS_TABLE_PREFIX
+                + relationship.getEntityA().getName()
+                + "_"
+                + relationship.getEntityB().getName(),
+            dataPointer);
+    FieldPointer idPairsIdA =
+        new FieldPointer.Builder()
+            .tablePointer(idPairsTable)
+            .columnName(ID_FIELD_NAME_PREFIX + relationship.getEntityA().getName())
+            .build();
+    FieldPointer idPairsIdB =
+        new FieldPointer.Builder()
+            .tablePointer(idPairsTable)
+            .columnName(ID_FIELD_NAME_PREFIX + relationship.getEntityB().getName())
+            .build();
+
+    // Rollup columns in entity A table.
+    TablePointer entityTableA =
+        relationship.getEntityA().getMapping(Underlay.MappingType.INDEX).getTablePointer();
+    FieldPointer rollupIdA =
+        relationship
+            .getEntityA()
+            .getIdAttribute()
+            .getMapping(Underlay.MappingType.INDEX)
+            .getValue();
+    FieldPointer rollupCountA =
+        new FieldPointer.Builder()
+            .tablePointer(entityTableA)
+            .columnName(
+                RelationshipField.getFieldAlias(
+                    relationship.getEntityB().getName(), RelationshipField.Type.COUNT))
+            .build();
+    FieldPointer rollupDisplayHintsA =
+        new FieldPointer.Builder()
+            .tablePointer(entityTableA)
+            .columnName(
+                RelationshipField.getFieldAlias(
+                    relationship.getEntityB().getName(), RelationshipField.Type.DISPLAY_HINTS))
+            .build();
+
+    // Rollup columns in entity B table.
+    TablePointer entityTableB =
+        relationship.getEntityB().getMapping(Underlay.MappingType.INDEX).getTablePointer();
+    FieldPointer rollupIdB =
+        relationship
+            .getEntityB()
+            .getIdAttribute()
+            .getMapping(Underlay.MappingType.INDEX)
+            .getValue();
+    FieldPointer rollupCountB =
+        new FieldPointer.Builder()
+            .tablePointer(entityTableB)
+            .columnName(
+                RelationshipField.getFieldAlias(
+                    relationship.getEntityA().getName(), RelationshipField.Type.COUNT))
+            .build();
+    FieldPointer rollupDisplayHintsB =
+        new FieldPointer.Builder()
+            .tablePointer(entityTableB)
+            .columnName(
+                RelationshipField.getFieldAlias(
+                    relationship.getEntityA().getName(), RelationshipField.Type.DISPLAY_HINTS))
+            .build();
+
+    return new Builder()
+        .idPairsTable(idPairsTable)
+        .idPairsIdA(idPairsIdA)
+        .idPairsIdB(idPairsIdB)
+        .rollupTableA(entityTableA)
+        .rollupIdA(rollupIdA)
+        .rollupCountA(rollupCountA)
+        .rollupDisplayHintsA(rollupDisplayHintsA)
+        .rollupTableB(entityTableB)
+        .rollupIdB(rollupIdB)
+        .rollupCountB(rollupCountB)
+        .rollupDisplayHintsB(rollupDisplayHintsB)
+        .build();
+  }
+
+  public Query queryIdPairs(String idAAlias, String idBAlias) {
+    TableVariable tableVariable = TableVariable.forPrimary(idPairsTable);
+    FieldVariable idAFieldVar = new FieldVariable(getIdPairsIdA(), tableVariable, idAAlias);
+    FieldVariable idBFieldVar = new FieldVariable(getIdPairsIdB(), tableVariable, idBAlias);
     return new Query.Builder()
-        .select(List.of(fromEntityIdFieldVariable, toEntityIdFieldVariable))
+        .select(List.of(idAFieldVar, idBFieldVar))
         .tables(List.of(tableVariable))
         .build();
   }
 
-  public TablePointer getTablePointer() {
-    return tablePointer;
+  public FieldPointer getIdPairsId(Entity entity) {
+    return (relationship.getEntityA().equals(entity)) ? getIdPairsIdA() : getIdPairsIdB();
   }
 
-  public FieldPointer getFromEntityId() {
-    return fromEntityId;
+  public TablePointer getRollupTable(Entity entity) {
+    return (relationship.getEntityA().equals(entity)) ? getRollupTableA() : getRollupTableB();
   }
 
-  public FieldPointer getToEntityId() {
-    return toEntityId;
+  public FieldPointer getRollupId(Entity entity) {
+    return (relationship.getEntityA().equals(entity)) ? getRollupIdA() : getRollupIdB();
+  }
+
+  public FieldPointer getRollupCount(Entity entity) {
+    return (relationship.getEntityA().equals(entity)) ? getRollupCountA() : getRollupCountB();
+  }
+
+  public FieldPointer getRollupDisplayHints(Entity entity) {
+    return (relationship.getEntityA().equals(entity))
+        ? getRollupDisplayHintsA()
+        : getRollupDisplayHintsB();
+  }
+
+  public TablePointer getIdPairsTable() {
+    return idPairsTable;
+  }
+
+  public FieldPointer getIdPairsIdA() {
+    return idPairsIdA;
+  }
+
+  public FieldPointer getIdPairsIdB() {
+    return idPairsIdB;
+  }
+
+  public TablePointer getRollupTableA() {
+    return rollupTableA;
+  }
+
+  public FieldPointer getRollupIdA() {
+    return rollupIdA;
+  }
+
+  public FieldPointer getRollupCountA() {
+    return rollupCountA;
+  }
+
+  public FieldPointer getRollupDisplayHintsA() {
+    return rollupDisplayHintsA;
+  }
+
+  public TablePointer getRollupTableB() {
+    return rollupTableB;
+  }
+
+  public FieldPointer getRollupIdB() {
+    return rollupIdB;
+  }
+
+  public FieldPointer getRollupCountB() {
+    return rollupCountB;
+  }
+
+  public FieldPointer getRollupDisplayHintsB() {
+    return rollupDisplayHintsB;
+  }
+
+  public static class Builder {
+    private TablePointer idPairsTable;
+    private FieldPointer idPairsIdA;
+    private FieldPointer idPairsIdB;
+
+    private TablePointer rollupTableA;
+    private FieldPointer rollupIdA;
+    private FieldPointer rollupCountA;
+    private FieldPointer rollupDisplayHintsA;
+
+    private TablePointer rollupTableB;
+    private FieldPointer rollupIdB;
+    private FieldPointer rollupCountB;
+    private FieldPointer rollupDisplayHintsB;
+
+    public Builder idPairsTable(TablePointer idPairsTable) {
+      this.idPairsTable = idPairsTable;
+      return this;
+    }
+
+    public Builder idPairsIdA(FieldPointer idPairsIdA) {
+      this.idPairsIdA = idPairsIdA;
+      return this;
+    }
+
+    public Builder idPairsIdB(FieldPointer idPairsIdB) {
+      this.idPairsIdB = idPairsIdB;
+      return this;
+    }
+
+    public Builder rollupTableA(TablePointer rollupTableA) {
+      this.rollupTableA = rollupTableA;
+      return this;
+    }
+
+    public Builder rollupIdA(FieldPointer rollupIdA) {
+      this.rollupIdA = rollupIdA;
+      return this;
+    }
+
+    public Builder rollupCountA(FieldPointer rollupCountA) {
+      this.rollupCountA = rollupCountA;
+      return this;
+    }
+
+    public Builder rollupDisplayHintsA(FieldPointer rollupDisplayHintsA) {
+      this.rollupDisplayHintsA = rollupDisplayHintsA;
+      return this;
+    }
+
+    public Builder rollupTableB(TablePointer rollupTableB) {
+      this.rollupTableB = rollupTableB;
+      return this;
+    }
+
+    public Builder rollupIdB(FieldPointer rollupIdB) {
+      this.rollupIdB = rollupIdB;
+      return this;
+    }
+
+    public Builder rollupCountB(FieldPointer rollupCountB) {
+      this.rollupCountB = rollupCountB;
+      return this;
+    }
+
+    public Builder rollupDisplayHintsB(FieldPointer rollupDisplayHintsB) {
+      this.rollupDisplayHintsB = rollupDisplayHintsB;
+      return this;
+    }
+
+    public RelationshipMapping build() {
+      return new RelationshipMapping(this);
+    }
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/RelationshipMapping.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/RelationshipMapping.java
@@ -6,48 +6,34 @@ import bio.terra.tanagra.query.Query;
 import bio.terra.tanagra.query.TablePointer;
 import bio.terra.tanagra.query.TableVariable;
 import bio.terra.tanagra.serialization.UFRelationshipMapping;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Map;
 
 public final class RelationshipMapping {
-  private static final Logger LOGGER = LoggerFactory.getLogger(RelationshipMapping.class);
-
   public static final String COUNT_FIELD_PREFIX = "count_";
   public static final String DISPLAY_HINTS_FIELD_PREFIX = "displayhints_";
   private static final String ID_PAIRS_TABLE_PREFIX = "idpairs_";
   private static final String ID_FIELD_NAME_PREFIX = "id_";
+  public static final String NO_HIERARCHY_KEY = "NO_HIERARCHY";
 
-  private final TablePointer idPairsTable;
   private final FieldPointer idPairsIdA;
   private final FieldPointer idPairsIdB;
-
-  private final TablePointer rollupTableA;
-  private final FieldPointer rollupIdA;
-  private final FieldPointer rollupCountA;
-  private final FieldPointer rollupDisplayHintsA;
-
-  private final TablePointer rollupTableB;
-  private final FieldPointer rollupIdB;
-  private final FieldPointer rollupCountB;
-  private final FieldPointer rollupDisplayHintsB;
+  private final Map<String, RollupInformation> rollupInformationMapA;
+  private final Map<String, RollupInformation> rollupInformationMapB;
 
   private Relationship relationship;
 
-  private RelationshipMapping(Builder builder) {
-    this.idPairsTable = builder.idPairsTable;
-    this.idPairsIdA = builder.idPairsIdA;
-    this.idPairsIdB = builder.idPairsIdB;
-
-    this.rollupTableA = builder.rollupTableA;
-    this.rollupIdA = builder.rollupIdA;
-    this.rollupCountA = builder.rollupCountA;
-    this.rollupDisplayHintsA = builder.rollupDisplayHintsA;
-
-    this.rollupTableB = builder.rollupTableB;
-    this.rollupIdB = builder.rollupIdB;
-    this.rollupCountB = builder.rollupCountB;
-    this.rollupDisplayHintsB = builder.rollupDisplayHintsB;
+  private RelationshipMapping(
+      FieldPointer idPairsIdA,
+      FieldPointer idPairsIdB,
+      Map<String, RollupInformation> rollupInformationMapA,
+      Map<String, RollupInformation> rollupInformationMapB) {
+    this.idPairsIdA = idPairsIdA;
+    this.idPairsIdB = idPairsIdB;
+    this.rollupInformationMapA = rollupInformationMapA;
+    this.rollupInformationMapB = rollupInformationMapB;
   }
 
   public void initialize(Relationship relationship) {
@@ -61,42 +47,31 @@ public final class RelationshipMapping {
         TablePointer.fromSerialized(serialized.getIdPairsTable(), dataPointer);
     FieldPointer idPairsIdA = FieldPointer.fromSerialized(serialized.getIdPairsIdA(), idPairsTable);
     FieldPointer idPairsIdB = FieldPointer.fromSerialized(serialized.getIdPairsIdB(), idPairsTable);
-    Builder builder =
-        new Builder().idPairsTable(idPairsTable).idPairsIdA(idPairsIdA).idPairsIdB(idPairsIdB);
 
     // Rollup columns for entity A.
-    if (serialized.getRollupTableA() != null) {
-      TablePointer rollupTableA =
-          TablePointer.fromSerialized(serialized.getRollupTableA(), dataPointer);
-      FieldPointer rollupIdA = FieldPointer.fromSerialized(serialized.getRollupIdA(), rollupTableA);
-      FieldPointer rollupCountA =
-          FieldPointer.fromSerialized(serialized.getRollupCountA(), rollupTableA);
-      FieldPointer rollupDisplayHintsA =
-          FieldPointer.fromSerialized(serialized.getRollupDisplayHintsA(), rollupTableA);
-      builder
-          .rollupTableA(rollupTableA)
-          .rollupIdA(rollupIdA)
-          .rollupCountA(rollupCountA)
-          .rollupDisplayHintsA(rollupDisplayHintsA);
+    Map<String, RollupInformation> rollupInformationMapA = new HashMap<>();
+    if (serialized.getRollupInformationMapA() != null) {
+      serialized.getRollupInformationMapA().entrySet().stream()
+          .forEach(
+              entry ->
+                  rollupInformationMapA.put(
+                      entry.getKey(),
+                      RollupInformation.fromSerialized(entry.getValue(), dataPointer)));
     }
 
     // Rollup columns for entity B.
-    if (serialized.getRollupTableB() != null) {
-      TablePointer rollupTableB =
-          TablePointer.fromSerialized(serialized.getRollupTableB(), dataPointer);
-      FieldPointer rollupIdB = FieldPointer.fromSerialized(serialized.getRollupIdB(), rollupTableB);
-      FieldPointer rollupCountB =
-          FieldPointer.fromSerialized(serialized.getRollupCountB(), rollupTableB);
-      FieldPointer rollupDisplayHintsB =
-          FieldPointer.fromSerialized(serialized.getRollupDisplayHintsB(), rollupTableB);
-      builder
-          .rollupTableB(rollupTableB)
-          .rollupIdB(rollupIdB)
-          .rollupCountB(rollupCountB)
-          .rollupDisplayHintsB(rollupDisplayHintsB);
+    Map<String, RollupInformation> rollupInformationMapB = new HashMap<>();
+    if (serialized.getRollupInformationMapB() != null) {
+      serialized.getRollupInformationMapB().entrySet().stream()
+          .forEach(
+              entry ->
+                  rollupInformationMapB.put(
+                      entry.getKey(),
+                      RollupInformation.fromSerialized(entry.getValue(), dataPointer)));
     }
 
-    return builder.build();
+    return new RelationshipMapping(
+        idPairsIdA, idPairsIdB, rollupInformationMapA, rollupInformationMapB);
   }
 
   public static RelationshipMapping defaultIndexMapping(
@@ -121,70 +96,43 @@ public final class RelationshipMapping {
             .build();
 
     // Rollup columns in entity A table.
-    TablePointer entityTableA =
-        relationship.getEntityA().getMapping(Underlay.MappingType.INDEX).getTablePointer();
-    FieldPointer rollupIdA =
-        relationship
-            .getEntityA()
-            .getIdAttribute()
-            .getMapping(Underlay.MappingType.INDEX)
-            .getValue();
-    FieldPointer rollupCountA =
-        new FieldPointer.Builder()
-            .tablePointer(entityTableA)
-            .columnName(
-                RelationshipField.getFieldAlias(
-                    relationship.getEntityB().getName(), RelationshipField.Type.COUNT))
-            .build();
-    FieldPointer rollupDisplayHintsA =
-        new FieldPointer.Builder()
-            .tablePointer(entityTableA)
-            .columnName(
-                RelationshipField.getFieldAlias(
-                    relationship.getEntityB().getName(), RelationshipField.Type.DISPLAY_HINTS))
-            .build();
+    Map<String, RollupInformation> rollupInformationMapA = new HashMap<>();
+    rollupInformationMapA.put(
+        NO_HIERARCHY_KEY,
+        RollupInformation.defaultIndexMapping(
+            relationship.getEntityA(), relationship.getEntityB(), null));
+    if (relationship.getEntityA().hasHierarchies()) {
+      relationship.getEntityA().getHierarchies().stream()
+          .forEach(
+              hierarchy ->
+                  rollupInformationMapA.put(
+                      hierarchy.getName(),
+                      RollupInformation.defaultIndexMapping(
+                          relationship.getEntityA(), relationship.getEntityB(), hierarchy)));
+    }
 
     // Rollup columns in entity B table.
-    TablePointer entityTableB =
-        relationship.getEntityB().getMapping(Underlay.MappingType.INDEX).getTablePointer();
-    FieldPointer rollupIdB =
-        relationship
-            .getEntityB()
-            .getIdAttribute()
-            .getMapping(Underlay.MappingType.INDEX)
-            .getValue();
-    FieldPointer rollupCountB =
-        new FieldPointer.Builder()
-            .tablePointer(entityTableB)
-            .columnName(
-                RelationshipField.getFieldAlias(
-                    relationship.getEntityA().getName(), RelationshipField.Type.COUNT))
-            .build();
-    FieldPointer rollupDisplayHintsB =
-        new FieldPointer.Builder()
-            .tablePointer(entityTableB)
-            .columnName(
-                RelationshipField.getFieldAlias(
-                    relationship.getEntityA().getName(), RelationshipField.Type.DISPLAY_HINTS))
-            .build();
+    Map<String, RollupInformation> rollupInformationMapB = new HashMap<>();
+    rollupInformationMapB.put(
+        NO_HIERARCHY_KEY,
+        RollupInformation.defaultIndexMapping(
+            relationship.getEntityB(), relationship.getEntityA(), null));
+    if (relationship.getEntityB().hasHierarchies()) {
+      relationship.getEntityB().getHierarchies().stream()
+          .forEach(
+              hierarchy ->
+                  rollupInformationMapB.put(
+                      hierarchy.getName(),
+                      RollupInformation.defaultIndexMapping(
+                          relationship.getEntityB(), relationship.getEntityA(), hierarchy)));
+    }
 
-    return new Builder()
-        .idPairsTable(idPairsTable)
-        .idPairsIdA(idPairsIdA)
-        .idPairsIdB(idPairsIdB)
-        .rollupTableA(entityTableA)
-        .rollupIdA(rollupIdA)
-        .rollupCountA(rollupCountA)
-        .rollupDisplayHintsA(rollupDisplayHintsA)
-        .rollupTableB(entityTableB)
-        .rollupIdB(rollupIdB)
-        .rollupCountB(rollupCountB)
-        .rollupDisplayHintsB(rollupDisplayHintsB)
-        .build();
+    return new RelationshipMapping(
+        idPairsIdA, idPairsIdB, rollupInformationMapA, rollupInformationMapB);
   }
 
   public Query queryIdPairs(String idAAlias, String idBAlias) {
-    TableVariable tableVariable = TableVariable.forPrimary(idPairsTable);
+    TableVariable tableVariable = TableVariable.forPrimary(getIdPairsTable());
     FieldVariable idAFieldVar = new FieldVariable(getIdPairsIdA(), tableVariable, idAAlias);
     FieldVariable idBFieldVar = new FieldVariable(getIdPairsIdB(), tableVariable, idBAlias);
     return new Query.Builder()
@@ -197,26 +145,8 @@ public final class RelationshipMapping {
     return (relationship.getEntityA().equals(entity)) ? getIdPairsIdA() : getIdPairsIdB();
   }
 
-  public TablePointer getRollupTable(Entity entity) {
-    return (relationship.getEntityA().equals(entity)) ? getRollupTableA() : getRollupTableB();
-  }
-
-  public FieldPointer getRollupId(Entity entity) {
-    return (relationship.getEntityA().equals(entity)) ? getRollupIdA() : getRollupIdB();
-  }
-
-  public FieldPointer getRollupCount(Entity entity) {
-    return (relationship.getEntityA().equals(entity)) ? getRollupCountA() : getRollupCountB();
-  }
-
-  public FieldPointer getRollupDisplayHints(Entity entity) {
-    return (relationship.getEntityA().equals(entity))
-        ? getRollupDisplayHintsA()
-        : getRollupDisplayHintsB();
-  }
-
   public TablePointer getIdPairsTable() {
-    return idPairsTable;
+    return idPairsIdA.getTablePointer();
   }
 
   public FieldPointer getIdPairsIdA() {
@@ -227,110 +157,25 @@ public final class RelationshipMapping {
     return idPairsIdB;
   }
 
-  public TablePointer getRollupTableA() {
-    return rollupTableA;
+  public RollupInformation getRollupInfo(Entity entity, Hierarchy hierarchy) {
+    return relationship.getEntityA().equals(entity)
+        ? getRollupInfoA(hierarchy)
+        : getRollupInfoB(hierarchy);
   }
 
-  public FieldPointer getRollupIdA() {
-    return rollupIdA;
+  public RollupInformation getRollupInfoA(Hierarchy hierarchy) {
+    return rollupInformationMapA.get(hierarchy == null ? NO_HIERARCHY_KEY : hierarchy.getName());
   }
 
-  public FieldPointer getRollupCountA() {
-    return rollupCountA;
+  public RollupInformation getRollupInfoB(Hierarchy hierarchy) {
+    return rollupInformationMapB.get(hierarchy == null ? NO_HIERARCHY_KEY : hierarchy.getName());
   }
 
-  public FieldPointer getRollupDisplayHintsA() {
-    return rollupDisplayHintsA;
+  public Map<String, RollupInformation> getRollupInformationMapA() {
+    return Collections.unmodifiableMap(rollupInformationMapA);
   }
 
-  public TablePointer getRollupTableB() {
-    return rollupTableB;
-  }
-
-  public FieldPointer getRollupIdB() {
-    return rollupIdB;
-  }
-
-  public FieldPointer getRollupCountB() {
-    return rollupCountB;
-  }
-
-  public FieldPointer getRollupDisplayHintsB() {
-    return rollupDisplayHintsB;
-  }
-
-  public static class Builder {
-    private TablePointer idPairsTable;
-    private FieldPointer idPairsIdA;
-    private FieldPointer idPairsIdB;
-
-    private TablePointer rollupTableA;
-    private FieldPointer rollupIdA;
-    private FieldPointer rollupCountA;
-    private FieldPointer rollupDisplayHintsA;
-
-    private TablePointer rollupTableB;
-    private FieldPointer rollupIdB;
-    private FieldPointer rollupCountB;
-    private FieldPointer rollupDisplayHintsB;
-
-    public Builder idPairsTable(TablePointer idPairsTable) {
-      this.idPairsTable = idPairsTable;
-      return this;
-    }
-
-    public Builder idPairsIdA(FieldPointer idPairsIdA) {
-      this.idPairsIdA = idPairsIdA;
-      return this;
-    }
-
-    public Builder idPairsIdB(FieldPointer idPairsIdB) {
-      this.idPairsIdB = idPairsIdB;
-      return this;
-    }
-
-    public Builder rollupTableA(TablePointer rollupTableA) {
-      this.rollupTableA = rollupTableA;
-      return this;
-    }
-
-    public Builder rollupIdA(FieldPointer rollupIdA) {
-      this.rollupIdA = rollupIdA;
-      return this;
-    }
-
-    public Builder rollupCountA(FieldPointer rollupCountA) {
-      this.rollupCountA = rollupCountA;
-      return this;
-    }
-
-    public Builder rollupDisplayHintsA(FieldPointer rollupDisplayHintsA) {
-      this.rollupDisplayHintsA = rollupDisplayHintsA;
-      return this;
-    }
-
-    public Builder rollupTableB(TablePointer rollupTableB) {
-      this.rollupTableB = rollupTableB;
-      return this;
-    }
-
-    public Builder rollupIdB(FieldPointer rollupIdB) {
-      this.rollupIdB = rollupIdB;
-      return this;
-    }
-
-    public Builder rollupCountB(FieldPointer rollupCountB) {
-      this.rollupCountB = rollupCountB;
-      return this;
-    }
-
-    public Builder rollupDisplayHintsB(FieldPointer rollupDisplayHintsB) {
-      this.rollupDisplayHintsB = rollupDisplayHintsB;
-      return this;
-    }
-
-    public RelationshipMapping build() {
-      return new RelationshipMapping(this);
-    }
+  public Map<String, RollupInformation> getRollupInformationMapB() {
+    return Collections.unmodifiableMap(rollupInformationMapB);
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/RollupInformation.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/RollupInformation.java
@@ -1,0 +1,85 @@
+package bio.terra.tanagra.underlay;
+
+import bio.terra.tanagra.query.FieldPointer;
+import bio.terra.tanagra.query.TablePointer;
+import bio.terra.tanagra.serialization.UFRollupInformation;
+
+public class RollupInformation {
+  private final FieldPointer id;
+  private final FieldPointer count;
+  private final FieldPointer displayHints;
+
+  private Relationship relationship;
+  private Entity entity;
+  private Hierarchy hierarchy;
+
+  public RollupInformation(FieldPointer id, FieldPointer count, FieldPointer displayHints) {
+    this.id = id;
+    this.count = count;
+    this.displayHints = displayHints;
+  }
+
+  public void initialize(Relationship relationship, Entity entity, Hierarchy hierarchy) {
+    this.relationship = relationship;
+    this.entity = entity;
+    this.hierarchy = hierarchy;
+  }
+
+  public static RollupInformation fromSerialized(
+      UFRollupInformation serialized, DataPointer dataPointer) {
+    TablePointer table = TablePointer.fromSerialized(serialized.getTable(), dataPointer);
+    FieldPointer id = FieldPointer.fromSerialized(serialized.getId(), table);
+    FieldPointer count = FieldPointer.fromSerialized(serialized.getCount(), table);
+    FieldPointer displayHints = FieldPointer.fromSerialized(serialized.getDisplayHints(), table);
+    return new RollupInformation(id, count, displayHints);
+  }
+
+  public static RollupInformation defaultIndexMapping(
+      Entity rollupEntity, Entity countedEntity, Hierarchy hierarchy) {
+    FieldPointer id =
+        rollupEntity.getIdAttribute().getMapping(Underlay.MappingType.INDEX).getValue();
+    FieldPointer count =
+        new FieldPointer.Builder()
+            .tablePointer(id.getTablePointer())
+            .columnName(
+                RelationshipField.getFieldAlias(
+                    RelationshipField.Type.COUNT, countedEntity, hierarchy))
+            .build();
+    FieldPointer displayHints =
+        new FieldPointer.Builder()
+            .tablePointer(id.getTablePointer())
+            .columnName(
+                RelationshipField.getFieldAlias(
+                    RelationshipField.Type.DISPLAY_HINTS, countedEntity, hierarchy))
+            .build();
+    return new RollupInformation(id, count, displayHints);
+  }
+
+  public TablePointer getTable() {
+    return id.getTablePointer();
+  }
+
+  public FieldPointer getId() {
+    return id;
+  }
+
+  public FieldPointer getCount() {
+    return count;
+  }
+
+  public FieldPointer getDisplayHints() {
+    return displayHints;
+  }
+
+  public Relationship getRelationship() {
+    return relationship;
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+
+  public Hierarchy getHierarchy() {
+    return hierarchy;
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -98,8 +98,13 @@ public final class Underlay {
               FileIO.getGetFileInputStreamFunction().apply(uiConfigFilePath));
     }
 
-    return new Underlay(
-        serialized.getName(), dataPointers, entities, primaryEntity, entityGroups, uiConfig);
+    Underlay underlay =
+        new Underlay(
+            serialized.getName(), dataPointers, entities, primaryEntity, entityGroups, uiConfig);
+
+    underlay.getEntities().values().stream().forEach(entity -> entity.initialize(underlay));
+
+    return underlay;
   }
 
   public String getName() {

--- a/api/src/main/java/bio/terra/tanagra/underlay/entitygroup/CriteriaOccurrence.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/entitygroup/CriteriaOccurrence.java
@@ -2,34 +2,25 @@ package bio.terra.tanagra.underlay.entitygroup;
 
 import bio.terra.tanagra.indexing.IndexingJob;
 import bio.terra.tanagra.indexing.job.ComputeRollupCounts;
-import bio.terra.tanagra.query.FieldVariable;
-import bio.terra.tanagra.query.Query;
-import bio.terra.tanagra.query.TableVariable;
 import bio.terra.tanagra.serialization.UFEntityGroup;
-import bio.terra.tanagra.underlay.AuxiliaryData;
 import bio.terra.tanagra.underlay.DataPointer;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityGroup;
 import bio.terra.tanagra.underlay.EntityGroupMapping;
 import bio.terra.tanagra.underlay.Relationship;
-import bio.terra.tanagra.underlay.RelationshipMapping;
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.relationshipfield.Count;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class CriteriaOccurrence extends EntityGroup {
   private static final String CRITERIA_ENTITY_NAME = "criteria";
   private static final String OCCURRENCE_ENTITY_NAME = "occurrence";
   private static final String OCCURRENCE_TO_CRITERIA_RELATIONSHIP_NAME = "occurrenceToCriteria";
   private static final String OCCURRENCE_TO_PRIMARY_RELATIONSHIP_NAME = "occurrenceToPrimary";
-
-  private static final String CRITERIA_PRIMARY_ROLLUP_COUNT_AUXILIARY_DATA_NAME =
-      "criteriaPrimaryRollupCount";
-  private static final AuxiliaryData CRITERIA_PRIMARY_ROLLUP_COUNT_AUXILIARY_DATA =
-      new AuxiliaryData(
-          CRITERIA_PRIMARY_ROLLUP_COUNT_AUXILIARY_DATA_NAME, List.of("id", "rollup_count"));
+  private static final String CRITERIA_TO_PRIMARY_RELATIONSHIP_NAME = "criteriaToPrimary";
 
   private final Entity criteriaEntity;
   private final Entity occurrenceEntity;
@@ -57,28 +48,35 @@ public class CriteriaOccurrence extends EntityGroup {
         Map.of(
             OCCURRENCE_TO_CRITERIA_RELATIONSHIP_NAME,
             new Relationship(
-                OCCURRENCE_TO_CRITERIA_RELATIONSHIP_NAME, occurrenceEntity, criteriaEntity),
+                OCCURRENCE_TO_CRITERIA_RELATIONSHIP_NAME,
+                occurrenceEntity,
+                criteriaEntity,
+                List.of(new Count(criteriaEntity))),
             OCCURRENCE_TO_PRIMARY_RELATIONSHIP_NAME,
             new Relationship(
-                OCCURRENCE_TO_PRIMARY_RELATIONSHIP_NAME, occurrenceEntity, primaryEntity));
-
-    // Auxiliary data.
-    Map<String, AuxiliaryData> auxiliaryData =
-        Map.of(
-            CRITERIA_PRIMARY_ROLLUP_COUNT_AUXILIARY_DATA_NAME,
-            CRITERIA_PRIMARY_ROLLUP_COUNT_AUXILIARY_DATA.cloneWithoutMappings());
+                OCCURRENCE_TO_PRIMARY_RELATIONSHIP_NAME,
+                occurrenceEntity,
+                primaryEntity,
+                Collections.emptyList()),
+            CRITERIA_TO_PRIMARY_RELATIONSHIP_NAME,
+            new Relationship(
+                CRITERIA_TO_PRIMARY_RELATIONSHIP_NAME,
+                criteriaEntity,
+                primaryEntity,
+                List.of(new Count(criteriaEntity))));
 
     // Source+index entity group mappings.
     EntityGroupMapping sourceDataMapping =
-        EntityGroupMapping.fromSerialized(serialized.getSourceDataMapping(), dataPointers);
+        EntityGroupMapping.fromSerialized(
+            serialized.getSourceDataMapping(), dataPointers, Underlay.MappingType.SOURCE);
     EntityGroupMapping indexDataMapping =
-        EntityGroupMapping.fromSerialized(serialized.getIndexDataMapping(), dataPointers);
+        EntityGroupMapping.fromSerialized(
+            serialized.getIndexDataMapping(), dataPointers, Underlay.MappingType.INDEX);
 
     Builder builder = new Builder();
     builder
         .name(serialized.getName())
         .relationships(relationships)
-        .auxiliaryData(auxiliaryData)
         .sourceDataMapping(sourceDataMapping)
         .indexDataMapping(indexDataMapping);
     CriteriaOccurrence criteriaOccurrence =
@@ -91,9 +89,8 @@ public class CriteriaOccurrence extends EntityGroup {
     sourceDataMapping.initialize(criteriaOccurrence);
     indexDataMapping.initialize(criteriaOccurrence);
 
-    // Source+index relationship, auxiliary data mappings.
+    // Source+index relationship mappings.
     EntityGroup.deserializeRelationshipMappings(serialized, criteriaOccurrence);
-    EntityGroup.deserializeAuxiliaryDataMappings(serialized, criteriaOccurrence);
 
     return criteriaOccurrence;
   }
@@ -104,20 +101,35 @@ public class CriteriaOccurrence extends EntityGroup {
   }
 
   @Override
-  public Map<String, Entity> getEntities() {
+  public Map<String, Entity> getEntityMap() {
     return ImmutableMap.of(
         CRITERIA_ENTITY_NAME, criteriaEntity, OCCURRENCE_ENTITY_NAME, occurrenceEntity);
   }
 
   @Override
   public List<IndexingJob> getIndexingJobs() {
-    if (criteriaEntity.hasHierarchies()) {
-      return criteriaEntity.getHierarchies().stream()
-          .map(hierarchy -> new ComputeRollupCounts(this, hierarchy.getName()))
-          .collect(Collectors.toList());
-    } else {
-      return List.of(new ComputeRollupCounts(this));
-    }
+    List<IndexingJob> jobs = super.getIndexingJobs();
+
+    // Compute the criteria rollup counts for both the criteria-primary and criteria-occurrence
+    // relationships.
+    jobs.add(new ComputeRollupCounts(criteriaEntity, getCriteriaPrimaryRelationship(), null));
+    jobs.add(new ComputeRollupCounts(criteriaEntity, getOccurrenceCriteriaRelationship(), null));
+
+    // If the criteria entity has a hierarchy, then also compute the counts for each hierarchy.
+    //    if (criteriaEntity.hasHierarchies()) {
+    //      criteriaEntity.getHierarchies().stream()
+    //          .forEach(
+    //              hierarchy -> {
+    //                jobs.add(
+    //                    new ComputeRollupCounts(
+    //                        criteriaEntity, getCriteriaPrimaryRelationship(), hierarchy));
+    //                jobs.add(
+    //                    new ComputeRollupCounts(
+    //                        criteriaEntity, getOccurrenceCriteriaRelationship(), hierarchy));
+    //              });
+    //    }
+
+    return jobs;
   }
 
   public Entity getCriteriaEntity() {
@@ -128,56 +140,12 @@ public class CriteriaOccurrence extends EntityGroup {
     return primaryEntity;
   }
 
-  public AuxiliaryData getCriteriaPrimaryRollupAuxiliaryData() {
-    return getAuxiliaryData().get(CRITERIA_PRIMARY_ROLLUP_COUNT_AUXILIARY_DATA_NAME);
+  public Relationship getCriteriaPrimaryRelationship() {
+    return relationships.get(CRITERIA_TO_PRIMARY_RELATIONSHIP_NAME);
   }
 
-  public Query queryCriteriaPrimaryPairs(String criteriaIdAlias, String primaryIdAlias) {
-    RelationshipMapping occToPriRelationshipMapping =
-        relationships
-            .get(OCCURRENCE_TO_PRIMARY_RELATIONSHIP_NAME)
-            .getMapping(Underlay.MappingType.SOURCE);
-    RelationshipMapping occToCriRelationshipMapping =
-        relationships
-            .get(OCCURRENCE_TO_CRITERIA_RELATIONSHIP_NAME)
-            .getMapping(Underlay.MappingType.SOURCE);
-
-    TableVariable occToPriTableVar =
-        TableVariable.forPrimary(occToPriRelationshipMapping.getTablePointer());
-    FieldVariable priIdFieldVar =
-        new FieldVariable(
-            occToPriRelationshipMapping.getToEntityId(), occToPriTableVar, primaryIdAlias);
-
-    if (occToPriRelationshipMapping
-        .getTablePointer()
-        .equals(occToCriRelationshipMapping.getTablePointer())) {
-      // if the two relationship mappings are in the same table, then just select from a single
-      // table
-      FieldVariable criIdFieldVar =
-          new FieldVariable(
-              occToCriRelationshipMapping.getToEntityId(), occToPriTableVar, criteriaIdAlias);
-      return new Query.Builder()
-          .select(List.of(criIdFieldVar, priIdFieldVar))
-          .tables(List.of(occToPriTableVar))
-          .build();
-    } else {
-      // otherwise, join the two tables
-      // SELECT primaryId, criteriaId FROM occurrencePrimaryTable
-      // JOIN occurrenceCriteriaTable ON occurrenceCriteriaTable.occurrenceId =
-      // occurrencePrimaryTable.occurrenceId
-      TableVariable occToCriTableVar =
-          TableVariable.forJoined(
-              occToCriRelationshipMapping.getTablePointer(),
-              occToCriRelationshipMapping.getFromEntityId().getColumnName(),
-              new FieldVariable(occToPriRelationshipMapping.getFromEntityId(), occToPriTableVar));
-      FieldVariable criIdFieldVar =
-          new FieldVariable(
-              occToCriRelationshipMapping.getToEntityId(), occToCriTableVar, criteriaIdAlias);
-      return new Query.Builder()
-          .select(List.of(criIdFieldVar, priIdFieldVar))
-          .tables(List.of(occToPriTableVar, occToCriTableVar))
-          .build();
-    }
+  public Relationship getOccurrenceCriteriaRelationship() {
+    return relationships.get(OCCURRENCE_TO_CRITERIA_RELATIONSHIP_NAME);
   }
 
   private static class Builder extends EntityGroup.Builder {

--- a/api/src/main/java/bio/terra/tanagra/underlay/entitygroup/GroupItems.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/entitygroup/GroupItems.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.underlay.entitygroup;
 
 import bio.terra.tanagra.serialization.UFEntityGroup;
-import bio.terra.tanagra.underlay.AuxiliaryData;
 import bio.terra.tanagra.underlay.DataPointer;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityGroup;
@@ -41,9 +40,6 @@ public class GroupItems extends EntityGroup {
             new Relationship(
                 GROUP_ITEMS_RELATIONSHIP_NAME, entity1, entityM, Collections.emptyList()));
 
-    // Auxiliary data.
-    Map<String, AuxiliaryData> auxiliaryData = Collections.emptyMap();
-
     // Source+index entity group mappings.
     EntityGroupMapping sourceDataMapping =
         EntityGroupMapping.fromSerialized(
@@ -56,7 +52,6 @@ public class GroupItems extends EntityGroup {
     builder
         .name(serialized.getName())
         .relationships(relationships)
-        .auxiliaryData(auxiliaryData)
         .sourceDataMapping(sourceDataMapping)
         .indexDataMapping(indexDataMapping);
     GroupItems groupItems = builder.groupEntity(entity1).itemsEntity(entityM).build();

--- a/api/src/main/java/bio/terra/tanagra/underlay/entitygroup/GroupItems.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/entitygroup/GroupItems.java
@@ -1,6 +1,5 @@
 package bio.terra.tanagra.underlay.entitygroup;
 
-import bio.terra.tanagra.indexing.IndexingJob;
 import bio.terra.tanagra.serialization.UFEntityGroup;
 import bio.terra.tanagra.underlay.AuxiliaryData;
 import bio.terra.tanagra.underlay.DataPointer;
@@ -8,9 +7,9 @@ import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityGroup;
 import bio.terra.tanagra.underlay.EntityGroupMapping;
 import bio.terra.tanagra.underlay.Relationship;
+import bio.terra.tanagra.underlay.Underlay;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public class GroupItems extends EntityGroup {
@@ -39,16 +38,19 @@ public class GroupItems extends EntityGroup {
     Map<String, Relationship> relationships =
         Map.of(
             GROUP_ITEMS_RELATIONSHIP_NAME,
-            new Relationship(GROUP_ITEMS_RELATIONSHIP_NAME, entity1, entityM));
+            new Relationship(
+                GROUP_ITEMS_RELATIONSHIP_NAME, entity1, entityM, Collections.emptyList()));
 
     // Auxiliary data.
     Map<String, AuxiliaryData> auxiliaryData = Collections.emptyMap();
 
     // Source+index entity group mappings.
     EntityGroupMapping sourceDataMapping =
-        EntityGroupMapping.fromSerialized(serialized.getSourceDataMapping(), dataPointers);
+        EntityGroupMapping.fromSerialized(
+            serialized.getSourceDataMapping(), dataPointers, Underlay.MappingType.SOURCE);
     EntityGroupMapping indexDataMapping =
-        EntityGroupMapping.fromSerialized(serialized.getIndexDataMapping(), dataPointers);
+        EntityGroupMapping.fromSerialized(
+            serialized.getIndexDataMapping(), dataPointers, Underlay.MappingType.INDEX);
 
     Builder builder = new Builder();
     builder
@@ -64,7 +66,6 @@ public class GroupItems extends EntityGroup {
 
     // Source+index relationship, auxiliary data mappings.
     EntityGroup.deserializeRelationshipMappings(serialized, groupItems);
-    EntityGroup.deserializeAuxiliaryDataMappings(serialized, groupItems);
 
     return groupItems;
   }
@@ -75,15 +76,8 @@ public class GroupItems extends EntityGroup {
   }
 
   @Override
-  public Map<String, Entity> getEntities() {
+  public Map<String, Entity> getEntityMap() {
     return ImmutableMap.of(GROUP_ENTITY_NAME, groupEntity, ITEMS_ENTITY_NAME, itemsEntity);
-  }
-
-  @Override
-  public List<IndexingJob> getIndexingJobs() {
-    // TODO: Add a new indexing job to write the group-item id pairs to a separate table, or a new
-    // column in the group denormalized entity instances table.
-    return Collections.emptyList();
   }
 
   private static class Builder extends EntityGroup.Builder {

--- a/api/src/main/java/bio/terra/tanagra/underlay/hierarchyfield/IsMember.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/hierarchyfield/IsMember.java
@@ -28,7 +28,6 @@ public class IsMember extends HierarchyField {
     // Currently, this is a calculated field. IS_MEMBER means path IS NOT NULL.
     FieldPointer pathFieldPointer = hierarchyMapping.getPathField();
 
-    // TODO: Handle the case where the path field is in the same table (i.e. not FK'd).
     return new FieldPointer.Builder()
         .tablePointer(pathFieldPointer.getTablePointer())
         .columnName(pathFieldPointer.getColumnName())

--- a/api/src/main/java/bio/terra/tanagra/underlay/hierarchyfield/IsRoot.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/hierarchyfield/IsRoot.java
@@ -28,7 +28,6 @@ public class IsRoot extends HierarchyField {
     // Currently, this is a calculated field. IS_ROOT means path IS NOT NULL AND path=''.
     FieldPointer pathFieldPointer = hierarchyMapping.getPathField();
 
-    // TODO: Handle the case where the path field is in the same table (i.e. not FK'd).
     return new FieldPointer.Builder()
         .tablePointer(pathFieldPointer.getTablePointer())
         .columnName(pathFieldPointer.getColumnName())

--- a/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/Count.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/Count.java
@@ -1,0 +1,22 @@
+package bio.terra.tanagra.underlay.relationshipfield;
+
+import bio.terra.tanagra.query.CellValue;
+import bio.terra.tanagra.query.ColumnSchema;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.RelationshipField;
+
+public class Count extends RelationshipField {
+  public Count(Entity entity) {
+    super(entity);
+  }
+
+  @Override
+  public Type getType() {
+    return Type.COUNT;
+  }
+
+  @Override
+  public ColumnSchema buildColumnSchema() {
+    return new ColumnSchema(getFieldAlias(getEntity()), CellValue.SQLDataType.INT64);
+  }
+}

--- a/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/Count.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/Count.java
@@ -2,12 +2,21 @@ package bio.terra.tanagra.underlay.relationshipfield;
 
 import bio.terra.tanagra.query.CellValue;
 import bio.terra.tanagra.query.ColumnSchema;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.TableVariable;
 import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.Hierarchy;
 import bio.terra.tanagra.underlay.RelationshipField;
+import bio.terra.tanagra.underlay.RelationshipMapping;
+import java.util.List;
 
 public class Count extends RelationshipField {
   public Count(Entity entity) {
     super(entity);
+  }
+
+  public Count(Entity entity, Hierarchy hierarchy) {
+    super(entity, hierarchy);
   }
 
   @Override
@@ -17,6 +26,17 @@ public class Count extends RelationshipField {
 
   @Override
   public ColumnSchema buildColumnSchema() {
-    return new ColumnSchema(getFieldAlias(getEntity()), CellValue.SQLDataType.INT64);
+    return new ColumnSchema(getFieldAlias(), CellValue.SQLDataType.INT64);
+  }
+
+  @Override
+  public FieldVariable buildFieldVariableFromEntityId(
+      RelationshipMapping relationshipMapping,
+      TableVariable entityTableVar,
+      List<TableVariable> tableVars) {
+    return relationshipMapping
+        .getRollupInfo(getEntity(), getHierarchy())
+        .getCount()
+        .buildVariable(entityTableVar, tableVars, getFieldAlias());
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/DisplayHints.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/DisplayHints.java
@@ -2,12 +2,21 @@ package bio.terra.tanagra.underlay.relationshipfield;
 
 import bio.terra.tanagra.query.CellValue;
 import bio.terra.tanagra.query.ColumnSchema;
+import bio.terra.tanagra.query.FieldVariable;
+import bio.terra.tanagra.query.TableVariable;
 import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.Hierarchy;
 import bio.terra.tanagra.underlay.RelationshipField;
+import bio.terra.tanagra.underlay.RelationshipMapping;
+import java.util.List;
 
 public class DisplayHints extends RelationshipField {
   public DisplayHints(Entity entity) {
     super(entity);
+  }
+
+  public DisplayHints(Entity entity, Hierarchy hierarchy) {
+    super(entity, hierarchy);
   }
 
   @Override
@@ -17,6 +26,17 @@ public class DisplayHints extends RelationshipField {
 
   @Override
   public ColumnSchema buildColumnSchema() {
-    return new ColumnSchema(getFieldAlias(getEntity()), CellValue.SQLDataType.STRING);
+    return new ColumnSchema(getFieldAlias(), CellValue.SQLDataType.STRING);
+  }
+
+  @Override
+  public FieldVariable buildFieldVariableFromEntityId(
+      RelationshipMapping relationshipMapping,
+      TableVariable entityTableVar,
+      List<TableVariable> tableVars) {
+    return relationshipMapping
+        .getRollupInfo(getEntity(), getHierarchy())
+        .getDisplayHints()
+        .buildVariable(entityTableVar, tableVars, getFieldAlias());
   }
 }

--- a/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/DisplayHints.java
+++ b/api/src/main/java/bio/terra/tanagra/underlay/relationshipfield/DisplayHints.java
@@ -1,0 +1,22 @@
+package bio.terra.tanagra.underlay.relationshipfield;
+
+import bio.terra.tanagra.query.CellValue;
+import bio.terra.tanagra.query.ColumnSchema;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.RelationshipField;
+
+public class DisplayHints extends RelationshipField {
+  public DisplayHints(Entity entity) {
+    super(entity);
+  }
+
+  @Override
+  public Type getType() {
+    return Type.DISPLAY_HINTS;
+  }
+
+  @Override
+  public ColumnSchema buildColumnSchema() {
+    return new ColumnSchema(getFieldAlias(getEntity()), CellValue.SQLDataType.STRING);
+  }
+}

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -1204,6 +1204,22 @@ components:
               items:
                 type: string
                 enum: ["IS_MEMBER", "PATH", "NUM_CHILDREN", "IS_ROOT"]
+        includeRelationshipFields:
+          description: Relationship fields to include in the returned instances.
+          type: array
+          items:
+            type: object
+            description: Related entity and optional hierarchy
+            properties:
+              relatedEntity:
+                type: string
+              hierarchy:
+                type: string
+              fields:
+                type: array
+                items:
+                  type: string
+                  enum: ["COUNT", "DISPLAY_HINTS"]
         filter:
           $ref: "#/components/schemas/FilterV2"
         orderBy:
@@ -1348,6 +1364,20 @@ components:
                 type: integer
               isRoot:
                 type: boolean
+        relationshipFields:
+          description: Relationship field values for this instance. Only the values requested are populated.
+          type: array
+          items:
+            type: object
+            properties:
+              relatedEntity:
+                type: string
+              hierarchy:
+                type: string
+              count:
+                type: integer
+              displayHints:
+                type: string
 
     InstanceListV2:
       type: object

--- a/api/src/main/resources/api/service_openapi.yaml
+++ b/api/src/main/resources/api/service_openapi.yaml
@@ -1209,12 +1209,15 @@ components:
           type: array
           items:
             type: object
-            description: Related entity and optional hierarchy
+            description: Related entity and optional hierarchies. Per-node rollups are always returned.
             properties:
               relatedEntity:
                 type: string
-              hierarchy:
-                type: string
+              hierarchies:
+                type: array
+                description: Hierarchy names
+                items:
+                  type: string
               fields:
                 type: array
                 items:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -18,4 +18,4 @@ tanagra:
   underlay:
     # TODO(tjennison): Split these for different environments.
     underlay-yaml-files: ["underlays/aou_synthetic.yaml", "underlays/synpuf.yaml", "underlays/sd.yaml", "underlays/test/aou_synthetic.yaml"]
-    underlay-files: [ "broad/cms_synpuf/expanded/cms_synpuf.json" ] # "broad/aou_synthetic/expanded/aou_synthetic.json",
+    underlay-files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json" ]

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -18,4 +18,4 @@ tanagra:
   underlay:
     # TODO(tjennison): Split these for different environments.
     underlay-yaml-files: ["underlays/aou_synthetic.yaml", "underlays/synpuf.yaml", "underlays/sd.yaml", "underlays/test/aou_synthetic.yaml"]
-    underlay-files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json" ]
+    underlay-files: [ "broad/cms_synpuf/expanded/cms_synpuf.json" ] # "broad/aou_synthetic/expanded/aou_synthetic.json",

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/brand_ingredient.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/brand_ingredient.json
@@ -9,34 +9,80 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "groupToItems" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "concept_relationship"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "concept_id_1"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "concept_id_2"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
-    },
-    "auxiliaryDataMappings" : { }
+    }
   },
   "indexDataMapping" : {
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "groupToItems" : {
-        "tablePointer" : {
-          "table" : "concept_relationship"
+        "idPairsTable" : {
+          "table" : "idpairs_brand_ingredient"
         },
-        "fromEntityId" : {
-          "column" : "concept_id_1"
+        "idPairsIdA" : {
+          "column" : "id_brand"
         },
-        "toEntityId" : {
-          "column" : "concept_id_2"
+        "idPairsIdB" : {
+          "column" : "id_ingredient"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "brand"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_brand_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_brand_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_brand"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_brand"
+            }
+          }
         }
       }
-    },
-    "auxiliaryDataMappings" : { }
+    }
   }
 }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/condition_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/condition_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "condition_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "condition_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "condition_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "condition_occurrence"
+        },
+        "idPairsIdA" : {
+          "column" : "condition_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "condition_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "condition_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "condition_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "condition_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_condition_occurrence_condition"
         },
-        "fromEntityId" : {
-          "column" : "condition_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_condition_occurrence"
         },
-        "toEntityId" : {
-          "column" : "condition_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_condition"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_condition_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_condition"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "condition_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_condition_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "condition_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_condition_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "condition_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/device_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/device_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "device_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "device_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "device_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "device_exposure"
+        },
+        "idPairsIdA" : {
+          "column" : "device_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "device_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "device_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "device_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,131 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "device_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_device_occurrence_device"
         },
-        "fromEntityId" : {
-          "column" : "device_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_device_occurrence"
         },
-        "toEntityId" : {
-          "column" : "device_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_device"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_device_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_device"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "device_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_device_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "device_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_device_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "device_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/ingredient_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/ingredient_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "drug_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "drug_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "drug_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "drug_exposure"
+        },
+        "idPairsIdA" : {
+          "column" : "drug_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "drug_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "drug_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "ingredient_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "drug_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_ingredient_occurrence_ingredient"
         },
-        "fromEntityId" : {
-          "column" : "drug_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_ingredient_occurrence"
         },
-        "toEntityId" : {
-          "column" : "drug_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_ingredient"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_ingredient_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_ingredient"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "drug_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_ingredient_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "drug_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_ingredient_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "ingredient_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/measurement_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/measurement_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "measurement"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "measurement_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "measurement_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "measurement"
+        },
+        "idPairsIdA" : {
+          "column" : "measurement_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "measurement"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "measurement_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "measurement_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "measurement"
+        "idPairsTable" : {
+          "table" : "idpairs_measurement_occurrence_measurement"
         },
-        "fromEntityId" : {
-          "column" : "measurement_id"
+        "idPairsIdA" : {
+          "column" : "id_measurement_occurrence"
         },
-        "toEntityId" : {
-          "column" : "measurement_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_measurement"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "measurement_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_measurement"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_measurement"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "measurement"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_measurement_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_measurement_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "measurement"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_measurement_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_measurement_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_measurement_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_measurement"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "measurement"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "measurement"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_measurement"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_measurement"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "measurement"
+        "idPairsTable" : {
+          "table" : "idpairs_measurement_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "measurement_id"
+        "idPairsIdA" : {
+          "column" : "id_measurement_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "measurement_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "measurement_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_measurement_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_measurement_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/observation_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/observation_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "observation"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "observation_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "observation_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "observation"
+        },
+        "idPairsIdA" : {
+          "column" : "observation_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "observation"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "observation_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "observation_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,131 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "observation"
+        "idPairsTable" : {
+          "table" : "idpairs_observation_occurrence_observation"
         },
-        "fromEntityId" : {
-          "column" : "observation_id"
+        "idPairsIdA" : {
+          "column" : "id_observation_occurrence"
         },
-        "toEntityId" : {
-          "column" : "observation_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_observation"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_observation_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_observation"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "observation"
+        "idPairsTable" : {
+          "table" : "idpairs_observation_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "observation_id"
+        "idPairsIdA" : {
+          "column" : "id_observation_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "observation_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/procedure_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/procedure_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "procedure_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "procedure_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "procedure_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "procedure_occurrence"
+        },
+        "idPairsIdA" : {
+          "column" : "procedure_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "procedure_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "procedure_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "procedure_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "procedure_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_procedure_occurrence_procedure"
         },
-        "fromEntityId" : {
-          "column" : "procedure_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_procedure_occurrence"
         },
-        "toEntityId" : {
-          "column" : "procedure_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_procedure"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_procedure_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_procedure"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "procedure_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_procedure_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "procedure_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_procedure_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "procedure_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/visit_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/expanded/entitygroup/visit_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "visit_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "visit_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "visit_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "visit_occurrence"
+        },
+        "idPairsIdA" : {
+          "column" : "visit_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "visit_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "visit_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "visit_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,131 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "visit_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_visit_occurrence_visit"
         },
-        "fromEntityId" : {
-          "column" : "visit_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_visit_occurrence"
         },
-        "toEntityId" : {
-          "column" : "visit_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_visit"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "visit_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_visit"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_visit"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "visit"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_visit_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_visit_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_visit_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_visit"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "visit"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_visit"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_visit"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "visit_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_visit_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "visit_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_visit_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "visit_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "visit_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_visit_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_visit_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/brand_ingredient.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/brand_ingredient.json
@@ -9,9 +9,9 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "groupToItems": {
-        "tablePointer": { "table": "concept_relationship" },
-        "fromEntityId": { "column": "concept_id_1" },
-        "toEntityId":  { "column": "concept_id_2" }
+        "idPairsTable": { "table": "concept_relationship" },
+        "idPairsIdA": { "column": "concept_id_1" },
+        "idPairsIdB":  { "column": "concept_id_2" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/condition_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/condition_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "condition_occurrence" },
-        "fromEntityId": { "column": "condition_occurrence_id" },
-        "toEntityId":  { "column": "condition_concept_id" }
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_occurrence_id" },
+        "idPairsIdB":  { "column": "condition_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "condition_occurrence" },
-        "fromEntityId": { "column": "condition_occurrence_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_occurrence_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/device_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/device_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "device_exposure" },
-        "fromEntityId": { "column": "device_exposure_id" },
-        "toEntityId":  { "column": "device_concept_id" }
+        "idPairsTable": { "table": "device_exposure" },
+        "idPairsIdA": { "column": "device_exposure_id" },
+        "idPairsIdB":  { "column": "device_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "device_exposure" },
-        "fromEntityId": { "column": "device_exposure_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "device_exposure" },
+        "idPairsIdA": { "column": "device_exposure_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "device_exposure" },
+        "idPairsIdA": { "column": "device_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/ingredient_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/ingredient_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "drug_exposure" },
-        "fromEntityId": { "column": "drug_exposure_id" },
-        "toEntityId":  { "column": "drug_concept_id" }
+        "idPairsTable": { "table": "drug_exposure" },
+        "idPairsIdA": { "column": "drug_exposure_id" },
+        "idPairsIdB":  { "column": "drug_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "drug_exposure" },
-        "fromEntityId": { "column": "drug_exposure_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "drug_exposure" },
+        "idPairsIdA": { "column": "drug_exposure_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "drug_exposure" },
+        "idPairsIdA": { "column": "drug_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/measurement_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/measurement_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "measurement" },
-        "fromEntityId": { "column": "measurement_id" },
-        "toEntityId":  { "column": "measurement_concept_id" }
+        "idPairsTable": { "table": "measurement" },
+        "idPairsIdA": { "column": "measurement_id" },
+        "idPairsIdB":  { "column": "measurement_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "measurement" },
-        "fromEntityId": { "column": "measurement_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "measurement" },
+        "idPairsIdA": { "column": "measurement_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "measurement" },
+        "idPairsIdA": { "column": "measurement_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/observation_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/observation_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "observation" },
-        "fromEntityId": { "column": "observation_id" },
-        "toEntityId":  { "column": "observation_concept_id" }
+        "idPairsTable": { "table": "observation" },
+        "idPairsIdA": { "column": "observation_id" },
+        "idPairsIdB":  { "column": "observation_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "observation" },
-        "fromEntityId": { "column": "observation_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "observation" },
+        "idPairsIdA": { "column": "observation_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "observation" },
+        "idPairsIdA": { "column": "observation_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/procedure_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/procedure_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "procedure_occurrence" },
-        "fromEntityId": { "column": "procedure_occurrence_id" },
-        "toEntityId":  { "column": "procedure_concept_id" }
+        "idPairsTable": { "table": "procedure_occurrence" },
+        "idPairsIdA": { "column": "procedure_occurrence_id" },
+        "idPairsIdB":  { "column": "procedure_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "procedure_occurrence" },
-        "fromEntityId": { "column": "procedure_occurrence_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "procedure_occurrence" },
+        "idPairsIdA": { "column": "procedure_occurrence_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "procedure_occurrence" },
+        "idPairsIdA": { "column": "procedure_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/visit_person_occurrence.json
+++ b/api/src/main/resources/config/broad/aou_synthetic/original/entitygroup/visit_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "visit_occurrence" },
-        "fromEntityId": { "column": "visit_occurrence_id" },
-        "toEntityId":  { "column": "visit_concept_id" }
+        "idPairsTable": { "table": "visit_occurrence" },
+        "idPairsIdA": { "column": "visit_occurrence_id" },
+        "idPairsIdB":  { "column": "visit_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "visit_occurrence" },
-        "fromEntityId": { "column": "visit_occurrence_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "visit_occurrence" },
+        "idPairsIdA": { "column": "visit_occurrence_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "visit_occurrence" },
+        "idPairsIdA": { "column": "visit_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/brand_ingredient.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/brand_ingredient.json
@@ -9,34 +9,80 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "groupToItems" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "concept_relationship"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "concept_id_1"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "concept_id_2"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
-    },
-    "auxiliaryDataMappings" : { }
+    }
   },
   "indexDataMapping" : {
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "groupToItems" : {
-        "tablePointer" : {
-          "table" : "concept_relationship"
+        "idPairsTable" : {
+          "table" : "idpairs_brand_ingredient"
         },
-        "fromEntityId" : {
-          "column" : "concept_id_1"
+        "idPairsIdA" : {
+          "column" : "id_brand"
         },
-        "toEntityId" : {
-          "column" : "concept_id_2"
+        "idPairsIdB" : {
+          "column" : "id_ingredient"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "brand"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_brand_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_brand_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_brand"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_brand"
+            }
+          }
         }
       }
-    },
-    "auxiliaryDataMappings" : { }
+    }
   }
 }

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/condition_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/condition_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "condition_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "condition_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "condition_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "condition_occurrence"
+        },
+        "idPairsIdA" : {
+          "column" : "condition_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "condition_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "condition_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "condition_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "condition_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_condition_occurrence_condition"
         },
-        "fromEntityId" : {
-          "column" : "condition_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_condition_occurrence"
         },
-        "toEntityId" : {
-          "column" : "condition_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_condition"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_condition_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_condition"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "condition_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_condition_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "condition_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_condition_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "condition_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "condition_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_condition_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_condition_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/device_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/device_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "device_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "device_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "device_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "device_exposure"
+        },
+        "idPairsIdA" : {
+          "column" : "device_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "device_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "device_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "device_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,131 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "device_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_device_occurrence_device"
         },
-        "fromEntityId" : {
-          "column" : "device_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_device_occurrence"
         },
-        "toEntityId" : {
-          "column" : "device_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_device"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_device_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_device"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "device_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_device_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "device_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_device_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "device_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "device_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_device_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_device_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/ingredient_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/ingredient_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "drug_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "drug_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "drug_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "drug_exposure"
+        },
+        "idPairsIdA" : {
+          "column" : "drug_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "drug_exposure"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "drug_exposure_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "ingredient_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "drug_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_ingredient_occurrence_ingredient"
         },
-        "fromEntityId" : {
-          "column" : "drug_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_ingredient_occurrence"
         },
-        "toEntityId" : {
-          "column" : "drug_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_ingredient"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_ingredient_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_ingredient"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "drug_exposure"
+        "idPairsTable" : {
+          "table" : "idpairs_ingredient_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "drug_exposure_id"
+        "idPairsIdA" : {
+          "column" : "id_ingredient_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "ingredient_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "ingredient_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_ingredient_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_ingredient_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/observation_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/observation_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "observation"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "observation_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "observation_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "observation"
+        },
+        "idPairsIdA" : {
+          "column" : "observation_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "observation"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "observation_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "observation_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,131 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "observation"
+        "idPairsTable" : {
+          "table" : "idpairs_observation_occurrence_observation"
         },
-        "fromEntityId" : {
-          "column" : "observation_id"
+        "idPairsIdA" : {
+          "column" : "id_observation_occurrence"
         },
-        "toEntityId" : {
-          "column" : "observation_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_observation"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_observation_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_observation"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "observation"
+        "idPairsTable" : {
+          "table" : "idpairs_observation_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "observation_id"
+        "idPairsIdA" : {
+          "column" : "id_observation_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "observation_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "observation_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_observation_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_observation_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/procedure_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/expanded/entitygroup/procedure_person_occurrence.json
@@ -9,41 +9,43 @@
     "dataPointer" : "omop_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "procedure_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "procedure_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "procedure_concept_id"
-        }
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "procedure_occurrence"
+        },
+        "idPairsIdA" : {
+          "column" : "procedure_concept_id"
+        },
+        "idPairsIdB" : {
+          "column" : "person_id"
+        },
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
+        "idPairsTable" : {
           "table" : "procedure_occurrence"
         },
-        "fromEntityId" : {
+        "idPairsIdA" : {
           "column" : "procedure_occurrence_id"
         },
-        "toEntityId" : {
+        "idPairsIdB" : {
           "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "procedure_person_occurrence_criteriaPrimaryRollupCount"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
-          }
-        }
+        "rollupInformationMapA" : { },
+        "rollupInformationMapB" : { }
       }
     }
   },
@@ -51,39 +53,159 @@
     "dataPointer" : "index_dataset",
     "relationshipMappings" : {
       "occurrenceToCriteria" : {
-        "tablePointer" : {
-          "table" : "procedure_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_procedure_occurrence_procedure"
         },
-        "fromEntityId" : {
-          "column" : "procedure_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_procedure_occurrence"
         },
-        "toEntityId" : {
-          "column" : "procedure_concept_id"
+        "idPairsIdB" : {
+          "column" : "id_procedure"
+        },
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "standard" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure_occurrence_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure_occurrence_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure_occurrence"
+            }
+          }
+        }
+      },
+      "criteriaToPrimary" : {
+        "idPairsTable" : {
+          "table" : "idpairs_procedure_person"
+        },
+        "idPairsIdA" : {
+          "column" : "id_procedure"
+        },
+        "idPairsIdB" : {
+          "column" : "id_person"
+        },
+        "rollupInformationMapA" : {
+          "standard" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person_standard"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person_standard"
+            }
+          },
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure"
+            }
+          }
         }
       },
       "occurrenceToPrimary" : {
-        "tablePointer" : {
-          "table" : "procedure_occurrence"
+        "idPairsTable" : {
+          "table" : "idpairs_procedure_occurrence_person"
         },
-        "fromEntityId" : {
-          "column" : "procedure_occurrence_id"
+        "idPairsIdA" : {
+          "column" : "id_procedure_occurrence"
         },
-        "toEntityId" : {
-          "column" : "person_id"
-        }
-      }
-    },
-    "auxiliaryDataMappings" : {
-      "criteriaPrimaryRollupCount" : {
-        "tablePointer" : {
-          "table" : "procedure_person_occurrence_criteriaPrimaryRollupCount"
+        "idPairsIdB" : {
+          "column" : "id_person"
         },
-        "fieldPointers" : {
-          "id" : {
-            "column" : "id"
-          },
-          "rollup_count" : {
-            "column" : "rollup_count"
+        "rollupInformationMapA" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "procedure_occurrence"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_person"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_person"
+            }
+          }
+        },
+        "rollupInformationMapB" : {
+          "NO_HIERARCHY" : {
+            "table" : {
+              "table" : "person"
+            },
+            "id" : {
+              "column" : "id"
+            },
+            "count" : {
+              "column" : "t_count_procedure_occurrence"
+            },
+            "displayHints" : {
+              "column" : "t_displayhints_procedure_occurrence"
+            }
           }
         }
       }

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/brand_ingredient.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/brand_ingredient.json
@@ -9,9 +9,9 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "groupToItems": {
-        "tablePointer": { "table": "concept_relationship" },
-        "fromEntityId": { "column": "concept_id_1" },
-        "toEntityId":  { "column": "concept_id_2" }
+        "idPairsTable": { "table": "concept_relationship" },
+        "idPairsIdA": { "column": "concept_id_1" },
+        "idPairsIdB":  { "column": "concept_id_2" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/condition_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/condition_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "condition_occurrence" },
-        "fromEntityId": { "column": "condition_occurrence_id" },
-        "toEntityId":  { "column": "condition_concept_id" }
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_occurrence_id" },
+        "idPairsIdB":  { "column": "condition_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "condition_occurrence" },
-        "fromEntityId": { "column": "condition_occurrence_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_occurrence_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/device_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/device_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "device_exposure" },
-        "fromEntityId": { "column": "device_exposure_id" },
-        "toEntityId":  { "column": "device_concept_id" }
+        "idPairsTable": { "table": "device_exposure" },
+        "idPairsIdA": { "column": "device_exposure_id" },
+        "idPairsIdB":  { "column": "device_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "device_exposure" },
-        "fromEntityId": { "column": "device_exposure_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "device_exposure" },
+        "idPairsIdA": { "column": "device_exposure_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "device_exposure" },
+        "idPairsIdA": { "column": "device_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/ingredient_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/ingredient_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "drug_exposure" },
-        "fromEntityId": { "column": "drug_exposure_id" },
-        "toEntityId":  { "column": "drug_concept_id" }
+        "idPairsTable": { "table": "drug_exposure" },
+        "idPairsIdA": { "column": "drug_exposure_id" },
+        "idPairsIdB":  { "column": "drug_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "drug_exposure" },
-        "fromEntityId": { "column": "drug_exposure_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "drug_exposure" },
+        "idPairsIdA": { "column": "drug_exposure_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "drug_exposure" },
+        "idPairsIdA": { "column": "drug_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/observation_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/observation_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "observation" },
-        "fromEntityId": { "column": "observation_id" },
-        "toEntityId":  { "column": "observation_concept_id" }
+        "idPairsTable": { "table": "observation" },
+        "idPairsIdA": { "column": "observation_id" },
+        "idPairsIdB":  { "column": "observation_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "observation" },
-        "fromEntityId": { "column": "observation_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "observation" },
+        "idPairsIdA": { "column": "observation_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "observation" },
+        "idPairsIdA": { "column": "observation_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/procedure_person_occurrence.json
+++ b/api/src/main/resources/config/broad/cms_synpuf/original/entitygroup/procedure_person_occurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "procedure_occurrence" },
-        "fromEntityId": { "column": "procedure_occurrence_id" },
-        "toEntityId":  { "column": "procedure_concept_id" }
+        "idPairsTable": { "table": "procedure_occurrence" },
+        "idPairsIdA": { "column": "procedure_occurrence_id" },
+        "idPairsIdB":  { "column": "procedure_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "procedure_occurrence" },
-        "fromEntityId": { "column": "procedure_occurrence_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "procedure_occurrence" },
+        "idPairsIdA": { "column": "procedure_occurrence_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "procedure_occurrence" },
+        "idPairsIdA": { "column": "procedure_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },

--- a/api/src/test/java/bio/terra/tanagra/indexing/command/IndexEntityGroupTest.java
+++ b/api/src/test/java/bio/terra/tanagra/indexing/command/IndexEntityGroupTest.java
@@ -1,11 +1,9 @@
 package bio.terra.tanagra.indexing.command;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.indexing.FileIO;
 import bio.terra.tanagra.indexing.IndexingJob;
-import bio.terra.tanagra.indexing.job.ComputeRollupCounts;
 import bio.terra.tanagra.underlay.DataPointer;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityGroup;
@@ -14,7 +12,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +36,8 @@ public class IndexEntityGroupTest {
         EntityGroup.fromJSON("BrandIngredient.json", dataPointers, entities, primaryEntityName);
     List<IndexingJob> jobs = brandIngredient.getIndexingJobs();
 
-    assertEquals(0, jobs.size(), "no indexing jobs generated");
+    // copy relationship id pairs
+    assertEquals(1, jobs.size());
   }
 
   @Test
@@ -49,13 +47,9 @@ public class IndexEntityGroupTest {
             "ConditionPersonOccurrence.json", dataPointers, entities, primaryEntityName);
     List<IndexingJob> jobs = conditionPersonOccurrence.getIndexingJobs();
 
-    assertEquals(1, jobs.size(), "one indexing job generated");
-
-    Optional<IndexingJob> computeRollupCounts =
-        jobs.stream().filter(job -> job.getClass().equals(ComputeRollupCounts.class)).findFirst();
-    assertTrue(computeRollupCounts.isPresent(), "ComputeRollupCounts indexing job generated");
-    assertEquals(
-        "broad-tanagra-dev:aou_synthetic_SR2019q4r4_indexes.condition_person_occurrence_criteriaPrimaryRollupCount",
-        ((ComputeRollupCounts) computeRollupCounts.get()).getTempTable().getPathForIndexing());
+    // copy relationship id pairs (x3 relationships)
+    // compute rollup counts (x2 relationships)
+    // compute rollup counts with hierarchy (x2 relationships)
+    assertEquals(7, jobs.size());
   }
 }

--- a/api/src/test/resources/config/entitygroup/BrandIngredient.json
+++ b/api/src/test/resources/config/entitygroup/BrandIngredient.json
@@ -9,9 +9,9 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "groupToItems": {
-        "tablePointer": { "table": "concept_relationship" },
-        "fromEntityId": { "column": "concept_id_1" },
-        "toEntityId":  { "column": "concept_id_2" }
+        "idPairsTable": { "table": "concept_relationship" },
+        "idPairsIdA": { "column": "concept_id_1" },
+        "idPairsIdB":  { "column": "concept_id_2" }
       }
     }
   },

--- a/api/src/test/resources/config/entitygroup/ConditionPersonOccurrence.json
+++ b/api/src/test/resources/config/entitygroup/ConditionPersonOccurrence.json
@@ -9,14 +9,19 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "occurrenceToCriteria": {
-        "tablePointer": { "table": "condition_occurrence" },
-        "fromEntityId": { "column": "condition_occurrence_id" },
-        "toEntityId":  { "column": "condition_concept_id" }
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_occurrence_id" },
+        "idPairsIdB":  { "column": "condition_concept_id" }
       },
       "occurrenceToPrimary": {
-        "tablePointer": { "table": "condition_occurrence" },
-        "fromEntityId": { "column": "condition_occurrence_id" },
-        "toEntityId":  { "column": "person_id" }
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_occurrence_id" },
+        "idPairsIdB":  { "column": "person_id" }
+      },
+      "criteriaToPrimary": {
+        "idPairsTable": { "table": "condition_occurrence" },
+        "idPairsIdA": { "column": "condition_concept_id" },
+        "idPairsIdB":  { "column": "person_id" }
       }
     }
   },


### PR DESCRIPTION
- Added a `RelationshipField` class similar to the `HierarchyField`. There are two types: `COUNT` AND `DISPLAY_HINTS`. Currently, only `COUNT` is populated with a valid number. `DISPLAY_HINTS` always returns a placeholder JSON string. This will be swapped for a map of objects in a follow-on PR.
- Wrote a new indexing job to copy the id pairs for every relationship over to a new table in the index dataset. Previously, we were joining against the source dataset for relationship filters. Now all queries only touch the index dataset.
- Updated the indexing job that computes rollup counts to copy the counts over to the entity table, so we don't have to join against a separate table every time.
- Removed the `AuxiliaryData` schema from relationship mappings in the underlay config files. Replaced it with a new `RollupInformation` schema to hold rollup count/display_hints field pointers for a relationship. I'm planning to make a similar change for the hierarchy mappings, and remove `AuxiliaryData` altogether, but will tackle that in a later PR.
- Added more indexing jobs for each entity group. Now we calculate rollup counts for the criteria-primary and criteria-occurrence relationships, for each criteria hierarchy. In the future, we should probably just calculate all possible rollup counts for every relationship, but since we're not using those fields now in the UI, I left them out for now so our indexing doesn't take longer.
- Updated all the config files for the `aou_synthetic` and `cms_synpuf` underlays and re-ran the indexing jobs for both.
- Wrapped each indexing job with a try/catch, so we do a best effort at running all the indexing jobs rather than quitting at the first failure.