### PR TITLE
Bump admin service client library version to latest.

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     annotationProcessor group: "org.springframework.boot", name: "spring-boot-configuration-processor"
 
     // VUMC Admin dependency
-    implementation group: "bio.terra", name: "tanagra-vumc-admin-client", version: "0.0.1d-SNAPSHOT"
+    implementation group: "bio.terra", name: "tanagra-vumc-admin-client", version: "0.0.2-SNAPSHOT"
     implementation group: "org.glassfish.jersey.core", name: "jersey-client", version: "2.32"
     // hk2 is required to use VUMC admin client, but not correctly exposed by the client
     implementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.32'


### PR DESCRIPTION
These client library versions should be identical, but the previous one `0.0.1d` was generated manually by me during testing. The new one `0.0.2` is the automatically generated one by the GHA. Bumping it just so we're always using the "official" library version, not a test one.