### PR TITLE
Define review counts endpoint.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -2,12 +2,15 @@ package bio.terra.tanagra.app.controller;
 
 import static bio.terra.tanagra.service.accesscontrol.Action.CREATE;
 import static bio.terra.tanagra.service.accesscontrol.Action.DELETE;
+import static bio.terra.tanagra.service.accesscontrol.Action.QUERY_COUNTS;
 import static bio.terra.tanagra.service.accesscontrol.Action.QUERY_INSTANCES;
 import static bio.terra.tanagra.service.accesscontrol.Action.READ;
 import static bio.terra.tanagra.service.accesscontrol.Action.UPDATE;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT_REVIEW;
 
 import bio.terra.tanagra.generated.controller.ReviewsV2Api;
+import bio.terra.tanagra.generated.model.ApiInstanceCountListV2;
+import bio.terra.tanagra.generated.model.ApiReviewCountQueryV2;
 import bio.terra.tanagra.generated.model.ApiReviewCreateInfoV2;
 import bio.terra.tanagra.generated.model.ApiReviewInstanceListV2;
 import bio.terra.tanagra.generated.model.ApiReviewListV2;
@@ -98,10 +101,18 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
   }
 
   @Override
-  public ResponseEntity<ApiReviewInstanceListV2> listInstancesAndAnnotations(
+  public ResponseEntity<ApiReviewInstanceListV2> listReviewInstancesAndAnnotations(
       String studyId, String cohortId, String reviewId, ApiReviewQueryV2 body) {
     accessControlService.throwIfUnauthorized(
         null, QUERY_INSTANCES, COHORT_REVIEW, new ResourceId(reviewId));
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public ResponseEntity<ApiInstanceCountListV2> countReviewInstances(
+      String studyId, String cohortId, String reviewId, ApiReviewCountQueryV2 body) {
+    accessControlService.throwIfUnauthorized(
+        null, QUERY_COUNTS, COHORT_REVIEW, new ResourceId(reviewId));
     return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
   }
 

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -492,8 +492,8 @@ paths:
       - $ref: '#/components/parameters/CohortIdV2'
       - $ref: '#/components/parameters/ReviewIdV2'
     post:
-      summary: List all primary entity instances in a review and any associated annotation values
-      operationId: listInstancesAndAnnotations
+      summary: List primary entity instances in a review and any associated annotation values
+      operationId: listReviewInstancesAndAnnotations
       tags: [ReviewsV2]
       requestBody:
         required: true
@@ -508,6 +508,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReviewInstanceListV2"
+        500:
+          $ref: "#/components/responses/ServerError"
+
+  "/v2/studies/{studyId}/cohorts/{cohortId}/reviews/{reviewId}/counts":
+    parameters:
+      - $ref: '#/components/parameters/StudyIdV2'
+      - $ref: '#/components/parameters/CohortIdV2'
+      - $ref: '#/components/parameters/ReviewIdV2'
+    post:
+      summary: Count primary entity instances in a review
+      operationId: countReviewInstances
+      tags: [ReviewsV2]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReviewCountQueryV2'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InstanceCountListV2"
         500:
           $ref: "#/components/responses/ServerError"
 
@@ -1239,6 +1264,18 @@ components:
         limit:
           $ref: "#/components/schemas/LimitV2"
 
+    ReviewCountQueryV2:
+      type: object
+      description: Count review instances
+      properties:
+        attributes:
+          description: |
+            Attributes to group by. One count will be returned for each possible combination of attribute values 
+            (e.g. [gender, hair_color] will return counts for man+red, man+black, woman+red, woman+black).
+          type: array
+          items:
+            type: string
+
     FilterV2:
       type: object
       description: Union of references to each filter type. Exactly one should be specified based on the filterType.
@@ -1403,7 +1440,7 @@ components:
         count:
           type: integer
         attributes:
-          description: A map of entity attribute names to their value for this group.
+          description: A map of entity attribute names to their value for this group
           type: object
           additionalProperties:
             type: object


### PR DESCRIPTION
Defined the review counts endpoint. This PR does not include the implementation; plan to do that in a follow-on PR.

Request = list of attributes to group by
Response = instance counts

This is very similar to the existing counts endpoint, but the request does not include an optional entity filter.