### PR TITLE
Fix type coercion of ancestor ids

### DIFF
--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -724,7 +724,9 @@ function processEntitiesResponse(
         if (path === "") {
           ancestors = [];
         } else {
-          ancestors = path.split(".").map((id) => id as typeof data.key);
+          ancestors = path
+            .split(".")
+            .map((id) => (typeof data.key === "number" ? +id : id));
         }
       }
 


### PR DESCRIPTION
This was preventing hierarchy expansion from working because the requests for the ancestor instance children were failing due to the requested id type being a string instead of an int64.