### PR TITLE
Override max hierarchy depth. Parallelize indexing jobs.

### DIFF
--- a/docs/INDEXING.md
+++ b/docs/INDEXING.md
@@ -80,7 +80,7 @@ Potential downside is more permissions needed by indexing service account.)
 Set the default application credentials to a service account key file that has read access to the source and read + 
 write access to the index data.
 ```
-export GOOGLE_APPLICATION_CREDENTIALS=/credentials/indexing_sa.json
+export GOOGLE_APPLICATION_CREDENTIALS=$HOME/tanagra/credentials/indexing_sa.json
 ```
 
 #### All Jobs
@@ -88,11 +88,11 @@ Do a dry run of all the indexing jobs. This provides a sanity check that the ind
 query inputs, are valid. This step is not required, but highly recommended to help catch errors/bugs sooner and without 
 running a bunch of computation first.
 ```
-./gradlew indexer:index -Dexec.args="INDEX_ALL /config/output/omop.json DRY_RUN"
+./gradlew indexer:index -Dexec.args="INDEX_ALL $HOME/tanagra/service/src/main/resources/config/output/omop.json DRY_RUN"
 ```
 Now actually kick off all the indexing jobs.
 ```
-./gradlew indexer:index -Dexec.args="INDEX_ALL /config/output/omop.json"
+./gradlew indexer:index -Dexec.args="INDEX_ALL $HOME/tanagra/service/src/main/resources/config/output/omop.json"
 ```
 This can take a long time to complete. If e.g. your computer falls asleep or you need to kill the process on your
 computer, you can re-run the same command again. You need to check that there are no in-progress Dataflow jobs in the
@@ -106,13 +106,13 @@ kicking them off again.
 You can also kickoff the indexing jobs for a single entity or entity group. This is helpful for testing and debugging.
 To kick off all the indexing jobs for a particular entity:
 ```
-./gradlew indexer:index -Dexec.args="INDEX_ENTITY /config/output/omop.json person DRY_RUN"
-./gradlew indexer:index -Dexec.args="INDEX_ENTITY /config/output/omop.json person"
+./gradlew indexer:index -Dexec.args="INDEX_ENTITY $HOME/tanagra/service/src/main/resources/config/output/omop.json person DRY_RUN"
+./gradlew indexer:index -Dexec.args="INDEX_ENTITY $HOME/tanagra/service/src/main/resources/config/output/omop.json person"
 ```
 or entity group:
 ```
-./gradlew indexer:index -Dexec.args="INDEX_ENTITY_GROUP /config/output/omop.json condition_occurrence_person DRY_RUN"
-./gradlew indexer:index -Dexec.args="INDEX_ENTITY_GROUP /config/output/omop.json condition_occurrence_person"
+./gradlew indexer:index -Dexec.args="INDEX_ENTITY_GROUP $HOME/tanagra/service/src/main/resources/config/output/omop.json condition_occurrence_person DRY_RUN"
+./gradlew indexer:index -Dexec.args="INDEX_ENTITY_GROUP $HOME/tanagra/service/src/main/resources/config/output/omop.json condition_occurrence_person"
 ```
 All the entities in a group should be indexed before the group. The `INDEX_ALL` command ensures this ordering, but keep 
 this in  mind if you're running the jobs for each entity or entity group separately.
@@ -121,8 +121,8 @@ this in  mind if you're running the jobs for each entity or entity group separat
 By default, the indexing jobs are run concurrently as much as possible. You can force it to run jobs serially by
 appending `SERIAL` to the command:
 ```
-./gradlew indexer:index -Dexec.args="INDEX_ALL /config/output/omop.json DRY_RUN SERIAL"
-./gradlew indexer:index -Dexec.args="INDEX_ALL /config/output/omop.json NOT_DRY_RUN SERIAL"
+./gradlew indexer:index -Dexec.args="INDEX_ALL $HOME/tanagra/service/src/main/resources/config/output/omop.json DRY_RUN SERIAL"
+./gradlew indexer:index -Dexec.args="INDEX_ALL $HOME/tanagra/service/src/main/resources/config/output/omop.json NOT_DRY_RUN SERIAL"
 ```
 
 ## OMOP Example

--- a/docs/INDEXING.md
+++ b/docs/INDEXING.md
@@ -117,6 +117,14 @@ or entity group:
 All the entities in a group should be indexed before the group. The `INDEX_ALL` command ensures this ordering, but keep 
 this in  mind if you're running the jobs for each entity or entity group separately.
 
+#### Concurrency
+By default, the indexing jobs are run concurrently as much as possible. You can force it to run jobs serially by
+appending `SERIAL` to the command:
+```
+./gradlew indexer:index -Dexec.args="INDEX_ALL /config/output/omop.json DRY_RUN SERIAL"
+./gradlew indexer:index -Dexec.args="INDEX_ALL /config/output/omop.json NOT_DRY_RUN SERIAL"
+```
+
 ## OMOP Example
 The `cms_synpuf` is a [public dataset](https://console.cloud.google.com/marketplace/product/hhs/synpuf) that uses the 
 standard OMOP schema.

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/BigQueryIndexingJob.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/BigQueryIndexingJob.java
@@ -48,21 +48,10 @@ public abstract class BigQueryIndexingJob implements IndexingJob {
 
   protected static final String DEFAULT_REGION = "us-central1";
 
-  // The maximum depth of ancestors present in a hierarchy. This may be larger
-  // than the actual max depth, but if it is smaller the resulting table will be incomplete.
-  // TODO: Allow overriding the default max hierarchy depth.
-  protected static final int DEFAULT_MAX_HIERARCHY_DEPTH = 64;
-
   private final Entity entity;
 
   protected BigQueryIndexingJob(Entity entity) {
     this.entity = entity;
-  }
-
-  @Override
-  public boolean prerequisitesComplete() {
-    // TODO: Implement a required ordering so we can run jobs in parallel.
-    return true;
   }
 
   protected Entity getEntity() {
@@ -232,6 +221,8 @@ public abstract class BigQueryIndexingJob implements IndexingJob {
 
   /** Build a name for the Dataflow job that will be visible in the Cloud Console. */
   private String getDataflowJobName() {
+    String underlayName = entity.getUnderlay().getName();
+    String normalizedUnderlayName = underlayName.toLowerCase().replaceAll("[^a-z0-9]", "-");
     String jobDisplayName = getName();
     String normalizedJobDisplayName =
         jobDisplayName == null || jobDisplayName.length() == 0
@@ -243,7 +234,8 @@ public abstract class BigQueryIndexingJob implements IndexingJob {
 
     String randomPart = Integer.toHexString(ThreadLocalRandom.current().nextInt());
     return String.format(
-        "%s-%s-%s-%s", normalizedJobDisplayName, normalizedUserName, datePart, randomPart);
+        "%s-%s-%s-%s-%s",
+        normalizedUnderlayName, normalizedJobDisplayName, normalizedUserName, datePart, randomPart);
   }
 
   protected String getAppDefaultSAEmail() {

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/Indexer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/Indexer.java
@@ -13,6 +13,10 @@ import bio.terra.tanagra.indexing.job.DenormalizeEntityInstances;
 import bio.terra.tanagra.indexing.job.WriteAncestorDescendantIdPairs;
 import bio.terra.tanagra.indexing.job.WriteParentChildIdPairs;
 import bio.terra.tanagra.indexing.job.WriteRelationshipIdPairs;
+import bio.terra.tanagra.indexing.jobexecutor.JobRunner;
+import bio.terra.tanagra.indexing.jobexecutor.ParallelRunner;
+import bio.terra.tanagra.indexing.jobexecutor.SequencedJobSet;
+import bio.terra.tanagra.indexing.jobexecutor.SerialRunner;
 import bio.terra.tanagra.serialization.UFEntity;
 import bio.terra.tanagra.serialization.UFEntityGroup;
 import bio.terra.tanagra.serialization.UFUnderlay;
@@ -21,7 +25,6 @@ import bio.terra.tanagra.underlay.EntityGroup;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitygroup.CriteriaOccurrence;
 import bio.terra.tanagra.utils.FileIO;
-import bio.terra.tanagra.utils.HttpUtils;
 import bio.terra.tanagra.utils.JacksonMapper;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -34,6 +37,23 @@ import org.slf4j.LoggerFactory;
 
 public final class Indexer {
   private static final Logger LOGGER = LoggerFactory.getLogger(Indexer.class);
+
+  enum JobExecutor {
+    PARALLEL,
+    SERIAL;
+
+    public JobRunner getRunner(
+        List<SequencedJobSet> jobSets, boolean isDryRun, IndexingJob.RunType runType) {
+      switch (this) {
+        case SERIAL:
+          return new SerialRunner(jobSets, isDryRun, runType);
+        case PARALLEL:
+          return new ParallelRunner(jobSets, isDryRun, runType);
+        default:
+          throw new IllegalArgumentException("Unknown JobExecution enum type: " + this);
+      }
+    }
+  }
 
   private final Underlay underlay;
   private UFUnderlay expandedUnderlay;
@@ -103,50 +123,48 @@ public final class Indexer {
     }
   }
 
-  public void runJobsForAllEntities(boolean isDryRun) {
-    underlay.getEntities().keySet().stream()
-        .sorted()
-        .forEach(name -> runJobsForEntity(name, isDryRun));
+  public JobRunner runJobsForAllEntities(
+      JobExecutor jobExecutor, boolean isDryRun, IndexingJob.RunType runType) {
+    LOGGER.info("INDEXING all entities");
+    List<SequencedJobSet> jobSets =
+        underlay.getEntities().values().stream()
+            .map(Indexer::getJobSetForEntity)
+            .collect(Collectors.toList());
+    return runJobs(jobExecutor, isDryRun, runType, jobSets);
   }
 
-  public void runJobsForEntity(String name, boolean isDryRun) {
-    LOGGER.info("RUN entity: {}", name);
-    getJobsForEntity(underlay.getEntity(name))
-        .forEach(ij -> tolerateJobExceptions(() -> ij.checkStatusAndRun(isDryRun), ij.getName()));
+  public JobRunner runJobsForSingleEntity(
+      JobExecutor jobExecutor, boolean isDryRun, IndexingJob.RunType runType, String name) {
+    LOGGER.info("INDEXING entity: {}", name);
+    List<SequencedJobSet> jobSets = List.of(getJobSetForEntity(underlay.getEntity(name)));
+    return runJobs(jobExecutor, isDryRun, runType, jobSets);
   }
 
-  public void runJobsForAllEntityGroups(boolean isDryRun) {
-    underlay.getEntityGroups().keySet().stream()
-        .sorted()
-        .forEach(name -> runJobsForEntityGroup(name, isDryRun));
+  public JobRunner runJobsForAllEntityGroups(
+      JobExecutor jobExecutor, boolean isDryRun, IndexingJob.RunType runType) {
+    LOGGER.info("INDEXING all entity groups");
+    List<SequencedJobSet> jobSets =
+        underlay.getEntityGroups().values().stream()
+            .map(Indexer::getJobSetForEntityGroup)
+            .collect(Collectors.toList());
+    return runJobs(jobExecutor, isDryRun, runType, jobSets);
   }
 
-  public void runJobsForEntityGroup(String name, boolean isDryRun) {
-    LOGGER.info("RUN entity group: {}", name);
-    getJobsForEntityGroup(underlay.getEntityGroup(name))
-        .forEach(ij -> tolerateJobExceptions(() -> ij.checkStatusAndRun(isDryRun), ij.getName()));
+  public JobRunner runJobsForSingleEntityGroup(
+      JobExecutor jobExecutor, boolean isDryRun, IndexingJob.RunType runType, String name) {
+    LOGGER.info("INDEXING entity group: {}", name);
+    List<SequencedJobSet> jobSets = List.of(getJobSetForEntityGroup(underlay.getEntityGroup(name)));
+    return runJobs(jobExecutor, isDryRun, runType, jobSets);
   }
 
-  public void cleanAllEntities(boolean isDryRun) {
-    underlay.getEntities().keySet().stream().sorted().forEach(name -> cleanEntity(name, isDryRun));
-  }
-
-  public void cleanEntity(String name, boolean isDryRun) {
-    LOGGER.info("CLEAN entity: {}", name);
-    getJobsForEntity(underlay.getEntity(name))
-        .forEach(ij -> tolerateJobExceptions(() -> ij.checkStatusAndClean(isDryRun), ij.getName()));
-  }
-
-  public void cleanAllEntityGroups(boolean isDryRun) {
-    underlay.getEntityGroups().keySet().stream()
-        .sorted()
-        .forEach(name -> cleanEntityGroup(name, isDryRun));
-  }
-
-  public void cleanEntityGroup(String name, boolean isDryRun) {
-    LOGGER.info("CLEAN entity group: {}", name);
-    getJobsForEntityGroup(underlay.getEntityGroup(name))
-        .forEach(ij -> tolerateJobExceptions(() -> ij.checkStatusAndClean(isDryRun), ij.getName()));
+  private JobRunner runJobs(
+      JobExecutor jobExecutor,
+      boolean isDryRun,
+      IndexingJob.RunType runType,
+      List<SequencedJobSet> jobSets) {
+    JobRunner jobRunner = jobExecutor.getRunner(jobSets, isDryRun, runType);
+    jobRunner.runJobSets();
+    return jobRunner;
   }
 
   @VisibleForTesting
@@ -165,6 +183,31 @@ public final class Indexer {
               jobs.add(new BuildNumChildrenAndPaths(entity, hierarchy.getName()));
             });
     return jobs;
+  }
+
+  public static SequencedJobSet getJobSetForEntity(Entity entity) {
+    SequencedJobSet jobSet = new SequencedJobSet(entity.getName());
+    jobSet.startNewStage();
+    jobSet.addJob(new CreateEntityTable(entity));
+
+    jobSet.startNewStage();
+    jobSet.addJob(new DenormalizeEntityInstances(entity));
+
+    if (entity.getTextSearch().isEnabled() || entity.hasHierarchies()) {
+      jobSet.startNewStage();
+    }
+
+    if (entity.getTextSearch().isEnabled()) {
+      jobSet.addJob(new BuildTextSearchStrings(entity));
+    }
+    entity.getHierarchies().stream()
+        .forEach(
+            hierarchy -> {
+              jobSet.addJob(new WriteParentChildIdPairs(entity, hierarchy.getName()));
+              jobSet.addJob(new WriteAncestorDescendantIdPairs(entity, hierarchy.getName()));
+              jobSet.addJob(new BuildNumChildrenAndPaths(entity, hierarchy.getName()));
+            });
+    return jobSet;
   }
 
   @VisibleForTesting
@@ -219,28 +262,65 @@ public final class Indexer {
                 criteriaOccurrence, criteriaOccurrence.getModifierAttributes()));
       }
     }
-
     return jobs;
+  }
+
+  public static SequencedJobSet getJobSetForEntityGroup(EntityGroup entityGroup) {
+    SequencedJobSet jobSet = new SequencedJobSet(entityGroup.getName());
+    jobSet.startNewStage();
+
+    // For each relationship, write the index relationship mapping.
+    entityGroup.getRelationships().values().stream()
+        .forEach(
+            // TODO: If the source relationship mapping table = one of the entity tables, then just
+            // populate a new column on that entity table, instead of always writing a new table.
+            relationship -> jobSet.addJob(new WriteRelationshipIdPairs(relationship)));
+
+    if (EntityGroup.Type.CRITERIA_OCCURRENCE.equals(entityGroup.getType())) {
+      CriteriaOccurrence criteriaOccurrence = (CriteriaOccurrence) entityGroup;
+      // Compute the criteria rollup counts for both the criteria-primary and criteria-occurrence
+      // relationships.
+      jobSet.addJob(
+          new ComputeRollupCounts(
+              criteriaOccurrence.getCriteriaEntity(),
+              criteriaOccurrence.getCriteriaPrimaryRelationship(),
+              null));
+      jobSet.addJob(
+          new ComputeRollupCounts(
+              criteriaOccurrence.getCriteriaEntity(),
+              criteriaOccurrence.getOccurrenceCriteriaRelationship(),
+              null));
+
+      // If the criteria entity has a hierarchy, then also compute the counts for each
+      // hierarchy.
+      if (criteriaOccurrence.getCriteriaEntity().hasHierarchies()) {
+        criteriaOccurrence.getCriteriaEntity().getHierarchies().stream()
+            .forEach(
+                hierarchy -> {
+                  jobSet.addJob(
+                      new ComputeRollupCounts(
+                          criteriaOccurrence.getCriteriaEntity(),
+                          criteriaOccurrence.getCriteriaPrimaryRelationship(),
+                          hierarchy));
+                  jobSet.addJob(
+                      new ComputeRollupCounts(
+                          criteriaOccurrence.getCriteriaEntity(),
+                          criteriaOccurrence.getOccurrenceCriteriaRelationship(),
+                          hierarchy));
+                });
+      }
+
+      // Compute display hints for the occurrence entity.
+      if (!criteriaOccurrence.getModifierAttributes().isEmpty()) {
+        jobSet.addJob(
+            new ComputeDisplayHints(
+                criteriaOccurrence, criteriaOccurrence.getModifierAttributes()));
+      }
+    }
+    return jobSet;
   }
 
   public Underlay getUnderlay() {
     return underlay;
-  }
-
-  /**
-   * Execute an indexing job. If an exception is thrown, make sure the error message and stack trace
-   * are logged.
-   *
-   * @param runJob function with no return value
-   * @param jobName name of the indexing job to include in log statements
-   */
-  private void tolerateJobExceptions(
-      HttpUtils.RunnableWithCheckedException<Exception> runJob, String jobName) {
-    try {
-      runJob.run();
-    } catch (Exception ex) {
-      LOGGER.error("Error running indexing job: {}", jobName);
-      LOGGER.error("Exception thrown: {}", ex);
-    }
   }
 }

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/BuildNumChildrenAndPaths.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/BuildNumChildrenAndPaths.java
@@ -166,7 +166,8 @@ public class BuildNumChildrenAndPaths extends BigQueryIndexingJob {
 
     // compute a path to a root node for each node in the hierarchy
     PCollection<KV<Long, String>> nodePathKVsPC =
-        PathUtils.computePaths(allNodesPC, childParentRelationshipsPC, DEFAULT_MAX_HIERARCHY_DEPTH);
+        PathUtils.computePaths(
+            allNodesPC, childParentRelationshipsPC, sourceHierarchyMapping.getMaxHierarchyDepth());
 
     // count the number of children for each node in the hierarchy
     PCollection<KV<Long, Long>> nodeNumChildrenKVsPC =

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeDisplayHints.java
@@ -198,12 +198,12 @@ public class ComputeDisplayHints extends BigQueryIndexingJob {
             .apply(
                 Filter.by(
                     occIdAndTableRow ->
-                        (occIdAndTableRow.getValue().get(numValColName) != null
+                        occIdAndTableRow.getValue().get(numValColName) != null
                             && !occIdAndTableRow
                                 .getValue()
                                 .get(numValColName)
                                 .toString()
-                                .isEmpty())))
+                                .isEmpty()))
             .apply(
                 MapElements.into(
                         TypeDescriptors.kvs(TypeDescriptors.longs(), TypeDescriptors.doubles()))

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/beam/GraphUtils.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/beam/GraphUtils.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.sdk.transforms.Distinct;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.KvSwap;
@@ -70,10 +71,14 @@ public final class GraphUtils {
     int n = 2;
     while (true) {
       PCollection<KV<T, T>> nExactPaths =
-          concatenate(exactPaths.get(n / 2), exactPaths.get(n / 2), "exactPaths N" + n);
+          concatenate(
+                  exactPaths.get(n / 2).apply(Distinct.create()),
+                  exactPaths.get(n / 2).apply(Distinct.create()),
+                  "exactPaths N" + n)
+              .apply(Distinct.create());
       exactPaths.put(n, nExactPaths);
 
-      PCollection<KV<T, T>> nMinus1AllPaths = allPaths.get(n - 1);
+      PCollection<KV<T, T>> nMinus1AllPaths = allPaths.get(n - 1).apply(Distinct.create());
 
       PCollection<KV<T, T>> newAllPaths =
           PCollectionList.of(nMinus1AllPaths)

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobResult.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobResult.java
@@ -1,0 +1,113 @@
+package bio.terra.tanagra.indexing.jobexecutor;
+
+import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.ANSI_GREEN;
+import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.ANSI_RED;
+import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.ANSI_RESET;
+
+import bio.terra.tanagra.indexing.IndexingJob;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Output of a thread that runs a single indexing job. */
+public class JobResult {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobResult.class);
+
+  private final String jobDescription;
+  private final String threadName;
+
+  private IndexingJob.JobStatus jobStatus;
+  private boolean threadTerminatedOnTime;
+  private boolean jobStatusAsExpected;
+  private long elapsedTimeNS;
+
+  private boolean exceptionWasThrown;
+  private String exceptionStackTrace;
+  private String exceptionMessage;
+
+  public JobResult(String jobDescription, String threadName) {
+    this.jobDescription = jobDescription;
+    this.threadName = threadName;
+
+    this.threadTerminatedOnTime = false;
+    this.jobStatusAsExpected = false;
+    this.exceptionWasThrown = false;
+    this.exceptionStackTrace = null;
+    this.exceptionMessage = null;
+  }
+
+  @SuppressWarnings("PMD.SystemPrintln")
+  public void print() {
+    System.out.println(
+        String.format(
+            "%s %s",
+            jobDescription,
+            isFailure()
+                ? (ANSI_RED + "FAILED" + ANSI_RESET)
+                : (ANSI_GREEN + "SUCCESS" + ANSI_RESET)));
+    System.out.println(String.format("   thread: %s", threadName));
+    System.out.println(String.format("   job status: %s", jobStatus));
+    System.out.println(String.format("   job status as expected: %s", jobStatusAsExpected));
+    System.out.println(
+        String.format(
+            "   elapsed time (sec): %d",
+            TimeUnit.MINUTES.convert(elapsedTimeNS, TimeUnit.NANOSECONDS)));
+    System.out.println(String.format("   thread terminated on time: %s", threadTerminatedOnTime));
+    System.out.println(String.format("   exception msg: %s", exceptionMessage));
+    System.out.println(String.format("   exception stack trace: %s", exceptionStackTrace));
+  }
+
+  /**
+   * Store the exception message and stack trace for the job results. Don't store the full {@link
+   * Throwable} object, because that may not always be serializable. This class may be serialized to
+   * disk as part of writing out the job results, so it needs to be a POJO.
+   */
+  public void saveExceptionThrown(Throwable exceptionThrown) {
+    exceptionWasThrown = true;
+    exceptionMessage =
+        StringUtils.isBlank(exceptionMessage)
+            ? exceptionThrown.getMessage()
+            : String.format("%s%n%s", exceptionMessage, exceptionThrown.getMessage());
+
+    StringWriter stackTraceStr = new StringWriter();
+    exceptionThrown.printStackTrace(new PrintWriter(stackTraceStr));
+    exceptionStackTrace = stackTraceStr.toString();
+
+    LOGGER.error("Job thread threw error", exceptionThrown); // print the stack trace to the console
+  }
+
+  public boolean isFailure() {
+    return exceptionWasThrown || !threadTerminatedOnTime || !jobStatusAsExpected;
+  }
+
+  public String getJobDescription() {
+    return jobDescription;
+  }
+
+  public IndexingJob.JobStatus getJobStatus() {
+    return jobStatus;
+  }
+
+  public void setJobStatus(IndexingJob.JobStatus jobStatus) {
+    this.jobStatus = jobStatus;
+  }
+
+  public void setThreadTerminatedOnTime(boolean threadTerminatedOnTime) {
+    this.threadTerminatedOnTime = threadTerminatedOnTime;
+  }
+
+  public void setJobStatusAsExpected(boolean jobStatusAsExpected) {
+    this.jobStatusAsExpected = jobStatusAsExpected;
+  }
+
+  public void setElapsedTimeNS(long elapsedTimeNS) {
+    this.elapsedTimeNS = elapsedTimeNS;
+  }
+
+  public void setExceptionWasThrown(boolean exceptionWasThrown) {
+    this.exceptionWasThrown = exceptionWasThrown;
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobResult.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobResult.java
@@ -1,8 +1,8 @@
 package bio.terra.tanagra.indexing.jobexecutor;
 
-import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.ANSI_GREEN;
-import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.ANSI_RED;
-import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.ANSI_RESET;
+import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.TERMINAL_ANSI_GREEN;
+import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.TERMINAL_ANSI_RED;
+import static bio.terra.tanagra.indexing.jobexecutor.ParallelRunner.TERMINAL_ESCAPE_RESET;
 
 import bio.terra.tanagra.indexing.IndexingJob;
 import java.io.PrintWriter;
@@ -46,8 +46,8 @@ public class JobResult {
             "%s %s",
             jobDescription,
             isFailure()
-                ? (ANSI_RED + "FAILED" + ANSI_RESET)
-                : (ANSI_GREEN + "SUCCESS" + ANSI_RESET)));
+                ? (TERMINAL_ANSI_RED + "FAILED" + TERMINAL_ESCAPE_RESET)
+                : (TERMINAL_ANSI_GREEN + "SUCCESS" + TERMINAL_ESCAPE_RESET)));
     System.out.println(String.format("   thread: %s", threadName));
     System.out.println(String.format("   job status: %s", jobStatus));
     System.out.println(String.format("   job status as expected: %s", jobStatusAsExpected));

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobRunner.java
@@ -11,10 +11,10 @@ public abstract class JobRunner {
   protected static final long MAX_TIME_PER_JOB_MIN = 60;
   protected static final long MAX_TIME_PER_JOB_DRY_RUN_MIN = 5;
 
-  public static final String ANSI_RESET = "\u001B[0m";
-  public static final String ANSI_PURPLE = "\u001B[35m";
-  public static final String ANSI_GREEN = "\u001b[32m";
-  public static final String ANSI_RED = "\u001b[31m";
+  public static final String TERMINAL_ESCAPE_RESET = "\u001B[0m";
+  public static final String TERMINAL_ANSI_PURPLE = "\u001B[35m";
+  public static final String TERMINAL_ANSI_GREEN = "\u001b[32m";
+  public static final String TERMINAL_ANSI_RED = "\u001b[31m";
 
   protected final List<SequencedJobSet> jobSets;
   protected final boolean isDryRun;
@@ -42,7 +42,8 @@ public abstract class JobRunner {
   @SuppressWarnings("PMD.SystemPrintln")
   public void printJobResultSummary() {
     System.out.println(System.lineSeparator());
-    System.out.println(ANSI_PURPLE + "Indexing job summary (" + getName() + ")" + ANSI_RESET);
+    System.out.println(
+        TERMINAL_ANSI_PURPLE + "Indexing job summary (" + getName() + ")" + TERMINAL_ESCAPE_RESET);
     jobResults.stream()
         .sorted(Comparator.comparing(JobResult::getJobDescription, String.CASE_INSENSITIVE_ORDER))
         .forEach(JobResult::print);

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobRunner.java
@@ -1,0 +1,60 @@
+package bio.terra.tanagra.indexing.jobexecutor;
+
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.indexing.IndexingJob;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public abstract class JobRunner {
+  protected static final long MAX_TIME_PER_JOB_MIN = 60;
+  protected static final long MAX_TIME_PER_JOB_DRY_RUN_MIN = 5;
+
+  public static final String ANSI_RESET = "\u001B[0m";
+  public static final String ANSI_PURPLE = "\u001B[35m";
+  public static final String ANSI_GREEN = "\u001b[32m";
+  public static final String ANSI_RED = "\u001b[31m";
+
+  protected final List<SequencedJobSet> jobSets;
+  protected final boolean isDryRun;
+  protected final IndexingJob.RunType runType;
+  protected final List<JobResult> jobResults;
+
+  public JobRunner(List<SequencedJobSet> jobSets, boolean isDryRun, IndexingJob.RunType runType) {
+    this.jobSets = jobSets;
+    this.isDryRun = isDryRun;
+    this.runType = runType;
+    this.jobResults = new ArrayList<>();
+  }
+
+  /** Name for display only. */
+  protected abstract String getName();
+
+  /** Run all job sets. */
+  public abstract void runJobSets();
+
+  /** Run a single job set. */
+  protected abstract void runSingleJobSet(SequencedJobSet sequencedJobSet)
+      throws InterruptedException, ExecutionException;
+
+  /** Pretty print the job results to the terminal. */
+  @SuppressWarnings("PMD.SystemPrintln")
+  public void printJobResultSummary() {
+    System.out.println(System.lineSeparator());
+    System.out.println(ANSI_PURPLE + "Indexing job summary (" + getName() + ")" + ANSI_RESET);
+    jobResults.stream()
+        .sorted(Comparator.comparing(JobResult::getJobDescription, String.CASE_INSENSITIVE_ORDER))
+        .forEach(JobResult::print);
+  }
+
+  public void throwIfAnyFailures() {
+    jobResults.stream()
+        .forEach(
+            jobResult -> {
+              if (jobResult.isFailure()) {
+                throw new SystemException("There were job failures");
+              }
+            });
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobThread.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobThread.java
@@ -1,0 +1,42 @@
+package bio.terra.tanagra.indexing.jobexecutor;
+
+import bio.terra.tanagra.indexing.IndexingJob;
+import java.util.concurrent.Callable;
+
+/** Thread that runs a single indexing job and outputs an instance of the result class. */
+public class JobThread implements Callable<JobResult> {
+  private final IndexingJob indexingJob;
+  private final boolean isDryRun;
+  private final IndexingJob.RunType runType;
+  private final String jobDescription;
+
+  public JobThread(
+      IndexingJob indexingJob,
+      boolean isDryRun,
+      IndexingJob.RunType runType,
+      String jobDescription) {
+    this.indexingJob = indexingJob;
+    this.isDryRun = isDryRun;
+    this.runType = runType;
+    this.jobDescription = jobDescription;
+  }
+
+  @Override
+  public JobResult call() {
+    JobResult result = new JobResult(jobDescription, Thread.currentThread().getName());
+
+    long startTime = System.nanoTime();
+    try {
+      IndexingJob.JobStatus status = indexingJob.execute(runType, isDryRun);
+      result.setJobStatus(status);
+      result.setJobStatusAsExpected(
+          IndexingJob.checkStatusAfterRunMatchesExpected(runType, isDryRun, status));
+      result.setExceptionWasThrown(false);
+    } catch (Throwable ex) {
+      result.saveExceptionThrown(ex);
+    }
+    result.setElapsedTimeNS(System.nanoTime() - startTime);
+
+    return result;
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/ParallelRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/ParallelRunner.java
@@ -1,0 +1,117 @@
+package bio.terra.tanagra.indexing.jobexecutor;
+
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.indexing.IndexingJob;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class that runs multiple job sets in parallel. */
+public final class ParallelRunner extends JobRunner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ParallelRunner.class);
+  private static final long MAX_TIME_FOR_SHUTDOWN_SEC = 60;
+
+  public ParallelRunner(
+      List<SequencedJobSet> jobSets, boolean isDryRun, IndexingJob.RunType runType) {
+    super(jobSets, isDryRun, runType);
+  }
+
+  @Override
+  protected String getName() {
+    return "PARALLEL";
+  }
+
+  /** Run all job sets in parallel. */
+  @Override
+  public void runJobSets() {
+    // Create a thread pool to run the job set.
+    ThreadPoolExecutor threadPool =
+        (ThreadPoolExecutor) Executors.newFixedThreadPool(jobSets.size());
+    LOGGER.info("Running job sets in parallel: {} sets", jobSets.size());
+
+    // Kick off each job set in a separate thread.
+    jobSets.forEach(
+        jobSet ->
+            threadPool.submit(
+                () -> {
+                  try {
+                    runSingleJobSet(jobSet);
+                  } catch (InterruptedException | ExecutionException ex) {
+                    throw new SystemException("Job set execution failed", ex);
+                  }
+                }));
+
+    try {
+      LOGGER.info("Waiting for job set to to finish");
+      shutdownThreadPool(threadPool);
+    } catch (InterruptedException intEx) {
+      LOGGER.error("Error running jobs in parallel. Try running in serial.");
+      throw new SystemException("Error running jobs in parallel", intEx);
+    }
+  }
+
+  /** Run a single job set. Run the stages serially, and the jobs within each stage in parallel. */
+  @Override
+  protected void runSingleJobSet(SequencedJobSet sequencedJobSet)
+      throws InterruptedException, ExecutionException {
+    // Iterate through the job stages, running all jobs in each stage.
+    Iterator<List<IndexingJob>> jobStagesIterator = sequencedJobSet.iterator();
+    while (jobStagesIterator.hasNext()) {
+      List<IndexingJob> jobsInStage = jobStagesIterator.next();
+
+      // Create a thread pool for each stage, one thread per job.
+      ThreadPoolExecutor threadPool =
+          (ThreadPoolExecutor) Executors.newFixedThreadPool(jobsInStage.size());
+      LOGGER.info("New job stage: {} jobs", jobsInStage.size());
+
+      // Kick off one thread per job.
+      List<Future<JobResult>> jobFutures = new ArrayList<>();
+      for (IndexingJob job : jobsInStage) {
+        LOGGER.info("Kicking off thread for job set: {}", job.getName());
+        Future<JobResult> jobFuture =
+            threadPool.submit(new JobThread(job, isDryRun, runType, job.getName()));
+        jobFutures.add(jobFuture);
+      }
+
+      // Wait for all jobs in this stage to finish, before moving to the next stage.
+      LOGGER.info("Waiting for jobs in stage to finish");
+      shutdownThreadPool(threadPool);
+
+      // Compile the results.
+      for (Future<JobResult> jobFuture : jobFutures) {
+        JobResult jobResult = jobFuture.get();
+        jobResult.setThreadTerminatedOnTime(true);
+        jobResults.add(jobResult);
+      }
+
+      LOGGER.info("Stage complete");
+    }
+  }
+
+  /**
+   * Tell a thread pool to stop accepting new jobs, wait for the existing jobs to finish. If the
+   * jobs time out, then interrupt the threads and force them to terminate.
+   */
+  private void shutdownThreadPool(ThreadPoolExecutor threadPool) throws InterruptedException {
+    // Wait for all threads to finish.
+    threadPool.shutdown();
+    boolean terminatedByItself =
+        threadPool.awaitTermination(
+            isDryRun ? MAX_TIME_PER_JOB_DRY_RUN_MIN : MAX_TIME_PER_JOB_MIN, TimeUnit.MINUTES);
+
+    // If the threads didn't finish in the expected time, then send them interrupts.
+    if (!terminatedByItself) {
+      threadPool.shutdownNow();
+    }
+    if (!threadPool.awaitTermination(MAX_TIME_FOR_SHUTDOWN_SEC, TimeUnit.SECONDS)) {
+      LOGGER.error("All threads in the pool failed to terminate");
+    }
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SequencedJobSet.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SequencedJobSet.java
@@ -1,0 +1,40 @@
+package bio.terra.tanagra.indexing.jobexecutor;
+
+import bio.terra.tanagra.indexing.IndexingJob;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Container for a set of jobs and the sequence they must be run in. The stages must be run
+ * serially. The jobs within each stage can be run in parallel.
+ */
+public class SequencedJobSet {
+  private final List<List<IndexingJob>> stages;
+  private final String description;
+
+  public SequencedJobSet(String description) {
+    this.stages = new ArrayList<>();
+    this.description = description;
+  }
+
+  public void startNewStage() {
+    stages.add(new ArrayList<>());
+  }
+
+  public void addJob(IndexingJob job) {
+    stages.get(stages.size() - 1).add(job);
+  }
+
+  public Iterator<List<IndexingJob>> iterator() {
+    return stages.iterator();
+  }
+
+  public int getNumStages() {
+    return stages.size();
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SerialRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SerialRunner.java
@@ -1,0 +1,49 @@
+package bio.terra.tanagra.indexing.jobexecutor;
+
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.indexing.IndexingJob;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/** Utility class that runs multiple job sets in serial. */
+public final class SerialRunner extends JobRunner {
+  public SerialRunner(
+      List<SequencedJobSet> jobSets, boolean isDryRun, IndexingJob.RunType runType) {
+    super(jobSets, isDryRun, runType);
+  }
+
+  @Override
+  protected String getName() {
+    return "SERIAL";
+  }
+
+  /** Run all job sets serially. */
+  @Override
+  public void runJobSets() {
+    jobSets.forEach(
+        jobSet -> {
+          try {
+            runSingleJobSet(jobSet);
+          } catch (InterruptedException | ExecutionException ex) {
+            throw new SystemException("Job set execution failed", ex);
+          }
+        });
+  }
+
+  /** Run a single job set. Run the stages serially, and the jobs within each stage serially. */
+  @Override
+  protected void runSingleJobSet(SequencedJobSet sequencedJobSet)
+      throws InterruptedException, ExecutionException {
+    // Iterate through the job stages, running all jobs in each stage.
+    Iterator<List<IndexingJob>> jobStagesIterator = sequencedJobSet.iterator();
+    while (jobStagesIterator.hasNext()) {
+      List<IndexingJob> jobsInStage = jobStagesIterator.next();
+      for (IndexingJob job : jobsInStage) {
+        JobResult jobResult = new JobThread(job, isDryRun, runType, job.getName()).call();
+        jobResult.setThreadTerminatedOnTime(true);
+        jobResults.add(jobResult);
+      }
+    }
+  }
+}

--- a/indexer/src/test/java/bio/terra/tanagra/indexing/command/IndexEntityGroupTest.java
+++ b/indexer/src/test/java/bio/terra/tanagra/indexing/command/IndexEntityGroupTest.java
@@ -3,7 +3,7 @@ package bio.terra.tanagra.indexing.command;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.tanagra.indexing.Indexer;
-import bio.terra.tanagra.indexing.IndexingJob;
+import bio.terra.tanagra.indexing.jobexecutor.SequencedJobSet;
 import bio.terra.tanagra.underlay.DataPointer;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.EntityGroup;
@@ -11,7 +11,6 @@ import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.utils.FileIO;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,10 +34,10 @@ public class IndexEntityGroupTest {
   void oneToMany() throws IOException {
     EntityGroup brandIngredient =
         EntityGroup.fromJSON("BrandIngredient.json", dataPointers, entities, primaryEntityName);
-    List<IndexingJob> jobs = Indexer.getJobsForEntityGroup(brandIngredient);
+    SequencedJobSet jobs = Indexer.getJobSetForEntityGroup(brandIngredient);
 
     // copy relationship id pairs
-    assertEquals(1, jobs.size());
+    assertEquals(1, jobs.getNumStages());
   }
 
   @Test
@@ -46,11 +45,11 @@ public class IndexEntityGroupTest {
     EntityGroup conditionPersonOccurrence =
         EntityGroup.fromJSON(
             "ConditionPersonOccurrence.json", dataPointers, entities, primaryEntityName);
-    List<IndexingJob> jobs = Indexer.getJobsForEntityGroup(conditionPersonOccurrence);
+    SequencedJobSet jobs = Indexer.getJobSetForEntityGroup(conditionPersonOccurrence);
 
     // copy relationship id pairs (x3 relationships)
     // compute rollup counts (x2 relationships)
     // compute rollup counts with hierarchy (x2 relationships)
-    assertEquals(7, jobs.size());
+    assertEquals(7, jobs.iterator().next().size());
   }
 }

--- a/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/condition.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/condition.json
@@ -201,7 +201,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 20
       }
     }
   },
@@ -291,7 +292,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 20
       }
     }
   }

--- a/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/ingredient.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/ingredient.json
@@ -189,7 +189,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 8
       }
     }
   },
@@ -279,7 +280,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 8
       }
     }
   }

--- a/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/measurement.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/measurement.json
@@ -269,7 +269,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 11
       }
     }
   },
@@ -359,7 +360,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 11
       }
     }
   }

--- a/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/procedure.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/expanded/entity/procedure.json
@@ -217,7 +217,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 19
       }
     }
   },
@@ -307,7 +308,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 19
       }
     }
   }

--- a/service/src/main/resources/config/broad/aou_synthetic/original/entity/condition.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/original/entity/condition.json
@@ -45,7 +45,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 20
       }
     }
   },

--- a/service/src/main/resources/config/broad/aou_synthetic/original/entity/ingredient.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/original/entity/ingredient.json
@@ -52,7 +52,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 8
       }
     }
   },

--- a/service/src/main/resources/config/broad/aou_synthetic/original/entity/measurement.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/original/entity/measurement.json
@@ -103,7 +103,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 11
       }
     }
   },

--- a/service/src/main/resources/config/broad/aou_synthetic/original/entity/procedure.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/original/entity/procedure.json
@@ -45,7 +45,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 19
       }
     }
   },

--- a/service/src/main/resources/config/broad/cms_synpuf/expanded/entity/condition.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/expanded/entity/condition.json
@@ -165,7 +165,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 20
       }
     }
   },
@@ -255,7 +256,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 20
       }
     }
   }

--- a/service/src/main/resources/config/broad/cms_synpuf/expanded/entity/ingredient.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/expanded/entity/ingredient.json
@@ -177,7 +177,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 8
       }
     }
   },
@@ -267,7 +268,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 8
       }
     }
   }

--- a/service/src/main/resources/config/broad/cms_synpuf/expanded/entity/procedure.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/expanded/entity/procedure.json
@@ -189,7 +189,8 @@
               "column" : "concept_id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 19
       }
     }
   },
@@ -279,7 +280,8 @@
               "column" : "id"
             }
           }
-        }
+        },
+        "maxHierarchyDepth" : 19
       }
     }
   }

--- a/service/src/main/resources/config/broad/cms_synpuf/original/entity/condition.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/original/entity/condition.json
@@ -45,7 +45,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 20
       }
     }
   },

--- a/service/src/main/resources/config/broad/cms_synpuf/original/entity/ingredient.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/original/entity/ingredient.json
@@ -52,7 +52,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 8
       }
     }
   },

--- a/service/src/main/resources/config/broad/cms_synpuf/original/entity/procedure.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/original/entity/procedure.json
@@ -45,7 +45,8 @@
           "fieldPointers": {
             "id": { "column": "concept_id" }
           }
-        }
+        },
+        "maxHierarchyDepth": 19
       }
     }
   },

--- a/service/src/main/resources/config/vumc/sdd/original/sql/brand_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd/original/sql/brand_textSearch.sql
@@ -22,5 +22,4 @@ ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Drug'
 AND c.concept_class_id = 'Brand Name'
-AND c.invalid_reason IS NULL
 AND c.vocabulary_id IN ('RxNorm', 'RxNorm Extension')

--- a/underlay/src/main/java/bio/terra/tanagra/serialization/UFHierarchyMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/serialization/UFHierarchyMapping.java
@@ -17,6 +17,7 @@ public class UFHierarchyMapping {
   private final UFAuxiliaryDataMapping rootNodesFilter;
   private final UFAuxiliaryDataMapping ancestorDescendant;
   private final UFAuxiliaryDataMapping pathNumChildren;
+  private final int maxHierarchyDepth;
 
   public UFHierarchyMapping(HierarchyMapping hierarchyMapping) {
     this.childParent = new UFAuxiliaryDataMapping(hierarchyMapping.getChildParent());
@@ -32,6 +33,7 @@ public class UFHierarchyMapping {
         hierarchyMapping.hasPathNumChildren()
             ? new UFAuxiliaryDataMapping(hierarchyMapping.getPathNumChildren())
             : null;
+    this.maxHierarchyDepth = hierarchyMapping.getMaxHierarchyDepth();
   }
 
   private UFHierarchyMapping(Builder builder) {
@@ -39,6 +41,7 @@ public class UFHierarchyMapping {
     this.rootNodesFilter = builder.rootNodesFilter;
     this.ancestorDescendant = builder.ancestorDescendant;
     this.pathNumChildren = builder.pathNumChildren;
+    this.maxHierarchyDepth = builder.maxHierarchyDepth;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -47,6 +50,7 @@ public class UFHierarchyMapping {
     private UFAuxiliaryDataMapping rootNodesFilter;
     private UFAuxiliaryDataMapping ancestorDescendant;
     private UFAuxiliaryDataMapping pathNumChildren;
+    private int maxHierarchyDepth;
 
     public Builder childParent(UFAuxiliaryDataMapping childParent) {
       this.childParent = childParent;
@@ -65,6 +69,11 @@ public class UFHierarchyMapping {
 
     public Builder pathNumChildren(UFAuxiliaryDataMapping pathNumChildren) {
       this.pathNumChildren = pathNumChildren;
+      return this;
+    }
+
+    public Builder maxHierarchyDepth(int maxHierarchyDepth) {
+      this.maxHierarchyDepth = maxHierarchyDepth;
       return this;
     }
 
@@ -88,5 +97,9 @@ public class UFHierarchyMapping {
 
   public UFAuxiliaryDataMapping getPathNumChildren() {
     return pathNumChildren;
+  }
+
+  public int getMaxHierarchyDepth() {
+    return maxHierarchyDepth;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Entity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Entity.java
@@ -208,7 +208,8 @@ public final class Entity {
                         ? HierarchyMapping.defaultIndexMapping(
                             serialized.getName(),
                             sourceHierarchyMappingSerialized.getKey(),
-                            idAttribute.getValue())
+                            idAttribute.getValue(),
+                            sourceHierarchyMappingSerialized.getValue().getMaxHierarchyDepth())
                         : HierarchyMapping.fromSerialized(
                             indexHierarchyMappingsSerialized.get(
                                 sourceHierarchyMappingSerialized.getKey()),
@@ -292,6 +293,10 @@ public final class Entity {
         .filter(relationship -> relationship.includesEntity(relatedEntity))
         .findFirst()
         .get();
+  }
+
+  public Underlay getUnderlay() {
+    return underlay;
   }
 
   public EntityMapping getMapping(Underlay.MappingType mappingType) {


### PR DESCRIPTION
- Allow overriding the max hierarchy depth, since this is typically much less than the default (64). I got the new max hierarchy depths from the [AoU-CB bash scripts](https://github.com/all-of-us/workbench/tree/main/api/db-cdr/generate-cdr): condition 20, ingredient 8, measurement 11, procedure 19.
- Allow running indexing jobs in parallel or serial. Serial is what we have currently. Parallel runs each entity's jobs concurrently, and then when all have finished, runs each entity group's jobs concurrently. There may also be concurrency within each entity/group -- jobs are defined in stages, any job in the same stage can be run concurrently.

Also some smaller fixes:
- Include the underlay name in the Apache Beam job name, so we can see it in the Dataflow Cloud Console.
- Handle null values in the modifers workflow.
- Add some Distinct steps to the ancestor-descendant workflow. This seems to have fixed the overflow cartesian product errors I was seeing when running this for ingredients.
- Print out a summary of the indexing jobs at the end.
- Remove the `invalid_reason IS NULL` condition from the brand definition in the SDD dataset, per VUMC feedback. 