### PR TITLE
Fix gradle build task.

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -61,6 +61,10 @@ dependencies {
     swaggerCodegen group: "io.swagger.codegen.v3", name: "swagger-codegen-cli"
 }
 
+bootJar {
+    enabled = false
+}
+
 def includeDir = "$projectDir/gradle"
 apply(from: "$includeDir/artifactory.gradle")
 apply(from: "$includeDir/open-api.gradle")


### PR DESCRIPTION
This task isn't used in any of our workflows, but it's often the first thing people try when they checkout the code. So it's nice to keep it working.