### PR TITLE
Boilerplate Validate Config GHA

### DIFF
--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -8,6 +8,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '**' ]
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/service-test.yaml
+++ b/.github/workflows/service-test.yaml
@@ -8,6 +8,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '**' ]
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/underlay-test.yaml
+++ b/.github/workflows/underlay-test.yaml
@@ -8,6 +8,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '**' ]
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -1,0 +1,44 @@
+name: Validate config
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up AdoptOpenJDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: 'temurin'
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+    - name: Pull credentials
+      id: pull_credentials
+      run: |
+        # For security reasons, Broad prefers we read GHA secrets instead of reading from vault.
+        # This step does the equivalent of the pull-credentials.sh script.
+        # On local machines, the script fetches a SA from Vault.
+        # In GH actions, the SA key is stored in a GH repo secret.
+        # Regardless of how it was fetched, tests and scripts expect these
+        # keys to be stored in rendered/.
+        mkdir -p rendered/broad/
+        echo "$TEST_PROJECT_SA_KEY" > rendered/broad/tanagra_sa.json
+      env:
+        TEST_PROJECT_SA_KEY: ${{ secrets.TEST_PROJECT_SA_KEY }}
+    - name: Gradle Build and Check
+      # The check task includes the build, test and static analysis tasks.
+      run: ./gradlew underlay:check
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: ../rendered/broad/tanagra_sa.json

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -37,8 +37,11 @@ jobs:
         echo "$TEST_PROJECT_SA_KEY" > rendered/broad/tanagra_sa.json
       env:
         TEST_PROJECT_SA_KEY: ${{ secrets.TEST_PROJECT_SA_KEY }}
-    - name: Gradle Build and Check
-      # The check task includes the build, test and static analysis tasks.
-      run: ./gradlew underlay:check
+    - name: Expand config
+      run: |
+        ./gradlew indexer:index -Dexec.args="EXPAND_CONFIG /Users/melchang/tanagra/service/src/main/resources/config/verily/aou_synthetic/original/aou_synthetic.json /Users/melchang/tanagra/service/src/main/resources/config/verily/aou_synthetic/expanded"
+        git status
+        # This will fail if there are new files in the working directory 
+        exit $(git status -s -uno | wc -l)
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ../rendered/broad/tanagra_sa.json

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ '**' ]
   workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -39,9 +40,6 @@ jobs:
         TEST_PROJECT_SA_KEY: ${{ secrets.TEST_PROJECT_SA_KEY }}
     - name: Expand config
       run: |
-        ./gradlew indexer:index -Dexec.args="EXPAND_CONFIG /Users/melchang/tanagra/service/src/main/resources/config/verily/aou_synthetic/original/aou_synthetic.json /Users/melchang/tanagra/service/src/main/resources/config/verily/aou_synthetic/expanded"
-        git status
-        # This will fail if there are new files in the working directory 
-        exit $(git status -s -uno | wc -l)
+         echo Hello
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ../rendered/broad/tanagra_sa.json


### PR DESCRIPTION
I'm going to write a GHA that validates config: expand config and make sure there are no files in git working directory, validate that verily/sdd/entity is the same as vumv/sdd/entity, etc.

This PR adds a workflow that does nothing. Workflow has `workflow_dispatch` so I can manually run from GitHub UI. This new workflow needs to be in main before I can manually run it.