### PR TITLE
Convert cohort and concept set editing to use backend

### DIFF
--- a/.github/actions/start-local-server/action.yml
+++ b/.github/actions/start-local-server/action.yml
@@ -1,0 +1,47 @@
+name: "start-local-server"
+description: "Launch a tanagra server"
+outputs:
+  tanagrapid:
+    description: "pid of the tanagra process"
+    value: ${{ steps.launch.outputs.tanagrapid }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Launch the background process
+      id: launch
+      run: |
+        # The redirect magic provides null input to work around a gradle bug and sends
+        # both stdout and stderr to the log file.
+        ./service/local-dev/run_server.sh -a 2>&1 < /dev/null | tee tanagra.log &
+        tanagrapid=$!
+        disown $tanagrapid
+        echo "Launched Tanagra service pid $tanagrapid"
+        echo "tanagrapid=$tanagrapid" >> $GITHUB_OUTPUT
+      shell: bash
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: ../rendered/broad/tanagra_sa.json
+
+    - name: Wait for boot run to be ready
+      id: wait-for-ready
+      run: |
+        # Give it some time before starting to poll.
+        sleep 40
+        started=1
+        for i in `seq 1 50`;
+        do
+          echo "try server connect $i"
+          if echo > /dev/tcp/localhost/8080
+          then
+            echo "Server started successfully"
+            started=0
+            break
+          fi
+          sleep 1
+        done
+        if [ "${started}" -eq "1" ]
+        then
+          echo "Server did not start successfully. Dumping log file"
+          cat tanagra.log
+        fi
+      shell: bash

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -15,15 +15,68 @@ jobs:
       matrix:
         node-version: [15.x]
 
+    services:
+      postgres:
+        image: postgres:13.1
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set up AdoptOpenJDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      - name: Initialize Postgres DB
+        env:
+          PGPASSWORD: postgres
+        run: psql -h 127.0.0.1 -U postgres -f ./service/local-dev/local-postgres-init.sql
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
+      - name: Pull credentials
+        id: pull_credentials
+        run: |
+          # For security reasons, Broad prefers we read GHA secrets instead of reading from vault.
+          # This step does the equivalent of the pull-credentials.sh script.
+          # On local machines, the script fetches a SA from Vault.
+          # In GH actions, the SA key is stored in a GH repo secret.
+          # Regardless of how it was fetched, tests and scripts expect these
+          # keys to be stored in rendered/.
+          mkdir -p rendered/broad/
+          echo "$TEST_PROJECT_SA_KEY" > rendered/broad/tanagra_sa.json
+          chmod a+r rendered/broad/tanagra_sa.json
+        env:
+          TEST_PROJECT_SA_KEY: ${{ secrets.TEST_PROJECT_SA_KEY }}
+
+      - name: Launch local server
+        uses: ./.github/actions/start-local-server
+
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
           build: npm run codegen
-          start: npm run fake
+          start: npm start
           wait-on: "http://localhost:3000"
           working-directory: ui
+
       # NOTE: screenshots will be generated only if E2E test failed
       # thus we store screenshots only on failures
       # Alternative: create and commit an empty cypress/screenshots folder
@@ -33,6 +86,7 @@ jobs:
         with:
           name: cypress-screenshots
           path: ui/cypress/screenshots
+
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v2
         if: always()

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
@@ -58,9 +58,22 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
     underlaysService.getEntity(body.getUnderlayName(), body.getEntity());
     studyService.getStudy(studyId);
 
-    // Generate random 10-character alphanumeric string for the new concept set ID.
+    // Generate random 10-character alphanumeric string for the new criteria and concept set IDs.
+    String newCriteriaId = RandomStringUtils.randomAlphanumeric(10);
     String newConceptSetId = RandomStringUtils.randomAlphanumeric(10);
 
+    Criteria criteria =
+        body.getCriteria() == null
+            ? null
+            : Criteria.builder()
+                .conceptSetId(newConceptSetId)
+                .criteriaId(newCriteriaId)
+                .userFacingCriteriaId(body.getCriteria().getId())
+                .displayName(body.getCriteria().getDisplayName())
+                .pluginName(body.getCriteria().getPluginName())
+                .selectionData(body.getCriteria().getSelectionData())
+                .uiConfig(body.getCriteria().getUiConfig())
+                .build();
     ConceptSet conceptSetToCreate =
         ConceptSet.builder()
             .studyId(studyId)
@@ -70,6 +83,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
             .createdBy(SpringAuthentication.getCurrentUser().getEmail())
             .displayName(body.getDisplayName())
             .description(body.getDescription())
+            .criteria(criteria)
             .build();
     conceptSetService.createConceptSet(conceptSetToCreate);
     return ResponseEntity.ok(

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1850,6 +1850,8 @@ components:
           $ref: "#/components/schemas/ConceptSetDisplayNameV2"
         description:
           $ref: "#/components/schemas/ConceptSetDescriptionV2"
+        criteria:
+          $ref: "#/components/schemas/CriteriaV2"
 
     ConceptSetUpdateInfoV2:
       type: object

--- a/ui/cypress/integration/tests.js
+++ b/ui/cypress/integration/tests.js
@@ -2,16 +2,22 @@ describe("Basic tests", () => {
   it("Contains title", () => {
     cy.visit("http://localhost:3000/");
 
-    cy.contains("underlay_name").click();
-    cy.contains("Test Study").click();
+    const id = Math.floor(1000000 * Math.random());
+    const cohortName = `New cohort ${id}`;
+
+    cy.contains("aou_synthetic").click();
+    cy.contains("Add study").click();
+    cy.get("input[name=text]").type(`New study ${id}`);
+    cy.get("button:Contains(Create)").click();
+    cy.get(`.MuiListItemButton-root:Contains(New study ${id})`).click();
     cy.contains("Datasets");
 
     cy.get("button[id=insert-cohort]").click();
-    cy.get("input[name=text]").type("New cohort");
+    cy.get("input[name=text]").type(cohortName);
     cy.get("button:Contains(Create)").click();
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("button:Contains(Condition)").click();
-    cy.get("button:Contains(test concept)").click();
+    cy.get("button:Contains(Clinical finding)").click();
 
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("button:Contains(Race)").click();
@@ -21,35 +27,35 @@ describe("Basic tests", () => {
 
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("button:Contains(Year of birth)").click();
-    cy.get(".MuiInput-input").first().type("{selectall}30");
+    cy.get(".MuiInput-input").first().type("{selectall}1940");
 
     cy.get("button:Contains(Add criteria)").last().click();
     cy.get("button:Contains(Observation)").click();
-    cy.get("button:Contains(test concept)").click();
+    cy.get("button:Contains(Marital status)", { timeout: 20000 }).click();
 
     cy.get("button:Contains(Add criteria)").last().click();
-    cy.get("input").type("test{enter}");
-    cy.get("button:Contains(test concept)").first().click();
+    cy.get("input").type("clinical");
+    cy.get("button:Contains(Imaging)").first().click();
 
     cy.get("a[aria-label=back]").click();
 
     cy.get("button[id=insert-concept-set]").click();
     cy.get("li:Contains(Condition)").click();
-    cy.get("button:Contains(test concept)").click();
+    cy.get("button:Contains(Clinical finding)").click();
 
-    cy.get("button[name='New cohort']").click();
-    cy.get("button[name='Condition: test concept']").click();
+    cy.get(`button[name='${cohortName}']`).click();
+    cy.get("button[name='Condition: Clinical finding']").click();
 
-    cy.get("button:Contains('condition_occurrence')");
+    cy.get("button:Contains('condition_occurrence')", { timeout: 40000 });
 
     cy.get("input[name='queries-mode']").click();
-    cy.contains("SELECT *");
+    cy.contains("SELECT");
 
     // Test persistence.
     cy.reload();
 
-    cy.get("a:Contains('New cohort')").click();
-    cy.get("a:Contains('Condition: test concept')").last().click();
-    cy.contains("test concept");
+    cy.get(`a:Contains(${cohortName})`).click();
+    cy.get("a:Contains('Condition: Clinical finding')").last().click();
+    cy.contains("Clinical finding");
   });
 });

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -4,7 +4,7 @@ import Chip from "@mui/material/Chip";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
-import { insertCriteria } from "cohortsSlice";
+import { insertCohortCriteria, useCohortContext } from "cohortContext";
 import CohortToolbar from "cohortToolbar";
 import Empty from "components/empty";
 import Loading from "components/loading";
@@ -17,7 +17,7 @@ import {
 } from "components/treegrid";
 import { MergedDataEntry, useSource } from "data/source";
 import { DataEntry, DataKey } from "data/types";
-import { useAppDispatch, useCohortAndGroup, useUnderlay } from "hooks";
+import { useCohortAndGroup, useUnderlay } from "hooks";
 import { useCallback, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { cohortURL, newCriteriaURL } from "router";
@@ -29,7 +29,7 @@ export function AddCriteria() {
   const underlay = useUnderlay();
   const source = useSource();
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
+  const context = useCohortContext();
   const { cohort, group } = useCohortAndGroup();
 
   const query = useSearchParams()[0].get("search") ?? "";
@@ -77,13 +77,7 @@ export function AddCriteria() {
       if (!!getCriteriaPlugin(criteria).renderEdit && !dataEntry) {
         navigate("../" + newCriteriaURL(config.id));
       } else {
-        dispatch(
-          insertCriteria({
-            cohortId: cohort.id,
-            groupId: group.id,
-            criteria,
-          })
-        );
+        insertCohortCriteria(context, group.id, criteria);
         navigate("../../" + cohortURL(cohort.id, group.id));
       }
     },

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -41,7 +41,18 @@ function generateFilter(group: tanagra.Group): Filter | null {
 }
 
 export function groupName(group: tanagra.Group, index: number) {
-  return group.name ?? "Group " + String(index + 1);
+  return group.name || "Group " + String(index + 1);
+}
+
+export function defaultGroup(criteria?: tanagra.Criteria): tanagra.Group {
+  return {
+    id: generateId(),
+    filter: {
+      kind: tanagra.GroupFilterKindEnum.Any,
+      excluded: false,
+    },
+    criteria: criteria ? [criteria] : [],
+  };
 }
 
 // Having typed data here allows the registry to treat all data generically

--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -1,0 +1,206 @@
+import { defaultGroup } from "cohort";
+import { useSource } from "data/source";
+import produce from "immer";
+import { createContext, useContext, useState } from "react";
+import { useParams } from "react-router-dom";
+import useSWR, { useSWRConfig } from "swr";
+import * as tanagra from "tanagra-api";
+
+type CohortState = {
+  past: tanagra.Cohort[];
+  present: tanagra.Cohort;
+  future: tanagra.Cohort[];
+};
+
+type CohortContextData = {
+  state: CohortState | null;
+  updateState: (update: (state: CohortState) => void) => void;
+  updatePresent: (update: (present: tanagra.Cohort) => void) => void;
+};
+
+export const CohortContext = createContext<CohortContextData | null>(null);
+
+export function useCohortContext() {
+  const context = useContext(CohortContext);
+  if (!context) {
+    throw new Error("Attempting to use cohort context when not provided.");
+  }
+  return context;
+}
+
+export function useNewCohortContext() {
+  const source = useSource();
+  const { studyId, cohortId } =
+    useParams<{ studyId: string; cohortId: string }>();
+
+  if (!studyId || !cohortId) {
+    throw new Error(
+      "Cannot create cohort context without study and cohort IDs."
+    );
+  }
+
+  const [state, setState] = useState<CohortState | null>(null);
+
+  const key = {
+    type: "cohort",
+    studyId,
+    cohortId,
+  };
+  const status = useSWR(key, async () => {
+    const cohort = await source.getCohort(studyId, cohortId);
+    setState((state) => ({
+      past: state?.past ?? [],
+      present: cohort,
+      future: state?.future ?? [],
+    }));
+    return cohort;
+  });
+
+  const updateCohort = async (newState: CohortState | null) => {
+    if (!newState) {
+      throw new Error("Invalid null cohort update.");
+    }
+    setState(newState);
+    await source.updateCohort(studyId, newState.present);
+    status.mutate();
+  };
+
+  const { mutate } = useSWRConfig();
+
+  return {
+    isLoading: status.isLoading || !state,
+    context: {
+      state: state,
+      updateState: async (update: (state: CohortState) => void) => {
+        updateCohort(produce(state, update));
+      },
+      updatePresent: async (update: (present: tanagra.Cohort) => void) => {
+        if (!state) {
+          throw new Error("Attempting to update null cohort.");
+        }
+
+        // Produce twice, otherwise edits to the present cohort still end up
+        // affecting the pushed cohort as well.
+        const pushed = produce(state, (state) => {
+          state.past.push(state.present);
+          state.future = [];
+        });
+        const newState = produce(pushed, (state) => {
+          update(state.present);
+        });
+
+        await updateCohort(newState);
+
+        mutate(
+          (key: { type: string; studyId: string; list: boolean }) =>
+            key.type === "cohort" &&
+            key.studyId === studyId &&
+            key.list === true,
+          undefined,
+          { revalidate: true }
+        );
+      },
+    },
+  };
+}
+
+export function insertCohortCriteria(
+  context: CohortContextData,
+  groupId: string,
+  criteria: tanagra.Criteria
+) {
+  context.updatePresent((present) => {
+    const group = present.groups.find((group) => group.id === groupId);
+    if (!group) {
+      throw new Error(`Group ${groupId} does not exist in cohort ${present}.`);
+    }
+    group.criteria.push(criteria);
+  });
+}
+
+export function updateCohortCriteria(
+  context: CohortContextData,
+  groupId: string,
+  criteriaId: string,
+  data: object
+) {
+  context.updatePresent((present) => {
+    const group = present.groups.find((group) => group.id === groupId);
+    if (!group) {
+      throw new Error(`Group ${groupId} does not exist in cohort ${present}.`);
+    }
+
+    const criteria = group.criteria.find((c) => c.id === criteriaId);
+    if (!criteria) {
+      throw new Error(
+        `Criteria ${criteriaId} does not exist on group ${group}.`
+      );
+    }
+
+    criteria.data = data;
+  });
+}
+
+export function deleteCohortCriteria(
+  context: CohortContextData,
+  groupId: string,
+  criteriaId: string
+) {
+  context.updatePresent((present) => {
+    const group = present.groups.find((group) => group.id === groupId);
+    if (!group) {
+      throw new Error(`Group ${groupId} does not exist in cohort ${present}.`);
+    }
+
+    const index = group.criteria.findIndex((c) => c.id === criteriaId);
+    if (index === -1) {
+      throw new Error(
+        `Criteria ${criteriaId} does not exist on group ${group}.`
+      );
+    }
+
+    group.criteria.splice(index, 1);
+  });
+}
+
+export function insertCohortGroup(
+  context: CohortContextData,
+  criteria?: tanagra.Criteria
+) {
+  context.updatePresent((present) => {
+    present.groups.push(defaultGroup(criteria));
+  });
+}
+
+export function deleteCohortGroup(context: CohortContextData, groupId: string) {
+  context.updatePresent((present) => {
+    if (present.groups.length === 1) {
+      present.groups = [defaultGroup()];
+      return;
+    }
+
+    const index = present.groups.findIndex((group) => group.id === groupId);
+    if (index === -1) {
+      throw new Error(`Group ${groupId} does not exist in cohort ${present}.`);
+    }
+
+    present.groups.splice(index, 1);
+  });
+}
+
+export function updateCohortGroup(
+  context: CohortContextData,
+  groupId: string,
+  name?: string,
+  filter?: tanagra.GroupFilter
+) {
+  context.updatePresent((present) => {
+    const group = present.groups.find((group) => group.id === groupId);
+    if (!group) {
+      throw new Error(`Group ${groupId} does not exist in cohort ${present}.`);
+    }
+
+    group.name = name ?? group.name;
+    group.filter = filter ?? group.filter;
+  });
+}

--- a/ui/src/cohortRoot.tsx
+++ b/ui/src/cohortRoot.tsx
@@ -1,0 +1,15 @@
+import { CohortContext, useNewCohortContext } from "cohortContext";
+import Loading from "components/loading";
+import { Outlet } from "react-router-dom";
+
+export default function CohortRoot() {
+  const status = useNewCohortContext();
+
+  return (
+    <Loading status={status}>
+      <CohortContext.Provider value={status.context}>
+        <Outlet />
+      </CohortContext.Provider>
+    </Loading>
+  );
+}

--- a/ui/src/cohortToolbar.tsx
+++ b/ui/src/cohortToolbar.tsx
@@ -5,58 +5,39 @@ import Button from "@mui/material/Button";
 import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
 import {
-  useAppDispatch,
-  useAppSelector,
   useCohort,
+  useRedoAction,
+  useUndoAction,
   useUndoRedoUrls,
 } from "hooks";
 import { Link as RouterLink } from "react-router-dom";
-import { ActionCreators as UndoActionCreators } from "redux-undo";
 import { absoluteCohortReviewURL, useBaseParams } from "router";
 
 export default function CohortToolbar() {
   const cohort = useCohort();
   const params = useBaseParams();
 
-  const dispatch = useAppDispatch();
-  const canUndo = useAppSelector((state) => {
-    if (state.past.length === 0) {
-      return false;
-    }
-
-    // TODO(tjennison): Eventually undo/redo will be contained within individual
-    // cohorts/concept sets but for now prevent undo across them. This isn't
-    // necessary in canRedo because they can't be undone in the first place.
-    const past = state.past[state.past.length - 1];
-    if (
-      state.present.cohorts.length !== past.cohorts.length ||
-      state.present.conceptSets.length !== past.conceptSets.length
-    ) {
-      return false;
-    }
-
-    return true;
-  });
-  const canRedo = useAppSelector((state) => state.future.length > 0);
   const [undoUrlPath, redoUrlPath] = useUndoRedoUrls();
+  const undo = useUndoAction();
+  const redo = useRedoAction();
 
   return (
     <Stack direction="row" spacing={1} sx={{ m: 1 }}>
       <Button
-        onClick={() => dispatch(UndoActionCreators.undo())}
+        onClick={() => undo?.()}
         variant="outlined"
         startIcon={<UndoIcon />}
-        disabled={!canUndo}
+        disabled={!undo}
         component={RouterLink}
         to={undoUrlPath}
       >
         Undo
       </Button>
       <Button
-        onClick={() => dispatch(UndoActionCreators.redo())}
+        onClick={() => redo?.()}
         variant="outlined"
         startIcon={<RedoIcon />}
-        disabled={!canRedo}
+        disabled={!redo}
         component={RouterLink}
         to={redoUrlPath}
       >

--- a/ui/src/components/textInputDialog.tsx
+++ b/ui/src/components/textInputDialog.tsx
@@ -37,7 +37,7 @@ export function useTextInputDialog(
       <Form
         onSubmit={({ text }) => {
           setOpen(false);
-          props.onConfirm(text);
+          props.onConfirm(text ?? "");
         }}
         initialValues={{
           text: props.initialText,

--- a/ui/src/conceptSetContext.ts
+++ b/ui/src/conceptSetContext.ts
@@ -1,0 +1,113 @@
+import { useSource } from "data/source";
+import { useUnderlay } from "hooks";
+import produce from "immer";
+import { createContext, useContext, useState } from "react";
+import { useParams } from "react-router-dom";
+import useSWR, { useSWRConfig } from "swr";
+import * as tanagra from "tanagra-api";
+
+// SWR treats falsy values as failures, so track uncreated concept sets here.
+type ConceptSetContextState = {
+  conceptSet: tanagra.ConceptSet | null;
+};
+
+type ConceptSetContextData = {
+  state: ConceptSetContextState;
+  updateState: (update: (state: ConceptSetContextState) => void) => void;
+};
+
+export const ConceptSetContext = createContext<ConceptSetContextData | null>(
+  null
+);
+
+export function useConceptSetContext() {
+  const context = useContext(ConceptSetContext);
+  if (!context) {
+    throw new Error("Attempting to use concept set context when not provided.");
+  }
+  return context;
+}
+
+export function useNewConceptSetContext() {
+  const underlay = useUnderlay();
+  const source = useSource();
+  const { studyId, conceptSetId } =
+    useParams<{ studyId: string; conceptSetId: string }>();
+
+  if (!studyId) {
+    throw new Error("Cannot create concept set context without a study ID.");
+  }
+
+  const [state, setState] = useState<ConceptSetContextState>({
+    conceptSet: null,
+  });
+
+  const key = {
+    type: "conceptSet",
+    studyId,
+    conceptSetId,
+  };
+  const status = useSWR(key, async () => {
+    const newState: ConceptSetContextState = { conceptSet: null };
+    if (conceptSetId) {
+      newState.conceptSet = await source.getConceptSet(studyId, conceptSetId);
+    }
+
+    setState(newState);
+    return newState;
+  });
+
+  const { mutate } = useSWRConfig();
+
+  return {
+    isLoading: status.isLoading || !state,
+    context: {
+      state: state,
+      updateState: async (update: (state: ConceptSetContextState) => void) => {
+        const newState = produce(state, update);
+        if (!newState?.conceptSet) {
+          throw new Error("Invalid null concept set update.");
+        }
+
+        setState(newState);
+        if (!state?.conceptSet) {
+          await source.createConceptSet(
+            underlay.name,
+            studyId,
+            newState.conceptSet.criteria
+          );
+        } else {
+          await source.updateConceptSet(studyId, newState.conceptSet);
+        }
+
+        mutate(
+          (key: { type: string; studyId: string; list: boolean }) =>
+            key.type === "conceptSet" &&
+            key.studyId === studyId &&
+            key.list === true,
+          undefined,
+          { revalidate: true }
+        );
+      },
+    },
+  };
+}
+
+export function createConceptSet(
+  context: ConceptSetContextData,
+  criteria: tanagra.Criteria
+) {
+  context.updateState((state) => {
+    state.conceptSet = { id: "", underlayName: "", criteria };
+  });
+}
+
+export function updateConceptSet(context: ConceptSetContextData, data: object) {
+  context.updateState((state) => {
+    if (!state?.conceptSet) {
+      throw new Error("Attempted to update invalid concept set.");
+    }
+
+    state.conceptSet.criteria.data = data;
+  });
+}

--- a/ui/src/conceptSetRoot.tsx
+++ b/ui/src/conceptSetRoot.tsx
@@ -1,0 +1,15 @@
+import Loading from "components/loading";
+import { ConceptSetContext, useNewConceptSetContext } from "conceptSetContext";
+import { Outlet } from "react-router-dom";
+
+export default function ConceptSetRoot() {
+  const status = useNewConceptSetContext();
+
+  return (
+    <Loading status={status}>
+      <ConceptSetContext.Provider value={status.context}>
+        <Outlet />
+      </ConceptSetContext.Provider>
+    </Loading>
+  );
+}

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -16,7 +16,6 @@ import {
   getCriteriaPlugin,
   getCriteriaTitle,
 } from "cohort";
-import { insertCohort } from "cohortsSlice";
 import Checkbox from "components/checkbox";
 import Empty from "components/empty";
 import Loading from "components/loading";
@@ -26,7 +25,7 @@ import { TreeGrid, TreeGridData } from "components/treegrid";
 import { findEntity } from "data/configuration";
 import { Filter, makeArrayFilter } from "data/filter";
 import { useSource } from "data/source";
-import { useAppDispatch, useAppSelector, useUnderlay } from "hooks";
+import { useStudyId, useUnderlay } from "hooks";
 import React, {
   Fragment,
   SyntheticEvent,
@@ -41,20 +40,32 @@ import {
   absoluteNewConceptSetURL,
   useBaseParams,
 } from "router";
+import useSWR from "swr";
 import useSWRImmutable from "swr/immutable";
 import * as tanagra from "tanagra-api";
 import { useImmer } from "use-immer";
 
 export function Datasets() {
-  const dispatch = useAppDispatch();
-  const unfilteredCohorts = useAppSelector((state) => state.present.cohorts);
-  const workspaceConceptSets = useAppSelector(
-    (state) => state.present.conceptSets
+  const source = useSource();
+  const studyId = useStudyId();
+  const unfilteredCohorts = useSWR(
+    { type: "cohort", studyId, list: true },
+    async () => await source.listCohorts(studyId)
   );
+
+  const workspaceConceptSets = useSWR(
+    { type: "conceptSet", studyId, list: true },
+    async () =>
+      await source
+        .listConceptSets(studyId)
+        .then((conceptSets) =>
+          conceptSets.filter((cs) => cs.underlayName === underlay.name)
+        )
+  );
+
   const navigate = useNavigate();
 
   const underlay = useUnderlay();
-  const source = useSource();
   const params = useBaseParams();
 
   const [selectedCohorts, updateSelectedCohorts] = useImmer(new Set<string>());
@@ -65,21 +76,18 @@ export function Datasets() {
     new Map<string, Set<string>>()
   );
 
-  const conceptSetOccurrences = useConceptSetOccurrences(selectedConceptSets);
+  const conceptSetOccurrences = useConceptSetOccurrences(
+    selectedConceptSets,
+    workspaceConceptSets.data
+  );
 
   const [dialog, showNewCohort] = useTextInputDialog({
     title: "New cohort",
     textLabel: "Cohort name",
     buttonLabel: "Create",
-    onConfirm: (name: string) => {
-      const action = dispatch(insertCohort(name, underlay.name));
-      navigate(
-        absoluteCohortURL(
-          params,
-          action.payload.id,
-          action.payload.groups[0].id
-        )
-      );
+    onConfirm: async (name: string) => {
+      const cohort = await source.createCohort(underlay.name, studyId, name);
+      navigate(absoluteCohortURL(params, cohort.id, cohort.groups[0].id));
     },
   });
 
@@ -163,10 +171,10 @@ export function Datasets() {
 
   const cohorts = useMemo(
     () =>
-      unfilteredCohorts.filter(
+      (unfilteredCohorts.data ?? []).filter(
         (cohort) => cohort.underlayName === underlay.name
       ),
-    [unfilteredCohorts]
+    [unfilteredCohorts.data]
   );
 
   return (
@@ -266,12 +274,10 @@ export function Datasets() {
             <Typography variant="h4">Workspace</Typography>
             {listConceptSets(
               true,
-              workspaceConceptSets
-                .filter((cs) => cs.underlayName === underlay.name)
-                .map((cs) => ({
-                  id: cs.id,
-                  name: getCriteriaTitle(cs.criteria),
-                }))
+              (workspaceConceptSets.data ?? []).map((cs) => ({
+                id: cs.id,
+                name: getCriteriaTitle(cs.criteria),
+              }))
             )}
           </Paper>
         </Grid>
@@ -392,45 +398,47 @@ type ConceptSetOccurrence = {
 };
 
 function useConceptSetOccurrences(
-  selectedConceptSets: Set<string>
+  selectedConceptSets: Set<string>,
+  workspaceConceptSets?: tanagra.ConceptSet[]
 ): ConceptSetOccurrence[] {
   const underlay = useUnderlay();
   const source = useSource();
 
-  const occurrences = new Map<string, Filter[]>();
-  const addFilter = (occurrence: string, filter?: Filter | null) => {
-    if (!occurrences.has(occurrence)) {
-      occurrences.set(occurrence, []);
-    }
-    if (filter) {
-      occurrences.get(occurrence)?.push(filter);
-    }
-  };
+  return useMemo(() => {
+    const occurrences = new Map<string, Filter[]>();
+    const addFilter = (occurrence: string, filter?: Filter | null) => {
+      if (!occurrences.has(occurrence)) {
+        occurrences.set(occurrence, []);
+      }
+      if (filter) {
+        occurrences.get(occurrence)?.push(filter);
+      }
+    };
 
-  underlay.uiConfiguration.prepackagedConceptSets?.forEach((conceptSet) => {
-    if (selectedConceptSets.has(conceptSet.id)) {
-      addFilter(conceptSet.occurrence, conceptSet.filter);
-    }
-  });
-
-  const workspaceConceptSets = useAppSelector((state) =>
-    state.present.conceptSets.filter((cs) => selectedConceptSets.has(cs.id))
-  );
-  workspaceConceptSets.forEach((conceptSet) => {
-    const plugin = getCriteriaPlugin(conceptSet.criteria);
-    addFilter(plugin.occurrenceID(), plugin.generateFilter());
-  });
-
-  return Array.from(occurrences)
-    .sort()
-    .map(([id, filters]) => {
-      return {
-        id,
-        name: findEntity(id, source.config).entity,
-        attributes: source.listAttributes(id),
-        filters,
-      };
+    underlay.uiConfiguration.prepackagedConceptSets?.forEach((conceptSet) => {
+      if (selectedConceptSets.has(conceptSet.id)) {
+        addFilter(conceptSet.occurrence, conceptSet.filter);
+      }
     });
+
+    workspaceConceptSets
+      ?.filter((cs) => selectedConceptSets.has(cs.id))
+      ?.forEach((conceptSet) => {
+        const plugin = getCriteriaPlugin(conceptSet.criteria);
+        addFilter(plugin.occurrenceID(), plugin.generateFilter());
+      });
+
+    return Array.from(occurrences)
+      .sort()
+      .map(([id, filters]) => {
+        return {
+          id,
+          name: findEntity(id, source.config).entity,
+          attributes: source.listAttributes(id),
+          filters,
+        };
+      });
+  }, [selectedConceptSets, workspaceConceptSets]);
 }
 
 type PreviewProps = {
@@ -442,10 +450,19 @@ type PreviewProps = {
 
 function Preview(props: PreviewProps) {
   const source = useSource();
-  const cohorts = useAppSelector((state) =>
-    state.present.cohorts.filter((cohort) =>
-      props.selectedCohorts.has(cohort.id)
-    )
+  const studyId = useStudyId();
+
+  const unfilteredCohorts = useSWR(
+    { type: "cohort", studyId, list: true },
+    async () => await source.listCohorts(studyId)
+  );
+
+  const cohorts = useMemo(
+    () =>
+      (unfilteredCohorts.data ?? []).filter((cohort) =>
+        props.selectedCohorts.has(cohort.id)
+      ),
+    [unfilteredCohorts.data]
   );
 
   const [tab, setTab] = useState(0);
@@ -453,7 +470,7 @@ function Preview(props: PreviewProps) {
 
   const tabDataState = useSWRImmutable<PreviewTabData[]>(
     {
-      component: "Datasets",
+      type: "previewData",
       cohorts,
       occurrences: props.conceptSetOccurrences,
       excludedAtrtibutes: props.excludedAttributes,
@@ -463,7 +480,7 @@ function Preview(props: PreviewProps) {
         props.conceptSetOccurrences.map(async (occurrence) => {
           const cohortsFilter = makeArrayFilter(
             { min: 1 },
-            cohorts.map((cohort) => generateCohortFilter(cohort))
+            (cohorts || []).map((cohort) => generateCohortFilter(cohort))
           );
           if (!cohortsFilter) {
             throw new Error("All selected cohorts are empty.");

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,11 +1,20 @@
 import { createCriteria } from "cohort";
-import { insertCriteria, updateCriteriaData } from "cohortsSlice";
-import { insertConceptSet, updateConceptSetData } from "conceptSetsSlice";
+import {
+  CohortContext,
+  insertCohortCriteria,
+  updateCohortCriteria,
+} from "cohortContext";
+import {
+  ConceptSetContext,
+  createConceptSet,
+  updateConceptSet,
+} from "conceptSetContext";
 import { useSource } from "data/source";
-import { useCallback, useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import { RootState } from "rootReducer";
+import { absoluteCohortURL, useBaseParams } from "router";
 import { AppDispatch } from "store";
 import * as tanagra from "tanagra-api";
 
@@ -25,13 +34,18 @@ export function useUnderlay() {
   return underlay;
 }
 
+export function useStudyId() {
+  const { studyId } = useParams<{ studyId: string }>();
+  if (!studyId) {
+    throw new PathError("Study id not found in URL.");
+  }
+  return studyId;
+}
+
 function useOptionalCohort(throwOnUnknown: boolean) {
-  const { cohortId } = useParams<{ cohortId: string }>();
-  const cohort = useAppSelector((state) =>
-    state.present.cohorts.find((cohort) => cohort.id === cohortId)
-  );
+  const cohort = useContext(CohortContext)?.state?.present;
   if (throwOnUnknown && !cohort) {
-    throw new PathError(`Unknown cohort "${cohortId}".`);
+    throw new PathError(`No valid cohort in current context.`);
   }
   return cohort;
 }
@@ -104,14 +118,9 @@ export function useGroupAndCriteria() {
 }
 
 function useOptionalConceptSet(throwOnUnknown: boolean) {
-  const { conceptSetId } = useParams<{ conceptSetId: string }>();
-  const conceptSet = useAppSelector((state) =>
-    state.present.conceptSets.find(
-      (conceptSet) => conceptSet.id === conceptSetId
-    )
-  );
+  const conceptSet = useContext(ConceptSetContext)?.state?.conceptSet;
   if (throwOnUnknown && !conceptSet) {
-    throw new PathError(`Unknown concept set "${conceptSetId}".`);
+    throw new PathError(`No valid concept set in current context.`);
   }
   return conceptSet;
 }
@@ -121,70 +130,53 @@ export function useConceptSet() {
 }
 
 export function useUpdateCriteria(criteriaId?: string) {
-  const underlay = useUnderlay();
   const cohort = useOptionalCohort(false);
   const { group, criteria } = useOptionalGroupAndCriteria(false);
   const newCriteria = useOptionalNewCriteria(false);
   const conceptSet = useOptionalConceptSet(false);
-  const dispatch = useAppDispatch();
+  const cohortContext = useContext(CohortContext);
+  const conceptSetContext = useContext(ConceptSetContext);
 
   if (cohort && group) {
+    if (!cohortContext) {
+      throw new Error("Null cohort context when updating a cohort criteria.");
+    }
+
     if (newCriteria) {
-      return useCallback(
-        (data: object) => {
-          dispatch(
-            insertCriteria({
-              cohortId: cohort.id,
-              groupId: group.id,
-              criteria: { ...newCriteria, data: data },
-            })
-          );
-        },
-        [cohort.id, group.id, newCriteria]
-      );
+      return (data: object) => {
+        insertCohortCriteria(cohortContext, group.id, {
+          ...newCriteria,
+          data: data,
+        });
+      };
     }
 
     const cId = criteriaId ?? criteria?.id;
     if (cId) {
-      return useCallback(
-        (data: object) => {
-          dispatch(
-            updateCriteriaData({
-              cohortId: cohort.id,
-              groupId: group.id,
-              criteriaId: cId,
-              data: data,
-            })
-          );
-        },
-        [cohort.id, group?.id, cId]
-      );
+      return (data: object) => {
+        updateCohortCriteria(cohortContext, group.id, cId, data);
+      };
     }
   }
 
   if (newCriteria) {
-    return useCallback(
-      (data: object) => {
-        dispatch(
-          insertConceptSet(underlay.name, { ...newCriteria, data: data })
-        );
-      },
-      [underlay, newCriteria]
-    );
+    if (!conceptSetContext) {
+      throw new Error("Null concept set context when creating a concept set.");
+    }
+
+    return (data: object) => {
+      createConceptSet(conceptSetContext, { ...newCriteria, data: data });
+    };
   }
 
   if (conceptSet) {
-    return useCallback(
-      (data: object) => {
-        dispatch(
-          updateConceptSetData({
-            conceptSetId: conceptSet.id,
-            data: data,
-          })
-        );
-      },
-      [conceptSet?.id]
-    );
+    if (!conceptSetContext) {
+      throw new Error("Null concept set context when updating a concept set.");
+    }
+
+    return (data: object) => {
+      updateConceptSet(conceptSetContext, data);
+    };
   }
 
   throw new Error(
@@ -193,9 +185,48 @@ export function useUpdateCriteria(criteriaId?: string) {
 }
 
 export function useUndoRedoUrls() {
-  const undoUrlPath = useAppSelector((state) => state.present.url);
-  const redoUrlPath = useAppSelector((state) =>
-    state.future.length > 0 ? state.future[0].url : ""
-  );
-  return [undoUrlPath, redoUrlPath];
+  const params = useBaseParams();
+  const context = useContext(CohortContext);
+
+  if (context?.state) {
+    const cohortURL = absoluteCohortURL(params, context.state.present.id);
+    return [
+      context.state.past.length > 0 ? cohortURL : "",
+      context.state.future.length > 0 ? cohortURL : "",
+    ];
+  }
+
+  return ["", ""];
+}
+
+export function useUndoAction() {
+  const context = useContext(CohortContext);
+
+  if (context?.state && context.state.past.length > 0) {
+    return () => {
+      context.updateState((state) => {
+        state.future.push(state.present);
+        state.present = state.past[state.past.length - 1];
+        state.past.pop();
+      });
+    };
+  }
+
+  return null;
+}
+
+export function useRedoAction() {
+  const context = useContext(CohortContext);
+
+  if (context?.state && context.state.future.length > 0) {
+    return () => {
+      context.updateState((state) => {
+        state.past.push(state.present);
+        state.present = state.future[state.future.length - 1];
+        state.future.pop();
+      });
+    };
+  }
+
+  return null;
 }

--- a/ui/src/newConceptSet.tsx
+++ b/ui/src/newConceptSet.tsx
@@ -11,7 +11,6 @@ export default function NewCriteria() {
     <CriteriaHolder
       title={`New ${criteria.config.title} Concept Set`}
       plugin={getCriteriaPlugin(criteria)}
-      defaultBackURL={exitURL(params)}
       doneURL={exitURL(params)}
     />
   );

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -16,20 +16,20 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
 import {
-  defaultFilter,
-  deleteCriteria,
-  deleteGroup,
-  insertGroup,
-  renameGroup,
-  setGroupFilter,
-} from "cohortsSlice";
+  deleteCohortCriteria,
+  deleteCohortGroup,
+  insertCohortGroup,
+  updateCohortGroup,
+  useCohortContext,
+} from "cohortContext";
+import { defaultFilter } from "cohortsSlice";
 import CohortToolbar from "cohortToolbar";
 import Empty from "components/empty";
 import Loading from "components/loading";
 import { useTextInputDialog } from "components/textInputDialog";
 import { useSource } from "data/source";
 import { DemographicCharts } from "demographicCharts";
-import { useAppDispatch, useCohort } from "hooks";
+import { useCohort } from "hooks";
 import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
 import { useCallback } from "react";
@@ -74,7 +74,7 @@ function GroupDivider() {
 }
 
 function GroupList() {
-  const dispatch = useAppDispatch();
+  const context = useCohortContext();
   const cohort = useCohort();
   const params = useBaseParams();
 
@@ -102,7 +102,7 @@ function GroupList() {
             <GroupDivider />
             <ListItem disableGutters key="" sx={{ p: 0 }}>
               <Button
-                onClick={() => dispatch(insertGroup(cohort.id))}
+                onClick={() => insertCohortGroup(context)}
                 variant="contained"
               >
                 Add group
@@ -121,7 +121,7 @@ function ParticipantsGroup(props: {
 }) {
   const source = useSource();
   const cohort = useCohort();
-  const dispatch = useAppDispatch();
+  const context = useCohortContext();
   const navigate = useNavigate();
 
   const fetchGroupCount = useCallback(async () => {
@@ -158,13 +158,7 @@ function ParticipantsGroup(props: {
     textLabel: "Group name",
     buttonLabel: "Rename group",
     onConfirm: (name: string) => {
-      dispatch(
-        renameGroup({
-          cohortId: cohort.id,
-          groupId: props.group.id,
-          groupName: name,
-        })
-      );
+      updateCohortGroup(context, props.group.id, name);
     },
   });
 
@@ -182,12 +176,10 @@ function ParticipantsGroup(props: {
               <Select
                 value={props.group.filter.excluded ? 1 : 0}
                 onChange={(event: SelectChangeEvent<number>) => {
-                  dispatch(
-                    setGroupFilter(cohort.id, props.group.id, {
-                      ...props.group.filter,
-                      excluded: event.target.value === 1,
-                    })
-                  );
+                  updateCohortGroup(context, props.group.id, undefined, {
+                    ...props.group.filter,
+                    excluded: event.target.value === 1,
+                  });
                 }}
               >
                 <MenuItem value={0}>Must</MenuItem>
@@ -199,12 +191,10 @@ function ParticipantsGroup(props: {
               <Select
                 value={props.group.filter.kind}
                 onChange={(event: SelectChangeEvent<string>) => {
-                  dispatch(
-                    setGroupFilter(cohort.id, props.group.id, {
-                      ...props.group.filter,
-                      kind: event.target.value as tanagra.GroupFilterKindEnum,
-                    })
-                  );
+                  updateCohortGroup(context, props.group.id, undefined, {
+                    ...props.group.filter,
+                    kind: event.target.value as tanagra.GroupFilterKindEnum,
+                  });
                 }}
               >
                 <MenuItem value={tanagra.GroupFilterKindEnum.Any}>any</MenuItem>
@@ -225,10 +215,7 @@ function ParticipantsGroup(props: {
             {renameGroupDialog}
             <IconButton
               onClick={() => {
-                const action = dispatch(deleteGroup(cohort, props.group.id));
-                navigate(
-                  "../" + cohortURL(cohort.id, action.payload.nextGroupId)
-                );
+                deleteCohortGroup(context, props.group.id);
               }}
             >
               <DeleteIcon />
@@ -289,7 +276,7 @@ function ParticipantCriteria(props: {
 }) {
   const source = useSource();
   const cohort = useCohort();
-  const dispatch = useAppDispatch();
+  const context = useCohortContext();
 
   const fetchCriteriaCount = useCallback(async () => {
     const cohortForFilter: tanagra.Cohort = {
@@ -346,13 +333,7 @@ function ParticipantCriteria(props: {
           )}
           <IconButton
             onClick={() => {
-              dispatch(
-                deleteCriteria({
-                  cohortId: cohort.id,
-                  groupId: props.group.id,
-                  criteriaId: props.criteria.id,
-                })
-              );
+              deleteCohortCriteria(context, props.group.id, props.criteria.id);
             }}
           >
             <DeleteIcon fontSize="small" sx={{ mt: "-3px" }} />

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,7 +1,9 @@
 import Button from "@mui/material/Button";
 import { AddCriteria } from "addCriteria";
 import { CohortReviewList } from "cohortReview/cohortReviewList";
+import CohortRoot from "cohortRoot";
 import ConceptSetEdit from "conceptSetEdit";
+import ConceptSetRoot from "conceptSetRoot";
 import Edit from "edit";
 import NewConceptSet from "newConceptSet";
 import NewCriteria from "newCriteria";
@@ -28,38 +30,48 @@ export function createAppRouter() {
       element: <Outlet />,
       children: [
         {
-          path: "cohorts/:cohortId/:groupId",
+          element: <CohortRoot />,
           children: [
             {
-              index: true,
-              element: <Overview />,
-            },
-            {
-              path: "add",
+              path: "cohorts/:cohortId/:groupId",
               children: [
                 {
                   index: true,
-                  element: <AddCriteria />,
+                  element: <Overview />,
                 },
                 {
-                  path: ":configId",
-                  element: <NewCriteria />,
+                  path: "add",
+                  children: [
+                    {
+                      index: true,
+                      element: <AddCriteria />,
+                    },
+                    {
+                      path: ":configId",
+                      element: <NewCriteria />,
+                    },
+                  ],
+                },
+                {
+                  path: "edit/:criteriaId",
+                  element: <Edit />,
                 },
               ],
-            },
-            {
-              path: "edit/:criteriaId",
-              element: <Edit />,
             },
           ],
         },
         {
-          path: "conceptSets/new/:configId",
-          element: <NewConceptSet />,
-        },
-        {
-          path: "conceptSets/edit/:conceptSetId",
-          element: <ConceptSetEdit />,
+          element: <ConceptSetRoot />,
+          children: [
+            {
+              path: "conceptSets/new/:configId",
+              element: <NewConceptSet />,
+            },
+            {
+              path: "conceptSets/edit/:conceptSetId",
+              element: <ConceptSetEdit />,
+            },
+          ],
         },
         {
           path: "review/:cohortId",

--- a/ui/src/studiesList.tsx
+++ b/ui/src/studiesList.tsx
@@ -67,7 +67,13 @@ export function StudiesList() {
                           {study.created.toLocaleString()}
                         </Typography>
                       </Stack>
-                      <IconButton onClick={() => onDeleteStudy(study.id)}>
+                      <IconButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          onDeleteStudy(study.id);
+                        }}
+                      >
                         <DeleteIcon />
                       </IconButton>
                     </Stack>


### PR DESCRIPTION
* The cohort/concept set currently being edited are stored in context to be available where necessary, similar to how they used to be available from redux.
* Adds intermediate routing nodes that inject the appropriate contexts across all cohort/concept set children.
* Removes dependencies on redux except for underlays, which will be similarly removed in a future PR.
* Adds the ability to set the criteria of a concept set during creation.
* Integration tests are changed to use real backends because mocking the necessary backend APIs within the current framework is impractical. A future PR will remove the fakes and potentially augment or replace the backend with Cypress or MSW based tests.