### PR TITLE
Boilerplate for Nightly tests GHA

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -1,0 +1,42 @@
+# Run EXPAND_CONFIG, INDEX_ALL every night. Even if there are no commits, this will
+# run every night and catch problems.
+name: Nightly tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up AdoptOpenJDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: 'temurin'
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+        restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+    - name: Pull credentials
+      id: pull_credentials
+      run: |
+        # For security reasons, Broad prefers we read GHA secrets instead of reading from vault.
+        # This step does the equivalent of the pull-credentials.sh script.
+        # On local machines, the script fetches a SA from Vault.
+        # In GH actions, the SA key is stored in a GH repo secret.
+        # Regardless of how it was fetched, tests and scripts expect these
+        # keys to be stored in rendered/.
+        mkdir -p rendered/broad/
+        echo "$TEST_PROJECT_SA_KEY" > rendered/broad/tanagra_sa.json
+      env:
+        TEST_PROJECT_SA_KEY: ${{ secrets.TEST_PROJECT_SA_KEY }}

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -3,11 +3,9 @@
 name: Nightly tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ '**' ]
   workflow_dispatch:
+  schedule:
+  - cron: '0 7 * * *' # 7AM UTC = 2AM EST
 
 jobs:
   test:


### PR DESCRIPTION
This GHA will run EXPAND_CONFIG, INDEX_ALL every night. Even if there are no commits, this will run every night and catch problems.