### PR TITLE
Bump beam version 2.32.0 -> 2.43.0

### DIFF
--- a/indexer/build.gradle
+++ b/indexer/build.gradle
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     ext {
-        beam = "2.32.0"
+        beam = "2.43.0"
     }
     implementation project(":underlay")
     testImplementation(testFixtures(project(":underlay")))


### PR DESCRIPTION
We're currently using a deprecated version.
![Screen Shot 2023-01-10 at 6 05 45 PM](https://user-images.githubusercontent.com/12446128/211680896-59a2c3eb-1dc2-41d1-883d-ecb9cdb8ce21.png)
