### PR TITLE
Annotation (key) endpoints implementation.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -1,0 +1,128 @@
+package bio.terra.tanagra.app.controller;
+
+import static bio.terra.tanagra.service.accesscontrol.Action.CREATE;
+import static bio.terra.tanagra.service.accesscontrol.Action.DELETE;
+import static bio.terra.tanagra.service.accesscontrol.Action.READ;
+import static bio.terra.tanagra.service.accesscontrol.Action.UPDATE;
+import static bio.terra.tanagra.service.accesscontrol.ResourceType.ANNOTATION;
+
+import bio.terra.tanagra.generated.controller.AnnotationsV2Api;
+import bio.terra.tanagra.generated.model.ApiAnnotationCreateInfoV2;
+import bio.terra.tanagra.generated.model.ApiAnnotationListV2;
+import bio.terra.tanagra.generated.model.ApiAnnotationUpdateInfoV2;
+import bio.terra.tanagra.generated.model.ApiAnnotationV2;
+import bio.terra.tanagra.generated.model.ApiDataTypeV2;
+import bio.terra.tanagra.query.Literal;
+import bio.terra.tanagra.service.AccessControlService;
+import bio.terra.tanagra.service.AnnotationService;
+import bio.terra.tanagra.service.accesscontrol.ResourceId;
+import bio.terra.tanagra.service.accesscontrol.ResourceIdCollection;
+import bio.terra.tanagra.service.artifact.Annotation;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class AnnotationsV2ApiController implements AnnotationsV2Api {
+  private final AnnotationService annotationService;
+  private final AccessControlService accessControlService;
+
+  @Autowired
+  public AnnotationsV2ApiController(
+      AnnotationService annotationService, AccessControlService accessControlService) {
+    this.annotationService = annotationService;
+    this.accessControlService = accessControlService;
+  }
+
+  @Override
+  public ResponseEntity<ApiAnnotationV2> createAnnotation(
+      String studyId, String cohortId, ApiAnnotationCreateInfoV2 body) {
+    accessControlService.throwIfUnauthorized(null, CREATE, ANNOTATION, new ResourceId(cohortId));
+
+    // Generate a random 10-character alphanumeric string for the new annotation ID.
+    String newAnnotationId = RandomStringUtils.randomAlphanumeric(10);
+
+    Annotation annotationToCreate =
+        Annotation.builder()
+            .annotationId(newAnnotationId)
+            .displayName(body.getDisplayName())
+            .description(body.getDescription())
+            .dataType(Literal.DataType.valueOf(body.getDataType().toString()))
+            .enumVals(body.getEnumVals())
+            .build();
+
+    annotationService.createAnnotation(studyId, cohortId, annotationToCreate);
+    return ResponseEntity.ok(
+        toApiObject(annotationService.getAnnotation(studyId, cohortId, newAnnotationId)));
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteAnnotation(
+      String studyId, String cohortId, String annotationId) {
+    accessControlService.throwIfUnauthorized(
+        null, DELETE, ANNOTATION, new ResourceId(annotationId));
+    annotationService.deleteAnnotation(studyId, cohortId, annotationId);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @Override
+  public ResponseEntity<ApiAnnotationV2> getAnnotation(
+      String studyId, String cohortId, String annotationId) {
+    accessControlService.throwIfUnauthorized(null, READ, ANNOTATION, new ResourceId(annotationId));
+    return ResponseEntity.ok(
+        toApiObject(annotationService.getAnnotation(studyId, cohortId, annotationId)));
+  }
+
+  @Override
+  public ResponseEntity<ApiAnnotationListV2> listAnnotations(
+      String studyId, String cohortId, Integer offset, Integer limit) {
+    ResourceIdCollection authorizedAnnotationIds =
+        accessControlService.listResourceIds(ANNOTATION, offset, limit);
+    List<Annotation> authorizedAnnotations;
+    if (authorizedAnnotationIds.isAllResourceIds()) {
+      authorizedAnnotations = annotationService.getAllAnnotations(studyId, cohortId, offset, limit);
+    } else {
+      authorizedAnnotations =
+          annotationService.getAnnotations(
+              studyId,
+              cohortId,
+              authorizedAnnotationIds.getResourceIds().stream()
+                  .map(ResourceId::getId)
+                  .collect(Collectors.toList()),
+              offset,
+              limit);
+    }
+
+    ApiAnnotationListV2 apiAnnotations = new ApiAnnotationListV2();
+    authorizedAnnotations.stream()
+        .forEach(
+            annotation -> {
+              apiAnnotations.add(toApiObject(annotation));
+            });
+    return ResponseEntity.ok(apiAnnotations);
+  }
+
+  @Override
+  public ResponseEntity<ApiAnnotationV2> updateAnnotation(
+      String studyId, String cohortId, String annotationId, ApiAnnotationUpdateInfoV2 body) {
+    accessControlService.throwIfUnauthorized(
+        null, UPDATE, ANNOTATION, new ResourceId(annotationId));
+    Annotation updatedAnnotation =
+        annotationService.updateAnnotation(
+            studyId, cohortId, annotationId, body.getDisplayName(), body.getDescription());
+    return ResponseEntity.ok(toApiObject(updatedAnnotation));
+  }
+
+  private static ApiAnnotationV2 toApiObject(Annotation annotation) {
+    return new ApiAnnotationV2()
+        .id(annotation.getAnnotationId())
+        .displayName(annotation.getDisplayName())
+        .description(annotation.getDescription())
+        .dataType(ApiDataTypeV2.fromValue(annotation.getDataType().name()))
+        .enumVals(annotation.getEnumVals());
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -61,7 +61,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
       String studyId, String cohortId, ApiReviewCreateInfoV2 body) {
     accessControlService.throwIfUnauthorized(null, CREATE, COHORT_REVIEW, new ResourceId(cohortId));
 
-    // Generate a random 10-character alphanumeric strings for the new review ID.
+    // Generate a random 10-character alphanumeric string for the new review ID.
     String newReviewId = RandomStringUtils.randomAlphanumeric(10);
 
     Review reviewToCreate =
@@ -100,7 +100,8 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
   @Override
   public ResponseEntity<ApiReviewInstanceListV2> listInstancesAndAnnotations(
       String studyId, String cohortId, String reviewId, ApiReviewQueryV2 body) {
-    accessControlService.throwIfUnauthorized(null, QUERY_INSTANCES, COHORT_REVIEW, new ResourceId(reviewId));
+    accessControlService.throwIfUnauthorized(
+        null, QUERY_INSTANCES, COHORT_REVIEW, new ResourceId(reviewId));
     return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
   }
 

--- a/service/src/main/java/bio/terra/tanagra/db/AnnotationDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/AnnotationDao.java
@@ -122,7 +122,7 @@ public class AnnotationDao {
       String studyId, String cohortRevisionGroupId, int offset, int limit) {
     String sql =
         ANNOTATION_SELECT_SQL
-            + " WHERE c.cohort_revision_group_id = :cohort_revision_group_id ORDER BY A.display_name OFFSET :offset LIMIT :limit";
+            + " WHERE c.cohort_revision_group_id = :cohort_revision_group_id ORDER BY a.display_name OFFSET :offset LIMIT :limit";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("cohort_revision_group_id", cohortRevisionGroupId)

--- a/service/src/main/java/bio/terra/tanagra/db/AnnotationDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/AnnotationDao.java
@@ -1,0 +1,223 @@
+package bio.terra.tanagra.db;
+
+import bio.terra.common.db.ReadTransaction;
+import bio.terra.common.db.WriteTransaction;
+import bio.terra.common.exception.MissingRequiredFieldException;
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.tanagra.db.exception.DuplicateAnnotationException;
+import bio.terra.tanagra.query.Literal;
+import bio.terra.tanagra.service.artifact.Annotation;
+import bio.terra.tanagra.service.artifact.Cohort;
+import java.sql.Array;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnotationDao {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationDao.class);
+
+  // SQL query and row mapper for reading an annotation.
+  private static final String ANNOTATION_SELECT_SQL =
+      "SELECT a.cohort_id, a.annotation_id, a.display_name, a.description, a.data_type, a.enum_vals FROM annotation AS a "
+          + "JOIN cohort AS c ON c.cohort_id = a.cohort_id";
+  private static final RowMapper<Annotation> ANNOTATION_ROW_MAPPER =
+      (rs, rowNum) ->
+          Annotation.builder()
+              .cohortId(rs.getString("cohort_id"))
+              .annotationId(rs.getString("annotation_id"))
+              .displayName(rs.getString("display_name"))
+              .description(rs.getString("description"))
+              .dataType(Literal.DataType.valueOf(rs.getString("data_type")))
+              .enumVals(List.of((String[]) rs.getArray("enum_vals").getArray()))
+              .build();
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final CohortDao cohortDao;
+
+  @Autowired
+  public AnnotationDao(NamedParameterJdbcTemplate jdbcTemplate, CohortDao cohortDao) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.cohortDao = cohortDao;
+  }
+
+  /** Create a new annotation. */
+  @WriteTransaction
+  public void createAnnotation(
+      String studyId, String cohortRevisionGroupId, Annotation annotation) {
+    Cohort cohort = cohortDao.getCohortLatestVersionOrThrow(studyId, cohortRevisionGroupId);
+
+    final String sql =
+        "INSERT INTO annotation (cohort_id, annotation_id, display_name, description, data_type, enum_vals) "
+            + "VALUES (:cohort_id, :annotation_id, :display_name, :description, :data_type, :enum_vals)";
+    Array enumValsArr =
+        jdbcTemplate
+            .getJdbcOperations()
+            .execute(
+                (ConnectionCallback<Array>)
+                    con ->
+                        con.createArrayOf("text", annotation.getEnumVals().toArray(new String[0])));
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("cohort_id", cohort.getCohortId())
+            .addValue("annotation_id", annotation.getAnnotationId())
+            .addValue("display_name", annotation.getDisplayName())
+            .addValue("description", annotation.getDescription())
+            .addValue("data_type", annotation.getDataType().toString())
+            .addValue("enum_vals", enumValsArr);
+
+    try {
+      jdbcTemplate.update(sql, params);
+      LOGGER.info("Inserted record for annotation {}", annotation.getAnnotationId());
+    } catch (DuplicateKeyException dkEx) {
+      if (dkEx.getMessage()
+          .contains("duplicate key value violates unique constraint \"annotation_pkey\"")) {
+        throw new DuplicateAnnotationException(
+            String.format(
+                "Annotation with id %s already exists - display name %s",
+                annotation.getAnnotationId(), annotation.getDisplayName()),
+            dkEx);
+      } else {
+        throw dkEx;
+      }
+    }
+  }
+
+  /** Delete an annotation. */
+  @WriteTransaction
+  public boolean deleteAnnotation(
+      String studyId, String cohortRevisionGroupId, String annotationId) {
+    final String sql = "DELETE FROM annotation WHERE annotation_id = :annotation_id";
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("annotation_id", annotationId);
+    int rowsAffected = jdbcTemplate.update(sql, params);
+    boolean deleted = rowsAffected > 0;
+
+    if (deleted) {
+      LOGGER.info("Deleted annotation for cohort {}", annotationId);
+    } else {
+      LOGGER.info("No record found for delete annotation {}", annotationId);
+    }
+    // Annotation value rows will cascade delete.
+    return deleted;
+  }
+
+  /** Fetch all annotations for a cohort. */
+  @ReadTransaction
+  public List<Annotation> getAllAnnotations(
+      String studyId, String cohortRevisionGroupId, int offset, int limit) {
+    String sql =
+        ANNOTATION_SELECT_SQL
+            + " WHERE c.cohort_revision_group_id = :cohort_revision_group_id ORDER BY A.display_name OFFSET :offset LIMIT :limit";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("cohort_revision_group_id", cohortRevisionGroupId)
+            .addValue("offset", offset)
+            .addValue("limit", limit);
+    return jdbcTemplate.query(sql, params, ANNOTATION_ROW_MAPPER);
+  }
+
+  /**
+   * Fetch all annotations for a cohort. Only include annotations whose ids are in the specified
+   * list.
+   */
+  @ReadTransaction
+  public List<Annotation> getAnnotationsMatchingList(
+      String studyId,
+      String cohortRevisionGroupId,
+      Set<String> annotationIdList,
+      int offset,
+      int limit) {
+    // If the incoming list is empty, the caller does not have permission to see any
+    // annotations, so we return an empty list.
+    if (annotationIdList.isEmpty()) {
+      return Collections.emptyList();
+    }
+    String sql =
+        ANNOTATION_SELECT_SQL
+            + " WHERE a.annotation_id IN (:annotation_ids) ORDER BY a.display_name OFFSET :offset LIMIT :limit";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("annotation_ids", annotationIdList)
+            .addValue("offset", offset)
+            .addValue("limit", limit);
+    return jdbcTemplate.query(sql, params, ANNOTATION_ROW_MAPPER);
+  }
+
+  @ReadTransaction
+  public Optional<Annotation> getAnnotationIfExists(
+      String studyId, String cohortRevisionGroupId, String annotationId) {
+    if (studyId == null || cohortRevisionGroupId == null || annotationId == null) {
+      throw new MissingRequiredFieldException(
+          "Valid study, cohort, and annotation ids are required");
+    }
+    String sql = ANNOTATION_SELECT_SQL + " WHERE a.annotation_id = :annotation_id";
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("annotation_id", annotationId);
+    try {
+      Annotation annotation =
+          DataAccessUtils.requiredSingleResult(
+              jdbcTemplate.query(sql, params, ANNOTATION_ROW_MAPPER));
+      LOGGER.info("Retrieved annotation record {}", annotation);
+      return Optional.of(annotation);
+    } catch (EmptyResultDataAccessException e) {
+      return Optional.empty();
+    }
+  }
+
+  public Annotation getAnnotation(
+      String studyId, String cohortRevisionGroupId, String annotationId) {
+    return getAnnotationIfExists(studyId, cohortRevisionGroupId, annotationId)
+        .orElseThrow(
+            () -> new NotFoundException(String.format("Annotation %s not found.", annotationId)));
+  }
+
+  @WriteTransaction
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  public boolean updateAnnotation(
+      String studyId,
+      String cohortRevisionGroupId,
+      String annotationId,
+      @Nullable String name,
+      @Nullable String description) {
+    if (name == null && description == null) {
+      throw new MissingRequiredFieldException("Must specify field to update.");
+    }
+
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue("annotation_id", annotationId);
+    if (name != null) {
+      params.addValue("display_name", name);
+    }
+    if (description != null) {
+      params.addValue("description", description);
+    }
+
+    String sql =
+        String.format(
+            "UPDATE annotation SET %s WHERE annotation_id = :annotation_id",
+            DbUtils.setColumnsClause(params));
+
+    int rowsAffected = jdbcTemplate.update(sql, params);
+    boolean updated = rowsAffected > 0;
+    LOGGER.info(
+        "{} record for annotation {}",
+        updated ? "Updated" : "No Update - did not find",
+        annotationId);
+    return updated;
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -124,7 +124,7 @@ public class ReviewDao {
     } else {
       LOGGER.info("No record found for delete review {}", reviewId);
     }
-    // Sampled primary entity ids and annotation rows will cascade delete.
+    // Sampled primary entity ids will cascade delete.
     return deleted;
   }
 
@@ -187,8 +187,8 @@ public class ReviewDao {
   @ReadTransaction
   public Optional<Review> getReviewIfExists(
       String studyId, String cohortRevisionGroupId, String reviewId) {
-    if (studyId == null || cohortRevisionGroupId == null) {
-      throw new MissingRequiredFieldException("Valid study and cohort ids are required");
+    if (studyId == null || cohortRevisionGroupId == null || reviewId == null) {
+      throw new MissingRequiredFieldException("Valid study, cohort, and review ids are required");
     }
     String sql = REVIEW_SELECT_SQL + " WHERE r.review_id = :review_id";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("review_id", reviewId);
@@ -235,7 +235,7 @@ public class ReviewDao {
     int rowsAffected = jdbcTemplate.update(sql, params);
     boolean updated = rowsAffected > 0;
     LOGGER.info(
-        "{} record for review {}", updated ? "Updated" : "No Update - did not find", studyId);
+        "{} record for review {}", updated ? "Updated" : "No Update - did not find", reviewId);
     return updated;
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/db/exception/DuplicateAnnotationException.java
+++ b/service/src/main/java/bio/terra/tanagra/db/exception/DuplicateAnnotationException.java
@@ -1,0 +1,14 @@
+package bio.terra.tanagra.db.exception;
+
+import bio.terra.common.exception.BadRequestException;
+
+/** An annotation with this id already exists. */
+public class DuplicateAnnotationException extends BadRequestException {
+  public DuplicateAnnotationException(String message) {
+    super(message);
+  }
+
+  public DuplicateAnnotationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
@@ -1,0 +1,78 @@
+package bio.terra.tanagra.service;
+
+import bio.terra.tanagra.app.configuration.FeatureConfiguration;
+import bio.terra.tanagra.db.AnnotationDao;
+import bio.terra.tanagra.service.artifact.Annotation;
+import java.util.HashSet;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnotationService {
+  private final AnnotationDao annotationDao;
+  private final FeatureConfiguration featureConfiguration;
+
+  @Autowired
+  public AnnotationService(AnnotationDao annotationDao, FeatureConfiguration featureConfiguration) {
+    this.annotationDao = annotationDao;
+    this.featureConfiguration = featureConfiguration;
+  }
+
+  /** Create a new annotation. */
+  public void createAnnotation(
+      String studyId, String cohortRevisionGroupId, Annotation annotation) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    annotationDao.createAnnotation(studyId, cohortRevisionGroupId, annotation);
+  }
+
+  /** Delete an existing annotation. */
+  public void deleteAnnotation(String studyId, String cohortRevisionGroupId, String annotationId) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    annotationDao.deleteAnnotation(studyId, cohortRevisionGroupId, annotationId);
+  }
+
+  /** Retrieves a list of all annotations for a cohort. */
+  public List<Annotation> getAllAnnotations(
+      String studyId, String cohortRevisionGroupId, int offset, int limit) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    return annotationDao.getAllAnnotations(studyId, cohortRevisionGroupId, offset, limit);
+  }
+
+  /** Retrieves a list of annotations by ID. */
+  public List<Annotation> getAnnotations(
+      String studyId,
+      String cohortRevisionGroupId,
+      List<String> annotationIds,
+      int offset,
+      int limit) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    return annotationDao.getAnnotationsMatchingList(
+        studyId, cohortRevisionGroupId, new HashSet<>(annotationIds), offset, limit);
+  }
+
+  /** Retrieves an annotation by ID. */
+  public Annotation getAnnotation(
+      String studyId, String cohortRevisionGroupId, String annotationId) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    return annotationDao.getAnnotation(studyId, cohortRevisionGroupId, annotationId);
+  }
+
+  /**
+   * Update an existing annotation. Currently, can change the annotation's display name or
+   * description.
+   */
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  public Annotation updateAnnotation(
+      String studyId,
+      String cohortRevisionGroupId,
+      String annotationId,
+      @Nullable String displayName,
+      @Nullable String description) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    annotationDao.updateAnnotation(
+        studyId, cohortRevisionGroupId, annotationId, displayName, description);
+    return annotationDao.getAnnotation(studyId, cohortRevisionGroupId, annotationId);
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceType.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceType.java
@@ -9,7 +9,8 @@ public enum ResourceType {
   COHORT(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
   CONCEPT_SET(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
   DATASET(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
-  COHORT_REVIEW(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE));
+  COHORT_REVIEW(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
+  ANNOTATION(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE));
 
   private List<Action> actions;
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Annotation.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Annotation.java
@@ -1,0 +1,105 @@
+package bio.terra.tanagra.service.artifact;
+
+import bio.terra.tanagra.query.Literal;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class Annotation {
+  private final String cohortId;
+  private final String annotationId;
+  private final @Nullable String displayName;
+  private final @Nullable String description;
+  private final Literal.DataType dataType;
+  private final List<String> enumVals;
+
+  private Annotation(Builder builder) {
+    this.cohortId = builder.cohortId;
+    this.annotationId = builder.annotationId;
+    this.displayName = builder.displayName;
+    this.description = builder.description;
+    this.dataType = builder.dataType;
+    this.enumVals = builder.enumVals;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Unique (per study) identifier of the cohort this annotation belongs to. */
+  public String getCohortId() {
+    return cohortId;
+  }
+
+  /** Unique (per cohort) identifier of this annotation. */
+  public String getAnnotationId() {
+    return annotationId;
+  }
+
+  /** Optional display name of this annotation. */
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  /** Optional description of this annotation. */
+  public String getDescription() {
+    return description;
+  }
+
+  /** Data type of the annotation. */
+  public Literal.DataType getDataType() {
+    return dataType;
+  }
+
+  /** List of enum values for the annotation. */
+  public List<String> getEnumVals() {
+    return Collections.unmodifiableList(enumVals);
+  }
+
+  public static class Builder {
+    private String cohortId;
+    private String annotationId;
+    private @Nullable String displayName;
+    private @Nullable String description;
+    private Literal.DataType dataType;
+    private List<String> enumVals;
+
+    public Builder cohortId(String cohortId) {
+      this.cohortId = cohortId;
+      return this;
+    }
+
+    public Builder annotationId(String annotationId) {
+      this.annotationId = annotationId;
+      return this;
+    }
+
+    public Builder displayName(String displayName) {
+      this.displayName = displayName;
+      return this;
+    }
+
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public Builder dataType(Literal.DataType dataType) {
+      this.dataType = dataType;
+      return this;
+    }
+
+    public Builder enumVals(List<String> enumVals) {
+      this.enumVals = enumVals;
+      return this;
+    }
+
+    public String getCohortId() {
+      return cohortId;
+    }
+
+    public Annotation build() {
+      return new Annotation(this);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Annotation.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Annotation.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.service.artifact;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.tanagra.query.Literal;
 import java.util.Collections;
 import java.util.List;
@@ -99,6 +100,9 @@ public class Annotation {
     }
 
     public Annotation build() {
+      if (enumVals != null && !enumVals.isEmpty() && !dataType.equals(Literal.DataType.STRING)) {
+        throw new BadRequestException("Enum values are only supported for the STRING data type.");
+      }
       return new Annotation(this);
     }
   }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Annotation.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Annotation.java
@@ -53,7 +53,7 @@ public class Annotation {
 
   /** List of enum values for the annotation. */
   public List<String> getEnumVals() {
-    return Collections.unmodifiableList(enumVals);
+    return enumVals == null ? Collections.emptyList() : Collections.unmodifiableList(enumVals);
   }
 
   public static class Builder {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -511,16 +511,15 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
-  "/v2/studies/{studyId}/cohorts/{cohortId}/reviews/{reviewId}/annotations":
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
       - $ref: '#/components/parameters/CohortIdV2'
-      - $ref: '#/components/parameters/ReviewIdV2'
     get:
       parameters:
         - $ref: "#/components/parameters/OffsetV2"
         - $ref: "#/components/parameters/LimitV2"
-      summary: List all annotations for a review
+      summary: List all annotations for a cohort
       operationId: listAnnotations
       tags: [AnnotationsV2]
       responses:
@@ -552,11 +551,10 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
-  "/v2/studies/{studyId}/cohorts/{cohortId}/reviews/{reviewId}/annotations/{annotationId}":
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
       - $ref: '#/components/parameters/CohortIdV2'
-      - $ref: '#/components/parameters/ReviewIdV2'
       - $ref: '#/components/parameters/AnnotationIdV2'
     get:
       summary: Get an existing annotation

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -3,4 +3,5 @@
     <include file="changesets/20221104_study_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20221116_cohort_tables.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20221118_review_tables.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221128_annotation_table.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20221128_annotation_table.yaml
+++ b/service/src/main/resources/db/changesets/20221128_annotation_table.yaml
@@ -44,5 +44,5 @@ databaseChangeLog:
                   name: enum_vals
                   type: text[]
                   constraints:
-                    nullable: true
+                    nullable: false
                     unique: false

--- a/service/src/main/resources/db/changesets/20221128_annotation_table.yaml
+++ b/service/src/main/resources/db/changesets/20221128_annotation_table.yaml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: initial_annotation_table
+      author: marikomedlock
+      changes:
+        - createTable:
+            tableName: annotation
+            columns:
+              - column:
+                  name: cohort_id
+                  type: text
+                  constraints:
+                    references: cohort(cohort_id)
+                    foreignKeyName: fk_annotation_cohort_id
+                    nullable: false
+                    deleteCascade: true
+                  remarks: Deleting a cohort will cascade to delete the annotations associated with it
+              - column:
+                  name: annotation_id
+                  type: text
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+                    unique: true
+              - column:
+                  name: display_name
+                  type: text
+                  constraints:
+                    nullable: true
+                    unique: false
+              - column:
+                  name: description
+                  type: text
+                  constraints:
+                    nullable: true
+                    unique: false
+              - column:
+                  name: data_type
+                  type: text
+                  constraints:
+                    nullable: false
+                    unique: false
+              - column:
+                  name: enum_vals
+                  type: text[]
+                  constraints:
+                    nullable: true
+                    unique: false


### PR DESCRIPTION
- Updated annotation (key) endpoint definitions to remove the `reviewId` parameter. Now annotations are only associated with a cohort.
- Implemented the annotation (key) endpoints.
- The `enumVals` property of an annotation only applies for the `STRING` data type.

I did spot testing with the Swagger UI page. Expect automated tests in a future PR.