### PR TITLE
Fix version bump regex match.

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -9,4 +9,4 @@ export ARTIFACTORY_USERNAME=$(docker run -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TO
  vault read -field username ${ARTIFACTORY_ACCOUNT_PATH})
 export ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
  vault read -field password ${ARTIFACTORY_ACCOUNT_PATH})
-./gradlew client:artifactoryPublish # test!!
+./gradlew test client:artifactoryPublish

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'tanagra'
 include('service', 'client', 'indexer', 'underlay')
 
-gradle.ext.tanagraVersion = '0.0.6-SNAPSHOT'
+// This line needs to match the VERSION_LINE_MATCH regex in the bump-tag-publish GHA.
+gradle.ext.tanagraVersion = "0.0.7-SNAPSHOT"


### PR DESCRIPTION
The `VERSION_LINE_MATCH` regex in the `bump-tag-publish` GHA is looking for a version string wrapped in double quotes, not single. Fixed and added a comment so we're careful about changing this line in the future.