### PR TITLE
Refactor ActionBar to be more customizable

### DIFF
--- a/ui/src/actionBar.tsx
+++ b/ui/src/actionBar.tsx
@@ -5,12 +5,12 @@ import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import { useAppSelector } from "hooks";
-import { useEffect, useState } from "react";
-import { Link as RouterLink, useLocation, useParams } from "react-router-dom";
-import UndoRedo from "./components/UndoRedo";
+import { Link as RouterLink, useParams } from "react-router-dom";
 
 type ActionBarProps = {
   title: string;
+  backURL?: string | null; // null hides the back button.
+  extraControls?: JSX.Element;
 };
 
 export default function ActionBar(props: ActionBarProps) {
@@ -18,11 +18,6 @@ export default function ActionBar(props: ActionBarProps) {
   const underlay = useAppSelector((state) =>
     state.present.underlays.find((underlay) => underlay.name === underlayName)
   );
-
-  const location = useLocation();
-
-  const [backURL, set] = useState<string>();
-  setBackURL = set;
 
   return (
     <Box className="action-bar">
@@ -40,9 +35,9 @@ export default function ActionBar(props: ActionBarProps) {
             color="inherit"
             aria-label="back"
             component={RouterLink}
-            to={backURL ?? ".."}
+            to={props.backURL ?? ".."}
             sx={{
-              visibility: location.pathname === "/" ? "hidden" : "visible",
+              visibility: props.backURL === null ? "hidden" : "visible",
             }}
           >
             <ArrowBackIcon />
@@ -58,7 +53,7 @@ export default function ActionBar(props: ActionBarProps) {
           >
             {props.title}
           </Typography>
-          <UndoRedo />
+          {props.extraControls}
           {underlay ? (
             <Typography variant="h4" className="underlay-name">
               Dataset: {underlay.name}
@@ -68,25 +63,4 @@ export default function ActionBar(props: ActionBarProps) {
       </AppBar>
     </Box>
   );
-}
-
-let setBackURL: ((url?: string) => void) | undefined;
-
-// TODO(tjennison): Migrate to a React context based implementation that also
-// allows the title to be configured and removes the duplicate copies of the
-// ActionBar.
-export function useActionBarBackURL(url?: string) {
-  useEffect(() => {
-    if (!setBackURL) {
-      return;
-    }
-
-    setBackURL(url);
-
-    return () => {
-      if (setBackURL) {
-        setBackURL(undefined);
-      }
-    };
-  }, [url]);
 }

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -14,6 +14,7 @@ import {
   TreeGridId,
   TreeGridItem,
 } from "components/treegrid";
+import UndoRedo from "components/UndoRedo";
 import { DataEntry, DataKey } from "data/configuration";
 import { MergedDataEntry, useSource } from "data/source";
 import { useAsyncWithApi } from "errors";
@@ -145,7 +146,7 @@ export function AddCriteria() {
       }}
     >
       <Search placeholder="Search criteria or select from the options below" />
-      <ActionBar title={"Add criteria"} />
+      <ActionBar title={"Add criteria"} extraControls={<UndoRedo />} />
       {showResults ? (
         <Loading status={searchState}>
           {!data.root?.children?.length ? (

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import { EntitiesApiContext, UnderlaysApiContext } from "apiContext";
@@ -62,7 +63,28 @@ export default function App() {
       <CssBaseline />
       <Loading status={underlaysState}>
         <HashRouter>
-          <AppRouter />
+          <Box
+            sx={{
+              display: "grid",
+              width: "100%",
+              height: "100%",
+              gridTemplateColumns: "1fr",
+              gridTemplateRows: (theme) => `${theme.spacing(6)} 1fr`,
+              gridTemplateAreas: "'actionBar' 'content'",
+            }}
+          >
+            <Box
+              sx={{
+                gridArea: "content",
+                width: "100%",
+                minWidth: "100%",
+                height: "100%",
+                minHeight: "100%",
+              }}
+            >
+              <AppRouter />
+            </Box>
+          </Box>
         </HashRouter>
       </Loading>
     </ThemeProvider>

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -60,7 +60,7 @@ export function groupFilterKindLabel(kind: tanagra.GroupFilterKindEnum) {
 export interface CriteriaPlugin<DataType> {
   id: string;
   data: DataType;
-  renderEdit?: () => JSX.Element;
+  renderEdit?: (setBackURL: (url?: string) => void) => JSX.Element;
   renderInline: (criteriaId: string) => JSX.Element;
   displayDetails: () => DisplayDetails;
   generateFilter: () => Filter | null;

--- a/ui/src/conceptSetEdit.tsx
+++ b/ui/src/conceptSetEdit.tsx
@@ -1,18 +1,15 @@
-import Toolbar from "@mui/material/Toolbar";
-import ActionBar from "actionBar";
 import { getCriteriaPlugin, getCriteriaTitle } from "cohort";
+import CriteriaHolder from "criteriaHolder";
 import { useConceptSet } from "hooks";
-import React from "react";
 
 export default function Edit() {
   const conceptSet = useConceptSet();
   const plugin = getCriteriaPlugin(conceptSet.criteria);
 
   return (
-    <>
-      <ActionBar title={getCriteriaTitle(conceptSet.criteria, plugin)} />
-      <Toolbar />
-      {plugin.renderEdit?.()}
-    </>
+    <CriteriaHolder
+      title={getCriteriaTitle(conceptSet.criteria, plugin)}
+      plugin={plugin}
+    />
   );
 }

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -2,7 +2,6 @@ import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
-import { useActionBarBackURL } from "actionBar";
 import { CriteriaPlugin, registerCriteriaPlugin } from "cohort";
 import Checkbox from "components/checkbox";
 import Empty from "components/empty";
@@ -88,8 +87,14 @@ class _ implements CriteriaPlugin<Data> {
     this.data = data as Data;
   }
 
-  renderEdit() {
-    return <ClassificationEdit data={this.data} config={this.config} />;
+  renderEdit(setBackURL: (url?: string) => void) {
+    return (
+      <ClassificationEdit
+        data={this.data}
+        config={this.config}
+        setBackURL={setBackURL}
+      />
+    );
   }
 
   renderInline() {
@@ -168,6 +173,7 @@ function searchParamsFromData(data?: SearchData) {
 type ClassificationEditProps = {
   data: Data;
   config: Config;
+  setBackURL: (url?: string) => void;
 };
 
 function ClassificationEdit(props: ClassificationEditProps) {
@@ -183,7 +189,7 @@ function ClassificationEdit(props: ClassificationEditProps) {
   const [searchData, updateSearchData] = useSearchData();
   const [data, updateData] = useImmer<TreeGridData>({});
 
-  useActionBarBackURL(
+  props.setBackURL(
     searchData.hierarchy
       ? `.?${searchParamsFromData({ query: searchData.query })}`
       : undefined

--- a/ui/src/criteriaHolder.tsx
+++ b/ui/src/criteriaHolder.tsx
@@ -1,0 +1,25 @@
+import ActionBar from "actionBar";
+import { CriteriaPlugin } from "cohort";
+import UndoRedo from "components/UndoRedo";
+import { useState } from "react";
+
+export type CriteriaHolderProps = {
+  title: string;
+  plugin: CriteriaPlugin<object>;
+  showUndoRedo?: boolean;
+};
+
+export default function CriteriaHolder(props: CriteriaHolderProps) {
+  const [backURL, setBackURL] = useState<string | undefined>();
+
+  return (
+    <>
+      <ActionBar
+        title={props.title}
+        backURL={backURL}
+        extraControls={props.showUndoRedo ? <UndoRedo /> : undefined}
+      />
+      {props.plugin.renderEdit?.(setBackURL)}
+    </>
+  );
+}

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -8,7 +8,6 @@ import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
-import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
 import {
@@ -161,7 +160,6 @@ export function Datasets() {
   return (
     <>
       <ActionBar title="Datasets" />
-      <Toolbar />
       <Grid container columns={3} className="datasets">
         <Grid item xs={1}>
           <Stack direction="row" alignItems="baseline">

--- a/ui/src/edit.tsx
+++ b/ui/src/edit.tsx
@@ -1,6 +1,5 @@
-import ActionBar from "actionBar";
+import CriteriaHolder from "criteriaHolder";
 import { useGroupAndCriteria } from "hooks";
-import React from "react";
 import { getCriteriaPlugin, getCriteriaTitle } from "./cohort";
 
 export default function Edit() {
@@ -8,9 +7,10 @@ export default function Edit() {
   const plugin = getCriteriaPlugin(criteria);
 
   return (
-    <>
-      <ActionBar title={getCriteriaTitle(criteria, plugin)} />
-      {plugin.renderEdit?.()}
-    </>
+    <CriteriaHolder
+      title={getCriteriaTitle(criteria, plugin)}
+      plugin={plugin}
+      showUndoRedo
+    />
   );
 }

--- a/ui/src/groupOverview.tsx
+++ b/ui/src/groupOverview.tsx
@@ -21,6 +21,7 @@ import {
 } from "cohortsSlice";
 import Empty from "components/empty";
 import { useTextInputDialog } from "components/textInputDialog";
+import UndoRedo from "components/UndoRedo";
 import { useAppDispatch, useCohortAndGroup } from "hooks";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { cohortURL, criteriaURL } from "router";
@@ -57,7 +58,7 @@ export function GroupOverview() {
 
   return (
     <Box sx={{ p: 1 }}>
-      <ActionBar title={cohort.name} />
+      <ActionBar title={cohort.name} extraControls={<UndoRedo />} />
       <Stack direction="row" justifyContent="space-between">
         <Stack direction="row" alignItems="center">
           <Typography variant="h2">{name}</Typography>

--- a/ui/src/newConceptSet.tsx
+++ b/ui/src/newConceptSet.tsx
@@ -1,17 +1,14 @@
-import Toolbar from "@mui/material/Toolbar";
-import ActionBar from "actionBar";
+import CriteriaHolder from "criteriaHolder";
 import { useNewCriteria } from "hooks";
-import React from "react";
 import { getCriteriaPlugin } from "./cohort";
 
 export default function NewCriteria() {
   const criteria = useNewCriteria();
 
   return (
-    <>
-      <ActionBar title={`New ${criteria.config.title} Concept Set`} />
-      <Toolbar />
-      {getCriteriaPlugin(criteria).renderEdit?.()}
-    </>
+    <CriteriaHolder
+      title={`New ${criteria.config.title} Concept Set`}
+      plugin={getCriteriaPlugin(criteria)}
+    />
   );
 }

--- a/ui/src/newCriteria.tsx
+++ b/ui/src/newCriteria.tsx
@@ -1,15 +1,14 @@
-import ActionBar from "actionBar";
+import CriteriaHolder from "criteriaHolder";
 import { useNewCriteria } from "hooks";
-import React from "react";
 import { getCriteriaPlugin } from "./cohort";
 
 export default function NewCriteria() {
   const criteria = useNewCriteria();
 
   return (
-    <>
-      <ActionBar title={`New ${criteria.config.title} Criteria`} />
-      {getCriteriaPlugin(criteria).renderEdit?.()}
-    </>
+    <CriteriaHolder
+      title={`New ${criteria.config.title} Criteria`}
+      plugin={getCriteriaPlugin(criteria)}
+    />
   );
 }

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -54,9 +54,9 @@ export function Overview() {
         width: "100%",
         height: "100%",
         gridTemplateColumns: (theme) =>
-          `300px 1fr ${showDemographics ? "380px" : theme.spacing(8)}`,
-        gridTemplateRows: (theme) => `${theme.spacing(6)} 1fr`,
-        gridTemplateAreas: "'header header header' 'outline content drawer'",
+          `280px 1fr ${showDemographics ? "380px" : theme.spacing(8)}`,
+        gridTemplateRows: "1fr",
+        gridTemplateAreas: "'outline content drawer'",
       }}
     >
       <Box
@@ -70,6 +70,8 @@ export function Overview() {
       <Box
         sx={{
           gridArea: "content",
+          height: "100%",
+          minHeight: "100%",
           overflow: "auto",
           borderColor: (theme) => theme.palette.divider,
           borderStyle: "solid",

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -49,7 +49,7 @@ export function cohortURL(cohortId: string, groupId: string) {
 }
 
 export function conceptSetURL(conceptSetId: string) {
-  return "conceptSets/" + conceptSetId;
+  return "conceptSets/edit/" + conceptSetId;
 }
 
 export function newConceptSetURL(configId: string) {

--- a/ui/src/underlaySelect.tsx
+++ b/ui/src/underlaySelect.tsx
@@ -2,7 +2,6 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
-import Toolbar from "@mui/material/Toolbar";
 import ActionBar from "actionBar";
 import { useAppSelector } from "hooks";
 import { Link as RouterLink } from "react-router-dom";
@@ -13,8 +12,7 @@ export function UnderlaySelect() {
 
   return (
     <>
-      <ActionBar title="Select Dataset" />
-      <Toolbar />
+      <ActionBar title="Select Dataset" backURL={null} />
       <List>
         {underlays.map((underlay) => (
           <ListItem key={underlay.name}>


### PR DESCRIPTION
I tried various more centralized approaches but ran into state or routing issues with each one. Instead, this applies an overall layout and each "page" is responsible for show it's own ActionBar. There are a few slightly tricky parts and a bit of duplicated code but both are minor and it's straightforward overall.

* Top level layout allocates space for the ActionBar on all "pages".
* No more duplicate ActionBars stacked on top of each other.
* ActionBar can be customized for different views, including upcoming cohort review.
* Refactor criteria based views as the amount of duplicated code increases.