### PR TITLE
Rename concept sets to data features

### DIFF
--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -45,6 +45,7 @@ export function AddConceptSetCriteria() {
   return (
     <AddCriteria
       conceptSet
+      title="New data feature"
       backURL={backURL}
       onInsertCriteria={onInsertCriteria}
     />
@@ -64,11 +65,14 @@ export function AddCohortCriteria() {
     [context, cohort.id, group.id]
   );
 
-  return <AddCriteria onInsertCriteria={onInsertCriteria} />;
+  return (
+    <AddCriteria title="Add criteria" onInsertCriteria={onInsertCriteria} />
+  );
 }
 
 type AddCriteriaProps = {
   conceptSet?: boolean;
+  title: string;
   backURL?: string;
   onInsertCriteria: (criteria: tanagra.Criteria) => void;
 };
@@ -186,7 +190,7 @@ function AddCriteria(props: AddCriteriaProps) {
     >
       <Search placeholder="Search criteria or select from the options below" />
       <ActionBar
-        title={"Add criteria"}
+        title={props.title}
         extraControls={!props.conceptSet ? <CohortToolbar /> : undefined}
         backURL={props.backURL}
       />

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -264,7 +264,7 @@ class FakeConceptSetsAPI {
         id: "test_concept_set",
         created: new Date(),
         createdBy: "test_user",
-        displayName: "Test Concept Set",
+        displayName: "Test data feature",
         lastModified: new Date(),
         underlayName: "test_underlay",
         entity: "test_entity",

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -225,7 +225,7 @@ export function Datasets() {
           >
             <Stack>
               <Typography variant="h4" sx={{ flexGrow: 1 }}>
-                2. Select concept sets
+                2. Select data features
               </Typography>
               <Typography variant="body1">
                 Which information to include about participants
@@ -310,7 +310,7 @@ export function Datasets() {
               <Empty
                 maxWidth="80%"
                 title="No inputs selected"
-                subtitle="You can view the available values by selecting at least one cohort and concept set"
+                subtitle="You can view the available values by selecting at least one cohort and data feature"
               />
             )}
             {conceptSetOccurrences.map((occurrence) => (
@@ -362,7 +362,7 @@ export function Datasets() {
                 minHeight="200px"
                 image="/empty.png"
                 title="No inputs selected"
-                subtitle="You can preview the data by selecting at least one cohort and concept set"
+                subtitle="You can preview the data by selecting at least one cohort and data feature"
               />
             )}
           </Paper>
@@ -567,7 +567,7 @@ function Preview(props: PreviewProps) {
                 minHeight="200px"
                 image="/empty.png"
                 title="No data matched"
-                subtitle="No data in this table matched the specified cohorts ands concept sets"
+                subtitle="No data in this table matched the specified cohorts and data features"
               />
             )}
           </div>

--- a/ui/src/newConceptSet.tsx
+++ b/ui/src/newConceptSet.tsx
@@ -9,7 +9,7 @@ export default function NewCriteria() {
 
   return (
     <CriteriaHolder
-      title={`New ${criteria.config.title} Concept Set`}
+      title={`New "${criteria.config.title}" data feature`}
       plugin={getCriteriaPlugin(criteria)}
       doneURL={exitURL(params)}
     />

--- a/ui/src/newCriteria.tsx
+++ b/ui/src/newCriteria.tsx
@@ -7,7 +7,7 @@ export default function NewCriteria() {
 
   return (
     <CriteriaHolder
-      title={`New ${criteria.config.title} Criteria`}
+      title={`New "${criteria.config.title}" criteria`}
       plugin={getCriteriaPlugin(criteria)}
       doneURL={"../.."}
       cohort


### PR DESCRIPTION
For now this only affects user visible strings. Naming is not final but "concept sets" is confusing during demos.