### PR TITLE
Don't push the Docker image to GCR.

### DIFF
--- a/.github/workflows/bump-tag-publish.yaml
+++ b/.github/workflows/bump-tag-publish.yaml
@@ -115,38 +115,6 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
           ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
 
-      - name: Auth to Google
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider
-          service_account: gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com
-      - name: Setup gcloud
-        if: steps.skiptest.outputs.is-bump == 'no'
-        uses: google-github-actions/setup-gcloud@v1
-      - name: Explicitly auth Docker for GCR
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: gcloud auth configure-docker --quiet
-
-      - name: Construct docker image name and tag
-        if: steps.skiptest.outputs.is-bump == 'no'
-        id: image-name
-        run: |
-          DOCKER_TAG=${{ steps.tag.outputs.tag }}
-          echo name=gcr.io/broad-dsp-gcr-public/${SERVICE_NAME}:${DOCKER_TAG} >> $GITHUB_OUTPUT
-      - name: Build image locally with jib
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: "./gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain"
-      - name: Run Trivy vulnerability scanner
-        if: steps.skiptest.outputs.is-bump == 'no'
-        # Link to the github location of the action https://github.com/broadinstitute/dsp-appsec-trivy-action
-        uses: broadinstitute/dsp-appsec-trivy-action@v1
-        with:
-          image: ${{ steps.image-name.outputs.name }}
-      - name: Push GCR image
-        if: steps.skiptest.outputs.is-bump == 'no'
-        run: "docker push ${{ steps.image-name.outputs.name }}"
-
       - name: Build the OpenAPI interface
         if: steps.skiptest.outputs.is-bump == 'no'
         run: ./gradlew :service:generateSwaggerCodeServer

--- a/.github/workflows/bump-tag-publish.yaml
+++ b/.github/workflows/bump-tag-publish.yaml
@@ -129,4 +129,4 @@ jobs:
         id: create_release
         with:
           tag: ${{ steps.tag.outputs.tag }}
-          artifacts: "service/build/resources/main/api/service_openapi.yaml"
+          artifacts: "./service/src/main/resources/api/service_openapi.yaml"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Indexer Build](https://github.com/DataBiosphere/tanagra/actions/workflows/indexer-test.yaml/badge.svg?branch=main)
 # Tanagra
 
-Tanagra is a project to build a configurable data explorer. It provides tools for indexing a dataseat, a backend
+Tanagra is a project to build a configurable data explorer. It provides tools for indexing a dataset, a backend
 service for running queries against the dataset, and a UI for building cohorts and concept sets for the dataset.
 
 More information about this codebase can be found in the links below.


### PR DESCRIPTION
Verily deployments are building their own Docker images, not pulling from the Broad public container registry. VUMC deployments are running a JAR on AppEngine, so don't use the Docker image at all.

If we ever have a non-Verily GKE deployment, we can consider enabling this then.