### PR TITLE
Vumc GitHub publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ workflow/rendered/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**
+*/bin
 
 ### Jenv ###
 .java-version

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -105,8 +105,6 @@ dependencies {
         exclude group: "org.junit.vintage", module: "junit-vintage-engine"
     }
 
-    // Cloud SQL
-    implementation "com.google.cloud.sql:postgres-socket-factory:1.7.0"
 
     // Static analysis
     compileOnly "com.google.code.findbugs:annotations:3.0.1u2"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -105,6 +105,9 @@ dependencies {
         exclude group: "org.junit.vintage", module: "junit-vintage-engine"
     }
 
+    // Cloud SQL
+    implementation "com.google.cloud.sql:postgres-socket-factory:1.7.0"
+
     // Static analysis
     compileOnly "com.google.code.findbugs:annotations:3.0.1u2"
     testCompileOnly "com.google.code.findbugs:annotations:3.0.1u2"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -130,4 +130,5 @@ apply from: "$rootDir/service/gradle/jib.gradle"
 apply from: "$rootDir/service/gradle/open-api.gradle"
 apply from: "$rootDir/service/gradle/version-properties.gradle"
 apply from: "$rootDir/service/gradle/task-dependencies.gradle"
+apply from: "$rootDir/service/gradle/vumc_github.gradle"
 

--- a/service/gradle/vumc_github.gradle
+++ b/service/gradle/vumc_github.gradle
@@ -1,0 +1,25 @@
+
+publishing {
+    repositories {
+        // The target repository
+        maven {
+            // Choose whatever name you want
+            name = "GitHubPackages"
+            // The url of the repository, where the artifacts will be published
+            url = uri("https://maven.pkg.github.com/vanderbilt/tanagra")
+            credentials {
+                // The credentials (described in the next section)
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        tanagraApi(MavenPublication) {
+            groupId "bio.terra"
+            artifactId "tanagraapi"
+            version "${version}"
+            artifact("../service/build/libs/service-${version}.jar")
+        }
+    }
+}


### PR DESCRIPTION
Added VUMC github specific publishing block to the API service, this will allow publishing to the VUMC jar repo once a token is provided to the databiosphere repository.