### PR TITLE
Add endpoint for exporting annotations

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,6 +10,7 @@ The project is shared across the All Of Us and Terra partnerships.
    * [Adding dependencies](#adding-dependencies)
    * [Generate SQL Golden Files](#generate-sql-golden-files)
 * [Deployment](#deployment)
+* [Tips](#tips)
 
 ## Development
 
@@ -116,3 +117,12 @@ To regenerate the golden files, run the tests with the `generateSqlFiles` Gradle
 
 If you want to export datasets to GCS bucket, create bucket and configure export
 properties. See TanagraExportConfiguration.java.
+
+## Tips
+
+For additional logging for debugging, add to property YAML (such as application.yaml):
+
+```
+# Print SQL queries
+logging.level.org.springframework.jdbc.core: trace
+```

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
     // GCP BOM version controlled libraries. GCP BOM specified in buildSrc/
     implementation group: "com.google.cloud", name: "google-cloud-bigquery"
+    implementation group: "com.google.cloud", name: "google-cloud-storage"
     implementation group: "com.google.guava", name: "guava"
     implementation 'com.google.apis:google-api-services-oauth2:v2-rev20200213-1.32.1'
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -27,7 +27,7 @@ import bio.terra.tanagra.service.accesscontrol.ResourceIdCollection;
 import bio.terra.tanagra.service.artifact.Annotation;
 import bio.terra.tanagra.service.artifact.AnnotationValue;
 import bio.terra.tanagra.service.utils.ToApiConversionUtils;
-import java.util.Collection;
+import com.google.common.collect.Table;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -76,9 +76,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiExportFile> exportAnnotationValues(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
         SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
-    Collection<AnnotationValue> values =
+    Table<String, String, String> latestValues =
         annotationService.getAnnotationValuesForLatestReview(studyId, cohortId);
-    String gcsSignedUrl = annotationService.writeAnnotationValuesToGcs(values);
+    String gcsSignedUrl =
+        annotationService.writeAnnotationValuesToGcs(studyId, cohortId, latestValues);
     return ResponseEntity.ok(new ApiExportFile().gcsSignedUrl(gcsSignedUrl));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -76,6 +76,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiExportFile> exportAnnotationValues(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
         SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
+
     Table<String, String, String> latestValues =
         annotationService.getAnnotationValuesForLatestReview(studyId, cohortId);
     String gcsSignedUrl =

--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -16,7 +16,6 @@ import bio.terra.tanagra.generated.model.ApiAnnotationUpdateInfoV2;
 import bio.terra.tanagra.generated.model.ApiAnnotationV2;
 import bio.terra.tanagra.generated.model.ApiAnnotationValueCreateUpdateInfoV2;
 import bio.terra.tanagra.generated.model.ApiAnnotationValueV2;
-import bio.terra.tanagra.generated.model.ApiAnnotationValuesExportInfoV2;
 import bio.terra.tanagra.generated.model.ApiDataTypeV2;
 import bio.terra.tanagra.generated.model.ApiExportFile;
 import bio.terra.tanagra.query.Literal;
@@ -28,9 +27,11 @@ import bio.terra.tanagra.service.accesscontrol.ResourceIdCollection;
 import bio.terra.tanagra.service.artifact.Annotation;
 import bio.terra.tanagra.service.artifact.AnnotationValue;
 import bio.terra.tanagra.service.utils.ToApiConversionUtils;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,10 +74,13 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   }
 
   @Override
-  public ResponseEntity<ApiExportFile> exportAnnotationValues(
-      String studyId, String cohortId, ApiAnnotationValuesExportInfoV2 body) {
+  public ResponseEntity<ApiExportFile> exportAnnotationValues(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
         SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
+
+    // List of pair of review create date, annotation value
+    List<Pair<OffsetDateTime, AnnotationValue>> valuesForAllReviews =
+        annotationService.getAnnotationValuesForCohort(studyId, cohortId);
 
     return ResponseEntity.ok(new ApiExportFile().gcsSignedUrl("foo"));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -5,6 +5,7 @@ import static bio.terra.tanagra.service.accesscontrol.Action.DELETE;
 import static bio.terra.tanagra.service.accesscontrol.Action.READ;
 import static bio.terra.tanagra.service.accesscontrol.Action.UPDATE;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.ANNOTATION;
+import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT_REVIEW;
 
 import bio.terra.tanagra.app.auth.SpringAuthentication;
@@ -15,7 +16,9 @@ import bio.terra.tanagra.generated.model.ApiAnnotationUpdateInfoV2;
 import bio.terra.tanagra.generated.model.ApiAnnotationV2;
 import bio.terra.tanagra.generated.model.ApiAnnotationValueCreateUpdateInfoV2;
 import bio.terra.tanagra.generated.model.ApiAnnotationValueV2;
+import bio.terra.tanagra.generated.model.ApiAnnotationValuesExportInfoV2;
 import bio.terra.tanagra.generated.model.ApiDataTypeV2;
+import bio.terra.tanagra.generated.model.ApiExportFile;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.service.AccessControlService;
 import bio.terra.tanagra.service.AnnotationService;
@@ -67,6 +70,15 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
     annotationService.createAnnotation(studyId, cohortId, annotationToCreate);
     return ResponseEntity.ok(
         toApiObject(annotationService.getAnnotation(studyId, cohortId, newAnnotationId)));
+  }
+
+  @Override
+  public ResponseEntity<ApiExportFile> exportAnnotationValues(
+      String studyId, String cohortId, ApiAnnotationValuesExportInfoV2 body) {
+    accessControlService.throwIfUnauthorized(
+        SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
+
+    return ResponseEntity.ok(new ApiExportFile().gcsSignedUrl("foo"));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -5,7 +5,6 @@ import static bio.terra.tanagra.service.accesscontrol.Action.DELETE;
 import static bio.terra.tanagra.service.accesscontrol.Action.READ;
 import static bio.terra.tanagra.service.accesscontrol.Action.UPDATE;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.ANNOTATION;
-import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT_REVIEW;
 
 import bio.terra.tanagra.app.auth.SpringAuthentication;
@@ -75,7 +74,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   @Override
   public ResponseEntity<ApiExportFile> exportAnnotationValues(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(), READ, ANNOTATION, new ResourceId(cohortId));
 
     Table<String, String, String> latestValues =
         annotationService.getAnnotationValuesForLatestReview(studyId, cohortId);
@@ -88,7 +87,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<Void> deleteAnnotation(
       String studyId, String cohortId, String annotationId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), DELETE, ANNOTATION, new ResourceId(annotationId));
+        SpringAuthentication.getCurrentUser(), DELETE, ANNOTATION, new ResourceId(cohortId));
     annotationService.deleteAnnotation(studyId, cohortId, annotationId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -97,7 +96,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiAnnotationV2> getAnnotation(
       String studyId, String cohortId, String annotationId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, ANNOTATION, new ResourceId(annotationId));
+        SpringAuthentication.getCurrentUser(), READ, ANNOTATION, new ResourceId(cohortId));
     return ResponseEntity.ok(
         toApiObject(annotationService.getAnnotation(studyId, cohortId, annotationId)));
   }
@@ -136,7 +135,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiAnnotationV2> updateAnnotation(
       String studyId, String cohortId, String annotationId, ApiAnnotationUpdateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, ANNOTATION, new ResourceId(annotationId));
+        SpringAuthentication.getCurrentUser(), UPDATE, ANNOTATION, new ResourceId(cohortId));
     Annotation updatedAnnotation =
         annotationService.updateAnnotation(
             studyId, cohortId, annotationId, body.getDisplayName(), body.getDescription());

--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -27,11 +27,10 @@ import bio.terra.tanagra.service.accesscontrol.ResourceIdCollection;
 import bio.terra.tanagra.service.artifact.Annotation;
 import bio.terra.tanagra.service.artifact.AnnotationValue;
 import bio.terra.tanagra.service.utils.ToApiConversionUtils;
-import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -77,12 +76,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiExportFile> exportAnnotationValues(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
         SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
-
-    // List of pair of review create date, annotation value
-    List<Pair<OffsetDateTime, AnnotationValue>> valuesForAllReviews =
-        annotationService.getAnnotationValuesForCohort(studyId, cohortId);
-
-    return ResponseEntity.ok(new ApiExportFile().gcsSignedUrl("foo"));
+    Collection<AnnotationValue> values =
+        annotationService.getAnnotationValuesForLatestReview(studyId, cohortId);
+    String gcsSignedUrl = annotationService.writeAnnotationValuesToGcs(values);
+    return ResponseEntity.ok(new ApiExportFile().gcsSignedUrl(gcsSignedUrl));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -209,9 +209,8 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
                 .attributes(attributes)
                 .entityFilter(entityFilter)
                 .annotationFilter(annotationFilter)
-                .entityInstanceIds(reviewService.getPrimaryEntityIds(studyId, cohortId, reviewId))
-                .annotationValues(
-                    annotationService.getAnnotationValues(studyId, cohortId, reviewId))
+                .entityInstanceIds(reviewService.getPrimaryEntityIds(reviewId))
+                .annotationValues(annotationService.getAnnotationValues(reviewId))
                 .orderBys(orderBys)
                 .build());
 
@@ -248,7 +247,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
         new AttributeFilter(
             entity.getIdAttribute(),
             FunctionFilterVariable.FunctionTemplate.IN,
-            reviewService.getPrimaryEntityIds(studyId, cohortId, reviewId));
+            reviewService.getPrimaryEntityIds(reviewId));
 
     QueryRequest queryRequest =
         querysService.buildInstanceCountsQuery(

--- a/service/src/main/java/bio/terra/tanagra/db/AnnotationValueDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/AnnotationValueDao.java
@@ -7,8 +7,10 @@ import bio.terra.common.exception.NotFoundException;
 import bio.terra.tanagra.db.exception.DuplicateAnnotationValueException;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.service.artifact.AnnotationValue;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,10 +28,13 @@ public class AnnotationValueDao {
   private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationValueDao.class);
 
   // SQL query and row mapper for reading an annotation value.
+  private static final String ANNOTATION_VALUE_SELECT_CLAUSE =
+      "av.review_id, av.annotation_id, av.annotation_value_id, av.entity_instance_id, av.bool_val, av.int64_val, av.string_val, av.date_val, a.data_type ";
   private static final String ANNOTATION_VALUE_SELECT_SQL =
-      "SELECT av.review_id, av.annotation_id, av.annotation_value_id, av.entity_instance_id, av.bool_val, av.int64_val, av.string_val, av.date_val, a.data_type "
-          + "FROM annotation_value AS av "
-          + "JOIN annotation AS a ON a.annotation_id = av.annotation_id";
+      "SELECT "
+          + ANNOTATION_VALUE_SELECT_CLAUSE
+          + "FROM annotation AS a, annotation_value AS av "
+          + "WHERE a.annotation_id = av.annotation_id ";
   private static final RowMapper<AnnotationValue> ANNOTATION_VALUE_ROW_MAPPER =
       (rs, rowNum) ->
           AnnotationValue.builder()
@@ -132,8 +137,7 @@ public class AnnotationValueDao {
       throw new MissingRequiredFieldException(
           "Valid study, cohort, annotation, review, and annotation value ids are required");
     }
-    String sql =
-        ANNOTATION_VALUE_SELECT_SQL + " WHERE av.annotation_value_id = :annotation_value_id";
+    String sql = ANNOTATION_VALUE_SELECT_SQL + " AND av.annotation_value_id = :annotation_value_id";
     MapSqlParameterSource params =
         new MapSqlParameterSource().addValue("annotation_value_id", annotationValueId);
     try {
@@ -162,13 +166,46 @@ public class AnnotationValueDao {
                     String.format("Annotation value %s not found.", annotationValueId)));
   }
 
+  /** Returns list of pair of review create date and AnnotationValue */
   @ReadTransaction
-  public List<AnnotationValue> getAnnotationValues(
-      String studyId, String cohortRevisionGroupId, String reviewId) {
-    if (studyId == null || cohortRevisionGroupId == null || reviewId == null) {
+  public List<Pair<OffsetDateTime, AnnotationValue>> getAnnotationValuesForCohort(String cohortId) {
+    if (cohortId == null) {
+      throw new MissingRequiredFieldException("Valid cohort id is required");
+    }
+    String sql =
+        "SELECT "
+            + ANNOTATION_VALUE_SELECT_CLAUSE
+            + ", r.created AS review_created "
+            + "FROM annotation AS a, annotation_value AS av, review AS r "
+            + "WHERE a.annotation_id = av.annotation_id AND a.cohort_id = :cohort_id AND r.review_id = av.review_id";
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue("cohort_id", cohortId);
+    RowMapper<Pair<OffsetDateTime, AnnotationValue>> mapper =
+        (rs, rowNum) ->
+            Pair.of(
+                DbUtils.timestampToOffsetDateTime(rs.getTimestamp("review_created")),
+                AnnotationValue.builder()
+                    .reviewId(rs.getString("review_id"))
+                    .annotationId(rs.getString("annotation_id"))
+                    .annotationValueId(rs.getString("annotation_value_id"))
+                    .entityInstanceId(rs.getString("entity_instance_id"))
+                    .literal(
+                        new Literal.Builder()
+                            .booleanVal(rs.getBoolean("bool_val"))
+                            .int64Val(rs.getLong("int64_val"))
+                            .stringVal(rs.getString("string_val"))
+                            .dateVal(rs.getDate("date_val"))
+                            .dataType(Literal.DataType.valueOf(rs.getString("data_type")))
+                            .build())
+                    .build());
+    return jdbcTemplate.query(sql, params, mapper);
+  }
+
+  @ReadTransaction
+  public List<AnnotationValue> getAnnotationValues(String reviewId) {
+    if (reviewId == null) {
       throw new MissingRequiredFieldException("Valid study, cohort, and review ids are required");
     }
-    String sql = ANNOTATION_VALUE_SELECT_SQL + " WHERE av.review_id = :review_id";
+    String sql = ANNOTATION_VALUE_SELECT_SQL + " AND av.review_id = :review_id";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("review_id", reviewId);
     return jdbcTemplate.query(sql, params, ANNOTATION_VALUE_ROW_MAPPER);
   }

--- a/service/src/main/java/bio/terra/tanagra/db/AnnotationValueDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/AnnotationValueDao.java
@@ -166,7 +166,7 @@ public class AnnotationValueDao {
                     String.format("Annotation value %s not found.", annotationValueId)));
   }
 
-  /** Returns list of pair of review create date and AnnotationValue */
+  /** @return list of pair of review create date and AnnotationValue */
   @ReadTransaction
   public List<Pair<OffsetDateTime, AnnotationValue>> getAnnotationValuesForCohort(String cohortId) {
     if (cohortId == null) {

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -255,8 +255,7 @@ public class ReviewDao {
   }
 
   @ReadTransaction
-  public List<Literal> getPrimaryEntityIds(
-      String studyId, String cohortRevisionGroupId, String reviewId) {
+  public List<Literal> getPrimaryEntityIds(String reviewId) {
     String sql = REVIEW_INSTANCE_SELECT_SQL + " WHERE review_id = :review_id";
     MapSqlParameterSource params = new MapSqlParameterSource().addValue("review_id", reviewId);
     return jdbcTemplate.query(sql, params, REVIEW_INSTANCE_ROW_MAPPER);

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -10,6 +10,8 @@ import bio.terra.tanagra.query.QueryResult;
 import bio.terra.tanagra.query.RowResult;
 import bio.terra.tanagra.service.artifact.Cohort;
 import bio.terra.tanagra.service.artifact.Review;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -88,7 +90,7 @@ public class ReviewDao {
             .addValue("display_name", review.getDisplayName())
             .addValue("description", review.getDescription())
             .addValue("size", review.getSize())
-            // Don't need to set created. Liquibase defaultValueComputed handles that.
+            .addValue("created", Timestamp.from(Instant.now()))
             .addValue("created_by", review.getCreatedBy());
     try {
       jdbcTemplate.update(sql, params);

--- a/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
@@ -251,7 +251,7 @@ public class AnnotationService {
         getAllAnnotations(studyId, cohortId, /*offset=*/ 0, /*limit=*/ Integer.MAX_VALUE);
     annotations.forEach(
         annotation -> {
-          columnHeaders.append(String.format(",%s", annotation.getDisplayName()));
+          columnHeaders.append(String.format("\t%s", annotation.getDisplayName()));
         });
     StringBuilder fileContents = new StringBuilder(columnHeaders + "\n");
     values

--- a/service/src/main/java/bio/terra/tanagra/service/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/ReviewService.java
@@ -118,9 +118,8 @@ public class ReviewService {
   }
 
   /** Retrieves a list of the frozen primary entity instance ids for this review. */
-  public List<Literal> getPrimaryEntityIds(
-      String studyId, String cohortRevisionGroupId, String reviewId) {
+  public List<Literal> getPrimaryEntityIds(String reviewId) {
     featureConfiguration.artifactStorageEnabledCheck();
-    return reviewDao.getPrimaryEntityIds(studyId, cohortRevisionGroupId, reviewId);
+    return reviewDao.getPrimaryEntityIds(reviewId);
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/utils/GcsUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/GcsUtils.java
@@ -13,6 +13,7 @@ public final class GcsUtils {
 
   private GcsUtils() {}
 
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
   public static void writeGcsFile(
       String projectId, String bucketName, String fileName, String fileContents) {
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();

--- a/service/src/main/java/bio/terra/tanagra/service/utils/GcsUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/GcsUtils.java
@@ -1,0 +1,25 @@
+package bio.terra.tanagra.service.utils;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class GcsUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GcsUtils.class);
+
+  private GcsUtils() {}
+
+  public static void writeGcsFile(
+      String projectId, String bucketName, String fileName, String fileContents) {
+    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    BlobId blobId = BlobId.of(bucketName, fileName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    storage.create(blobInfo, fileContents.getBytes(StandardCharsets.UTF_8));
+
+    LOGGER.info("Wrote file {} to bucket {} in project {}", fileName, bucketName, projectId);
+  }
+}

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2000,6 +2000,9 @@ components:
           $ref: "#/components/schemas/DataTypeV2"
         enumVals:
           type: array
+          description: |
+            May only be set if dataType=STRING. Annotation value must be one of
+            enumVals.
           items:
             type: string
       required:
@@ -2023,6 +2026,9 @@ components:
           $ref: "#/components/schemas/DataTypeV2"
         enumVals:
           type: array
+          description: |
+            May only be set if dataType=STRING. Annotation value must be one of
+            enumVals.
           items:
             type: string
       required:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -645,16 +645,11 @@ paths:
       description: |
         Export a table with column headers: primary entity instance id, all
         annotation keys. Table cells contain annotation values. For each cell,
-        the annotation value from the latest review will be used. Exports to a
-        file in bucket specified in application.yaml.
+        the annotation value from the latest review is used, ordered by review
+        creation date. Exports to a file in bucket specified in
+        application.yaml.
       operationId: exportAnnotationValues
       tags: [AnnotationsV2]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AnnotationValuesExportInfoV2"
       responses:
         200:
           description: OK
@@ -2063,17 +2058,6 @@ components:
       required:
         - displayName
         - dataType
-
-    AnnotationValuesExportInfoV2:
-      type: object
-      properties:
-        includeAttributes:
-          description: Attributes to include in the returned instances
-          type: array
-          items:
-            type: string
-        entityFilter:
-          $ref: "#/components/schemas/FilterV2"
 
     AnnotationUpdateInfoV2:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -646,7 +646,7 @@ paths:
         Export a table with column headers: primary entity instance id, all
         annotation keys. Table cells contain annotation values. For each cell,
         the annotation value from the latest review is used, ordered by review
-        creation date. Exports to a file in bucket specified in
+        creation date. Exports to a TSV file in bucket specified in
         application.yaml.
       operationId: exportAnnotationValues
       tags: [AnnotationsV2]

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -636,6 +636,35 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  "/v2/studies/{studyId}/cohorts/{cohortId}/annotationValues/export":
+    parameters:
+    - $ref: '#/components/parameters/StudyIdV2'
+    - $ref: '#/components/parameters/CohortIdV2'
+    post:
+      summary: Export annotation values
+      description: |
+        Export a table with column headers: primary entity instance id, all
+        annotation keys. Table cells contain annotation values. For each cell,
+        the annotation value from the latest review will be used. Exports to a
+        file in bucket specified in application.yaml.
+      operationId: exportAnnotationValues
+      tags: [AnnotationsV2]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnnotationValuesExportInfoV2"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportFile"
+        500:
+          $ref: "#/components/responses/ServerError"
+
   "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
@@ -2034,6 +2063,17 @@ components:
       required:
         - displayName
         - dataType
+
+    AnnotationValuesExportInfoV2:
+      type: object
+      properties:
+        includeAttributes:
+          description: Attributes to include in the returned instances
+          type: array
+          items:
+            type: string
+        entityFilter:
+          $ref: "#/components/schemas/FilterV2"
 
     AnnotationUpdateInfoV2:
       type: object

--- a/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
@@ -118,6 +118,24 @@ public class Literal implements SQLExpression {
     }
   }
 
+  @Override
+  public String toString() {
+    switch (dataType) {
+      case STRING:
+        return stringVal;
+      case INT64:
+        return String.valueOf(int64Val);
+      case BOOLEAN:
+        return String.valueOf(booleanVal);
+      case DATE:
+        return dateVal.toString();
+      case DOUBLE:
+        return String.valueOf(doubleVal);
+      default:
+        throw new SystemException("Unknown Literal data type");
+    }
+  }
+
   public String getStringVal() {
     return dataType.equals(DataType.STRING) ? stringVal : null;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BigQueryExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BigQueryExecutor.java
@@ -41,7 +41,7 @@ public class BigQueryExecutor implements QueryExecutor {
   public String executeAndExportResultsToGcs(QueryRequest queryRequest, String gcsBucketName) {
     // TODO: Add study and dataset names.
     String fileName =
-        "tanagra_export_"
+        "tanagra_export_dataset_"
             + System.currentTimeMillis()
             // GCS file name must be in wildcard format.
             // https://cloud.google.com/bigquery/docs/reference/standard-sql/other-statements#export_option_list:~:text=The%20uri%20option%20must%20be%20a%20single%2Dwildcard%20URI


### PR DESCRIPTION
**Manual testing**

- Create study
- Create cohort [snp = `RS12925749`](https://github.com/DataBiosphere/tanagra/pull/333#issue-1555781947) (356 people)
- Create annotations `A1`, `A2`
- Create review R1 with `size=400` to get all 356 people, review R2 with `size=400`
- Add annotation values:
  ```
  person_id    16804   17681   25259    32638   35089
  A1 R1        V1      V1               V1
  A1 R2        V2              V1       V1
  A2 R1                                         V3
  ```
- CSV file written:
  ```
  person_id,A1,A2
  16804,V2,
  17681,V1,
  32638,V1,
  35089,,V3
  25259,V1,
  ```

**Also:**

- I ended up not needing a request body. I don't need `entityFilter` because there is a `review_instance` -- with entity instance id -- for each entity in review. (I don't think `entityFilter` is needed for `listReviewInstancesAndAnnotations`.) I don't need `includeAttributes` because I'm not returning any concept set info.
- If gcsBucketProjectId or gcsBucketName aren't set in application.yaml, an exception is thrown