### PR TITLE
Log db migration flags. Remove verily underlays from default spring p…

### DIFF
--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -5,6 +5,7 @@ export TANAGRA_DB_INITIALIZE_ON_START=true
 export TANAGRA_DB_USERNAME=dbuser
 export TANAGRA_DB_PASSWORD=dbpwd
 
+export TANAGRA_UNDERLAY_FILES=broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json
 export TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED=true
 
 ./gradlew bootRun

--- a/service/src/main/java/bio/terra/tanagra/app/StartupInitializer.java
+++ b/service/src/main/java/bio/terra/tanagra/app/StartupInitializer.java
@@ -25,7 +25,8 @@ public final class StartupInitializer {
     FeatureConfiguration featureConfiguration =
         applicationContext.getBean(FeatureConfiguration.class);
 
-    // Log the state of the feature flags.
+    // Log the state of the database migration and feature flags.
+    tanagraDatabaseProperties.logFlags();
     featureConfiguration.logFeatures();
 
     // Migrate the database.

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/FeatureConfiguration.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/FeatureConfiguration.java
@@ -29,11 +29,7 @@ public class FeatureConfiguration {
     }
   }
 
-  /**
-   * Write the feature settings into the log
-   *
-   * <p>Add an entry here for each new feature
-   */
+  /** Write the feature flags into the log. Add an entry here for each new feature flag. */
   public void logFeatures() {
     LOGGER.info("Feature: artifact-storage-enabled: {}", isArtifactStorageEnabled());
   }

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/TanagraDatabaseProperties.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/TanagraDatabaseProperties.java
@@ -1,10 +1,14 @@
 package bio.terra.tanagra.app.configuration;
 
 import bio.terra.common.db.BaseDatabaseProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "tanagra.db")
 public class TanagraDatabaseProperties extends BaseDatabaseProperties {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TanagraDatabaseProperties.class);
+
   /** If true, primary database will be wiped */
   private boolean initializeOnStart;
   /** If true, primary database will have changesets applied */
@@ -24,5 +28,11 @@ public class TanagraDatabaseProperties extends BaseDatabaseProperties {
 
   public void setUpgradeOnStart(boolean upgradeOnStart) {
     this.upgradeOnStart = upgradeOnStart;
+  }
+
+  /** Write the properties into the log. Add an entry here for each new property. */
+  public void logFlags() {
+    LOGGER.info("Database flag: initialize-on-start: {}", isInitializeOnStart());
+    LOGGER.info("Database flag: upgrade-on-start: {}", isUpgradeOnStart());
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/UnderlayConfiguration.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/UnderlayConfiguration.java
@@ -12,13 +12,13 @@ import org.springframework.context.annotation.Configuration;
 public class UnderlayConfiguration {
   // The list of underlay config files in the resources/config directory. (e.g.
   // 'broad/aou_synthetic/expanded/aou_synthetic.json')
-  private List<String> underlayFiles = new ArrayList<>();
+  private List<String> files = new ArrayList<>();
 
-  public List<String> getUnderlayFiles() {
-    return underlayFiles;
+  public List<String> getFiles() {
+    return files;
   }
 
-  public void setUnderlayFiles(List<String> underlayFiles) {
-    this.underlayFiles = underlayFiles;
+  public void setFiles(List<String> files) {
+    this.files = files;
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlaysService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlaysService.java
@@ -25,7 +25,7 @@ public class UnderlaysService {
     // read in underlays from resource files
     Map<String, Underlay> underlaysMapBuilder = new HashMap<>();
     FileIO.setToReadResourceFiles();
-    for (String underlayFile : underlayConfiguration.getUnderlayFiles()) {
+    for (String underlayFile : underlayConfiguration.getFiles()) {
       Path resourceConfigPath = Path.of("config").resolve(underlayFile);
       FileIO.setInputParentDir(resourceConfigPath.getParent());
       try {

--- a/service/src/main/resources/application-test.yml
+++ b/service/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 tanagra:
   underlay:
-    underlay-files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json" ]
+    files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json" ]
 
   feature:
     artifact-storage-enabled: true

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,11 +1,9 @@
 tanagra:
   underlay:
-    # TODO(tjennison): Split these for different environments.
-    underlay-files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json", "verily/aou_synthetic/expanded/verily_aou_synthetic.json", "verily/cms_synpuf/expanded/verily_cms_synpuf.json" ]
+    files: [ "broad/aou_synthetic/expanded/aou_synthetic.json", "broad/cms_synpuf/expanded/cms_synpuf.json" ]
 
   feature:
-    # TODO: Turn on artifact storage by default once we have a CloudSQL deployed in the dev environment.
-    artifact-storage-enabled: false
+    artifact-storage-enabled: true
 
   db:
     initialize-on-start: false
@@ -14,7 +12,7 @@ tanagra:
     username:
     password:
 
-#logging.pattern.level: '%X{requestId} %5p'
+logging.pattern.level: '%X{requestId} %5p'
 
 server:
   compression:


### PR DESCRIPTION
- Added logging for the DB migration flags, similar to what we do for feature flags. These often get overridden per deployment (e.g. by Helm charts), so it's useful to know what value the service actually ends up seeing.
- Modified the log string format to something I think is going to be easier to query in GCP/stackdriver logging.
- Renamed the Spring application property `tanagra.underlay.underlay-files` -> `tanagra.underlay.files`.
- Removed the Verily underlays from the default list. Only Broad underlays are included in the default list. I plan to override this property in the Verily deployment. Included an example of how to override it with an env var in the `run_server.sh` script.