### PR TITLE
Fix SD null year_of_birth

### DIFF
--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -11,10 +11,10 @@
       <env name="TANAGRA_DB_INITIALIZE_ON_START" value="false" />
       <env name="TANAGRA_DB_USERNAME" value="dbuser" />
       <env name="TANAGRA_DB_PASSWORD" value="dbpwd" />
-      <env name="TANAGRA_UNDERLAY_FILES" value="broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json" />
+      <env name="TANAGRA_UNDERLAY_FILES" value="broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json,verily/sdd/expanded/sdd.json" />
       <env name="TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED" value="true" />
       <env name="TANAGRA_AUTH_IAP_GKE_JWT" value="false" />
-      <env name="GOOGLE_APPLICATION_CREDENTIALS" value="$PROJECT_DIR$/rendered/tanagra_sa.json" />
+      <env name="GOOGLE_APPLICATION_CREDENTIALS" value="$PROJECT_DIR$/../Downloads/verily-tanagra-dev-d9842d6d2d76.json" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -11,10 +11,10 @@
       <env name="TANAGRA_DB_INITIALIZE_ON_START" value="false" />
       <env name="TANAGRA_DB_USERNAME" value="dbuser" />
       <env name="TANAGRA_DB_PASSWORD" value="dbpwd" />
-      <env name="TANAGRA_UNDERLAY_FILES" value="broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json,verily/sdd/expanded/sdd.json" />
+      <env name="TANAGRA_UNDERLAY_FILES" value="broad/aou_synthetic/expanded/aou_synthetic.json,broad/cms_synpuf/expanded/cms_synpuf.json" />
       <env name="TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED" value="true" />
       <env name="TANAGRA_AUTH_IAP_GKE_JWT" value="false" />
-      <env name="GOOGLE_APPLICATION_CREDENTIALS" value="$PROJECT_DIR$/../Downloads/verily-tanagra-dev-d9842d6d2d76.json" />
+      <env name="GOOGLE_APPLICATION_CREDENTIALS" value="$PROJECT_DIR$/rendered/tanagra_sa.json" />
     </envs>
     <method v="2">
       <option name="Make" enabled="true" />

--- a/service/src/main/resources/config/verily/sdd/expanded/entity/person.json
+++ b/service/src/main/resources/config/verily/sdd/expanded/entity/person.json
@@ -123,8 +123,8 @@
     "dataType" : "INT64",
     "displayHint" : {
       "type" : "RANGE",
-      "minVal" : 1799.0,
-      "maxVal" : 2993.0
+      "minVal" : 1.0,
+      "maxVal" : 5227737.0
     }
   } ],
   "sourceDataMapping" : {
@@ -173,7 +173,8 @@
       },
       "year_of_birth" : {
         "value" : {
-          "column" : "year_of_birth"
+          "column" : "year_of_birth",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 0 ELSE ${fieldSql} END)"
         }
       }
     },

--- a/service/src/main/resources/config/verily/sdd/expanded/entity/person.json
+++ b/service/src/main/resources/config/verily/sdd/expanded/entity/person.json
@@ -123,8 +123,8 @@
     "dataType" : "INT64",
     "displayHint" : {
       "type" : "RANGE",
-      "minVal" : 1.0,
-      "maxVal" : 5227737.0
+      "minVal" : 0.0,
+      "maxVal" : 2993.0
     }
   } ],
   "sourceDataMapping" : {

--- a/service/src/main/resources/config/verily/sdd/original/entity/person.json
+++ b/service/src/main/resources/config/verily/sdd/original/entity/person.json
@@ -13,6 +13,10 @@
     "tablePointer": { "table": "person" },
     "attributeMappings": {
       "id": { "value": { "column": "person_id" } },
+      "year_of_birth": {
+        "value": {
+          "column": "year_of_birth",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 0 ELSE ${fieldSql} END)" } },
       "gender": {
         "value": { "column": "gender_concept_id" },
         "display": {

--- a/service/src/main/resources/config/vumc/sdd/expanded/entity/person.json
+++ b/service/src/main/resources/config/vumc/sdd/expanded/entity/person.json
@@ -123,8 +123,8 @@
     "dataType" : "INT64",
     "displayHint" : {
       "type" : "RANGE",
-      "minVal" : 1799.0,
-      "maxVal" : 2993.0
+      "minVal" : 1.0,
+      "maxVal" : 5227737.0
     }
   } ],
   "sourceDataMapping" : {
@@ -173,7 +173,8 @@
       },
       "year_of_birth" : {
         "value" : {
-          "column" : "year_of_birth"
+          "column" : "year_of_birth",
+          "sqlFunctionWrapper" : "(CASE WHEN ${fieldSql} IS NULL THEN 0 ELSE ${fieldSql} END)"
         }
       }
     },

--- a/service/src/main/resources/config/vumc/sdd/expanded/entity/person.json
+++ b/service/src/main/resources/config/vumc/sdd/expanded/entity/person.json
@@ -123,8 +123,8 @@
     "dataType" : "INT64",
     "displayHint" : {
       "type" : "RANGE",
-      "minVal" : 1.0,
-      "maxVal" : 5227737.0
+      "minVal" : 0.0,
+      "maxVal" : 2993.0
     }
   } ],
   "sourceDataMapping" : {

--- a/service/src/main/resources/config/vumc/sdd/original/entity/person.json
+++ b/service/src/main/resources/config/vumc/sdd/original/entity/person.json
@@ -13,6 +13,10 @@
     "tablePointer": { "table": "person" },
     "attributeMappings": {
       "id": { "value": { "column": "person_id" } },
+      "year_of_birth": {
+        "value": {
+          "column": "year_of_birth",
+          "sqlFunctionWrapper": "(CASE WHEN ${fieldSql} IS NULL THEN 0 ELSE ${fieldSql} END)" } },
       "gender": {
         "value": { "column": "gender_concept_id" },
         "display": {


### PR DESCRIPTION
In source data, some people have null year_of_birth. This caused the cohort preview graphs to not load:

![image](https://user-images.githubusercontent.com/10929390/213592448-ae4f64ad-e08b-4db2-99c8-d5c868774f02.png)

Backend error:

```
2023-01-19 15:47:01.207  ERROR 56142 --- [nio-8080-exec-7] b.t.c.e.AbstractGlobalExceptionHandler   : Global exception handler: cause: java.lang.NullPointerException,

java.lang.NullPointerException: null
at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:880)
at com.google.cloud.bigquery.FieldValue.getStringValue(FieldValue.java:109)
at com.google.cloud.bigquery.FieldValue.getLongValue(FieldValue.java:139)
at bio.terra.tanagra.query.bigquery.BigQueryCellValue.getLiteral(BigQueryCellValue.java:63)
at bio.terra.tanagra.service.instances.EntityInstanceCount.fromRowResult(EntityInstanceCount.java:41)
at bio.terra.tanagra.service.QuerysService.runInstanceCountsQuery(QuerysService.java:294)
at bio.terra.tanagra.app.controller.InstancesV2ApiController.countInstances(InstancesV2ApiController.java:228)
```

I used sqlFunctionWrapper to replace `null` with `0` in the index. Now graphs load:

![image](https://user-images.githubusercontent.com/10929390/213592494-4c1a08f5-667e-4c79-a047-927d080f8af0.png)