### PR TITLE
Default limit value in query request.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/instances/EntityQueryRequest.java
+++ b/service/src/main/java/bio/terra/tanagra/service/instances/EntityQueryRequest.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class EntityQueryRequest {
+  private static final int DEFAULT_LIMIT = 250;
+
   private final Entity entity;
   private final Underlay.MappingType mappingType;
   private final List<Attribute> selectAttributes;
@@ -76,7 +78,7 @@ public class EntityQueryRequest {
     private List<RelationshipField> selectRelationshipFields;
     private EntityFilter filter;
     private List<EntityQueryOrderBy> orderBys;
-    private int limit;
+    private Integer limit;
 
     public Builder entity(Entity entity) {
       this.entity = entity;
@@ -113,12 +115,15 @@ public class EntityQueryRequest {
       return this;
     }
 
-    public Builder limit(int limit) {
+    public Builder limit(Integer limit) {
       this.limit = limit;
       return this;
     }
 
     public EntityQueryRequest build() {
+      if (limit == null) {
+        limit = DEFAULT_LIMIT;
+      }
       return new EntityQueryRequest(this);
     }
   }


### PR DESCRIPTION
OpenAPI default value was not getting set in the request body. Defaulted the value in the Java code instead. This is a better approach anyway because now any code (including internally) building a request will get a default limit, not just requests that come through the service API.