### PR TITLE
Add getMe endpoint for current user information.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/AuthInterceptor.java
+++ b/service/src/main/java/bio/terra/tanagra/app/AuthInterceptor.java
@@ -51,6 +51,12 @@ public class AuthInterceptor implements HandlerInterceptor {
       return true;
     }
 
+    if (!(handler instanceof HandlerMethod)) {
+      LOGGER.error(
+          "Unexpected handler class: {}, {}", request.getRequestURL(), request.getMethod());
+      return false;
+    }
+
     HandlerMethod method = (HandlerMethod) handler;
     boolean isAuthRequired = false;
     ApiOperation apiOp = AnnotationUtils.findAnnotation(method.getMethod(), ApiOperation.class);

--- a/service/src/main/java/bio/terra/tanagra/app/WebMvcConfig.java
+++ b/service/src/main/java/bio/terra/tanagra/app/WebMvcConfig.java
@@ -17,6 +17,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(authInterceptor);
+    registry.addInterceptor(authInterceptor).addPathPatterns("/v2/**", "/status");
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/WebMvcConfig.java
+++ b/service/src/main/java/bio/terra/tanagra/app/WebMvcConfig.java
@@ -17,6 +17,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(authInterceptor).addPathPatterns("/v2/**", "/status");
+    registry
+        .addInterceptor(authInterceptor)
+        .addPathPatterns("/**")
+        .excludePathPatterns(
+            "/swagger-resources/**", "/swagger-ui.html", "/service_openapi.yaml", "/webjars/**");
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UsersV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UsersV2ApiController.java
@@ -1,0 +1,20 @@
+package bio.terra.tanagra.app.controller;
+
+import bio.terra.tanagra.generated.controller.UsersV2Api;
+import bio.terra.tanagra.generated.model.ApiUserProfileV2;
+import bio.terra.tanagra.service.auth.UserAuthentication;
+import bio.terra.tanagra.service.auth.UserId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class UsersV2ApiController implements UsersV2Api {
+  @Override
+  public ResponseEntity<ApiUserProfileV2> getMe() {
+    UserId userId =
+        ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication())
+            .getPrincipal();
+    return ResponseEntity.ok(new ApiUserProfileV2().email(userId.getEmail()));
+  }
+}

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -24,6 +24,21 @@ paths:
         500:
           description: Service is broken
 
+  "/v2/profile":
+    get:
+      tags: [UsersV2]
+      description: Returns the current user's profile information
+      operationId: getMe
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserProfileV2"
+        500:
+          $ref: '#/components/responses/ServerError'
+
   "/v2/underlays":
     get:
       summary: List the underlays
@@ -1012,6 +1027,15 @@ components:
         - id
         - title
       additionalProperties: true
+
+    UserProfileV2:
+      type: object
+      description: User profile
+      properties:
+        email:
+          type: string
+      required:
+        - email
 
     UnderlayV2:
       type: object


### PR DESCRIPTION
- Added an endpoint `/v2/profile` for getting information about the logged in user. Currently the only information returned is the user's email.
- Explicitly specified the paths that we don't need to decode the authentication token for. Not sure if this is strictly required, but seems better/clearer to be explicit about this anyway.