### PR TITLE
Add config property for disabling authentication.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,6 +65,13 @@ starts a local server on `localhost:8080`.
 
 See [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) for the Swagger API page.
 
+You can also run the local server with authentication disabled. This is useful when testing the UI, which does not 
+have a login flow yet. (We rely on IAP to handle the Google OAuth flow in our dev deployments.)
+
+```
+./service/local-dev/run_server.sh disable-auth
+```
+
 ### Adding dependencies
 **UPDATE: Dependency locking has been temporarily disabled because it's causing problems for collaborators. 
 Planning to debug and add this back once we've debugged the problems.**

--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -1,13 +1,34 @@
 #!/bin/bash
 
-export TANAGRA_DATABASE_NAME=tanagra_db
-export TANAGRA_DB_INITIALIZE_ON_START=true
-export TANAGRA_DB_USERNAME=dbuser
-export TANAGRA_DB_PASSWORD=dbpwd
+setupEnvVars() {
+  disableAuthChecks=$1 # 0=false, 1=true
 
-export TANAGRA_UNDERLAY_FILES=broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json
-export TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED=true
-export TANAGRA_AUTH_IAP_GKE_JWT=false
-export TANAGRA_AUTH_BEARER_TOKEN=true
+  export TANAGRA_DATABASE_NAME=tanagra_db
+  export TANAGRA_DB_INITIALIZE_ON_START=true
+  export TANAGRA_DB_USERNAME=dbuser
+  export TANAGRA_DB_PASSWORD=dbpwd
+
+  export TANAGRA_UNDERLAY_FILES=broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json
+  export TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED=true
+  export TANAGRA_AUTH_IAP_GKE_JWT=false
+
+  if [ $disableAuthChecks == 1 ]; then
+    export TANAGRA_AUTH_DISABLE_CHECKS=true
+    export TANAGRA_AUTH_BEARER_TOKEN=false
+  else
+    export TANAGRA_AUTH_DISABLE_CHECKS=false
+    export TANAGRA_AUTH_BEARER_TOKEN=true
+  fi
+}
+
+COMMAND=$1
+if [ ${#@} == 0 ]; then
+    setupEnvVars 0
+elif [ $COMMAND = "disable-auth" ]; then
+    setupEnvVars 1
+else
+    echo "Usage: $0 [disable-auth]"
+    exit 1
+fi
 
 ./gradlew bootRun

--- a/service/src/main/java/bio/terra/tanagra/app/AuthInterceptor.java
+++ b/service/src/main/java/bio/terra/tanagra/app/AuthInterceptor.java
@@ -97,6 +97,9 @@ public class AuthInterceptor implements HandlerInterceptor {
         userAuth =
             new UserAuthentication(
                 userId, bearerToken.getToken(), UserAuthentication.TokenType.BEARER_TOKEN);
+      } else if (authConfiguration.isDisableChecks()) {
+        LOGGER.warn("Authentication checks are disabled");
+        userAuth = new UserAuthentication(UserId.forDisabledAuthentication(), null, null);
       } else {
         throw new SystemException("Invalid auth configuration");
       }

--- a/service/src/main/java/bio/terra/tanagra/app/AuthInterceptor.java
+++ b/service/src/main/java/bio/terra/tanagra/app/AuthInterceptor.java
@@ -98,7 +98,7 @@ public class AuthInterceptor implements HandlerInterceptor {
             new UserAuthentication(
                 userId, bearerToken.getToken(), UserAuthentication.TokenType.BEARER_TOKEN);
       } else if (authConfiguration.isDisableChecks()) {
-        LOGGER.warn("Authentication checks are disabled");
+        LOGGER.warn("Authentication checks are disabled. This should only happen for local development.");
         userAuth = new UserAuthentication(UserId.forDisabledAuthentication(), null, null);
       } else {
         throw new SystemException("Invalid auth configuration");

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/AuthConfiguration.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/AuthConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 public class AuthConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(AuthConfiguration.class);
 
+  private boolean disableChecks;
   private boolean iapGkeJwt;
   private boolean iapAppEngineJwt;
   private boolean bearerToken;
@@ -19,6 +20,10 @@ public class AuthConfiguration {
   private String gcpProjectNumber;
   private String gcpProjectId;
   private String gkeBackendServiceId;
+
+  public boolean isDisableChecks() {
+    return disableChecks;
+  }
 
   public boolean isIapGkeJwt() {
     return iapGkeJwt;
@@ -56,6 +61,10 @@ public class AuthConfiguration {
     }
   }
 
+  public void setDisableChecks(boolean disableChecks) {
+    this.disableChecks = disableChecks;
+  }
+
   public void setIapGkeJwt(boolean iapGkeJwt) {
     this.iapGkeJwt = iapGkeJwt;
   }
@@ -82,6 +91,7 @@ public class AuthConfiguration {
 
   /** Write the auth flags into the log. Add an entry here for each new auth flag. */
   public void logConfig() {
+    LOGGER.info("Auth config: disable-checks: {}", isDisableChecks());
     LOGGER.info("Auth config: iap-gke-jwt: {}", isIapGkeJwt());
     LOGGER.info("Auth config: iap-appengine-jwt: {}", isIapAppEngineJwt());
     LOGGER.info("Auth config: bearer-token: {}", isBearerToken());

--- a/service/src/main/java/bio/terra/tanagra/service/auth/UserId.java
+++ b/service/src/main/java/bio/terra/tanagra/service/auth/UserId.java
@@ -10,12 +10,19 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * or its plugins need can be stored here.
  */
 public final class UserId implements Serializable {
+  private static final String DISABLED_AUTHENTICATION_USER_ID = "authentication-disabled";
+
   private final String subject;
   private final String email;
 
   private UserId(String subject, String email) {
     this.subject = subject;
     this.email = email;
+  }
+
+  /** Build a default user object for when authentication is disabled. */
+  public static UserId forDisabledAuthentication() {
+    return new UserId(DISABLED_AUTHENTICATION_USER_ID, DISABLED_AUTHENTICATION_USER_ID);
   }
 
   /** Build a user object with information from an authentication token. */

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -6,6 +6,7 @@ tanagra:
     artifact-storage-enabled: true
 
   auth:
+    disable-checks: false
     iap-gke-jwt: true
     iap-appengine-jwt: false
     bearer-token: false


### PR DESCRIPTION
Added a config property for disabling authentication. Updated the `service/local-dev/run_server.sh` script to optionally set this config property (default is still to enable authentication).

This change is intended for use during local UI development only. Since the UI doesn't currently include a login flow, all endpoints are returning `401`s now that I've added checks for the authentication headers to the backend. The 2 existing Tanagra deployments are both behind IAP, so the login flow is handled by the proxy and the UI doesn't need to do anything to stick the authentication token in the header. For local backend development, we can enable authentication because the Swagger UI page allows you to supply a bearer token that the backend knows how to handle.