### PR TITLE
Use workload identity provider for docker push instead of key file.

### DIFF
--- a/.github/workflows/bump-tag-publish.yaml
+++ b/.github/workflows/bump-tag-publish.yaml
@@ -1,4 +1,4 @@
-name: Bump, Tag, Publish, and Deploy
+name: Bump, Tag, Publish
 # The purpose of the workflow is to:
 #  1. Bump the version number and tag the release
 #  2. Build and publish the client to Artifactory
@@ -119,14 +119,15 @@ jobs:
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/auth@v1
         with:
-          version: '411.0.0'
-          credentials_json: ${{ secrets.GCR_PUBLISH_KEY }}
+          workload_identity_provider: projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider
+          service_account: gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com
       - name: Setup gcloud
         if: steps.skiptest.outputs.is-bump == 'no'
         uses: google-github-actions/setup-gcloud@v1
       - name: Explicitly auth Docker for GCR
         if: steps.skiptest.outputs.is-bump == 'no'
         run: gcloud auth configure-docker --quiet
+
       - name: Construct docker image name and tag
         if: steps.skiptest.outputs.is-bump == 'no'
         id: image-name

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ out/
 ### Cypress ###
 ui/cypress/videos/
 ui/cypress/screenshots/
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
"Auth to GCP" step is failing in the bump-tag-publish GHA, just before pushing the Docker image.

I tried to follow the example in the java-project-template GH repo. Companion [PR](https://github.com/broadinstitute/terraform-ap-deployments/pull/859) in `terraform-ap-deployments` to allow GHAs in this repo to impersonate the `gcr-publish` SA. (Plan to merge that PR first.)