### PR TITLE
Review counts endpoint implementation.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
@@ -8,7 +8,6 @@ import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.controller.InstancesV2Api;
 import bio.terra.tanagra.generated.model.ApiCountQueryV2;
 import bio.terra.tanagra.generated.model.ApiInstanceCountListV2;
-import bio.terra.tanagra.generated.model.ApiInstanceCountV2;
 import bio.terra.tanagra.generated.model.ApiInstanceListV2;
 import bio.terra.tanagra.generated.model.ApiInstanceV2;
 import bio.terra.tanagra.generated.model.ApiInstanceV2HierarchyFields;
@@ -304,23 +303,10 @@ public class InstancesV2ApiController implements InstancesV2Api {
         new ApiInstanceCountListV2()
             .instanceCounts(
                 entityInstanceCounts.stream()
-                    .map(entityInstanceCount -> toApiObject(entityInstanceCount))
+                    .map(
+                        entityInstanceCount ->
+                            ToApiConversionUtils.toApiObject(entityInstanceCount))
                     .collect(Collectors.toList()))
             .sql(queryRequest.getSql()));
-  }
-
-  private ApiInstanceCountV2 toApiObject(EntityInstanceCount entityInstanceCount) {
-    ApiInstanceCountV2 instanceCount = new ApiInstanceCountV2();
-    Map<String, ApiValueDisplayV2> attributes = new HashMap<>();
-    for (Map.Entry<Attribute, ValueDisplay> attributeValue :
-        entityInstanceCount.getAttributeValues().entrySet()) {
-      attributes.put(
-          attributeValue.getKey().getName(),
-          ToApiConversionUtils.toApiObject(attributeValue.getValue()));
-    }
-
-    return instanceCount
-        .count(Math.toIntExact(entityInstanceCount.getCount()))
-        .attributes(attributes);
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/ReviewService.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.service;
 import bio.terra.tanagra.app.configuration.FeatureConfiguration;
 import bio.terra.tanagra.db.ReviewDao;
 import bio.terra.tanagra.query.ColumnHeaderSchema;
+import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.query.OrderByVariable;
 import bio.terra.tanagra.query.Query;
 import bio.terra.tanagra.query.QueryRequest;
@@ -114,5 +115,11 @@ public class ReviewService {
     featureConfiguration.artifactStorageEnabledCheck();
     reviewDao.updateReview(studyId, cohortRevisionGroupId, reviewId, displayName, description);
     return reviewDao.getReview(studyId, cohortRevisionGroupId, reviewId);
+  }
+
+  public List<Literal> getPrimaryEntityIds(
+      String studyId, String cohortRevisionGroupId, String reviewId) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    return reviewDao.getPrimaryEntityIds(studyId, cohortRevisionGroupId, reviewId);
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceType.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceType.java
@@ -9,7 +9,14 @@ public enum ResourceType {
   COHORT(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
   CONCEPT_SET(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
   DATASET(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
-  COHORT_REVIEW(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE)),
+  COHORT_REVIEW(
+      List.of(
+          Action.READ,
+          Action.CREATE,
+          Action.UPDATE,
+          Action.DELETE,
+          Action.QUERY_INSTANCES,
+          Action.QUERY_COUNTS)),
   ANNOTATION(List.of(Action.READ, Action.CREATE, Action.UPDATE, Action.DELETE));
 
   private List<Action> actions;

--- a/service/src/main/java/bio/terra/tanagra/service/instances/filter/AttributeFilter.java
+++ b/service/src/main/java/bio/terra/tanagra/service/instances/filter/AttributeFilter.java
@@ -5,6 +5,7 @@ import bio.terra.tanagra.query.FilterVariable;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.query.TableVariable;
 import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
+import bio.terra.tanagra.query.filtervariable.FunctionFilterVariable;
 import bio.terra.tanagra.underlay.Attribute;
 import bio.terra.tanagra.underlay.Underlay;
 import java.util.List;
@@ -12,13 +13,25 @@ import java.util.List;
 public class AttributeFilter extends EntityFilter {
   private final Attribute attribute;
   private final BinaryFilterVariable.BinaryOperator operator;
-  private final Literal value;
+  private final FunctionFilterVariable.FunctionTemplate functionTemplate;
+  private final List<Literal> values;
 
   public AttributeFilter(
       Attribute attribute, BinaryFilterVariable.BinaryOperator operator, Literal value) {
     this.attribute = attribute;
     this.operator = operator;
-    this.value = value;
+    this.functionTemplate = null;
+    this.values = List.of(value);
+  }
+
+  public AttributeFilter(
+      Attribute attribute,
+      FunctionFilterVariable.FunctionTemplate functionTemplate,
+      List<Literal> values) {
+    this.attribute = attribute;
+    this.operator = null;
+    this.functionTemplate = functionTemplate;
+    this.values = values;
   }
 
   @Override
@@ -29,6 +42,9 @@ public class AttributeFilter extends EntityFilter {
             .getMapping(Underlay.MappingType.INDEX)
             .getValue()
             .buildVariable(entityTableVar, tableVars);
-    return new BinaryFilterVariable(valueFieldVar, operator, value);
+    return functionTemplate == null
+        ? new BinaryFilterVariable(valueFieldVar, operator, values.get(0))
+        : new FunctionFilterVariable(
+            functionTemplate, valueFieldVar, values.toArray(new Literal[0]));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -6,6 +6,7 @@ import bio.terra.tanagra.generated.model.ApiCohortV2;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroupV2;
 import bio.terra.tanagra.generated.model.ApiCriteriaV2;
 import bio.terra.tanagra.generated.model.ApiDataTypeV2;
+import bio.terra.tanagra.generated.model.ApiInstanceCountV2;
 import bio.terra.tanagra.generated.model.ApiLiteralV2;
 import bio.terra.tanagra.generated.model.ApiLiteralV2ValueUnion;
 import bio.terra.tanagra.generated.model.ApiValueDisplayV2;
@@ -13,8 +14,11 @@ import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.service.artifact.Cohort;
 import bio.terra.tanagra.service.artifact.Criteria;
 import bio.terra.tanagra.service.artifact.CriteriaGroup;
+import bio.terra.tanagra.service.instances.EntityInstanceCount;
 import bio.terra.tanagra.underlay.Attribute;
 import bio.terra.tanagra.underlay.ValueDisplay;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class ToApiConversionUtils {
@@ -90,5 +94,18 @@ public final class ToApiConversionUtils {
         .pluginName(criteria.getPluginName())
         .selectionData(criteria.getSelectionData())
         .uiConfig(criteria.getUiConfig());
+  }
+
+  public static ApiInstanceCountV2 toApiObject(EntityInstanceCount entityInstanceCount) {
+    ApiInstanceCountV2 instanceCount = new ApiInstanceCountV2();
+    Map<String, ApiValueDisplayV2> attributes = new HashMap<>();
+    for (Map.Entry<Attribute, ValueDisplay> attributeValue :
+        entityInstanceCount.getAttributeValues().entrySet()) {
+      attributes.put(attributeValue.getKey().getName(), toApiObject(attributeValue.getValue()));
+    }
+
+    return instanceCount
+        .count(Math.toIntExact(entityInstanceCount.getCount()))
+        .attributes(attributes);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/FilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/FilterVariable.java
@@ -1,18 +1,13 @@
 package bio.terra.tanagra.query;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import java.util.List;
 import org.apache.commons.text.StringSubstitutor;
 
 public abstract class FilterVariable implements SQLExpression {
-  protected String getSubstitutionTemplate() {
-    throw new UnsupportedOperationException("Substitution template required");
-  }
+  protected abstract String getSubstitutionTemplate();
 
-  protected List<FieldVariable> getFieldVariables() {
-    return Collections.EMPTY_LIST;
-  }
+  public abstract List<FieldVariable> getFieldVariables();
 
   @Override
   public String renderSQL() {

--- a/underlay/src/main/java/bio/terra/tanagra/query/FilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/FilterVariable.java
@@ -1,7 +1,27 @@
 package bio.terra.tanagra.query;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.List;
+import org.apache.commons.text.StringSubstitutor;
 
 public abstract class FilterVariable implements SQLExpression {
-  public abstract List<TableVariable> getTableVariables();
+  protected String getSubstitutionTemplate() {
+    throw new UnsupportedOperationException("Substitution template required");
+  }
+
+  protected List<FieldVariable> getFieldVariables() {
+    return Collections.EMPTY_LIST;
+  }
+
+  @Override
+  public String renderSQL() {
+    ImmutableMap.Builder paramsBuilder = ImmutableMap.<String, String>builder();
+    List<FieldVariable> fieldVars = getFieldVariables();
+    for (int ctr = 0; ctr < fieldVars.size(); ctr++) {
+      paramsBuilder.put(
+          "fieldVariable" + (ctr == 0 ? "" : ctr), fieldVars.get(ctr).renderSqlForWhere());
+    }
+    return StringSubstitutor.replace(getSubstitutionTemplate(), paramsBuilder.build());
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BinaryFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BinaryFilterVariable.java
@@ -4,13 +4,14 @@ import bio.terra.tanagra.query.FieldVariable;
 import bio.terra.tanagra.query.FilterVariable;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.query.SQLExpression;
-import bio.terra.tanagra.query.TableVariable;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.text.StringSubstitutor;
 
 public class BinaryFilterVariable extends FilterVariable {
+  private static final String SUBSTITUTION_TEMPLATE = "${fieldVariable} ${operator} ${value}";
+
   private final FieldVariable fieldVariable;
   private final BinaryOperator operator;
   private final Literal value;
@@ -22,20 +23,18 @@ public class BinaryFilterVariable extends FilterVariable {
   }
 
   @Override
-  public String renderSQL() {
-    String template = "${fieldSQL} ${operator} ${value}";
+  protected String getSubstitutionTemplate() {
     Map<String, String> params =
         ImmutableMap.<String, String>builder()
-            .put("fieldSQL", fieldVariable.renderSqlForWhere())
             .put("operator", operator.renderSQL())
             .put("value", value.renderSQL())
             .build();
-    return StringSubstitutor.replace(template, params);
+    return StringSubstitutor.replace(SUBSTITUTION_TEMPLATE, params);
   }
 
   @Override
-  public List<TableVariable> getTableVariables() {
-    return null;
+  protected List<FieldVariable> getFieldVariables() {
+    return List.of(fieldVariable);
   }
 
   public enum BinaryOperator implements SQLExpression {

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BinaryFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BinaryFilterVariable.java
@@ -33,7 +33,7 @@ public class BinaryFilterVariable extends FilterVariable {
   }
 
   @Override
-  protected List<FieldVariable> getFieldVariables() {
+  public List<FieldVariable> getFieldVariables() {
     return List.of(fieldVariable);
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BooleanAndOrFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BooleanAndOrFilterVariable.java
@@ -1,7 +1,9 @@
 package bio.terra.tanagra.query.filtervariable;
 
+import bio.terra.tanagra.query.FieldVariable;
 import bio.terra.tanagra.query.FilterVariable;
 import bio.terra.tanagra.query.SQLExpression;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -12,6 +14,18 @@ public class BooleanAndOrFilterVariable extends FilterVariable {
   public BooleanAndOrFilterVariable(LogicalOperator operator, List<FilterVariable> subFilters) {
     this.operator = operator;
     this.subFilters = subFilters;
+  }
+
+  @Override
+  protected String getSubstitutionTemplate() {
+    return null;
+  }
+
+  @Override
+  public List<FieldVariable> getFieldVariables() {
+    List<FieldVariable> fieldVars = new ArrayList<>();
+    subFilters.stream().forEach(subFilter -> fieldVars.addAll(subFilter.getFieldVariables()));
+    return fieldVars;
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BooleanAndOrFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/BooleanAndOrFilterVariable.java
@@ -2,31 +2,25 @@ package bio.terra.tanagra.query.filtervariable;
 
 import bio.terra.tanagra.query.FilterVariable;
 import bio.terra.tanagra.query.SQLExpression;
-import bio.terra.tanagra.query.TableVariable;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class BooleanAndOrFilterVariable extends FilterVariable {
   private final LogicalOperator operator;
-  private final List<FilterVariable> subfilters;
+  private final List<FilterVariable> subFilters;
 
-  public BooleanAndOrFilterVariable(LogicalOperator operator, List<FilterVariable> subfilters) {
+  public BooleanAndOrFilterVariable(LogicalOperator operator, List<FilterVariable> subFilters) {
     this.operator = operator;
-    this.subfilters = subfilters;
+    this.subFilters = subFilters;
   }
 
   @Override
   public String renderSQL() {
     return "("
-        + subfilters.stream()
+        + subFilters.stream()
             .map(sf -> sf.renderSQL())
             .collect(Collectors.joining(" " + operator.renderSQL() + " "))
         + ")";
-  }
-
-  @Override
-  public List<TableVariable> getTableVariables() {
-    return null;
   }
 
   public enum LogicalOperator implements SQLExpression {

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/FunctionFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/FunctionFilterVariable.java
@@ -3,42 +3,45 @@ package bio.terra.tanagra.query.filtervariable;
 import bio.terra.tanagra.query.FieldVariable;
 import bio.terra.tanagra.query.FilterVariable;
 import bio.terra.tanagra.query.Literal;
-import bio.terra.tanagra.query.TableVariable;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
 public class FunctionFilterVariable extends FilterVariable {
   private final FieldVariable fieldVariable;
   private final FunctionTemplate functionTemplate;
-  private final Literal value;
+  private final List<Literal> values;
 
   public FunctionFilterVariable(
-      FunctionTemplate functionTemplate, FieldVariable fieldVariable, Literal value) {
+      FunctionTemplate functionTemplate, FieldVariable fieldVariable, Literal... values) {
     this.functionTemplate = functionTemplate;
     this.fieldVariable = fieldVariable;
-    this.value = value;
+    this.values = List.of(values);
   }
 
   @Override
-  public String renderSQL() {
+  protected String getSubstitutionTemplate() {
+    String valuesSQL =
+        values.size() > 1
+            ? values.stream().map(Literal::renderSQL).collect(Collectors.joining(","))
+            : values.get(0).renderSQL();
     Map<String, String> params =
-        ImmutableMap.<String, String>builder()
-            .put("fieldVariable", fieldVariable.renderSqlForWhere())
-            .put("value", value.renderSQL())
-            .build();
+        ImmutableMap.<String, String>builder().put("value", valuesSQL).build();
     return StringSubstitutor.replace(functionTemplate.getSqlTemplate(), params);
   }
 
   @Override
-  public List<TableVariable> getTableVariables() {
-    return null;
+  protected List<FieldVariable> getFieldVariables() {
+    return List.of(fieldVariable);
   }
 
   public enum FunctionTemplate {
     TEXT_EXACT_MATCH("CONTAINS_SUBSTR(${fieldVariable}, ${value})"),
-    TEXT_FUZZY_MATCH("bqutil.fn.levenshtein(UPPER(${fieldVariable}), UPPER(${value}))<5");
+    TEXT_FUZZY_MATCH("bqutil.fn.levenshtein(UPPER(${fieldVariable}), UPPER(${value}))<5"),
+    IN("${fieldVariable} IN (${value})"),
+    NOT_IN("${fieldVariable} NOT IN (${value})");
 
     private String sqlTemplate;
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/FunctionFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/FunctionFilterVariable.java
@@ -33,7 +33,7 @@ public class FunctionFilterVariable extends FilterVariable {
   }
 
   @Override
-  protected List<FieldVariable> getFieldVariables() {
+  public List<FieldVariable> getFieldVariables() {
     return List.of(fieldVariable);
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/NotFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/NotFilterVariable.java
@@ -1,23 +1,16 @@
 package bio.terra.tanagra.query.filtervariable;
 
 import bio.terra.tanagra.query.FilterVariable;
-import bio.terra.tanagra.query.TableVariable;
-import java.util.List;
 
 public class NotFilterVariable extends FilterVariable {
-  private final FilterVariable subfilter;
+  private final FilterVariable subFilter;
 
-  public NotFilterVariable(FilterVariable subfilter) {
-    this.subfilter = subfilter;
+  public NotFilterVariable(FilterVariable subFilter) {
+    this.subFilter = subFilter;
   }
 
   @Override
   public String renderSQL() {
-    return "(NOT " + subfilter.renderSQL() + ")";
-  }
-
-  @Override
-  public List<TableVariable> getTableVariables() {
-    return null;
+    return "(NOT " + subFilter.renderSQL() + ")";
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/NotFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/NotFilterVariable.java
@@ -1,12 +1,24 @@
 package bio.terra.tanagra.query.filtervariable;
 
+import bio.terra.tanagra.query.FieldVariable;
 import bio.terra.tanagra.query.FilterVariable;
+import java.util.List;
 
 public class NotFilterVariable extends FilterVariable {
   private final FilterVariable subFilter;
 
   public NotFilterVariable(FilterVariable subFilter) {
     this.subFilter = subFilter;
+  }
+
+  @Override
+  protected String getSubstitutionTemplate() {
+    return null;
+  }
+
+  @Override
+  public List<FieldVariable> getFieldVariables() {
+    return subFilter.getFieldVariables();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
@@ -4,13 +4,39 @@ import bio.terra.tanagra.query.FieldVariable;
 import bio.terra.tanagra.query.FilterVariable;
 import bio.terra.tanagra.query.Query;
 import bio.terra.tanagra.query.SQLExpression;
-import bio.terra.tanagra.query.TableVariable;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.text.StringSubstitutor;
 
 public class SubQueryFilterVariable extends FilterVariable {
+  private static final String SUBSTITUTION_TEMPLATE = "${fieldVariable} ${operator} (${subQuery})";
+
+  private final FieldVariable fieldVariable;
+  private final Operator operator;
+  private final Query subQuery;
+
+  public SubQueryFilterVariable(FieldVariable fieldVariable, Operator operator, Query subQuery) {
+    this.fieldVariable = fieldVariable;
+    this.operator = operator;
+    this.subQuery = subQuery;
+  }
+
+  @Override
+  protected String getSubstitutionTemplate() {
+    Map<String, String> params =
+        ImmutableMap.<String, String>builder()
+            .put("operator", operator.renderSQL())
+            .put("subQuery", subQuery.renderSQL())
+            .build();
+    return StringSubstitutor.replace(SUBSTITUTION_TEMPLATE, params);
+  }
+
+  @Override
+  protected List<FieldVariable> getFieldVariables() {
+    return List.of(fieldVariable);
+  }
+
   public enum Operator implements SQLExpression {
     IN("IN"),
     NOT_IN("NOT IN");
@@ -25,32 +51,5 @@ public class SubQueryFilterVariable extends FilterVariable {
     public String renderSQL() {
       return sql;
     }
-  }
-
-  private final FieldVariable fieldVariable;
-  private final Operator operator;
-  private final Query subQuery;
-
-  public SubQueryFilterVariable(FieldVariable fieldVariable, Operator operator, Query subQuery) {
-    this.fieldVariable = fieldVariable;
-    this.operator = operator;
-    this.subQuery = subQuery;
-  }
-
-  @Override
-  public String renderSQL() {
-    String template = "${fieldSQL} ${operator} (${subQuerySQL})";
-    Map<String, String> params =
-        ImmutableMap.<String, String>builder()
-            .put("fieldSQL", fieldVariable.renderSqlForWhere())
-            .put("operator", operator.renderSQL())
-            .put("subQuerySQL", subQuery.renderSQL())
-            .build();
-    return StringSubstitutor.replace(template, params);
-  }
-
-  @Override
-  public List<TableVariable> getTableVariables() {
-    return null;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/filtervariable/SubQueryFilterVariable.java
@@ -33,7 +33,7 @@ public class SubQueryFilterVariable extends FilterVariable {
   }
 
   @Override
-  protected List<FieldVariable> getFieldVariables() {
+  public List<FieldVariable> getFieldVariables() {
     return List.of(fieldVariable);
   }
 


### PR DESCRIPTION
- Added two new `FilterVariable` operators: `IN` and `NOT IN`. `FilterVariable` = SQL `WHERE` clause.
- Implemented the cohort review counts endpoint. This endpoint takes a list of primary entity (`person` for OMOP) attributes (e.g. `gender`, `ethnicity`) and returns a breakdown of the people in the cohort by these attributes (e.g. 5 male+american, 3 female+american, 60 male+canadian, 300 female+canadian).

I tested this manually on the Swagger page. Automated tests to come in a future PR.