### PR TITLE
Add cohort audit to admin tabs

### DIFF
--- a/ui/src/sd-admin/cohortAdmin.tsx
+++ b/ui/src/sd-admin/cohortAdmin.tsx
@@ -9,7 +9,7 @@ import TextField from "@mui/material/TextField";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { useAdminSource } from "sd-admin/source";
-import { CohortV2, StudyV2 } from "tanagra-api";
+import { CohortV2, CriteriaGroupV2, StudyV2 } from "tanagra-api";
 
 const columns = (
   filterFn: (name: string, value: string) => void
@@ -106,7 +106,7 @@ const columns = (
   },
 ];
 
-const mapCohortRow = (
+export const mapCohortRow = (
   {
     created,
     createdBy,
@@ -176,12 +176,12 @@ const initialFormState = {
 
 const requiredFields = ["displayName", "studyName"];
 
-interface CohortRow {
+export interface CohortRow {
   id: string;
   studyName: string;
   displayName: string;
   description: string;
-  criteriaGroups: [];
+  criteriaGroups: CriteriaGroupV2[];
   created: string;
   createdBy: string;
   lastModified: string;

--- a/ui/src/sd-admin/cohortAudit.tsx
+++ b/ui/src/sd-admin/cohortAudit.tsx
@@ -17,6 +17,8 @@ import { useAdminSource } from "sd-admin/source";
 import { CohortV2, CriteriaGroupV2OperatorEnum, StudyV2 } from "tanagra-api";
 import { CohortRow, mapCohortRow } from "./cohortAdmin";
 
+// TODO dolbeew: may move the study table and functions to a separate component
+//  in a follow-up pr since everything is duplicated in studyAdmin.tsx
 const studyColumns = (
   filterFn: (name: string, value: string) => void
 ): GridColDef[] => [
@@ -100,7 +102,7 @@ const cohortColumns = [
     headerName: "Created",
   },
 ];
-// Mocked cohort to test the expandable rows that list cohort criteria
+// Temp mocked cohort to test the expandable rows that list cohort criteria
 const mockCohort: CohortV2 = {
   id: "f8YLRL8t",
   displayName: "Mocked cohort criteria test",
@@ -117,7 +119,7 @@ const mockCohort: CohortV2 = {
       criteria: [
         {
           id: "ZMiJsSL8",
-          displayName: "Disorder of body system",
+          displayName: "Condition: Disorder of body system",
           pluginName: "",
           selectionData: "",
           uiConfig: "",
@@ -125,14 +127,14 @@ const mockCohort: CohortV2 = {
         {
           id: "GkWUoXtT",
           displayName:
-            "Traumatic and/or non-traumatic injury of anatomical site",
+            "Condition: Traumatic and/or non-traumatic injury of anatomical site",
           pluginName: "",
           selectionData: "",
           uiConfig: "",
         },
         {
           id: "Rto3T4r6",
-          displayName: "Neoplasm by body site",
+          displayName: "Condition: Neoplasm by body site",
           pluginName: "",
           selectionData: "",
           uiConfig: "",
@@ -147,7 +149,7 @@ const mockCohort: CohortV2 = {
       criteria: [
         {
           id: "zyX8UoO8",
-          displayName: "Not Hispanic or Latino",
+          displayName: "Ethnicity: Not Hispanic or Latino",
           pluginName: "",
           selectionData: "",
           uiConfig: "",
@@ -162,7 +164,7 @@ const mockCohort: CohortV2 = {
       criteria: [
         {
           id: "lxYjNNH3",
-          displayName: "Male",
+          displayName: "Sex assigned at birth: Male",
           pluginName: "",
           selectionData: "",
           uiConfig: "",
@@ -251,7 +253,7 @@ interface StudyRow {
   pi: string;
 }
 
-function Row(props: { cohortRow: CohortRow }) {
+function CohortTableRow(props: { cohortRow: CohortRow }) {
   const {
     cohortRow: { id, created, createdBy, criteriaGroups, displayName },
   } = props;
@@ -457,7 +459,7 @@ export function CohortAudit() {
               </TableHead>
               <TableBody>
                 {getFilteredRowsFromCohorts().map((cohort) => (
-                  <Row key={cohort.id} cohortRow={cohort} />
+                  <CohortTableRow key={cohort.id} cohortRow={cohort} />
                 ))}
               </TableBody>
             </Table>

--- a/ui/src/sd-admin/cohortAudit.tsx
+++ b/ui/src/sd-admin/cohortAudit.tsx
@@ -1,17 +1,23 @@
-import Autocomplete from "@mui/material/Autocomplete";
 import Backdrop from "@mui/material/Backdrop";
 import Box from "@mui/material/Box";
-import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
+import Collapse from "@mui/material/Collapse";
 import Grid from "@mui/material/Grid";
-import Stack from "@mui/material/Stack";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { useEffect, useState } from "react";
 import { useAdminSource } from "sd-admin/source";
-import { StudyV2 } from "tanagra-api";
+import { CohortV2, CriteriaGroupV2OperatorEnum, StudyV2 } from "tanagra-api";
+import { CohortRow, mapCohortRow } from "./cohortAdmin";
 
-const columns = (
+const studyColumns = (
   filterFn: (name: string, value: string) => void
 ): GridColDef[] => [
   {
@@ -76,8 +82,126 @@ const columns = (
   },
 ];
 
-// Temp PI options until endpoint in place
-const piOptions = ["", "Will", "Erik", "Tim", "Brian", "Chenchal"];
+const cohortColumns = [
+  {
+    field: "id",
+    headerName: "Cohort Id",
+  },
+  {
+    field: "displayName",
+    headerName: "Cohort Name",
+  },
+  {
+    field: "createdBy",
+    headerName: "Owner",
+  },
+  {
+    field: "created",
+    headerName: "Created",
+  },
+];
+// Mocked cohort to test the expandable rows that list cohort criteria
+const mockCohort: CohortV2 = {
+  id: "f8YLRL8t",
+  displayName: "Mocked cohort criteria test",
+  underlayName: "verily_aou_synthetic",
+  lastModified: new Date(),
+  created: new Date(),
+  createdBy: "test user",
+  criteriaGroups: [
+    {
+      id: "n3jTaIjK",
+      displayName: "Group 1",
+      operator: CriteriaGroupV2OperatorEnum.And,
+      excluded: false,
+      criteria: [
+        {
+          id: "ZMiJsSL8",
+          displayName: "Disorder of body system",
+          pluginName: "",
+          selectionData: "",
+          uiConfig: "",
+        },
+        {
+          id: "GkWUoXtT",
+          displayName:
+            "Traumatic and/or non-traumatic injury of anatomical site",
+          pluginName: "",
+          selectionData: "",
+          uiConfig: "",
+        },
+        {
+          id: "Rto3T4r6",
+          displayName: "Neoplasm by body site",
+          pluginName: "",
+          selectionData: "",
+          uiConfig: "",
+        },
+      ],
+    },
+    {
+      id: "iZM84IuY",
+      displayName: "Group 2",
+      operator: CriteriaGroupV2OperatorEnum.Or,
+      excluded: false,
+      criteria: [
+        {
+          id: "zyX8UoO8",
+          displayName: "Not Hispanic or Latino",
+          pluginName: "",
+          selectionData: "",
+          uiConfig: "",
+        },
+      ],
+    },
+    {
+      id: "CPYKJ3yH",
+      displayName: "Group 2",
+      operator: CriteriaGroupV2OperatorEnum.Or,
+      excluded: true,
+      criteria: [
+        {
+          id: "lxYjNNH3",
+          displayName: "Male",
+          pluginName: "",
+          selectionData: "",
+          uiConfig: "",
+        },
+      ],
+    },
+  ],
+};
+
+function CohortHeader(props: {
+  field: string;
+  headerName: string;
+  filterFn: (name: string, value: string) => void;
+}) {
+  const { field, headerName, filterFn } = props;
+  return (
+    <div style={{ lineHeight: "1.5rem" }}>
+      <div>{headerName}</div>
+      <div>
+        <TextField
+          sx={{
+            "& .MuiInputBase-root": {
+              margin: 0,
+            },
+            "& .MuiInputLabel-root": {
+              top: "-16px",
+            },
+          }}
+          name={field}
+          onChange={({ target: { name, value } }) => filterFn(name, value)}
+          label="Filter"
+          variant="standard"
+          size="small"
+          margin="none"
+        />
+      </div>
+    </div>
+  );
+}
 
 const getValueFromStudyProperty = (
   properties: StudyV2Property[],
@@ -99,15 +223,6 @@ const mapStudyRows = ({
   ),
   pi: getValueFromStudyProperty(properties as StudyV2Property[], "pi"),
 });
-// Style override to slightly darken the text of disabled form fields
-const DISABLED_SX = [
-  {
-    ".Mui-disabled": {
-      color: "rgba(0, 0, 0, 0.6)",
-      "-webkit-text-fill-color": "rgba(0, 0, 0, 0.6)",
-    },
-  },
-];
 const ROWS_PER_PAGE = 25;
 
 const emptyStudy: StudyV2 = {
@@ -123,31 +238,6 @@ const emptyStudy: StudyV2 = {
   lastModified: new Date(),
 };
 
-const initialFormState = {
-  displayName: {
-    touched: false,
-    value: "",
-  },
-  description: {
-    touched: false,
-    value: "",
-  },
-  irbNumber: {
-    touched: false,
-    value: "",
-  },
-  pi: {
-    touched: false,
-    value: "",
-  },
-  piInput: {
-    touched: false,
-    value: "",
-  },
-};
-
-const requiredFields = ["displayName", "irbNumber", "pi"];
-
 interface StudyV2Property {
   key: string;
   value: string;
@@ -161,23 +251,98 @@ interface StudyRow {
   pi: string;
 }
 
+function Row(props: { cohortRow: CohortRow }) {
+  const {
+    cohortRow: { id, created, createdBy, criteriaGroups, displayName },
+  } = props;
+  const [open, setOpen] = useState(false);
+  const closedStyle = {
+    border: 0,
+    paddingBottom: 0,
+    paddingTop: 0,
+  };
+  return (
+    <>
+      <TableRow
+        sx={{ cursor: "pointer", height: "2.5rem" }}
+        onClick={() => setOpen(!open)}
+      >
+        <TableCell>{id}</TableCell>
+        <TableCell>{displayName}</TableCell>
+        <TableCell>{createdBy}</TableCell>
+        <TableCell>{created}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell style={!open ? closedStyle : {}} colSpan={4}>
+          <Collapse in={open}>
+            {criteriaGroups.length === 0 && (
+              <Typography variant="body2">
+                Cohort &quot;{displayName}&quot; has no criteria groups
+              </Typography>
+            )}
+            {criteriaGroups.map(
+              ({
+                id: gid,
+                criteria,
+                displayName: groupName,
+                excluded,
+                operator,
+              }) => (
+                <div key={gid}>
+                  <Typography variant="h6">
+                    {excluded ? "Excludes" : "Includes"}{" "}
+                    {operator === CriteriaGroupV2OperatorEnum.Or
+                      ? "any of"
+                      : "all of"}
+                  </Typography>
+                  {criteria.length === 0 && (
+                    <Typography variant="body2">
+                      Group &quot;{groupName}&quot; has no criteria
+                    </Typography>
+                  )}
+                  {criteria.map(({ id: cid, displayName: criteriaName }) => (
+                    <Typography key={cid} variant="body1">
+                      {criteriaName}
+                    </Typography>
+                  ))}
+                </div>
+              )
+            )}
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
+
 export function CohortAudit() {
   const source = useAdminSource();
   const [activeStudy, setActiveStudy] = useState<StudyV2>(emptyStudy);
-  const [formState, setFormState] = useState(initialFormState);
-  const [columnFilters, setColumnFilters] = useState({
+  const [cohortFilters, setCohortFilters] = useState({
+    id: "",
+    displayName: "",
+    createdBy: "",
+    created: "",
+  });
+  const [studyFilters, setStudyFilters] = useState({
     displayName: "",
     irbNumber: "",
   });
-  const [creatingStudy, setCreatingStudy] = useState<boolean>(false);
-  const [editingStudy, setEditingStudy] = useState<boolean>(false);
-  const [loadingStudy, setLoadingStudy] = useState<boolean>(false);
+  const [loadingStudyCohorts, setLoadingStudyCohorts] =
+    useState<boolean>(false);
   const [loadingStudyList, setLoadingStudyList] = useState<boolean>(true);
   const [studies, setStudies] = useState<StudyV2[]>([]);
+  const [studyCohorts, setStudyCohorts] = useState<CohortRow[]>([]);
 
   useEffect(() => {
     getStudies();
   }, []);
+
+  useEffect(() => {
+    if (activeStudy.id) {
+      getStudyCohorts();
+    }
+  }, [activeStudy]);
 
   const getStudies = async () => {
     const studies = await source.getStudiesList();
@@ -185,151 +350,79 @@ export function CohortAudit() {
     setLoadingStudyList(false);
   };
 
-  const updateStudy = async () => {
-    setLoadingStudy(true);
-    const updatedStudy = await source.updateStudy(
-      activeStudy?.id,
-      formState.displayName.value,
-      formState.description.value
+  const getStudyCohorts = async () => {
+    setLoadingStudyCohorts(true);
+    const cohorts = await source.getCohortsForStudy(activeStudy.id);
+    // Add mock cohort since cohorts returned from endpoint currently have no criteria groups
+    cohorts.push(mockCohort);
+    setStudyCohorts(
+      cohorts.map((cohort) => mapCohortRow(cohort, activeStudy.displayName))
     );
-    setActiveStudy(updatedStudy);
-    setEditingStudy(false);
-    setLoadingStudy(false);
-    setLoadingStudyList(true);
-    getStudies();
+    setLoadingStudyCohorts(false);
   };
 
-  const createStudy = async () => {
-    setLoadingStudy(true);
-    const newStudy = await source.createStudy(
-      formState.displayName.value,
-      formState.description.value,
-      [
-        { key: "irbNumber", value: formState.irbNumber.value },
-        { key: "pi", value: formState.pi.value },
-      ]
-    );
-    setActiveStudy(newStudy);
-    await getStudies();
-    setCreatingStudy(false);
-    setLoadingStudy(false);
+  const handleStudyFilterChange = (name: string, value: string) => {
+    setStudyFilters((prevState) => ({ ...prevState, [name]: value }));
   };
 
-  const handleInputChange = (name: string, value: string) => {
-    setFormState((prevState) => ({
-      ...prevState,
-      [name]: { value, touched: true },
-    }));
-  };
-
-  const handleFilterChange = (name: string, value: string) => {
-    setColumnFilters((prevState) => ({ ...prevState, [name]: value }));
+  const handleCohortFilterChange = (name: string, value: string) => {
+    setCohortFilters((prevState) => ({ ...prevState, [name]: value }));
   };
 
   const getFilteredRowsFromStudies = () => {
     return studies.filter(filterStudyRows).map(mapStudyRows);
   };
 
-  const populateStudyForm = (study: StudyV2) => {
-    const newFormState = {
-      displayName: {
-        touched: false,
-        value: study.displayName || "",
-      },
-      description: {
-        touched: false,
-        value: study.description || "",
-      },
-      irbNumber: {
-        touched: false,
-        value:
-          getValueFromStudyProperty(
-            study.properties as StudyV2Property[],
-            "irbNumber"
-          ) || "",
-      },
-      pi: {
-        touched: false,
-        value:
-          getValueFromStudyProperty(
-            study.properties as StudyV2Property[],
-            "pi"
-          ) || "",
-      },
-      piInput: {
-        touched: false,
-        value:
-          getValueFromStudyProperty(
-            study.properties as StudyV2Property[],
-            "pi"
-          ) || "",
-      },
-    };
-    setFormState(newFormState);
-  };
-
-  const clearStudyForm = () => {
-    setFormState(initialFormState);
+  const getFilteredRowsFromCohorts = () => {
+    return studyCohorts.filter(filterCohortRows);
   };
 
   const filterStudyRows = (study: StudyV2) =>
-    (!columnFilters.displayName ||
+    (!studyFilters.displayName ||
       study?.displayName
         ?.toLowerCase()
-        .includes(columnFilters.displayName.toLowerCase())) &&
-    (!columnFilters.irbNumber ||
+        .includes(studyFilters.displayName.toLowerCase())) &&
+    (!studyFilters.irbNumber ||
       study?.properties?.some((pair) => {
         const { key, value } = pair as StudyV2Property;
         return (
           key === "irbNumber" &&
-          value.toLowerCase().includes(columnFilters.irbNumber.toLowerCase())
+          value.toLowerCase().includes(studyFilters.irbNumber.toLowerCase())
         );
       }));
 
-  const onRowSelect = (row: StudyRow) => {
+  const filterCohortRows = (cohort: CohortRow) =>
+    (!cohortFilters.id ||
+      cohort?.id?.toLowerCase().includes(cohortFilters.id.toLowerCase())) &&
+    (!cohortFilters.displayName ||
+      cohort?.displayName
+        ?.toLowerCase()
+        .includes(cohortFilters.displayName.toLowerCase())) &&
+    (!cohortFilters.createdBy ||
+      cohort?.createdBy
+        ?.toLowerCase()
+        .includes(cohortFilters.createdBy.toLowerCase())) &&
+    (!cohortFilters.created ||
+      cohort?.created
+        ?.toLowerCase()
+        .includes(cohortFilters.created.toLowerCase()));
+
+  const onStudySelect = (row: StudyRow) => {
     const newActiveStudy = studies.find((ws) => ws.id === row.id);
-    const newFormState = {
-      displayName: {
-        touched: false,
-        value: row.displayName,
-      },
-      description: {
-        touched: false,
-        value: row.description,
-      },
-      irbNumber: {
-        touched: false,
-        value: row.irbNumber,
-      },
-      pi: {
-        touched: false,
-        value: row.pi,
-      },
-      piInput: {
-        touched: false,
-        value: row.pi,
-      },
-    };
-    setFormState(newFormState);
     if (newActiveStudy) {
       setActiveStudy(newActiveStudy);
     }
   };
-
-  const formIsInvalid = () =>
-    Object.entries(formState).some(
-      ([key, formField]) => requiredFields.includes(key) && !formField.value
-    );
 
   return (
     <Grid container spacing={2}>
       <Grid item xs={6}>
         <Box sx={{ height: 400, width: "100%" }}>
           <DataGrid
-            columns={columns(handleFilterChange)}
+            columns={studyColumns(handleStudyFilterChange)}
             rows={getFilteredRowsFromStudies()}
             loading={loadingStudyList}
-            onRowClick={({ row }) => onRowSelect(row as StudyRow)}
+            onRowClick={({ row }) => onStudySelect(row as StudyRow)}
             hideFooter={getFilteredRowsFromStudies().length <= ROWS_PER_PAGE}
             hideFooterSelectedRowCount
             disableSelectionOnClick
@@ -340,153 +433,35 @@ export function CohortAudit() {
       </Grid>
       <Grid item xs={6}>
         <Box sx={{ position: "relative" }}>
-          <Backdrop invisible open={loadingStudy} sx={{ position: "absolute" }}>
+          <Backdrop
+            invisible
+            open={loadingStudyCohorts}
+            sx={{ position: "absolute" }}
+          >
             <CircularProgress />
           </Backdrop>
-          <Stack spacing={2} direction="row">
-            <Button
-              disabled={loadingStudy}
-              onClick={() => {
-                clearStudyForm();
-                setCreatingStudy(true);
-              }}
-              variant="outlined"
-            >
-              Add Study
-            </Button>
-            <Button
-              disabled={activeStudy?.id === "" || loadingStudy}
-              onClick={() => setEditingStudy(true)}
-              variant="outlined"
-            >
-              Edit Study
-            </Button>
-            <Button
-              disabled={activeStudy?.id === "" || loadingStudy}
-              variant="outlined"
-            >
-              Add Study Users
-            </Button>
-          </Stack>
-          <div>
-            <TextField
-              sx={DISABLED_SX}
-              disabled={!(creatingStudy || editingStudy)}
-              label={"Study name"}
-              name="displayName"
-              fullWidth
-              InputLabelProps={{
-                shrink: !!formState?.displayName,
-              }}
-              value={formState?.displayName.value || ""}
-              onChange={({ target: { name, value } }) =>
-                handleInputChange(name, value)
-              }
-              error={
-                formState.displayName.touched && !formState.displayName.value
-              }
-              variant={"outlined"}
-            />
-          </div>
-          <div>
-            <TextField
-              sx={DISABLED_SX}
-              disabled={!(creatingStudy || editingStudy)}
-              label={"Description"}
-              name="description"
-              fullWidth
-              InputLabelProps={{
-                shrink: !!formState?.description,
-              }}
-              multiline
-              rows={4}
-              value={formState?.description.value || ""}
-              onChange={({ target: { name, value } }) =>
-                handleInputChange(name, value)
-              }
-              variant={"outlined"}
-            />
-          </div>
-          <div>
-            <TextField
-              sx={DISABLED_SX}
-              disabled={!(creatingStudy || editingStudy)}
-              label={"IRB Number"}
-              name="irbNumber"
-              InputLabelProps={{
-                shrink: !!formState?.irbNumber,
-              }}
-              value={formState?.irbNumber.value || ""}
-              onChange={({ target: { name, value } }) =>
-                handleInputChange(name, value)
-              }
-              error={formState.irbNumber.touched && !formState.irbNumber.value}
-              variant={"outlined"}
-            />
-          </div>
-          <div>
-            <Autocomplete
-              sx={DISABLED_SX}
-              disabled={!(creatingStudy || editingStudy)}
-              options={piOptions}
-              value={formState?.pi.value}
-              onChange={(event, newValue) =>
-                handleInputChange("pi", newValue || "")
-              }
-              inputValue={formState?.piInput.value || ""}
-              onInputChange={(event, newInputValue) =>
-                handleInputChange("piInput", newInputValue)
-              }
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label={"PI"}
-                  name="pi"
-                  fullWidth
-                  InputLabelProps={{
-                    shrink: !!formState?.pi,
-                  }}
-                  onChange={({ target: { name, value } }) =>
-                    handleInputChange(name, value)
-                  }
-                  error={formState.pi.touched && !formState.pi.value}
-                  variant={"outlined"}
-                />
-              )}
-            />
-          </div>
-          {(creatingStudy || editingStudy) && (
-            <Stack spacing={2} direction="row">
-              <Button
-                disabled={loadingStudy || formIsInvalid()}
-                onClick={() => {
-                  if (creatingStudy) {
-                    createStudy();
-                  } else {
-                    updateStudy();
-                  }
-                }}
-                variant="outlined"
-              >
-                {creatingStudy ? "Save" : "Update"} Study
-              </Button>
-              <Button
-                disabled={loadingStudy}
-                onClick={() => {
-                  if (creatingStudy) {
-                    clearStudyForm();
-                    setCreatingStudy(false);
-                  } else {
-                    populateStudyForm(activeStudy);
-                    setEditingStudy(false);
-                  }
-                }}
-                variant="outlined"
-              >
-                Cancel
-              </Button>
-            </Stack>
-          )}
+          <TableContainer>
+            <Table aria-label="collapsible table">
+              <TableHead>
+                <TableRow>
+                  {cohortColumns.map(({ field, headerName }, index) => (
+                    <TableCell key={index}>
+                      <CohortHeader
+                        field={field}
+                        headerName={headerName}
+                        filterFn={handleCohortFilterChange}
+                      />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {getFilteredRowsFromCohorts().map((cohort) => (
+                  <Row key={cohort.id} cohortRow={cohort} />
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
         </Box>
       </Grid>
     </Grid>

--- a/ui/src/sd-admin/cohortAudit.tsx
+++ b/ui/src/sd-admin/cohortAudit.tsx
@@ -1,0 +1,494 @@
+import Autocomplete from "@mui/material/Autocomplete";
+import Backdrop from "@mui/material/Backdrop";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import Grid from "@mui/material/Grid";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { useEffect, useState } from "react";
+import { useAdminSource } from "sd-admin/source";
+import { StudyV2 } from "tanagra-api";
+
+const columns = (
+  filterFn: (name: string, value: string) => void
+): GridColDef[] => [
+  {
+    field: "displayName",
+    headerName: "Study Name",
+    sortable: true,
+    disableColumnMenu: true,
+    flex: 1,
+    renderHeader: () => (
+      <div style={{ lineHeight: "1.5rem" }}>
+        <div>Study Name</div>
+        <div>
+          <TextField
+            sx={{
+              "& .MuiInputBase-root": {
+                margin: 0,
+              },
+              "& .MuiInputLabel-root": {
+                top: "-16px",
+              },
+            }}
+            name="displayName"
+            onChange={({ target: { name, value } }) => filterFn(name, value)}
+            label="Filter"
+            variant="standard"
+            size="small"
+            margin="none"
+          />
+        </div>
+      </div>
+    ),
+  },
+  {
+    field: "irbNumber",
+    headerName: "IRB Number",
+    sortable: true,
+    disableColumnMenu: true,
+    width: 120,
+    renderHeader: () => (
+      <div style={{ lineHeight: "1.5rem" }}>
+        <div>IRB Number</div>
+        <div>
+          <TextField
+            sx={{
+              "& .MuiInputBase-root": {
+                margin: 0,
+              },
+              "& .MuiInputLabel-root": {
+                top: "-16px",
+              },
+            }}
+            name="irbNumber"
+            onChange={({ target: { name, value } }) => filterFn(name, value)}
+            label="Filter"
+            variant="standard"
+            size="small"
+            margin="none"
+          />
+        </div>
+      </div>
+    ),
+  },
+];
+
+// Temp PI options until endpoint in place
+const piOptions = ["", "Will", "Erik", "Tim", "Brian", "Chenchal"];
+
+const getValueFromStudyProperty = (
+  properties: StudyV2Property[],
+  key: string
+) => properties?.find((pair) => pair.key === key)?.value;
+
+const mapStudyRows = ({
+  id,
+  displayName,
+  description,
+  properties,
+}: StudyV2) => ({
+  id,
+  displayName,
+  description,
+  irbNumber: getValueFromStudyProperty(
+    properties as StudyV2Property[],
+    "irbNumber"
+  ),
+  pi: getValueFromStudyProperty(properties as StudyV2Property[], "pi"),
+});
+// Style override to slightly darken the text of disabled form fields
+const DISABLED_SX = [
+  {
+    ".Mui-disabled": {
+      color: "rgba(0, 0, 0, 0.6)",
+      "-webkit-text-fill-color": "rgba(0, 0, 0, 0.6)",
+    },
+  },
+];
+const ROWS_PER_PAGE = 25;
+
+const emptyStudy: StudyV2 = {
+  id: "",
+  displayName: "",
+  description: "",
+  properties: [
+    { key: "irbNumber", value: "" },
+    { key: "pi", value: "" },
+  ],
+  created: new Date(),
+  createdBy: "user@gmail.com",
+  lastModified: new Date(),
+};
+
+const initialFormState = {
+  displayName: {
+    touched: false,
+    value: "",
+  },
+  description: {
+    touched: false,
+    value: "",
+  },
+  irbNumber: {
+    touched: false,
+    value: "",
+  },
+  pi: {
+    touched: false,
+    value: "",
+  },
+  piInput: {
+    touched: false,
+    value: "",
+  },
+};
+
+const requiredFields = ["displayName", "irbNumber", "pi"];
+
+interface StudyV2Property {
+  key: string;
+  value: string;
+}
+
+interface StudyRow {
+  id: string;
+  displayName: string;
+  description: string;
+  irbNumber: string;
+  pi: string;
+}
+
+export function CohortAudit() {
+  const source = useAdminSource();
+  const [activeStudy, setActiveStudy] = useState<StudyV2>(emptyStudy);
+  const [formState, setFormState] = useState(initialFormState);
+  const [columnFilters, setColumnFilters] = useState({
+    displayName: "",
+    irbNumber: "",
+  });
+  const [creatingStudy, setCreatingStudy] = useState<boolean>(false);
+  const [editingStudy, setEditingStudy] = useState<boolean>(false);
+  const [loadingStudy, setLoadingStudy] = useState<boolean>(false);
+  const [loadingStudyList, setLoadingStudyList] = useState<boolean>(true);
+  const [studies, setStudies] = useState<StudyV2[]>([]);
+
+  useEffect(() => {
+    getStudies();
+  }, []);
+
+  const getStudies = async () => {
+    const studies = await source.getStudiesList();
+    setStudies(studies);
+    setLoadingStudyList(false);
+  };
+
+  const updateStudy = async () => {
+    setLoadingStudy(true);
+    const updatedStudy = await source.updateStudy(
+      activeStudy?.id,
+      formState.displayName.value,
+      formState.description.value
+    );
+    setActiveStudy(updatedStudy);
+    setEditingStudy(false);
+    setLoadingStudy(false);
+    setLoadingStudyList(true);
+    getStudies();
+  };
+
+  const createStudy = async () => {
+    setLoadingStudy(true);
+    const newStudy = await source.createStudy(
+      formState.displayName.value,
+      formState.description.value,
+      [
+        { key: "irbNumber", value: formState.irbNumber.value },
+        { key: "pi", value: formState.pi.value },
+      ]
+    );
+    setActiveStudy(newStudy);
+    await getStudies();
+    setCreatingStudy(false);
+    setLoadingStudy(false);
+  };
+
+  const handleInputChange = (name: string, value: string) => {
+    setFormState((prevState) => ({
+      ...prevState,
+      [name]: { value, touched: true },
+    }));
+  };
+
+  const handleFilterChange = (name: string, value: string) => {
+    setColumnFilters((prevState) => ({ ...prevState, [name]: value }));
+  };
+
+  const getFilteredRowsFromStudies = () => {
+    return studies.filter(filterStudyRows).map(mapStudyRows);
+  };
+
+  const populateStudyForm = (study: StudyV2) => {
+    const newFormState = {
+      displayName: {
+        touched: false,
+        value: study.displayName || "",
+      },
+      description: {
+        touched: false,
+        value: study.description || "",
+      },
+      irbNumber: {
+        touched: false,
+        value:
+          getValueFromStudyProperty(
+            study.properties as StudyV2Property[],
+            "irbNumber"
+          ) || "",
+      },
+      pi: {
+        touched: false,
+        value:
+          getValueFromStudyProperty(
+            study.properties as StudyV2Property[],
+            "pi"
+          ) || "",
+      },
+      piInput: {
+        touched: false,
+        value:
+          getValueFromStudyProperty(
+            study.properties as StudyV2Property[],
+            "pi"
+          ) || "",
+      },
+    };
+    setFormState(newFormState);
+  };
+
+  const clearStudyForm = () => {
+    setFormState(initialFormState);
+  };
+
+  const filterStudyRows = (study: StudyV2) =>
+    (!columnFilters.displayName ||
+      study?.displayName
+        ?.toLowerCase()
+        .includes(columnFilters.displayName.toLowerCase())) &&
+    (!columnFilters.irbNumber ||
+      study?.properties?.some((pair) => {
+        const { key, value } = pair as StudyV2Property;
+        return (
+          key === "irbNumber" &&
+          value.toLowerCase().includes(columnFilters.irbNumber.toLowerCase())
+        );
+      }));
+
+  const onRowSelect = (row: StudyRow) => {
+    const newActiveStudy = studies.find((ws) => ws.id === row.id);
+    const newFormState = {
+      displayName: {
+        touched: false,
+        value: row.displayName,
+      },
+      description: {
+        touched: false,
+        value: row.description,
+      },
+      irbNumber: {
+        touched: false,
+        value: row.irbNumber,
+      },
+      pi: {
+        touched: false,
+        value: row.pi,
+      },
+      piInput: {
+        touched: false,
+        value: row.pi,
+      },
+    };
+    setFormState(newFormState);
+    if (newActiveStudy) {
+      setActiveStudy(newActiveStudy);
+    }
+  };
+
+  const formIsInvalid = () =>
+    Object.entries(formState).some(
+      ([key, formField]) => requiredFields.includes(key) && !formField.value
+    );
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={6}>
+        <Box sx={{ height: 400, width: "100%" }}>
+          <DataGrid
+            columns={columns(handleFilterChange)}
+            rows={getFilteredRowsFromStudies()}
+            loading={loadingStudyList}
+            onRowClick={({ row }) => onRowSelect(row as StudyRow)}
+            hideFooter={getFilteredRowsFromStudies().length <= ROWS_PER_PAGE}
+            hideFooterSelectedRowCount
+            disableSelectionOnClick
+            pageSize={ROWS_PER_PAGE}
+            rowsPerPageOptions={[]}
+          />
+        </Box>
+      </Grid>
+      <Grid item xs={6}>
+        <Box sx={{ position: "relative" }}>
+          <Backdrop invisible open={loadingStudy} sx={{ position: "absolute" }}>
+            <CircularProgress />
+          </Backdrop>
+          <Stack spacing={2} direction="row">
+            <Button
+              disabled={loadingStudy}
+              onClick={() => {
+                clearStudyForm();
+                setCreatingStudy(true);
+              }}
+              variant="outlined"
+            >
+              Add Study
+            </Button>
+            <Button
+              disabled={activeStudy?.id === "" || loadingStudy}
+              onClick={() => setEditingStudy(true)}
+              variant="outlined"
+            >
+              Edit Study
+            </Button>
+            <Button
+              disabled={activeStudy?.id === "" || loadingStudy}
+              variant="outlined"
+            >
+              Add Study Users
+            </Button>
+          </Stack>
+          <div>
+            <TextField
+              sx={DISABLED_SX}
+              disabled={!(creatingStudy || editingStudy)}
+              label={"Study name"}
+              name="displayName"
+              fullWidth
+              InputLabelProps={{
+                shrink: !!formState?.displayName,
+              }}
+              value={formState?.displayName.value || ""}
+              onChange={({ target: { name, value } }) =>
+                handleInputChange(name, value)
+              }
+              error={
+                formState.displayName.touched && !formState.displayName.value
+              }
+              variant={"outlined"}
+            />
+          </div>
+          <div>
+            <TextField
+              sx={DISABLED_SX}
+              disabled={!(creatingStudy || editingStudy)}
+              label={"Description"}
+              name="description"
+              fullWidth
+              InputLabelProps={{
+                shrink: !!formState?.description,
+              }}
+              multiline
+              rows={4}
+              value={formState?.description.value || ""}
+              onChange={({ target: { name, value } }) =>
+                handleInputChange(name, value)
+              }
+              variant={"outlined"}
+            />
+          </div>
+          <div>
+            <TextField
+              sx={DISABLED_SX}
+              disabled={!(creatingStudy || editingStudy)}
+              label={"IRB Number"}
+              name="irbNumber"
+              InputLabelProps={{
+                shrink: !!formState?.irbNumber,
+              }}
+              value={formState?.irbNumber.value || ""}
+              onChange={({ target: { name, value } }) =>
+                handleInputChange(name, value)
+              }
+              error={formState.irbNumber.touched && !formState.irbNumber.value}
+              variant={"outlined"}
+            />
+          </div>
+          <div>
+            <Autocomplete
+              sx={DISABLED_SX}
+              disabled={!(creatingStudy || editingStudy)}
+              options={piOptions}
+              value={formState?.pi.value}
+              onChange={(event, newValue) =>
+                handleInputChange("pi", newValue || "")
+              }
+              inputValue={formState?.piInput.value || ""}
+              onInputChange={(event, newInputValue) =>
+                handleInputChange("piInput", newInputValue)
+              }
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label={"PI"}
+                  name="pi"
+                  fullWidth
+                  InputLabelProps={{
+                    shrink: !!formState?.pi,
+                  }}
+                  onChange={({ target: { name, value } }) =>
+                    handleInputChange(name, value)
+                  }
+                  error={formState.pi.touched && !formState.pi.value}
+                  variant={"outlined"}
+                />
+              )}
+            />
+          </div>
+          {(creatingStudy || editingStudy) && (
+            <Stack spacing={2} direction="row">
+              <Button
+                disabled={loadingStudy || formIsInvalid()}
+                onClick={() => {
+                  if (creatingStudy) {
+                    createStudy();
+                  } else {
+                    updateStudy();
+                  }
+                }}
+                variant="outlined"
+              >
+                {creatingStudy ? "Save" : "Update"} Study
+              </Button>
+              <Button
+                disabled={loadingStudy}
+                onClick={() => {
+                  if (creatingStudy) {
+                    clearStudyForm();
+                    setCreatingStudy(false);
+                  } else {
+                    populateStudyForm(activeStudy);
+                    setEditingStudy(false);
+                  }
+                }}
+                variant="outlined"
+              >
+                Cancel
+              </Button>
+            </Stack>
+          )}
+        </Box>
+      </Grid>
+    </Grid>
+  );
+}

--- a/ui/src/sd-admin/sdAdmin.tsx
+++ b/ui/src/sd-admin/sdAdmin.tsx
@@ -3,6 +3,7 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import { useState } from "react";
 import { CohortAdmin } from "./cohortAdmin";
+import { CohortAudit } from "./cohortAudit";
 import { StudyAdmin } from "./studyAdmin";
 
 const TabPanel = ({ index }: { index: number }) => {
@@ -11,7 +12,7 @@ const TabPanel = ({ index }: { index: number }) => {
       {index === 0 && <StudyAdmin />}
       {index === 1 && <div>User content</div>}
       {index === 2 && <CohortAdmin />}
-      {index === 3 && <div>Cohort audit content</div>}
+      {index === 3 && <CohortAudit />}
     </div>
   );
 };


### PR DESCRIPTION
Selecting a study will show a list of all cohorts in that study. Selecting a cohort will expand to show all criteria selections for that cohort. Using a mocked cohort to display criteria.

![Screenshot 2023-01-20 at 10 16 11 AM](https://user-images.githubusercontent.com/40036095/213749556-6e6b6183-1fe3-4d1b-b16f-984d6d2a8c3a.png)
