### PR TITLE
Add created, created_by columns to artifacts

### DIFF
--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Main" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <module name="tanagra.service.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.tanagra.app.Main" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/service" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <envs>
+      <env name="TANAGRA_DATABASE_NAME" value="tanagra_db" />
+      <env name="TANAGRA_DB_INITIALIZE_ON_START" value="true" />
+      <env name="TANAGRA_DB_USERNAME" value="dbuser" />
+      <env name="TANAGRA_DB_PASSWORD" value="dbpwd" />
+      <env name="TANAGRA_UNDERLAY_FILES" value="broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json" />
+      <env name="TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED" value="true" />
+      <env name="TANAGRA_AUTH_IAP_GKE_JWT" value="false" />
+      <env name="TANAGRA_AUTH_BEARER_TOKEN" value="true" />
+    </envs>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -6,13 +6,14 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <envs>
       <env name="TANAGRA_DATABASE_NAME" value="tanagra_db" />
-      <env name="TANAGRA_DB_INITIALIZE_ON_START" value="true" />
+      <env name="TANAGRA_DB_INITIALIZE_ON_START" value="false" />
       <env name="TANAGRA_DB_USERNAME" value="dbuser" />
       <env name="TANAGRA_DB_PASSWORD" value="dbpwd" />
       <env name="TANAGRA_UNDERLAY_FILES" value="broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json" />
       <env name="TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED" value="true" />
       <env name="TANAGRA_AUTH_IAP_GKE_JWT" value="false" />
       <env name="TANAGRA_AUTH_BEARER_TOKEN" value="true" />
+      <env name="GOOGLE_APPLICATION_CREDENTIALS" value="$PROJECT_DIR$/rendered/tanagra_sa.json" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "tanagra",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "tanagra",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsV2ApiController.java
@@ -70,6 +70,7 @@ public class CohortsV2ApiController implements CohortsV2Api {
             .underlayName(body.getUnderlayName())
             .cohortRevisionGroupId(newCohortRevisionGroupId)
             .version(Cohort.STARTING_VERSION)
+            .createdBy(UserId.currentUser().getEmail())
             .displayName(body.getDisplayName())
             .description(body.getDescription())
             .build();

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
@@ -67,6 +67,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
             .conceptSetId(newConceptSetId)
             .underlayName(body.getUnderlayName())
             .entityName(body.getEntity())
+            .createdBy(UserId.currentUser().getEmail())
             .displayName(body.getDisplayName())
             .description(body.getDescription())
             .build();

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
@@ -72,7 +72,8 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
             .build();
     conceptSetService.createConceptSet(conceptSetToCreate);
     return ResponseEntity.ok(
-        toApiObject(conceptSetService.getConceptSet(studyId, newConceptSetId)));
+        ToApiConversionUtils.toApiObject(
+            conceptSetService.getConceptSet(studyId, newConceptSetId)));
   }
 
   @Override
@@ -87,7 +88,8 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
   public ResponseEntity<ApiConceptSetV2> getConceptSet(String studyId, String conceptSetId) {
     accessControlService.throwIfUnauthorized(
         UserId.currentUser(), READ, CONCEPT_SET, new ResourceId(conceptSetId));
-    return ResponseEntity.ok(toApiObject(conceptSetService.getConceptSet(studyId, conceptSetId)));
+    return ResponseEntity.ok(
+        ToApiConversionUtils.toApiObject(conceptSetService.getConceptSet(studyId, conceptSetId)));
   }
 
   @Override
@@ -111,7 +113,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
 
     ApiConceptSetListV2 apiConceptSets = new ApiConceptSetListV2();
     authorizedConceptSets.stream()
-        .forEach(conceptSet -> apiConceptSets.add(toApiObject(conceptSet)));
+        .forEach(conceptSet -> apiConceptSets.add(ToApiConversionUtils.toApiObject(conceptSet)));
     return ResponseEntity.ok(apiConceptSets);
   }
 
@@ -150,21 +152,6 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
             body.getDisplayName(),
             body.getDescription(),
             criteria);
-    return ResponseEntity.ok(toApiObject(updatedConceptSet));
-  }
-
-  /** Convert the internal Concept Set object to an API Concept Set object. */
-  private static ApiConceptSetV2 toApiObject(ConceptSet conceptSet) {
-    return new ApiConceptSetV2()
-        .id(conceptSet.getConceptSetId())
-        .underlayName(conceptSet.getUnderlayName())
-        .entity(conceptSet.getEntityName())
-        .displayName(conceptSet.getDisplayName())
-        .description(conceptSet.getDescription())
-        .lastModified(conceptSet.getLastModifiedUTC())
-        .criteria(
-            conceptSet.getCriteria() == null
-                ? null
-                : ToApiConversionUtils.toApiObject(conceptSet.getCriteria()));
+    return ResponseEntity.ok(ToApiConversionUtils.toApiObject(updatedConceptSet));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
@@ -73,8 +73,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
             .build();
     conceptSetService.createConceptSet(conceptSetToCreate);
     return ResponseEntity.ok(
-        ToApiConversionUtils.toApiObject(
-            conceptSetService.getConceptSet(studyId, newConceptSetId)));
+        toApiObject(conceptSetService.getConceptSet(studyId, newConceptSetId)));
   }
 
   @Override
@@ -89,8 +88,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
   public ResponseEntity<ApiConceptSetV2> getConceptSet(String studyId, String conceptSetId) {
     accessControlService.throwIfUnauthorized(
         UserId.currentUser(), READ, CONCEPT_SET, new ResourceId(conceptSetId));
-    return ResponseEntity.ok(
-        ToApiConversionUtils.toApiObject(conceptSetService.getConceptSet(studyId, conceptSetId)));
+    return ResponseEntity.ok(toApiObject(conceptSetService.getConceptSet(studyId, conceptSetId)));
   }
 
   @Override
@@ -114,7 +112,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
 
     ApiConceptSetListV2 apiConceptSets = new ApiConceptSetListV2();
     authorizedConceptSets.stream()
-        .forEach(conceptSet -> apiConceptSets.add(ToApiConversionUtils.toApiObject(conceptSet)));
+        .forEach(conceptSet -> apiConceptSets.add(toApiObject(conceptSet)));
     return ResponseEntity.ok(apiConceptSets);
   }
 
@@ -153,6 +151,22 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
             body.getDisplayName(),
             body.getDescription(),
             criteria);
-    return ResponseEntity.ok(ToApiConversionUtils.toApiObject(updatedConceptSet));
+    return ResponseEntity.ok(toApiObject(updatedConceptSet));
+  }
+
+  private static ApiConceptSetV2 toApiObject(ConceptSet conceptSet) {
+    return new ApiConceptSetV2()
+        .id(conceptSet.getConceptSetId())
+        .underlayName(conceptSet.getUnderlayName())
+        .entity(conceptSet.getEntityName())
+        .displayName(conceptSet.getDisplayName())
+        .description(conceptSet.getDescription())
+        .created(conceptSet.getCreated())
+        .createdBy(conceptSet.getCreatedBy())
+        .lastModified(conceptSet.getLastModified())
+        .criteria(
+            conceptSet.getCriteria() == null
+                ? null
+                : ToApiConversionUtils.toApiObject(conceptSet.getCriteria()));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -106,6 +106,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
             .displayName(body.getDisplayName())
             .description(body.getDescription())
             .size(body.getSize())
+            .createdBy(UserId.currentUser().getEmail())
             .build();
 
     // TODO: Move this to the ReviewService once we can build the EntityFilter from the Cohort on
@@ -310,6 +311,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
         .description(review.getDescription())
         .size(review.getSize())
         .created(review.getCreated())
+        .createdBy(review.getCreatedBy())
         .lastModified(review.getLastModified())
         .cohort(ToApiConversionUtils.toApiObject(review.getCohort()));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -309,7 +309,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
         .displayName(review.getDisplayName())
         .description(review.getDescription())
         .size(review.getSize())
-        .created(review.getCreatedUTC())
+        .created(review.getCreated())
         .cohort(ToApiConversionUtils.toApiObject(review.getCohort()));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -310,6 +310,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
         .description(review.getDescription())
         .size(review.getSize())
         .created(review.getCreated())
+        .lastModified(review.getLastModified())
         .cohort(ToApiConversionUtils.toApiObject(review.getCohort()));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
@@ -133,7 +133,8 @@ public class StudiesV2ApiController implements StudiesV2Api {
         .id(study.getStudyId())
         .displayName(study.getDisplayName())
         .description(study.getDescription())
-        .properties(apiProperties);
+        .properties(apiProperties)
+        .created(study.getCreated());
   }
 
   private static ImmutableMap<String, String> fromApiObject(

--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
@@ -55,6 +55,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
             .displayName(body.getDisplayName())
             .description(body.getDescription())
             .properties(fromApiObject(body.getProperties()))
+            .createdBy(UserId.currentUser().getEmail())
             .build();
     studyService.createStudy(studyToCreate);
     return ResponseEntity.ok(toApiObject(studyToCreate));
@@ -135,6 +136,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
         .description(study.getDescription())
         .properties(apiProperties)
         .created(study.getCreated())
+        .createdBy(study.getCreatedBy())
         .lastModified(study.getLastModified());
   }
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
@@ -134,7 +134,8 @@ public class StudiesV2ApiController implements StudiesV2Api {
         .displayName(study.getDisplayName())
         .description(study.getDescription())
         .properties(apiProperties)
-        .created(study.getCreated());
+        .created(study.getCreated())
+        .lastModified(study.getLastModified());
   }
 
   private static ImmutableMap<String, String> fromApiObject(

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -353,6 +353,7 @@ public class CohortDao {
             .addValue("underlay_name", cohort.getUnderlayName())
             .addValue("cohort_revision_group_id", cohort.getCohortRevisionGroupId())
             .addValue("version", cohort.getVersion())
+            // Don't need to set created. Liquibase defaultValueComputed handles that.
             .addValue("created_by", cohort.getCreatedBy())
             .addValue("last_modified", Timestamp.from(Instant.now()))
             .addValue("display_name", cohort.getDisplayName())

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -38,7 +38,7 @@ public class CohortDao {
 
   // SQL query and row mapper for reading a cohort.
   private static final String COHORT_SELECT_SQL =
-      "SELECT study_id, cohort_id, underlay_name, cohort_revision_group_id, version, is_most_recent, is_editable, created, last_modified, display_name, description FROM cohort";
+      "SELECT study_id, cohort_id, underlay_name, cohort_revision_group_id, version, is_most_recent, is_editable, created, created_by, last_modified, display_name, description FROM cohort";
   private static final RowMapper<Cohort.Builder> COHORT_ROW_MAPPER =
       (rs, rowNum) ->
           Cohort.builder()
@@ -49,6 +49,7 @@ public class CohortDao {
               .version(rs.getInt("version"))
               .isMostRecent(rs.getBoolean("is_most_recent"))
               .isEditable(rs.getBoolean("is_editable"))
+              .createdBy(rs.getString("created_by"))
               .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
               .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))
               .displayName(rs.getString("display_name"))
@@ -343,8 +344,8 @@ public class CohortDao {
   private void createCohortHelper(Cohort cohort) {
     // Store the cohort. New cohort rows are always the most recent and editable.
     final String cohortSql =
-        "INSERT INTO cohort (study_id, cohort_id, underlay_name, cohort_revision_group_id, version, is_most_recent, is_editable, last_modified, display_name, description) "
-            + "VALUES (:study_id, :cohort_id, :underlay_name, :cohort_revision_group_id, :version, TRUE, TRUE, :last_modified, :display_name, :description)";
+        "INSERT INTO cohort (study_id, cohort_id, underlay_name, cohort_revision_group_id, version, is_most_recent, is_editable, created_by, last_modified, display_name, description) "
+            + "VALUES (:study_id, :cohort_id, :underlay_name, :cohort_revision_group_id, :version, TRUE, TRUE, :created_by, :last_modified, :display_name, :description)";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("study_id", cohort.getStudyId())
@@ -352,6 +353,7 @@ public class CohortDao {
             .addValue("underlay_name", cohort.getUnderlayName())
             .addValue("cohort_revision_group_id", cohort.getCohortRevisionGroupId())
             .addValue("version", cohort.getVersion())
+            .addValue("created_by", cohort.getCreatedBy())
             .addValue("last_modified", Timestamp.from(Instant.now()))
             .addValue("display_name", cohort.getDisplayName())
             .addValue("description", cohort.getDescription());

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -38,7 +38,7 @@ public class CohortDao {
 
   // SQL query and row mapper for reading a cohort.
   private static final String COHORT_SELECT_SQL =
-      "SELECT study_id, cohort_id, underlay_name, cohort_revision_group_id, version, is_most_recent, is_editable, last_modified, display_name, description FROM cohort";
+      "SELECT study_id, cohort_id, underlay_name, cohort_revision_group_id, version, is_most_recent, is_editable, created, last_modified, display_name, description FROM cohort";
   private static final RowMapper<Cohort.Builder> COHORT_ROW_MAPPER =
       (rs, rowNum) ->
           Cohort.builder()
@@ -49,7 +49,8 @@ public class CohortDao {
               .version(rs.getInt("version"))
               .isMostRecent(rs.getBoolean("is_most_recent"))
               .isEditable(rs.getBoolean("is_editable"))
-              .lastModified(rs.getTimestamp("last_modified"))
+              .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
+              .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))
               .displayName(rs.getString("display_name"))
               .description(rs.getString("description"));
 

--- a/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
@@ -35,7 +35,7 @@ public class ConceptSetDao {
 
   // SQL query and row mapper for reading a concept set.
   private static final String CONCEPT_SET_SELECT_SQL =
-      "SELECT study_id, concept_set_id, underlay_name, entity_name, created, last_modified, display_name, description FROM concept_set";
+      "SELECT study_id, concept_set_id, underlay_name, entity_name, created, created_by, last_modified, display_name, description FROM concept_set";
   private static final RowMapper<ConceptSet.Builder> CONCEPT_SET_ROW_MAPPER =
       (rs, rowNum) ->
           ConceptSet.builder()
@@ -44,6 +44,7 @@ public class ConceptSetDao {
               .underlayName(rs.getString("underlay_name"))
               .entityName(rs.getString("entity_name"))
               .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
+              .createdBy(rs.getString("created_by"))
               .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))
               .displayName(rs.getString("display_name"))
               .description(rs.getString("description"));
@@ -171,14 +172,15 @@ public class ConceptSetDao {
   public void createConceptSet(ConceptSet conceptSet) {
     // Store the concept set.
     final String sql =
-        "INSERT INTO concept_set (study_id, concept_set_id, underlay_name, entity_name, last_modified, display_name, description) "
-            + "VALUES (:study_id, :concept_set_id, :underlay_name, :entity_name, :last_modified, :display_name, :description)";
+        "INSERT INTO concept_set (study_id, concept_set_id, underlay_name, entity_name, created_by, last_modified, display_name, description) "
+            + "VALUES (:study_id, :concept_set_id, :underlay_name, :entity_name, :created_by, :last_modified, :display_name, :description)";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("study_id", conceptSet.getStudyId())
             .addValue("concept_set_id", conceptSet.getConceptSetId())
             .addValue("underlay_name", conceptSet.getUnderlayName())
             .addValue("entity_name", conceptSet.getEntityName())
+            .addValue("created_by", conceptSet.getCreatedBy())
             .addValue("last_modified", Timestamp.from(Instant.now()))
             .addValue("display_name", conceptSet.getDisplayName())
             .addValue("description", conceptSet.getDescription());

--- a/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
@@ -35,7 +35,7 @@ public class ConceptSetDao {
 
   // SQL query and row mapper for reading a concept set.
   private static final String CONCEPT_SET_SELECT_SQL =
-      "SELECT study_id, concept_set_id, underlay_name, entity_name, last_modified, display_name, description FROM concept_set";
+      "SELECT study_id, concept_set_id, underlay_name, entity_name, created, last_modified, display_name, description FROM concept_set";
   private static final RowMapper<ConceptSet.Builder> CONCEPT_SET_ROW_MAPPER =
       (rs, rowNum) ->
           ConceptSet.builder()
@@ -43,7 +43,8 @@ public class ConceptSetDao {
               .conceptSetId(rs.getString("concept_set_id"))
               .underlayName(rs.getString("underlay_name"))
               .entityName(rs.getString("entity_name"))
-              .lastModified(rs.getTimestamp("last_modified"))
+              .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
+              .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))
               .displayName(rs.getString("display_name"))
               .description(rs.getString("description"));
 

--- a/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
@@ -180,6 +180,7 @@ public class ConceptSetDao {
             .addValue("concept_set_id", conceptSet.getConceptSetId())
             .addValue("underlay_name", conceptSet.getUnderlayName())
             .addValue("entity_name", conceptSet.getEntityName())
+            // Don't need to set created. Liquibase defaultValueComputed handles that.
             .addValue("created_by", conceptSet.getCreatedBy())
             .addValue("last_modified", Timestamp.from(Instant.now()))
             .addValue("display_name", conceptSet.getDisplayName())

--- a/service/src/main/java/bio/terra/tanagra/db/DbUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/db/DbUtils.java
@@ -1,6 +1,9 @@
 package bio.terra.tanagra.db;
 
 import bio.terra.common.exception.MissingRequiredFieldException;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -38,5 +41,9 @@ public final class DbUtils {
     }
 
     return sb.toString();
+  }
+
+  public static OffsetDateTime timestampToOffsetDateTime(Timestamp timestamp) {
+    return OffsetDateTime.ofInstant(timestamp.toInstant(), ZoneId.of("UTC"));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -10,8 +10,6 @@ import bio.terra.tanagra.query.QueryResult;
 import bio.terra.tanagra.query.RowResult;
 import bio.terra.tanagra.service.artifact.Cohort;
 import bio.terra.tanagra.service.artifact.Review;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -47,7 +47,7 @@ public class ReviewDao {
               .displayName(rs.getString("display_name"))
               .description(rs.getString("description"))
               .size(rs.getInt("size"))
-              .created(rs.getTimestamp("created"));
+              .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")));
 
   // SQL query and row mapper for reading a review instance.
   private static final String REVIEW_INSTANCE_SELECT_SQL =

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -37,7 +37,7 @@ public class ReviewDao {
 
   // SQL query and row mapper for reading a review.
   private static final String REVIEW_SELECT_SQL =
-      "SELECT r.cohort_id, r.review_id, r.display_name, r.description, r.size, r.created FROM review AS r "
+      "SELECT r.cohort_id, r.review_id, r.display_name, r.description, r.size, r.created, r.last_modified FROM review AS r "
           + "JOIN cohort AS c ON c.cohort_id = r.cohort_id";
   private static final RowMapper<Review.Builder> REVIEW_ROW_MAPPER =
       (rs, rowNum) ->
@@ -47,7 +47,8 @@ public class ReviewDao {
               .displayName(rs.getString("display_name"))
               .description(rs.getString("description"))
               .size(rs.getInt("size"))
-              .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")));
+              .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
+              .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")));
 
   // SQL query and row mapper for reading a review instance.
   private static final String REVIEW_INSTANCE_SELECT_SQL =

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -48,7 +48,7 @@ public class ReviewDao {
               .description(rs.getString("description"))
               .size(rs.getInt("size"))
               .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
-              .createdBy(rs.getString("created"))
+              .createdBy(rs.getString("created_by"))
               .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")));
 
   // SQL query and row mapper for reading a review instance.
@@ -90,8 +90,8 @@ public class ReviewDao {
             .addValue("display_name", review.getDisplayName())
             .addValue("description", review.getDescription())
             .addValue("size", review.getSize())
-            .addValue("created", Timestamp.from(Instant.now()))
-            .addValue("created", review.getCreatedBy());
+            // Don't need to set created. Liquibase defaultValueComputed handles that.
+            .addValue("created_by", review.getCreatedBy());
     try {
       jdbcTemplate.update(sql, params);
       LOGGER.info("Inserted record for review {}", review.getReviewId());

--- a/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
@@ -70,6 +70,7 @@ public class StudyDao {
             .addValue("display_name", study.getDisplayName())
             .addValue("description", study.getDescription())
             .addValue("properties", DbSerDes.propertiesToJson(study.getProperties()))
+            // Don't need to set created. Liquibase defaultValueComputed handles that.
             .addValue("created_by", study.getCreatedBy());
     try {
       jdbcTemplate.update(sql, params);

--- a/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
@@ -30,7 +30,7 @@ public class StudyDao {
 
   // SQL query and row mapper for reading a study.
   private static final String STUDY_SELECT_SQL =
-      "SELECT study_id, display_name, description, properties, created FROM study";
+      "SELECT study_id, display_name, description, properties, created, last_modified FROM study";
   private static final RowMapper<Study> STUDY_ROW_MAPPER =
       (rs, rowNum) ->
           Study.builder()
@@ -42,6 +42,7 @@ public class StudyDao {
                       .map(DbSerDes::jsonToProperties)
                       .orElse(null))
               .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
+              .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))
               .build();
 
   private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
@@ -30,7 +30,7 @@ public class StudyDao {
 
   // SQL query and row mapper for reading a study.
   private static final String STUDY_SELECT_SQL =
-      "SELECT study_id, display_name, description, properties FROM study";
+      "SELECT study_id, display_name, description, properties, created FROM study";
   private static final RowMapper<Study> STUDY_ROW_MAPPER =
       (rs, rowNum) ->
           Study.builder()
@@ -41,6 +41,7 @@ public class StudyDao {
                   Optional.ofNullable(rs.getString("properties"))
                       .map(DbSerDes::jsonToProperties)
                       .orElse(null))
+              .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
               .build();
 
   private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
@@ -30,7 +30,7 @@ public class StudyDao {
 
   // SQL query and row mapper for reading a study.
   private static final String STUDY_SELECT_SQL =
-      "SELECT study_id, display_name, description, properties, created, last_modified FROM study";
+      "SELECT study_id, display_name, description, properties, created, created_by, last_modified FROM study";
   private static final RowMapper<Study> STUDY_ROW_MAPPER =
       (rs, rowNum) ->
           Study.builder()
@@ -42,6 +42,7 @@ public class StudyDao {
                       .map(DbSerDes::jsonToProperties)
                       .orElse(null))
               .created(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
+              .createdBy(rs.getString("created_by"))
               .lastModified(DbUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))
               .build();
 
@@ -60,15 +61,16 @@ public class StudyDao {
   @WriteTransaction
   public void createStudy(Study study) {
     final String sql =
-        "INSERT INTO study (study_id, display_name, description, properties) "
-            + "VALUES (:study_id, :display_name, :description, CAST(:properties AS jsonb))";
+        "INSERT INTO study (study_id, display_name, description, properties, created_by) "
+            + "VALUES (:study_id, :display_name, :description, CAST(:properties AS jsonb), :created_by)";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("study_id", study.getStudyId())
             .addValue("display_name", study.getDisplayName())
             .addValue("description", study.getDescription())
-            .addValue("properties", DbSerDes.propertiesToJson(study.getProperties()));
+            .addValue("properties", DbSerDes.propertiesToJson(study.getProperties()))
+            .addValue("created_by", study.getCreatedBy());
     try {
       jdbcTemplate.update(sql, params);
       LOGGER.info("Inserted record for study {}", study.getStudyId());

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Cohort.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Cohort.java
@@ -18,6 +18,7 @@ public class Cohort {
   private final boolean isMostRecent;
   private final boolean isEditable;
   private final OffsetDateTime created;
+  private final String createdBy;
   private final OffsetDateTime lastModified;
   private final @Nullable String displayName;
   private final @Nullable String description;
@@ -32,6 +33,7 @@ public class Cohort {
     this.isMostRecent = builder.isMostRecent;
     this.isEditable = builder.isEditable;
     this.created = builder.created;
+    this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.displayName = builder.displayName;
     this.description = builder.description;
@@ -52,6 +54,7 @@ public class Cohort {
         .isMostRecent(isMostRecent)
         .isEditable(isEditable)
         .created(created)
+        .createdBy(createdBy)
         .lastModified(lastModified)
         .displayName(displayName)
         .description(description)
@@ -104,6 +107,11 @@ public class Cohort {
     return created;
   }
 
+  /** Email of user who created this cohort. */
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
   /** Timestamp of when this cohort was last modified. */
   public OffsetDateTime getLastModified() {
     return lastModified;
@@ -137,6 +145,7 @@ public class Cohort {
     private boolean isMostRecent;
     private boolean isEditable;
     private OffsetDateTime created;
+    private String createdBy;
     private OffsetDateTime lastModified;
     private @Nullable String displayName;
     private @Nullable String description;
@@ -179,6 +188,11 @@ public class Cohort {
 
     public Builder created(OffsetDateTime created) {
       this.created = created;
+      return this;
+    }
+
+    public Builder createdBy(String createdBy) {
+      this.createdBy = createdBy;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Cohort.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Cohort.java
@@ -1,9 +1,7 @@
 package bio.terra.tanagra.service.artifact;
 
 import bio.terra.tanagra.exception.SystemException;
-import java.sql.Timestamp;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,7 +17,8 @@ public class Cohort {
   private final int version;
   private final boolean isMostRecent;
   private final boolean isEditable;
-  private final Timestamp lastModified;
+  private final OffsetDateTime created;
+  private final OffsetDateTime lastModified;
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final List<CriteriaGroup> criteriaGroups;
@@ -32,6 +31,7 @@ public class Cohort {
     this.version = builder.version;
     this.isMostRecent = builder.isMostRecent;
     this.isEditable = builder.isEditable;
+    this.created = builder.created;
     this.lastModified = builder.lastModified;
     this.displayName = builder.displayName;
     this.description = builder.description;
@@ -51,6 +51,7 @@ public class Cohort {
         .version(version)
         .isMostRecent(isMostRecent)
         .isEditable(isEditable)
+        .created(created)
         .lastModified(lastModified)
         .displayName(displayName)
         .description(description)
@@ -98,9 +99,14 @@ public class Cohort {
     return isEditable;
   }
 
+  /** Timestamp of when this cohort was created. */
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
   /** Timestamp of when this cohort was last modified. */
-  public OffsetDateTime getLastModifiedUTC() {
-    return lastModified.toInstant().atOffset(ZoneOffset.UTC);
+  public OffsetDateTime getLastModified() {
+    return lastModified;
   }
 
   /** Optional display name for the cohort. */
@@ -130,7 +136,8 @@ public class Cohort {
     private int version;
     private boolean isMostRecent;
     private boolean isEditable;
-    private Timestamp lastModified;
+    private OffsetDateTime created;
+    private OffsetDateTime lastModified;
     private @Nullable String displayName;
     private @Nullable String description;
     private List<CriteriaGroup> criteriaGroups = new ArrayList<>();
@@ -170,8 +177,13 @@ public class Cohort {
       return this;
     }
 
-    public Builder lastModified(Timestamp lastModified) {
-      this.lastModified = (Timestamp) lastModified.clone();
+    public Builder created(OffsetDateTime created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder lastModified(OffsetDateTime lastModified) {
+      this.lastModified = lastModified;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSet.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSet.java
@@ -1,9 +1,7 @@
 package bio.terra.tanagra.service.artifact;
 
 import bio.terra.tanagra.exception.SystemException;
-import java.sql.Timestamp;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import javax.annotation.Nullable;
 
 public class ConceptSet {
@@ -11,7 +9,8 @@ public class ConceptSet {
   private final String conceptSetId;
   private final String underlayName;
   private final String entityName;
-  private final Timestamp lastModified;
+  private final OffsetDateTime created;
+  private final OffsetDateTime lastModified;
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final Criteria criteria;
@@ -21,6 +20,7 @@ public class ConceptSet {
     this.conceptSetId = builder.conceptSetId;
     this.underlayName = builder.underlayName;
     this.entityName = builder.entityName;
+    this.created = builder.created;
     this.lastModified = builder.lastModified;
     this.displayName = builder.displayName;
     this.description = builder.description;
@@ -37,6 +37,7 @@ public class ConceptSet {
         .conceptSetId(conceptSetId)
         .underlayName(underlayName)
         .entityName(entityName)
+        .created(created)
         .lastModified(lastModified)
         .displayName(displayName)
         .description(description)
@@ -63,9 +64,14 @@ public class ConceptSet {
     return entityName;
   }
 
+  /** Timestamp of when this concept set was created. */
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
   /** Timestamp of when this concept set was last modified. */
-  public OffsetDateTime getLastModifiedUTC() {
-    return lastModified.toInstant().atOffset(ZoneOffset.UTC);
+  public OffsetDateTime getLastModified() {
+    return lastModified;
   }
 
   /** Optional display name for the concept set. */
@@ -88,7 +94,8 @@ public class ConceptSet {
     private String conceptSetId;
     private String underlayName;
     private String entityName;
-    private Timestamp lastModified;
+    private OffsetDateTime created;
+    private OffsetDateTime lastModified;
     private @Nullable String displayName;
     private @Nullable String description;
     private Criteria criteria;
@@ -113,8 +120,13 @@ public class ConceptSet {
       return this;
     }
 
-    public Builder lastModified(Timestamp lastModified) {
-      this.lastModified = (Timestamp) lastModified.clone();
+    public Builder created(OffsetDateTime created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder lastModified(OffsetDateTime lastModified) {
+      this.lastModified = lastModified;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSet.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSet.java
@@ -10,6 +10,7 @@ public class ConceptSet {
   private final String underlayName;
   private final String entityName;
   private final OffsetDateTime created;
+  private final String createdBy;
   private final OffsetDateTime lastModified;
   private final @Nullable String displayName;
   private final @Nullable String description;
@@ -21,6 +22,7 @@ public class ConceptSet {
     this.underlayName = builder.underlayName;
     this.entityName = builder.entityName;
     this.created = builder.created;
+    this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.displayName = builder.displayName;
     this.description = builder.description;
@@ -38,6 +40,7 @@ public class ConceptSet {
         .underlayName(underlayName)
         .entityName(entityName)
         .created(created)
+        .createdBy(createdBy)
         .lastModified(lastModified)
         .displayName(displayName)
         .description(description)
@@ -69,6 +72,11 @@ public class ConceptSet {
     return created;
   }
 
+  /** Email of user who created this concept set. */
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
   /** Timestamp of when this concept set was last modified. */
   public OffsetDateTime getLastModified() {
     return lastModified;
@@ -95,6 +103,7 @@ public class ConceptSet {
     private String underlayName;
     private String entityName;
     private OffsetDateTime created;
+    private String createdBy;
     private OffsetDateTime lastModified;
     private @Nullable String displayName;
     private @Nullable String description;
@@ -122,6 +131,11 @@ public class ConceptSet {
 
     public Builder created(OffsetDateTime created) {
       this.created = created;
+      return this;
+    }
+
+    public Builder createdBy(String createdBy) {
+      this.createdBy = createdBy;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
@@ -113,7 +113,7 @@ public class Review {
       return this;
     }
 
-    public Builder createdBy(String created) {
+    public Builder createdBy(String createdBy) {
       this.createdBy = createdBy;
       return this;
     }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
@@ -1,8 +1,6 @@
 package bio.terra.tanagra.service.artifact;
 
-import java.sql.Timestamp;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import javax.annotation.Nullable;
 
 public class Review {
@@ -11,7 +9,7 @@ public class Review {
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final int size;
-  private final Timestamp created;
+  private final OffsetDateTime created;
   private final Cohort cohort;
 
   private Review(Builder builder) {
@@ -53,9 +51,9 @@ public class Review {
     return size;
   }
 
-  /** Timestamp of when this review was last modified. */
-  public OffsetDateTime getCreatedUTC() {
-    return created.toInstant().atOffset(ZoneOffset.UTC);
+  /** Timestamp of when this review was created. */
+  public OffsetDateTime getCreated() {
+    return created;
   }
 
   /** Cohort revision that this review is pinned to. */
@@ -69,7 +67,7 @@ public class Review {
     private @Nullable String displayName;
     private @Nullable String description;
     private int size;
-    private Timestamp created;
+    private OffsetDateTime created;
     private Cohort cohort;
 
     public Builder cohortId(String cohortId) {
@@ -97,8 +95,8 @@ public class Review {
       return this;
     }
 
-    public Builder created(Timestamp created) {
-      this.created = (Timestamp) created.clone();
+    public Builder created(OffsetDateTime created) {
+      this.created = created;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
@@ -10,6 +10,7 @@ public class Review {
   private final @Nullable String description;
   private final int size;
   private final OffsetDateTime created;
+  private final String createdBy;
   private final OffsetDateTime lastModified;
   private final Cohort cohort;
 
@@ -20,6 +21,7 @@ public class Review {
     this.description = builder.description;
     this.size = builder.size;
     this.created = builder.created;
+    this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.cohort = builder.cohort;
   }
@@ -57,6 +59,10 @@ public class Review {
     return created;
   }
 
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
   public OffsetDateTime getLastModified() {
     return lastModified;
   }
@@ -73,6 +79,7 @@ public class Review {
     private @Nullable String description;
     private int size;
     private OffsetDateTime created;
+    private String createdBy;
     private OffsetDateTime lastModified;
     private Cohort cohort;
 
@@ -103,6 +110,11 @@ public class Review {
 
     public Builder created(OffsetDateTime created) {
       this.created = created;
+      return this;
+    }
+
+    public Builder createdBy(String created) {
+      this.createdBy = createdBy;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
@@ -10,6 +10,7 @@ public class Review {
   private final @Nullable String description;
   private final int size;
   private final OffsetDateTime created;
+  private final OffsetDateTime lastModified;
   private final Cohort cohort;
 
   private Review(Builder builder) {
@@ -19,6 +20,7 @@ public class Review {
     this.description = builder.description;
     this.size = builder.size;
     this.created = builder.created;
+    this.lastModified = builder.lastModified;
     this.cohort = builder.cohort;
   }
 
@@ -51,9 +53,12 @@ public class Review {
     return size;
   }
 
-  /** Timestamp of when this review was created. */
   public OffsetDateTime getCreated() {
     return created;
+  }
+
+  public OffsetDateTime getLastModified() {
+    return lastModified;
   }
 
   /** Cohort revision that this review is pinned to. */
@@ -68,6 +73,7 @@ public class Review {
     private @Nullable String description;
     private int size;
     private OffsetDateTime created;
+    private OffsetDateTime lastModified;
     private Cohort cohort;
 
     public Builder cohortId(String cohortId) {
@@ -97,6 +103,11 @@ public class Review {
 
     public Builder created(OffsetDateTime created) {
       this.created = created;
+      return this;
+    }
+
+    public Builder lastModified(OffsetDateTime lastModified) {
+      this.lastModified = lastModified;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
@@ -22,6 +22,7 @@ public class Study {
   private final @Nullable String description;
   private final Map<String, String> properties;
   private final OffsetDateTime created;
+  private final String createdBy;
   private final OffsetDateTime lastModified;
 
   public Study(
@@ -30,12 +31,14 @@ public class Study {
       @Nullable String description,
       Map<String, String> properties,
       OffsetDateTime created,
+      String createdBy,
       OffsetDateTime lastModified) {
     this.studyId = studyId;
     this.displayName = displayName;
     this.description = description;
     this.properties = properties;
     this.created = created;
+    this.createdBy = createdBy;
     this.lastModified = lastModified;
   }
 
@@ -63,6 +66,10 @@ public class Study {
     return created;
   }
 
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
   public OffsetDateTime getLastModified() {
     return lastModified;
   }
@@ -85,6 +92,7 @@ public class Study {
         .append(description, study.description)
         .append(properties, study.properties)
         .append(created, study.created)
+        .append(createdBy, study.createdBy)
         .append(lastModified, study.lastModified)
         .isEquals();
   }
@@ -97,6 +105,7 @@ public class Study {
         .append(description)
         .append(properties)
         .append(created)
+        .append(createdBy)
         .append(lastModified)
         .toHashCode();
   }
@@ -112,6 +121,7 @@ public class Study {
     private String description;
     private Map<String, String> properties;
     private OffsetDateTime created;
+    private String createdBy;
     private OffsetDateTime lastModified;
 
     public Builder studyId(String studyId) {
@@ -139,6 +149,11 @@ public class Study {
       return this;
     }
 
+    public Builder createdBy(String createdBy) {
+      this.createdBy = createdBy;
+      return this;
+    }
+
     public Builder lastModified(OffsetDateTime lastModified) {
       this.lastModified = lastModified;
       return this;
@@ -152,7 +167,8 @@ public class Study {
       if (studyId == null) {
         throw new SystemException("Study requires id");
       }
-      return new Study(studyId, displayName, description, properties, created, lastModified);
+      return new Study(
+          studyId, displayName, description, properties, created, createdBy, lastModified);
     }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.service.artifact;
 import bio.terra.tanagra.exception.SystemException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -20,16 +21,19 @@ public class Study {
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final Map<String, String> properties;
+  private final OffsetDateTime created;
 
   public Study(
       String studyId,
       @Nullable String displayName,
       @Nullable String description,
-      Map<String, String> properties) {
+      Map<String, String> properties,
+      OffsetDateTime created) {
     this.studyId = studyId;
     this.displayName = displayName;
     this.description = description;
     this.properties = properties;
+    this.created = created;
   }
 
   /** The globally unique identifier of this study. */
@@ -52,6 +56,10 @@ public class Study {
     return properties;
   }
 
+  public OffsetDateTime getCreated() {
+    return created;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +77,7 @@ public class Study {
         .append(displayName, study.displayName)
         .append(description, study.description)
         .append(properties, study.properties)
+        .append(created, study.created)
         .isEquals();
   }
 
@@ -79,6 +88,7 @@ public class Study {
         .append(displayName)
         .append(description)
         .append(properties)
+        .append(created)
         .toHashCode();
   }
 
@@ -92,6 +102,7 @@ public class Study {
     private @Nullable String displayName;
     private String description;
     private Map<String, String> properties;
+    private OffsetDateTime created;
 
     public Builder studyId(String studyId) {
       this.studyId = studyId;
@@ -113,6 +124,11 @@ public class Study {
       return this;
     }
 
+    public Builder created(OffsetDateTime created) {
+      this.created = created;
+      return this;
+    }
+
     public Study build() {
       // Always have a map, even if it is empty
       if (properties == null) {
@@ -121,7 +137,7 @@ public class Study {
       if (studyId == null) {
         throw new SystemException("Study requires id");
       }
-      return new Study(studyId, displayName, description, properties);
+      return new Study(studyId, displayName, description, properties, created);
     }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
@@ -22,18 +22,21 @@ public class Study {
   private final @Nullable String description;
   private final Map<String, String> properties;
   private final OffsetDateTime created;
+  private final OffsetDateTime lastModified;
 
   public Study(
       String studyId,
       @Nullable String displayName,
       @Nullable String description,
       Map<String, String> properties,
-      OffsetDateTime created) {
+      OffsetDateTime created,
+      OffsetDateTime lastModified) {
     this.studyId = studyId;
     this.displayName = displayName;
     this.description = description;
     this.properties = properties;
     this.created = created;
+    this.lastModified = lastModified;
   }
 
   /** The globally unique identifier of this study. */
@@ -60,6 +63,10 @@ public class Study {
     return created;
   }
 
+  public OffsetDateTime getLastModified() {
+    return lastModified;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -78,6 +85,7 @@ public class Study {
         .append(description, study.description)
         .append(properties, study.properties)
         .append(created, study.created)
+        .append(lastModified, study.lastModified)
         .isEquals();
   }
 
@@ -89,6 +97,7 @@ public class Study {
         .append(description)
         .append(properties)
         .append(created)
+        .append(lastModified)
         .toHashCode();
   }
 
@@ -103,6 +112,7 @@ public class Study {
     private String description;
     private Map<String, String> properties;
     private OffsetDateTime created;
+    private OffsetDateTime lastModified;
 
     public Builder studyId(String studyId) {
       this.studyId = studyId;
@@ -129,6 +139,11 @@ public class Study {
       return this;
     }
 
+    public Builder lastModified(OffsetDateTime lastModified) {
+      this.lastModified = lastModified;
+      return this;
+    }
+
     public Study build() {
       // Always have a map, even if it is empty
       if (properties == null) {
@@ -137,7 +152,7 @@ public class Study {
       if (studyId == null) {
         throw new SystemException("Study requires id");
       }
-      return new Study(studyId, displayName, description, properties, created);
+      return new Study(studyId, displayName, description, properties, created, lastModified);
     }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -70,7 +70,8 @@ public final class ToApiConversionUtils {
         .underlayName(cohort.getUnderlayName())
         .displayName(cohort.getDisplayName())
         .description(cohort.getDescription())
-        .lastModified(cohort.getLastModifiedUTC())
+        .created(cohort.getCreated())
+        .lastModified(cohort.getLastModified())
         .criteriaGroups(
             cohort.getCriteriaGroups().stream()
                 .map(criteriaGroup -> toApiObject(criteriaGroup))

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -4,6 +4,7 @@ import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.model.ApiAnnotationValueV2;
 import bio.terra.tanagra.generated.model.ApiAttributeV2;
 import bio.terra.tanagra.generated.model.ApiCohortV2;
+import bio.terra.tanagra.generated.model.ApiConceptSetV2;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroupV2;
 import bio.terra.tanagra.generated.model.ApiCriteriaV2;
 import bio.terra.tanagra.generated.model.ApiDataTypeV2;
@@ -14,6 +15,7 @@ import bio.terra.tanagra.generated.model.ApiValueDisplayV2;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.service.artifact.AnnotationValue;
 import bio.terra.tanagra.service.artifact.Cohort;
+import bio.terra.tanagra.service.artifact.ConceptSet;
 import bio.terra.tanagra.service.artifact.Criteria;
 import bio.terra.tanagra.service.artifact.CriteriaGroup;
 import bio.terra.tanagra.service.instances.EntityInstanceCount;
@@ -97,6 +99,21 @@ public final class ToApiConversionUtils {
         .pluginName(criteria.getPluginName())
         .selectionData(criteria.getSelectionData())
         .uiConfig(criteria.getUiConfig());
+  }
+
+  public static ApiConceptSetV2 toApiObject(ConceptSet conceptSet) {
+    return new ApiConceptSetV2()
+        .id(conceptSet.getConceptSetId())
+        .underlayName(conceptSet.getUnderlayName())
+        .entity(conceptSet.getEntityName())
+        .displayName(conceptSet.getDisplayName())
+        .description(conceptSet.getDescription())
+        .created(conceptSet.getCreated())
+        .lastModified(conceptSet.getLastModified())
+        .criteria(
+            conceptSet.getCriteria() == null
+                ? null
+                : ToApiConversionUtils.toApiObject(conceptSet.getCriteria()));
   }
 
   public static ApiInstanceCountV2 toApiObject(EntityInstanceCount entityInstanceCount) {

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -110,6 +110,7 @@ public final class ToApiConversionUtils {
         .displayName(conceptSet.getDisplayName())
         .description(conceptSet.getDescription())
         .created(conceptSet.getCreated())
+        .createdBy(conceptSet.getCreatedBy())
         .lastModified(conceptSet.getLastModified())
         .criteria(
             conceptSet.getCriteria() == null

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -73,6 +73,7 @@ public final class ToApiConversionUtils {
         .displayName(cohort.getDisplayName())
         .description(cohort.getDescription())
         .created(cohort.getCreated())
+        .createdBy(cohort.getCreatedBy())
         .lastModified(cohort.getLastModified())
         .criteriaGroups(
             cohort.getCriteriaGroups().stream()

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -4,7 +4,6 @@ import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.model.ApiAnnotationValueV2;
 import bio.terra.tanagra.generated.model.ApiAttributeV2;
 import bio.terra.tanagra.generated.model.ApiCohortV2;
-import bio.terra.tanagra.generated.model.ApiConceptSetV2;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroupV2;
 import bio.terra.tanagra.generated.model.ApiCriteriaV2;
 import bio.terra.tanagra.generated.model.ApiDataTypeV2;
@@ -15,7 +14,6 @@ import bio.terra.tanagra.generated.model.ApiValueDisplayV2;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.service.artifact.AnnotationValue;
 import bio.terra.tanagra.service.artifact.Cohort;
-import bio.terra.tanagra.service.artifact.ConceptSet;
 import bio.terra.tanagra.service.artifact.Criteria;
 import bio.terra.tanagra.service.artifact.CriteriaGroup;
 import bio.terra.tanagra.service.instances.EntityInstanceCount;
@@ -100,22 +98,6 @@ public final class ToApiConversionUtils {
         .pluginName(criteria.getPluginName())
         .selectionData(criteria.getSelectionData())
         .uiConfig(criteria.getUiConfig());
-  }
-
-  public static ApiConceptSetV2 toApiObject(ConceptSet conceptSet) {
-    return new ApiConceptSetV2()
-        .id(conceptSet.getConceptSetId())
-        .underlayName(conceptSet.getUnderlayName())
-        .entity(conceptSet.getEntityName())
-        .displayName(conceptSet.getDisplayName())
-        .description(conceptSet.getDescription())
-        .created(conceptSet.getCreated())
-        .createdBy(conceptSet.getCreatedBy())
-        .lastModified(conceptSet.getLastModified())
-        .criteria(
-            conceptSet.getCriteria() == null
-                ? null
-                : ToApiConversionUtils.toApiObject(conceptSet.getCriteria()));
   }
 
   public static ApiInstanceCountV2 toApiObject(EntityInstanceCount entityInstanceCount) {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1706,6 +1706,9 @@ components:
           description: Timestamp of when the concept set was created
           type: string
           format: date-time
+        createdBy:
+          description: Email of user who created the concept set
+          type: string
         lastModified:
           description: Timestamp of when the concept set was last modified
           type: string

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1637,6 +1637,7 @@ components:
         - underlayName
         - displayName
         - criteriaGroups
+        - created
         - lastModified
 
     CohortListV2:
@@ -1691,6 +1692,10 @@ components:
           $ref: "#/components/schemas/ConceptSetDescriptionV2"
         criteria:
           $ref: "#/components/schemas/CriteriaV2"
+        created:
+          description: Timestamp of when the concept set was created
+          type: string
+          format: date-time
         lastModified:
           description: Timestamp of when the concept set was last modified
           type: string
@@ -1701,6 +1706,7 @@ components:
         - entity
         - displayName
         - criteria
+        - created
         - lastModified
 
     ConceptSetListV2:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1842,6 +1842,9 @@ components:
           description: Timestamp of when the review was created
           type: string
           format: date-time
+        createdBy:
+          description: Email of user who created the review
+          type: string
         lastModified:
           description: Timestamp of when the review was last modified
           type: string

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1542,7 +1542,7 @@ components:
 
     StudyV2:
       type: object
-      required: [id]
+      required: [id, created]
       properties:
         id:
           description: ID of the study, immutable
@@ -1553,6 +1553,9 @@ components:
           $ref: "#/components/schemas/StudyDescriptionV2"
         properties:
           $ref: "#/components/schemas/PropertiesV2"
+        created:
+          type: string
+          format: date-time
 
     StudyListV2:
       type: array

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1624,6 +1624,10 @@ components:
           description: Groups of criteria that define the entity filter
           items:
             $ref: "#/components/schemas/CriteriaGroupV2"
+        created:
+          description: Timestamp of when the cohort was created
+          type: string
+          format: date-time
         lastModified:
           description: Timestamp of when the cohort was last modified
           type: string

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1542,7 +1542,7 @@ components:
 
     StudyV2:
       type: object
-      required: [id, created, lastModified]
+      required: [id, created, createdBy, lastModified]
       properties:
         id:
           description: ID of the study, immutable
@@ -1556,6 +1556,9 @@ components:
         created:
           type: string
           format: date-time
+        createdBy:
+          description: Email of user who created the study
+          type: string
         lastModified:
           type: string
           format: date-time
@@ -1720,6 +1723,7 @@ components:
         - displayName
         - criteria
         - created
+        - createdBy
         - lastModified
 
     ConceptSetListV2:
@@ -1855,6 +1859,7 @@ components:
         - size
         - cohortRevision
         - created
+        - createdBy
         - lastModified
 
     ReviewListV2:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1542,7 +1542,7 @@ components:
 
     StudyV2:
       type: object
-      required: [id, created]
+      required: [id, created, lastModified]
       properties:
         id:
           description: ID of the study, immutable
@@ -1554,6 +1554,9 @@ components:
         properties:
           $ref: "#/components/schemas/PropertiesV2"
         created:
+          type: string
+          format: date-time
+        lastModified:
           type: string
           format: date-time
 
@@ -1631,6 +1634,9 @@ components:
           description: Timestamp of when the cohort was created
           type: string
           format: date-time
+        createdBy:
+          description: Email of user who created cohort
+          type: string
         lastModified:
           description: Timestamp of when the cohort was last modified
           type: string
@@ -1641,6 +1647,7 @@ components:
         - displayName
         - criteriaGroups
         - created
+        - createdBy
         - lastModified
 
     CohortListV2:
@@ -1832,12 +1839,17 @@ components:
           description: Timestamp of when the review was created
           type: string
           format: date-time
+        lastModified:
+          description: Timestamp of when the review was last modified
+          type: string
+          format: date-time
       required:
         - id
         - displayName
         - size
         - cohortRevision
         - created
+        - lastModified
 
     ReviewListV2:
       type: array

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -6,4 +6,5 @@
     <include file="changesets/20221128_annotation_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20221202_annotation_value_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20221215_annotation_value_instance_col.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221219_created_columns.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -6,17 +6,28 @@ databaseChangeLog:
     runOnChange: true
     changes:
     # Add created, created_by columns
+#    - addColumn:
+#          tableName: cohort
+#          columns:
+#          - column:
+#                name: created
+#                type: timestamptz
+#                constraints:
+#                    nullable: false
+#                # Needed to backfill rows that existed before this changeset.
+#                # Will also set "created" for new rows.
+#                defaultValueComputed: now()
     - addColumn:
-          tableName: cohort
-          columns:
-          - column:
-                name: created
-                type: timestamptz
-                constraints:
-                    nullable: false
-                # Needed to backfill rows that existed before this changeset.
-                # Will also set "created" for new rows.
-                defaultValueComputed: now()
+            tableName: concept_set
+            columns:
+            - column:
+                    name: created
+                    type: timestamptz
+                    constraints:
+                          nullable: false
+                    # Needed to backfill rows that existed before this changeset.
+                    # Will also set "created" for new rows.
+                    defaultValueComputed: now()
 
     # Change existing columns from timestamp to timestamptz
     - modifyDataType:

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -64,20 +64,35 @@ databaseChangeLog:
     # We want existing rows to have "unknown" and new rows to not have
     # "unknown". Unfortunately this takes 3 steps. See
     # https://stackoverflow.com/a/8906534/6447189
+#    - addColumn:
+#        tableName: cohort
+#        columns:
+#        - column:
+#            name: created_by
+#            type: text
+#    - update:
+#        tableName: cohort
+#        columns:
+#        - column:
+#            name: created_by
+#            value: "unknown"
+#    - addNotNullConstraint:
+#        tableName: cohort
+#        columnName: created_by
     - addColumn:
-        tableName: cohort
+        tableName: concept_set
         columns:
         - column:
             name: created_by
             type: text
     - update:
-        tableName: cohort
+        tableName: concept_set
         columns:
         - column:
             name: created_by
             value: "unknown"
     - addNotNullConstraint:
-        tableName: cohort
+        tableName: concept_set
         columnName: created_by
 
     # Change existing columns from timestamp to timestamptz

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -15,7 +15,7 @@ databaseChangeLog:
 #                constraints:
 #                    nullable: false
 #                # Needed to backfill rows that existed before this changeset.
-#                # Will also set "created" for new rows.
+#                # Will also set for new rows.
 #                defaultValueComputed: now()
     - addColumn:
             tableName: concept_set
@@ -26,9 +26,19 @@ databaseChangeLog:
                     constraints:
                           nullable: false
                     # Needed to backfill rows that existed before this changeset.
-                    # Will also set "created" for new rows.
+                    # Will also set for new rows.
                     defaultValueComputed: now()
-
+    - addColumn:
+        tableName: study
+        columns:
+        - column:
+            name: created
+            type: timestamptz
+            constraints:
+              nullable: false
+            # Needed to backfill rows that existed before this changeset.
+            # Will also set for new rows.
+            defaultValueComputed: now()
     # Change existing columns from timestamp to timestamptz
     - modifyDataType:
           tableName: cohort

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -2,98 +2,96 @@ databaseChangeLog:
 - changeSet:
     id: created_columns
     author: melchang
-    # DO NOT SUBMIT
-    runOnChange: true
     changes:
     # Add created, created_by, last_modified columns
-#    - addColumn:
-#          tableName: cohort
-#          columns:
-#          - column:
-#                name: created
-#                type: timestamptz
-#                constraints:
-#                    nullable: false
-#                # Needed to backfill rows that existed before this changeset.
-#                # Will also set for new rows.
-#                defaultValueComputed: now()
-#    - addColumn:
-#            tableName: concept_set
-#            columns:
-#            - column:
-#                    name: created
-#                    type: timestamptz
-#                    constraints:
-#                          nullable: false
-#                    # Needed to backfill rows that existed before this changeset.
-#                    # Will also set for new rows.
-#                    defaultValueComputed: now()
-#    - addColumn:
-#        tableName: study
-#        columns:
-#        - column:
-#            name: created
-#            type: timestamptz
-#            constraints:
-#              nullable: false
-#            # Needed to backfill rows that existed before this changeset.
-#            # Will also set for new rows.
-#            defaultValueComputed: now()
-#    - addColumn:
-#        tableName: review
-#        columns:
-#        - column:
-#            name: last_modified
-#            type: timestamptz
-#            constraints:
-#              nullable: false
-#            # Needed to backfill rows that existed before this changeset.
-#            # Will also set for new rows.
-#            defaultValueComputed: now()
-#    - addColumn:
-#        tableName: study
-#        columns:
-#        - column:
-#            name: last_modified
-#            type: timestamptz
-#            constraints:
-#              nullable: false
-#            # Needed to backfill rows that existed before this changeset.
-#            # Will also set for new rows.
-#            defaultValueComputed: now()
+    - addColumn:
+          tableName: cohort
+          columns:
+          - column:
+                name: created
+                type: timestamptz
+                constraints:
+                    nullable: false
+                # Needed to backfill rows that existed before this changeset.
+                # Will also set for new rows.
+                defaultValueComputed: now()
+    - addColumn:
+            tableName: concept_set
+            columns:
+            - column:
+                    name: created
+                    type: timestamptz
+                    constraints:
+                          nullable: false
+                    # Needed to backfill rows that existed before this changeset.
+                    # Will also set for new rows.
+                    defaultValueComputed: now()
+    - addColumn:
+        tableName: study
+        columns:
+        - column:
+            name: created
+            type: timestamptz
+            constraints:
+              nullable: false
+            # Needed to backfill rows that existed before this changeset.
+            # Will also set for new rows.
+            defaultValueComputed: now()
+    - addColumn:
+        tableName: review
+        columns:
+        - column:
+            name: last_modified
+            type: timestamptz
+            constraints:
+              nullable: false
+            # Needed to backfill rows that existed before this changeset.
+            # Will also set for new rows.
+            defaultValueComputed: now()
+    - addColumn:
+        tableName: study
+        columns:
+        - column:
+            name: last_modified
+            type: timestamptz
+            constraints:
+              nullable: false
+            # Needed to backfill rows that existed before this changeset.
+            # Will also set for new rows.
+            defaultValueComputed: now()
     # We want existing rows to have "unknown" and new rows to not have
     # "unknown". Unfortunately this takes 3 steps. See
     # https://stackoverflow.com/a/8906534/6447189
-#    - addColumn:
-#        tableName: cohort
-#        columns:
-#        - column:
-#            name: created_by
-#            type: text
-#    - update:
-#        tableName: cohort
-#        columns:
-#        - column:
-#            name: created_by
-#            value: "unknown"
-#    - addNotNullConstraint:
-#        tableName: cohort
-#        columnName: created_by
-#    - addColumn:
-#        tableName: concept_set
-#        columns:
-#        - column:
-#            name: created_by
-#            type: text
-#    - update:
-#        tableName: concept_set
-#        columns:
-#        - column:
-#            name: created_by
-#            value: "unknown"
-#    - addNotNullConstraint:
-#        tableName: concept_set
-#        columnName: created_by
+    - addColumn:
+        tableName: cohort
+        columns:
+        - column:
+            name: created_by
+            type: text
+    - update:
+        tableName: cohort
+        columns:
+        - column:
+            name: created_by
+            value: "unknown"
+    - addNotNullConstraint:
+        tableName: cohort
+        columnName: created_by
+    - addColumn:
+        tableName: concept_set
+        columns:
+        - column:
+            name: created_by
+            type: text
+    - update:
+        tableName: concept_set
+        columns:
+        - column:
+            name: created_by
+            value: "unknown"
+    - addNotNullConstraint:
+        tableName: concept_set
+        columnName: created_by
     - addColumn:
         tableName: review
         columns:
@@ -108,6 +106,21 @@ databaseChangeLog:
             value: "unknown"
     - addNotNullConstraint:
         tableName: review
+        columnName: created_by
+    - addColumn:
+        tableName: study
+        columns:
+        - column:
+            name: created_by
+            type: text
+    - update:
+        tableName: study
+        columns:
+        - column:
+            name: created_by
+            value: "unknown"
+    - addNotNullConstraint:
+        tableName: study
         columnName: created_by
 
     # Change existing columns from timestamp to timestamptz

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -79,20 +79,35 @@ databaseChangeLog:
 #    - addNotNullConstraint:
 #        tableName: cohort
 #        columnName: created_by
+#    - addColumn:
+#        tableName: concept_set
+#        columns:
+#        - column:
+#            name: created_by
+#            type: text
+#    - update:
+#        tableName: concept_set
+#        columns:
+#        - column:
+#            name: created_by
+#            value: "unknown"
+#    - addNotNullConstraint:
+#        tableName: concept_set
+#        columnName: created_by
     - addColumn:
-        tableName: concept_set
+        tableName: review
         columns:
         - column:
             name: created_by
             type: text
     - update:
-        tableName: concept_set
+        tableName: review
         columns:
         - column:
             name: created_by
             value: "unknown"
     - addNotNullConstraint:
-        tableName: concept_set
+        tableName: review
         columnName: created_by
 
     # Change existing columns from timestamp to timestamptz

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -1,0 +1,44 @@
+databaseChangeLog:
+- changeSet:
+    id: created_columnbs
+    author: melchang
+    # DO NOT SUBMIT
+    runOnChange: true
+    changes:
+    # Add created, created_by columns
+    - addColumn:
+          tableName: cohort
+          columns:
+          - column:
+                name: created
+                type: timestamptz
+                constraints:
+                    nullable: false
+                # Needed to backfill rows that existed before this changeset.
+                # Will also set "created" for new rows.
+                defaultValueComputed: now()
+
+    # Change existing columns from timestamp to timestamptz
+    - modifyDataType:
+          tableName: cohort
+          columnName: last_modified
+          newDataType: timestamptz
+    - modifyDataType:
+          tableName: concept_set
+          columnName: last_modified
+          newDataType: timestamptz
+    - modifyDataType:
+          tableName: review
+          columnName: created
+          newDataType: timestamptz
+
+    # Add not null constraint to existing columns
+    - addNotNullConstraint:
+          tableName: cohort
+          columnName: last_modified
+    - addNotNullConstraint:
+          tableName: concept_set
+          columnName: last_modified
+    - addNotNullConstraint:
+          tableName: review
+          columnName: created

--- a/service/src/main/resources/db/changesets/20221219_created_columns.yaml
+++ b/service/src/main/resources/db/changesets/20221219_created_columns.yaml
@@ -1,11 +1,11 @@
 databaseChangeLog:
 - changeSet:
-    id: created_columnbs
+    id: created_columns
     author: melchang
     # DO NOT SUBMIT
     runOnChange: true
     changes:
-    # Add created, created_by columns
+    # Add created, created_by, last_modified columns
 #    - addColumn:
 #          tableName: cohort
 #          columns:
@@ -17,28 +17,69 @@ databaseChangeLog:
 #                # Needed to backfill rows that existed before this changeset.
 #                # Will also set for new rows.
 #                defaultValueComputed: now()
+#    - addColumn:
+#            tableName: concept_set
+#            columns:
+#            - column:
+#                    name: created
+#                    type: timestamptz
+#                    constraints:
+#                          nullable: false
+#                    # Needed to backfill rows that existed before this changeset.
+#                    # Will also set for new rows.
+#                    defaultValueComputed: now()
+#    - addColumn:
+#        tableName: study
+#        columns:
+#        - column:
+#            name: created
+#            type: timestamptz
+#            constraints:
+#              nullable: false
+#            # Needed to backfill rows that existed before this changeset.
+#            # Will also set for new rows.
+#            defaultValueComputed: now()
+#    - addColumn:
+#        tableName: review
+#        columns:
+#        - column:
+#            name: last_modified
+#            type: timestamptz
+#            constraints:
+#              nullable: false
+#            # Needed to backfill rows that existed before this changeset.
+#            # Will also set for new rows.
+#            defaultValueComputed: now()
+#    - addColumn:
+#        tableName: study
+#        columns:
+#        - column:
+#            name: last_modified
+#            type: timestamptz
+#            constraints:
+#              nullable: false
+#            # Needed to backfill rows that existed before this changeset.
+#            # Will also set for new rows.
+#            defaultValueComputed: now()
+    # We want existing rows to have "unknown" and new rows to not have
+    # "unknown". Unfortunately this takes 3 steps. See
+    # https://stackoverflow.com/a/8906534/6447189
     - addColumn:
-            tableName: concept_set
-            columns:
-            - column:
-                    name: created
-                    type: timestamptz
-                    constraints:
-                          nullable: false
-                    # Needed to backfill rows that existed before this changeset.
-                    # Will also set for new rows.
-                    defaultValueComputed: now()
-    - addColumn:
-        tableName: study
+        tableName: cohort
         columns:
         - column:
-            name: created
-            type: timestamptz
-            constraints:
-              nullable: false
-            # Needed to backfill rows that existed before this changeset.
-            # Will also set for new rows.
-            defaultValueComputed: now()
+            name: created_by
+            type: text
+    - update:
+        tableName: cohort
+        columns:
+        - column:
+            name: created_by
+            value: "unknown"
+    - addNotNullConstraint:
+        tableName: cohort
+        columnName: created_by
+
     # Change existing columns from timestamp to timestamptz
     - modifyDataType:
           tableName: cohort

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -465,6 +465,8 @@ export class BackendSource implements Source {
       size,
       cohort: toAPICohort(cohort),
       created: new Date(),
+      createdBy: "",
+      lastModified: new Date(),
     };
 
     const reviews = loadLocalReviews();
@@ -1066,6 +1068,8 @@ function toAPICohort(cohort: tanagra.Cohort): tanagra.CohortV2 {
     id: cohort.id,
     displayName: cohort.name,
     underlayName: cohort.underlayName,
+    created: new Date(),
+    createdBy: "",
     lastModified: new Date(),
     criteriaGroups: cohort.groups.map((group) => ({
       id: group.id,

--- a/ui/src/sd-admin/studyAdmin.tsx
+++ b/ui/src/sd-admin/studyAdmin.tsx
@@ -118,6 +118,9 @@ const emptyStudy: StudyV2 = {
     { key: "irbNumber", value: "" },
     { key: "pi", value: "" },
   ],
+  created: new Date(),
+  createdBy: "user@gmail.com",
+  lastModified: new Date(),
 };
 
 const initialFormState = {


### PR DESCRIPTION
Add created, createdBy columns to Cohort, Concept Set, Cohort Review, Study.

Also added last_modified to artifacts that were missing it.

I noticed when I update cohort (change name), last_modified isn't updated. That's because [this method](https://github.com/DataBiosphere/tanagra/blob/952892907fdf67f8929a111a65fa94141a5dea8d/service/src/main/java/bio/terra/tanagra/db/CohortDao.java#L307) doesn't set last_modified. I'll follow up with Mariko after the holidays.

Manually tested:
- New fields returned

![image](https://user-images.githubusercontent.com/10929390/209024674-fb59b1d2-6b9c-439d-a255-5cc0434c979a.png)

- created/created_by don't change after update
- For created_by: Existing rows (rows that existed before changeset) have "unknown". New rows are set to user email.