### PR TITLE
Define annotation value endpoints.

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -604,11 +604,12 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
-  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/values":
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/reviews/{reviewId}/values":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
       - $ref: '#/components/parameters/CohortIdV2'
       - $ref: '#/components/parameters/AnnotationIdV2'
+      - $ref: '#/components/parameters/ReviewIdV2'
     post:
       summary: Create a new annotation value
       operationId: createAnnotationValue
@@ -618,7 +619,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AnnotationValueCreateInfoV2"
+              $ref: "#/components/schemas/AnnotationValueCreateUpdateInfoV2"
       responses:
         200:
           description: OK
@@ -629,11 +630,12 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
-  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/values/{valueId}":
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/reviews/{reviewId}/values/{valueId}":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
       - $ref: '#/components/parameters/CohortIdV2'
       - $ref: '#/components/parameters/AnnotationIdV2'
+      - $ref: '#/components/parameters/ReviewIdV2'
       - $ref: '#/components/parameters/AnnotationValueIdV2'
     patch:
       summary: Update an existing annotation value
@@ -644,7 +646,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AnnotationValueUpdateInfoV2'
+              $ref: '#/components/schemas/AnnotationValueCreateUpdateInfoV2'
       responses:
         200:
           description: OK
@@ -1880,22 +1882,15 @@ components:
       required:
         - id
         - value
+        - review
 
-    AnnotationValueCreateInfoV2:
+    AnnotationValueCreateUpdateInfoV2:
       type: object
       properties:
         value:
           $ref: "#/components/schemas/LiteralV2"
-        review:
-          $ref: "#/components/schemas/ReviewIdV2"
       required:
         - value
-
-    AnnotationValueUpdateInfoV2:
-      type: object
-      properties:
-        value:
-          $ref: "#/components/schemas/LiteralV2"
 
     ReviewInstanceV2:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -604,6 +604,70 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/values":
+    parameters:
+      - $ref: '#/components/parameters/StudyIdV2'
+      - $ref: '#/components/parameters/CohortIdV2'
+      - $ref: '#/components/parameters/AnnotationIdV2'
+    post:
+      summary: Create a new annotation value
+      operationId: createAnnotationValue
+      tags: [AnnotationsV2]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnnotationValueCreateInfoV2"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnnotationValueV2"
+        500:
+          $ref: "#/components/responses/ServerError"
+
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/values/{valueId}":
+    parameters:
+      - $ref: '#/components/parameters/StudyIdV2'
+      - $ref: '#/components/parameters/CohortIdV2'
+      - $ref: '#/components/parameters/AnnotationIdV2'
+      - $ref: '#/components/parameters/AnnotationValueIdV2'
+    patch:
+      summary: Update an existing annotation value
+      operationId: updateAnnotationValue
+      tags: [AnnotationsV2]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnnotationValueUpdateInfoV2'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationValueV2'
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/ServerError'
+    delete:
+      summary: Delete an annotation value
+      operationId: deleteAnnotationValue
+      tags: [AnnotationsV2]
+      responses:
+        204:
+          description: OK
+        404:
+          $ref: '#/components/responses/NotFound'
+        500:
+          $ref: '#/components/responses/ServerError'
+
   "/v2/studies/{studyId}/conceptSets":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
@@ -749,6 +813,14 @@ components:
       name: annotationId
       in: path
       description: ID of the annotation
+      required: true
+      schema:
+        type: string
+
+    AnnotationValueIdV2:
+      name: valueId
+      in: path
+      description: ID of the annotation value
       required: true
       schema:
         type: string
@@ -1667,8 +1739,7 @@ components:
       type: object
       properties:
         id:
-          description: ID of the review, immutable
-          type: string
+          $ref: "#/components/schemas/ReviewIdV2"
         displayName:
           $ref: "#/components/schemas/ReviewDisplayNameV2"
         description:
@@ -1720,6 +1791,10 @@ components:
           $ref: "#/components/schemas/ReviewDisplayNameV2"
         description:
           $ref: "#/components/schemas/ReviewDescriptionV2"
+
+    ReviewIdV2:
+      type: string
+      description: ID of the review, immutable
 
     ReviewDisplayNameV2:
       type: string
@@ -1792,6 +1867,36 @@ components:
       type: string
       description: Description of the annotation
 
+    AnnotationValueV2:
+      type: object
+      properties:
+        id:
+          description: ID of the annotation value, immutable
+          type: string
+        value:
+          $ref: "#/components/schemas/LiteralV2"
+        review:
+          $ref: "#/components/schemas/ReviewIdV2"
+      required:
+        - id
+        - value
+
+    AnnotationValueCreateInfoV2:
+      type: object
+      properties:
+        value:
+          $ref: "#/components/schemas/LiteralV2"
+        review:
+          $ref: "#/components/schemas/ReviewIdV2"
+      required:
+        - value
+
+    AnnotationValueUpdateInfoV2:
+      type: object
+      properties:
+        value:
+          $ref: "#/components/schemas/LiteralV2"
+
     ReviewInstanceV2:
       type: object
       properties:
@@ -1803,12 +1908,13 @@ components:
             nullable: true
             $ref: "#/components/schemas/ValueDisplayV2"
         annotations:
-          description: A map of annotation ids to their value for this instance in this review
+          description: A map of annotation ids to their values for this instance in this review
           type: object
           additionalProperties:
-            type: object
+            type: array
             nullable: true
-            $ref: "#/components/schemas/ValueDisplayV2"
+            items:
+              $ref: "#/components/schemas/AnnotationValueV2"
 
     ReviewInstanceListV2:
       type: array


### PR DESCRIPTION
- Defined endpoints for creating, updating, and deleting annotation values. Annotation value = literal + (optional) review id.
- Endpoints for listing and getting annotation values are not included because they will always be fetched as part of a review instance via the `/v2/studies/{studyId}/cohorts/{cohortId}/reviews/{reviewId}/instances` endpoint.
- Updated the review instances endpoint to allow multiple values for a single annotation (key).