### PR TITLE
Datatable and form for studies admin tab

### DIFF
--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -227,6 +227,8 @@ class FakeHintsApi {
   }
 }
 
+class FakeStudiesAPI {}
+
 function apiForEnvironment<Real, Fake>(
   real: { new (c: tanagra.Configuration): Real },
   fake: { new (): Fake }
@@ -259,4 +261,8 @@ export const EntitiesApiContext = apiForEnvironment(
 export const HintsApiContext = apiForEnvironment(
   tanagra.HintsV2Api,
   FakeHintsApi
+);
+export const StudiesApiContext = apiForEnvironment(
+  tanagra.StudiesV2Api,
+  FakeStudiesAPI
 );

--- a/ui/src/sd-admin/sdAdmin.tsx
+++ b/ui/src/sd-admin/sdAdmin.tsx
@@ -2,12 +2,12 @@ import Box from "@mui/material/Box";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import { useState } from "react";
-import { WorkspaceAdmin } from "./workspaceAdmin";
+import { StudyAdmin } from "./studyAdmin";
 
 const TabPanel = ({ index }: { index: number }) => {
   return (
     <div style={{ padding: "1rem" }}>
-      {index === 0 && <WorkspaceAdmin />}
+      {index === 0 && <StudyAdmin />}
       {index === 1 && <div>User content</div>}
       {index === 2 && <div>Cohort content</div>}
       {index === 3 && <div>Cohort audit content</div>}
@@ -24,7 +24,7 @@ export function SdAdmin() {
         onChange={(e, newTab) => setActiveTab(newTab)}
         sx={{ position: "fixed", top: 0 }}
       >
-        <Tab label="Workspaces" />
+        <Tab label="Studies" />
         <Tab label="Users" />
         <Tab label="Cohorts" />
         <Tab label="Cohort Audit" />

--- a/ui/src/sd-admin/sdAdmin.tsx
+++ b/ui/src/sd-admin/sdAdmin.tsx
@@ -2,11 +2,12 @@ import Box from "@mui/material/Box";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import { useState } from "react";
+import { WorkspaceAdmin } from "./workspaceAdmin";
 
 const TabPanel = ({ index }: { index: number }) => {
   return (
     <div style={{ padding: "1rem" }}>
-      {index === 0 && <div>Workspace content</div>}
+      {index === 0 && <WorkspaceAdmin />}
       {index === 1 && <div>User content</div>}
       {index === 2 && <div>Cohort content</div>}
       {index === 3 && <div>Cohort audit content</div>}

--- a/ui/src/sd-admin/source.tsx
+++ b/ui/src/sd-admin/source.tsx
@@ -4,9 +4,17 @@ import * as tanagra from "tanagra-api";
 import { CreateStudyRequest, StudyV2, UpdateStudyRequest } from "tanagra-api";
 
 export interface AdminSource {
-  createStudy(createStudyRequest: CreateStudyRequest): Promise<StudyV2>;
+  createStudy(
+    displayName: string,
+    description: string,
+    properties: Array<object>
+  ): Promise<StudyV2>;
 
-  updateStudy(updateStudyRequest: UpdateStudyRequest): Promise<StudyV2>;
+  updateStudy(
+    studyId: string,
+    displayName: string,
+    description: string
+  ): Promise<StudyV2>;
 
   getStudiesList(): Promise<StudyV2[]>;
 }
@@ -19,11 +27,29 @@ export function useAdminSource(): AdminSource {
 export class BackendAdminSource implements AdminSource {
   constructor(private studiesApi: tanagra.StudiesV2Api) {}
 
-  async createStudy(createStudyRequest: CreateStudyRequest): Promise<StudyV2> {
+  async createStudy(
+    displayName: string,
+    description: string,
+    properties: Array<object>
+  ): Promise<StudyV2> {
+    const createStudyRequest: CreateStudyRequest = {
+      studyCreateInfoV2: { displayName, description, properties },
+    };
     return await this.studiesApi.createStudy(createStudyRequest);
   }
 
-  async updateStudy(updateStudyRequest: UpdateStudyRequest): Promise<StudyV2> {
+  async updateStudy(
+    studyId: string,
+    displayName: string,
+    description: string
+  ): Promise<StudyV2> {
+    const updateStudyRequest: UpdateStudyRequest = {
+      studyId,
+      studyUpdateInfoV2: {
+        displayName,
+        description,
+      },
+    };
     return await this.studiesApi.updateStudy(updateStudyRequest);
   }
 

--- a/ui/src/sd-admin/source.tsx
+++ b/ui/src/sd-admin/source.tsx
@@ -1,0 +1,33 @@
+import { StudiesApiContext } from "apiContext";
+import { useContext, useMemo } from "react";
+import * as tanagra from "tanagra-api";
+import { CreateStudyRequest, StudyV2, UpdateStudyRequest } from "tanagra-api";
+
+export interface AdminSource {
+  createStudy(createStudyRequest: CreateStudyRequest): Promise<StudyV2>;
+
+  updateStudy(updateStudyRequest: UpdateStudyRequest): Promise<StudyV2>;
+
+  getStudiesList(): Promise<StudyV2[]>;
+}
+
+export function useAdminSource(): AdminSource {
+  const studiesApi = useContext(StudiesApiContext) as tanagra.StudiesV2Api;
+  return useMemo(() => new BackendAdminSource(studiesApi), []);
+}
+
+export class BackendAdminSource implements AdminSource {
+  constructor(private studiesApi: tanagra.StudiesV2Api) {}
+
+  async createStudy(createStudyRequest: CreateStudyRequest): Promise<StudyV2> {
+    return await this.studiesApi.createStudy(createStudyRequest);
+  }
+
+  async updateStudy(updateStudyRequest: UpdateStudyRequest): Promise<StudyV2> {
+    return await this.studiesApi.updateStudy(updateStudyRequest);
+  }
+
+  async getStudiesList(): Promise<StudyV2[]> {
+    return await this.studiesApi.listStudies({});
+  }
+}

--- a/ui/src/sd-admin/studyAdmin.tsx
+++ b/ui/src/sd-admin/studyAdmin.tsx
@@ -9,7 +9,7 @@ import TextField from "@mui/material/TextField";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { useAdminSource } from "sd-admin/source";
-import { CreateStudyRequest, StudyV2, UpdateStudyRequest } from "tanagra-api";
+import { StudyV2 } from "tanagra-api";
 
 const columns = (
   filterFn: (name: string, value: string) => void
@@ -26,10 +26,10 @@ const columns = (
         <div>
           <TextField
             sx={{
-              "label+.css-apw9r9-MuiInputBase-root-MuiInput-root": {
+              "& .MuiInputBase-root": {
                 margin: 0,
               },
-              ".css-1ktftp8-MuiFormLabel-root-MuiInputLabel-root": {
+              "& .MuiInputLabel-root": {
                 top: "-16px",
               },
             }}
@@ -56,10 +56,10 @@ const columns = (
         <div>
           <TextField
             sx={{
-              "label+.css-apw9r9-MuiInputBase-root-MuiInput-root": {
+              "& .MuiInputBase-root": {
                 margin: 0,
               },
-              ".css-1ktftp8-MuiFormLabel-root-MuiInputLabel-root": {
+              "& .MuiInputLabel-root": {
                 top: "-16px",
               },
             }}
@@ -184,14 +184,11 @@ export function StudyAdmin() {
 
   const updateStudy = async () => {
     setLoadingStudy(true);
-    const updateStudyRequest: UpdateStudyRequest = {
-      studyId: activeStudy?.id,
-      studyUpdateInfoV2: {
-        displayName: formState.displayName.value,
-        description: formState.description.value,
-      },
-    };
-    const updatedStudy = await source.updateStudy(updateStudyRequest);
+    const updatedStudy = await source.updateStudy(
+      activeStudy?.id,
+      formState.displayName.value,
+      formState.description.value
+    );
     setActiveStudy(updatedStudy);
     setEditingStudy(false);
     setLoadingStudy(false);
@@ -201,17 +198,14 @@ export function StudyAdmin() {
 
   const createStudy = async () => {
     setLoadingStudy(true);
-    const creatStudyRequest: CreateStudyRequest = {
-      studyCreateInfoV2: {
-        displayName: formState.displayName.value,
-        description: formState.description.value,
-        properties: [
-          { key: "irbNumber", value: formState.irbNumber.value },
-          { key: "pi", value: formState.pi.value },
-        ],
-      },
-    };
-    const newStudy = await source.createStudy(creatStudyRequest);
+    const newStudy = await source.createStudy(
+      formState.displayName.value,
+      formState.description.value,
+      [
+        { key: "irbNumber", value: formState.irbNumber.value },
+        { key: "pi", value: formState.pi.value },
+      ]
+    );
     setActiveStudy(newStudy);
     await getStudies();
     setCreatingStudy(false);

--- a/ui/src/sd-admin/studyAdmin.tsx
+++ b/ui/src/sd-admin/studyAdmin.tsx
@@ -99,6 +99,16 @@ const mapStudyRows = ({
   ),
   pi: getValueFromStudyProperty(properties as StudyV2Property[], "pi"),
 });
+// Style override to slightly darken the text of disabled form fields
+const DISABLED_SX = [
+  {
+    ".Mui-disabled": {
+      color: "rgba(0, 0, 0, 0.6)",
+      "-webkit-text-fill-color": "rgba(0, 0, 0, 0.6)",
+    },
+  },
+];
+const ROWS_PER_PAGE = 25;
 
 const emptyStudy: StudyV2 = {
   id: "",
@@ -323,6 +333,11 @@ export function StudyAdmin() {
             rows={getFilteredRowsFromStudies()}
             loading={loadingStudyList}
             onRowClick={({ row }) => onRowSelect(row as StudyRow)}
+            hideFooter={getFilteredRowsFromStudies().length <= ROWS_PER_PAGE}
+            hideFooterSelectedRowCount
+            disableSelectionOnClick
+            pageSize={ROWS_PER_PAGE}
+            rowsPerPageOptions={[]}
           />
         </Box>
       </Grid>
@@ -358,6 +373,7 @@ export function StudyAdmin() {
           </Stack>
           <div>
             <TextField
+              sx={DISABLED_SX}
               disabled={!(creatingStudy || editingStudy)}
               label={"Study name"}
               name="displayName"
@@ -377,6 +393,7 @@ export function StudyAdmin() {
           </div>
           <div>
             <TextField
+              sx={DISABLED_SX}
               disabled={!(creatingStudy || editingStudy)}
               label={"Description"}
               name="description"
@@ -395,6 +412,7 @@ export function StudyAdmin() {
           </div>
           <div>
             <TextField
+              sx={DISABLED_SX}
               disabled={!(creatingStudy || editingStudy)}
               label={"IRB Number"}
               name="irbNumber"
@@ -411,6 +429,7 @@ export function StudyAdmin() {
           </div>
           <div>
             <Autocomplete
+              sx={DISABLED_SX}
               disabled={!(creatingStudy || editingStudy)}
               options={piOptions}
               value={formState?.pi.value}

--- a/ui/src/sd-admin/studyAdmin.tsx
+++ b/ui/src/sd-admin/studyAdmin.tsx
@@ -16,13 +16,13 @@ const columns = (
 ): GridColDef[] => [
   {
     field: "displayName",
-    headerName: "Workspace Name",
+    headerName: "Study Name",
     sortable: true,
     disableColumnMenu: true,
     flex: 1,
     renderHeader: () => (
       <div style={{ lineHeight: "1.5rem" }}>
-        <div>Workspace Name</div>
+        <div>Study Name</div>
         <div>
           <TextField
             sx={{
@@ -84,7 +84,7 @@ const getValueFromStudyProperty = (
   key: string
 ) => properties?.find((pair) => pair.key === key)?.value;
 
-const mapWorkspaceRows = ({
+const mapStudyRows = ({
   id,
   displayName,
   description,
@@ -100,7 +100,7 @@ const mapWorkspaceRows = ({
   pi: getValueFromStudyProperty(properties as StudyV2Property[], "pi"),
 });
 
-const emptyWorkspace: StudyV2 = {
+const emptyStudy: StudyV2 = {
   id: "",
   displayName: "",
   description: "",
@@ -140,7 +140,7 @@ interface StudyV2Property {
   value: string;
 }
 
-interface WorkspaceRow {
+interface StudyRow {
   id: string;
   displayName: string;
   description: string;
@@ -148,51 +148,49 @@ interface WorkspaceRow {
   pi: string;
 }
 
-export function WorkspaceAdmin() {
+export function StudyAdmin() {
   const source = useAdminSource();
-  const [activeWorkspace, setActiveWorkspace] =
-    useState<StudyV2>(emptyWorkspace);
+  const [activeStudy, setActiveStudy] = useState<StudyV2>(emptyStudy);
   const [formState, setFormState] = useState(initialFormState);
   const [columnFilters, setColumnFilters] = useState({
     displayName: "",
     irbNumber: "",
   });
-  const [creatingWorkspace, setCreatingWorkspace] = useState<boolean>(false);
-  const [editingWorkspace, setEditingWorkspace] = useState<boolean>(false);
-  const [loadingWorkspace, setLoadingWorkspace] = useState<boolean>(false);
-  const [loadingWorkspaceList, setLoadingWorkspaceList] =
-    useState<boolean>(true);
-  const [workspaces, setWorkspaces] = useState<StudyV2[]>([]);
+  const [creatingStudy, setCreatingStudy] = useState<boolean>(false);
+  const [editingStudy, setEditingStudy] = useState<boolean>(false);
+  const [loadingStudy, setLoadingStudy] = useState<boolean>(false);
+  const [loadingStudyList, setLoadingStudyList] = useState<boolean>(true);
+  const [studies, setStudies] = useState<StudyV2[]>([]);
 
   useEffect(() => {
-    getWorkspaces();
+    getStudies();
   }, []);
 
-  const getWorkspaces = async () => {
+  const getStudies = async () => {
     const studies = await source.getStudiesList();
-    setWorkspaces(studies);
-    setLoadingWorkspaceList(false);
+    setStudies(studies);
+    setLoadingStudyList(false);
   };
 
-  const updateWorkspace = async () => {
-    setLoadingWorkspace(true);
+  const updateStudy = async () => {
+    setLoadingStudy(true);
     const updateStudyRequest: UpdateStudyRequest = {
-      studyId: activeWorkspace?.id,
+      studyId: activeStudy?.id,
       studyUpdateInfoV2: {
         displayName: formState.displayName.value,
         description: formState.description.value,
       },
     };
-    const updatedWorkspace = await source.updateStudy(updateStudyRequest);
-    setActiveWorkspace(updatedWorkspace);
-    setEditingWorkspace(false);
-    setLoadingWorkspace(false);
-    setLoadingWorkspaceList(true);
-    getWorkspaces();
+    const updatedStudy = await source.updateStudy(updateStudyRequest);
+    setActiveStudy(updatedStudy);
+    setEditingStudy(false);
+    setLoadingStudy(false);
+    setLoadingStudyList(true);
+    getStudies();
   };
 
-  const createWorkspace = async () => {
-    setLoadingWorkspace(true);
+  const createStudy = async () => {
+    setLoadingStudy(true);
     const creatStudyRequest: CreateStudyRequest = {
       studyCreateInfoV2: {
         displayName: formState.displayName.value,
@@ -203,11 +201,11 @@ export function WorkspaceAdmin() {
         ],
       },
     };
-    const newWorkspace = await source.createStudy(creatStudyRequest);
-    setActiveWorkspace(newWorkspace);
-    await getWorkspaces();
-    setCreatingWorkspace(false);
-    setLoadingWorkspace(false);
+    const newStudy = await source.createStudy(creatStudyRequest);
+    setActiveStudy(newStudy);
+    await getStudies();
+    setCreatingStudy(false);
+    setLoadingStudy(false);
   };
 
   const handleInputChange = (name: string, value: string) => {
@@ -222,24 +220,24 @@ export function WorkspaceAdmin() {
   };
 
   const getFilteredRowsFromStudies = () => {
-    return workspaces.filter(filterWorkspaceRows).map(mapWorkspaceRows);
+    return studies.filter(filterStudyRows).map(mapStudyRows);
   };
 
-  const populateWorkspaceForm = (workspace: StudyV2) => {
+  const populateStudyForm = (study: StudyV2) => {
     const newFormState = {
       displayName: {
         touched: false,
-        value: workspace.displayName || "",
+        value: study.displayName || "",
       },
       description: {
         touched: false,
-        value: workspace.description || "",
+        value: study.description || "",
       },
       irbNumber: {
         touched: false,
         value:
           getValueFromStudyProperty(
-            workspace.properties as StudyV2Property[],
+            study.properties as StudyV2Property[],
             "irbNumber"
           ) || "",
       },
@@ -247,7 +245,7 @@ export function WorkspaceAdmin() {
         touched: false,
         value:
           getValueFromStudyProperty(
-            workspace.properties as StudyV2Property[],
+            study.properties as StudyV2Property[],
             "pi"
           ) || "",
       },
@@ -255,7 +253,7 @@ export function WorkspaceAdmin() {
         touched: false,
         value:
           getValueFromStudyProperty(
-            workspace.properties as StudyV2Property[],
+            study.properties as StudyV2Property[],
             "pi"
           ) || "",
       },
@@ -263,17 +261,17 @@ export function WorkspaceAdmin() {
     setFormState(newFormState);
   };
 
-  const clearWorkspaceForm = () => {
+  const clearStudyForm = () => {
     setFormState(initialFormState);
   };
 
-  const filterWorkspaceRows = (workspace: StudyV2) =>
+  const filterStudyRows = (study: StudyV2) =>
     (!columnFilters.displayName ||
-      workspace?.displayName
+      study?.displayName
         ?.toLowerCase()
         .includes(columnFilters.displayName.toLowerCase())) &&
     (!columnFilters.irbNumber ||
-      workspace?.properties?.some((pair) => {
+      study?.properties?.some((pair) => {
         const { key, value } = pair as StudyV2Property;
         return (
           key === "irbNumber" &&
@@ -281,8 +279,8 @@ export function WorkspaceAdmin() {
         );
       }));
 
-  const onRowSelect = (row: WorkspaceRow) => {
-    const newActiveWorkspace = workspaces.find((ws) => ws.id === row.id);
+  const onRowSelect = (row: StudyRow) => {
+    const newActiveStudy = studies.find((ws) => ws.id === row.id);
     const newFormState = {
       displayName: {
         touched: false,
@@ -306,8 +304,8 @@ export function WorkspaceAdmin() {
       },
     };
     setFormState(newFormState);
-    if (newActiveWorkspace) {
-      setActiveWorkspace(newActiveWorkspace);
+    if (newActiveStudy) {
+      setActiveStudy(newActiveStudy);
     }
   };
 
@@ -323,49 +321,45 @@ export function WorkspaceAdmin() {
           <DataGrid
             columns={columns(handleFilterChange)}
             rows={getFilteredRowsFromStudies()}
-            loading={loadingWorkspaceList}
-            onRowClick={({ row }) => onRowSelect(row as WorkspaceRow)}
+            loading={loadingStudyList}
+            onRowClick={({ row }) => onRowSelect(row as StudyRow)}
           />
         </Box>
       </Grid>
       <Grid item xs={6}>
         <Box sx={{ position: "relative" }}>
-          <Backdrop
-            invisible
-            open={loadingWorkspace}
-            sx={{ position: "absolute" }}
-          >
+          <Backdrop invisible open={loadingStudy} sx={{ position: "absolute" }}>
             <CircularProgress />
           </Backdrop>
           <Stack spacing={2} direction="row">
             <Button
-              disabled={loadingWorkspace}
+              disabled={loadingStudy}
               onClick={() => {
-                clearWorkspaceForm();
-                setCreatingWorkspace(true);
+                clearStudyForm();
+                setCreatingStudy(true);
               }}
               variant="outlined"
             >
-              Add Workspace
+              Add Study
             </Button>
             <Button
-              disabled={activeWorkspace?.id === "" || loadingWorkspace}
-              onClick={() => setEditingWorkspace(true)}
+              disabled={activeStudy?.id === "" || loadingStudy}
+              onClick={() => setEditingStudy(true)}
               variant="outlined"
             >
-              Edit Workspace
+              Edit Study
             </Button>
             <Button
-              disabled={activeWorkspace?.id === "" || loadingWorkspace}
+              disabled={activeStudy?.id === "" || loadingStudy}
               variant="outlined"
             >
-              Add Workspace Users
+              Add Study Users
             </Button>
           </Stack>
           <div>
             <TextField
-              disabled={!(creatingWorkspace || editingWorkspace)}
-              label={"Workspace name"}
+              disabled={!(creatingStudy || editingStudy)}
+              label={"Study name"}
               name="displayName"
               fullWidth
               InputLabelProps={{
@@ -383,7 +377,7 @@ export function WorkspaceAdmin() {
           </div>
           <div>
             <TextField
-              disabled={!(creatingWorkspace || editingWorkspace)}
+              disabled={!(creatingStudy || editingStudy)}
               label={"Description"}
               name="description"
               fullWidth
@@ -401,7 +395,7 @@ export function WorkspaceAdmin() {
           </div>
           <div>
             <TextField
-              disabled={!(creatingWorkspace || editingWorkspace)}
+              disabled={!(creatingStudy || editingStudy)}
               label={"IRB Number"}
               name="irbNumber"
               InputLabelProps={{
@@ -417,7 +411,7 @@ export function WorkspaceAdmin() {
           </div>
           <div>
             <Autocomplete
-              disabled={!(creatingWorkspace || editingWorkspace)}
+              disabled={!(creatingStudy || editingStudy)}
               options={piOptions}
               value={formState?.pi.value}
               onChange={(event, newValue) =>
@@ -445,30 +439,30 @@ export function WorkspaceAdmin() {
               )}
             />
           </div>
-          {(creatingWorkspace || editingWorkspace) && (
+          {(creatingStudy || editingStudy) && (
             <Stack spacing={2} direction="row">
               <Button
-                disabled={loadingWorkspace || formIsInvalid()}
+                disabled={loadingStudy || formIsInvalid()}
                 onClick={() => {
-                  if (creatingWorkspace) {
-                    createWorkspace();
+                  if (creatingStudy) {
+                    createStudy();
                   } else {
-                    updateWorkspace();
+                    updateStudy();
                   }
                 }}
                 variant="outlined"
               >
-                {creatingWorkspace ? "Save" : "Update"} Workspace
+                {creatingStudy ? "Save" : "Update"} Study
               </Button>
               <Button
-                disabled={loadingWorkspace}
+                disabled={loadingStudy}
                 onClick={() => {
-                  if (creatingWorkspace) {
-                    clearWorkspaceForm();
-                    setCreatingWorkspace(false);
+                  if (creatingStudy) {
+                    clearStudyForm();
+                    setCreatingStudy(false);
                   } else {
-                    populateWorkspaceForm(activeWorkspace);
-                    setEditingWorkspace(false);
+                    populateStudyForm(activeStudy);
+                    setEditingStudy(false);
                   }
                 }}
                 variant="outlined"

--- a/ui/src/sd-admin/workspaceAdmin.tsx
+++ b/ui/src/sd-admin/workspaceAdmin.tsx
@@ -1,0 +1,488 @@
+import Autocomplete from "@mui/material/Autocomplete";
+import Backdrop from "@mui/material/Backdrop";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { useEffect, useState } from "react";
+
+const columns = (
+  filterFn: (name: string, value: string) => void
+): GridColDef[] => [
+  {
+    field: "workspaceName",
+    headerName: "Workspace Name",
+    sortable: true,
+    disableColumnMenu: true,
+    flex: 1,
+    renderHeader: () => (
+      <div style={{ lineHeight: "1.5rem" }}>
+        <div>Workspace Name</div>
+        <div>
+          <TextField
+            sx={{
+              "label+.css-apw9r9-MuiInputBase-root-MuiInput-root": {
+                margin: 0,
+              },
+              ".css-1ktftp8-MuiFormLabel-root-MuiInputLabel-root": {
+                top: "-16px",
+              },
+            }}
+            name="workspaceName"
+            onChange={({ target: { name, value } }) => filterFn(name, value)}
+            label="Filter"
+            variant="standard"
+            size="small"
+            margin="none"
+          />
+        </div>
+      </div>
+    ),
+  },
+  {
+    field: "irbNumber",
+    headerName: "IRB Number",
+    sortable: true,
+    disableColumnMenu: true,
+    width: 120,
+    renderHeader: () => (
+      <div style={{ lineHeight: "1.5rem" }}>
+        <div>IRB Number</div>
+        <div>
+          <TextField
+            sx={{
+              "label+.css-apw9r9-MuiInputBase-root-MuiInput-root": {
+                margin: 0,
+              },
+              ".css-1ktftp8-MuiFormLabel-root-MuiInputLabel-root": {
+                top: "-16px",
+              },
+            }}
+            name="irbNumber"
+            onChange={({ target: { name, value } }) => filterFn(name, value)}
+            label="Filter"
+            variant="standard"
+            size="small"
+            margin="none"
+          />
+        </div>
+      </div>
+    ),
+  },
+];
+
+interface MockWorkspace {
+  id: number;
+  workspaceName: string;
+  description: string;
+  irbNumber: number;
+  pi: string;
+}
+let mockWorkspaces: MockWorkspace[] = [
+  {
+    id: 1,
+    workspaceName:
+      "A case-control AQP11 gene association study in the context to toxic AKI patients",
+    description: "Mock workspace 1 for testing SD Admin",
+    irbNumber: 91526,
+    pi: "Will",
+  },
+  {
+    id: 2,
+    workspaceName:
+      "A retrospective analysis to determine diagnostic markers of RYGB failure",
+    description: "Mock workspace 2 for testing SD Admin",
+    irbNumber: 130747,
+    pi: "Erik",
+  },
+  {
+    id: 3,
+    workspaceName: "Risk Factors for Enteral Access Complications",
+    description: "Mock workspace 3 for testing SD Admin",
+    irbNumber: 91571,
+    pi: "Tim",
+  },
+  {
+    id: 4,
+    workspaceName: "Exploration of Neurological Atlas Development",
+    description: "Mock workspace 4 for testing SD Admin",
+    irbNumber: 91193,
+    pi: "Brian",
+  },
+  {
+    id: 5,
+    workspaceName:
+      "Genetic determinants of hypothyroidism and uncontrolled hypertension:  Electronic phenotype detection",
+    description: "Mock workspace 5 for testing SD Admin",
+    irbNumber: 91078,
+    pi: "Chenchal",
+  },
+  {
+    id: 6,
+    workspaceName:
+      "Magnesium deficiency among patients with chronic and acute diseases",
+    description: "Mock workspace 6 for testing SD Admin",
+    irbNumber: 91221,
+    pi: "Will",
+  },
+  {
+    id: 7,
+    workspaceName: "Genetic Polymorphisms and Pain",
+    description: "Mock workspace 7 for testing SD Admin",
+    irbNumber: 90968,
+    pi: "Erik",
+  },
+  {
+    id: 8,
+    workspaceName:
+      "VESPA - Vanderbilt Electronic Systems for Pharmacogenomic Assessment",
+    description: "Mock workspace 8 for testing SD Admin",
+    irbNumber: 90945,
+    pi: "Tim",
+  },
+  {
+    id: 9,
+    workspaceName:
+      "Evaluation of Natural Language Processing Software in De-identified Electronic Medical Records",
+    description: "Mock workspace 9 for testing SD Admin",
+    irbNumber: 91193,
+    pi: "Brian",
+  },
+  {
+    id: 10,
+    workspaceName:
+      "Evaluation of Sources, Frequency, and Various Methods of Removal of PHI Within Vanderbilt EMRs",
+    description: "Mock workspace 10 for testing SD Admin",
+    irbNumber: 56789,
+    pi: "Chenchal",
+  },
+];
+const piOptions = ["", "Will", "Erik", "Tim", "Brian", "Chenchal"];
+
+function getMockWorkspaces(): Promise<MockWorkspace[]> {
+  return new Promise<MockWorkspace[]>((resolve) => resolve(mockWorkspaces));
+}
+function getMockWorkspace(workspaceId: number): Promise<MockWorkspace> {
+  return new Promise<MockWorkspace>((resolve) => {
+    const mockWorkspace =
+      mockWorkspaces.find(({ id }) => id === workspaceId) ||
+      ({} as MockWorkspace);
+    resolve(mockWorkspace);
+  });
+}
+function updateMockWorkspace(
+  updatedWorkspace: MockWorkspace
+): Promise<MockWorkspace> {
+  return new Promise<MockWorkspace>((resolve) => {
+    mockWorkspaces = mockWorkspaces.map((mockWs) =>
+      mockWs.id === updatedWorkspace.id ? updatedWorkspace : mockWs
+    );
+    resolve(updatedWorkspace);
+  });
+}
+function createMockWorkspace(workspace: MockWorkspace): Promise<MockWorkspace> {
+  return new Promise<MockWorkspace>((resolve) => {
+    if (workspace.id === -1) {
+      workspace.id =
+        mockWorkspaces.reduce((max, ws) => Math.max(max, ws.id), 0) + 1;
+    }
+    mockWorkspaces.push(workspace);
+    resolve(workspace);
+  });
+}
+
+const emptyWorkspace: MockWorkspace = {
+  id: -1,
+  workspaceName: "",
+  description: "",
+  irbNumber: -1,
+  pi: "",
+};
+
+export function WorkspaceAdmin() {
+  const [activeWorkspace, setActiveWorkspace] =
+    useState<MockWorkspace>(emptyWorkspace);
+  const [formState, setFormState] = useState({
+    workspaceName: "",
+    description: "",
+    irbNumber: "",
+    pi: "",
+    piInput: "",
+  });
+  const [columnFilters, setColumnFilters] = useState({
+    workspaceName: "",
+    irbNumber: "",
+  });
+  const [creatingWorkspace, setCreatingWorkspace] = useState<boolean>(false);
+  const [editingWorkspace, setEditingWorkspace] = useState<boolean>(false);
+  const [loadingWorkspace, setLoadingWorkspace] = useState<boolean>(false);
+  const [loadingWorkspaceList, setLoadingWorkspaceList] =
+    useState<boolean>(true);
+  const [workspaces, setWorkspaces] = useState<MockWorkspace[]>([]);
+
+  const getWorkspaces = async () => {
+    await setTimeout(async () => {
+      const workspacesResponse = await getMockWorkspaces();
+      setWorkspaces(workspacesResponse);
+      setLoadingWorkspaceList(false);
+    }, 1000);
+  };
+
+  const getWorkspace = async (id: number) => {
+    setLoadingWorkspace(true);
+    await setTimeout(async () => {
+      const workspaceResponse = await getMockWorkspace(id);
+      populateWorkspaceForm(workspaceResponse);
+      setActiveWorkspace(workspaceResponse);
+      setLoadingWorkspace(false);
+    }, 1000);
+  };
+
+  const updateWorkspace = async () => {
+    setLoadingWorkspace(true);
+    await setTimeout(async () => {
+      const updatedWorkspace = {
+        id: activeWorkspace?.id || -1,
+        workspaceName: formState.workspaceName,
+        description: formState.description,
+        irbNumber: +formState.irbNumber,
+        pi: formState.pi,
+      };
+      const updatedResponse = await updateMockWorkspace(updatedWorkspace);
+      setActiveWorkspace(updatedResponse);
+      setWorkspaces((prevState) =>
+        prevState.map((ws) =>
+          ws.id === updatedResponse.id ? updatedResponse : ws
+        )
+      );
+      setEditingWorkspace(false);
+      setLoadingWorkspace(false);
+    }, 1000);
+  };
+
+  const createWorkspace = async () => {
+    setLoadingWorkspace(true);
+    await setTimeout(async () => {
+      const newWorkspace = {
+        id: -1,
+        workspaceName: formState.workspaceName,
+        description: formState.description,
+        irbNumber: +formState.irbNumber,
+        pi: formState.pi,
+      };
+      const createdResponse = await createMockWorkspace(newWorkspace);
+      setActiveWorkspace(createdResponse);
+      await getWorkspaces();
+      setCreatingWorkspace(false);
+      setLoadingWorkspace(false);
+    }, 1000);
+  };
+
+  const handleInputChange = (name: string, value: string) => {
+    setFormState((prevState) => ({ ...prevState, [name]: value }));
+  };
+
+  const handleFilterChange = (name: string, value: string) => {
+    setColumnFilters((prevState) => ({ ...prevState, [name]: value }));
+  };
+
+  const populateWorkspaceForm = (workspace: MockWorkspace) => {
+    const newFormState = {
+      workspaceName: workspace.workspaceName,
+      description: workspace.description,
+      irbNumber: workspace.irbNumber.toString(),
+      pi: workspace.pi,
+      piInput: workspace.pi,
+    };
+    setFormState(newFormState);
+  };
+
+  const clearWorkspaceForm = () => {
+    setFormState({
+      workspaceName: "",
+      description: "",
+      irbNumber: "",
+      pi: "",
+      piInput: "",
+    });
+  };
+
+  const filterWorkspaceRows = (workspace: MockWorkspace) =>
+    (!columnFilters.workspaceName ||
+      workspace.workspaceName
+        .toLowerCase()
+        .includes(columnFilters.workspaceName.toLowerCase())) &&
+    (!columnFilters.irbNumber ||
+      workspace.irbNumber
+        .toString()
+        .toLowerCase()
+        .includes(columnFilters.irbNumber.toLowerCase()));
+
+  useEffect(() => {
+    getWorkspaces();
+  }, []);
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={6}>
+        <Box sx={{ height: 400, width: "100%" }}>
+          <DataGrid
+            columns={columns(handleFilterChange)}
+            rows={workspaces.filter(filterWorkspaceRows)}
+            loading={loadingWorkspaceList}
+            onRowClick={({ row }) => getWorkspace(row.id)}
+          />
+        </Box>
+      </Grid>
+      <Grid item xs={6}>
+        <Box sx={{ position: "relative" }}>
+          <Backdrop
+            invisible
+            open={loadingWorkspace}
+            sx={{ position: "absolute" }}
+          >
+            <CircularProgress />
+          </Backdrop>
+          <Stack spacing={2} direction="row">
+            <Button
+              disabled={loadingWorkspace}
+              onClick={() => {
+                clearWorkspaceForm();
+                setCreatingWorkspace(true);
+              }}
+              variant="outlined"
+            >
+              Add Workspace
+            </Button>
+            <Button
+              disabled={activeWorkspace?.id < 0 || loadingWorkspace}
+              onClick={() => setEditingWorkspace(true)}
+              variant="outlined"
+            >
+              Edit Workspace
+            </Button>
+            <Button
+              disabled={activeWorkspace?.id < 0 || loadingWorkspace}
+              variant="outlined"
+            >
+              Add Workspace Users
+            </Button>
+          </Stack>
+          <div>
+            <TextField
+              disabled={!(creatingWorkspace || editingWorkspace)}
+              label={"Workspace name"}
+              name="workspaceName"
+              fullWidth
+              InputLabelProps={{
+                shrink: !!formState?.workspaceName,
+              }}
+              value={formState?.workspaceName || ""}
+              onChange={({ target: { name, value } }) =>
+                handleInputChange(name, value)
+              }
+              variant={"outlined"}
+            />
+          </div>
+          <div>
+            <TextField
+              disabled={!(creatingWorkspace || editingWorkspace)}
+              label={"Description"}
+              name="description"
+              fullWidth
+              InputLabelProps={{
+                shrink: !!formState?.description,
+              }}
+              multiline
+              rows={4}
+              value={formState?.description || ""}
+              onChange={({ target: { name, value } }) =>
+                handleInputChange(name, value)
+              }
+              variant={"outlined"}
+            />
+          </div>
+          <div>
+            <TextField
+              disabled={!(creatingWorkspace || editingWorkspace)}
+              label={"IRB Number"}
+              name="irbNumber"
+              InputLabelProps={{
+                shrink: !!formState?.irbNumber,
+              }}
+              value={formState?.irbNumber || ""}
+              onChange={({ target: { name, value } }) =>
+                handleInputChange(name, value)
+              }
+              variant={"outlined"}
+            />
+          </div>
+          <div>
+            <Autocomplete
+              disabled={!(creatingWorkspace || editingWorkspace)}
+              options={piOptions}
+              value={formState?.pi}
+              onChange={(event, newValue) =>
+                handleInputChange("pi", newValue || "")
+              }
+              inputValue={formState?.piInput || ""}
+              onInputChange={(event, newInputValue) =>
+                handleInputChange("piInput", newInputValue)
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label={"PI"}
+                  name="pi"
+                  fullWidth
+                  InputLabelProps={{
+                    shrink: !!formState?.pi,
+                  }}
+                  onChange={({ target: { name, value } }) =>
+                    handleInputChange(name, value)
+                  }
+                  variant={"outlined"}
+                />
+              )}
+            />
+          </div>
+          {(creatingWorkspace || editingWorkspace) && (
+            <Stack spacing={2} direction="row">
+              <Button
+                disabled={loadingWorkspace}
+                onClick={() => {
+                  if (creatingWorkspace) {
+                    createWorkspace();
+                  } else {
+                    updateWorkspace();
+                  }
+                }}
+                variant="outlined"
+              >
+                {creatingWorkspace ? "Save" : "Update"} Workspace
+              </Button>
+              <Button
+                disabled={loadingWorkspace}
+                onClick={() => {
+                  if (creatingWorkspace) {
+                    clearWorkspaceForm();
+                    setCreatingWorkspace(false);
+                  } else {
+                    populateWorkspaceForm(activeWorkspace);
+                    setEditingWorkspace(false);
+                  }
+                }}
+                variant="outlined"
+              >
+                Cancel
+              </Button>
+            </Stack>
+          )}
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}


### PR DESCRIPTION
Adds a new `StudyAdmin` component for the studies tab:
- Datatable for viewing a list of all studies
- Form for creating or editing studies
- Added separate `sd-admin/source.tsx` file for endpoints from the `StudyV2` api