### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/actions/bump-skip/action.yaml
+++ b/.github/actions/bump-skip/action.yaml
@@ -23,5 +23,5 @@ runs:
           IS_BUMP=yes
         fi
         echo "IS_BUMP=$IS_BUMP"
-        echo ::set-output name=is-bump::$IS_BUMP
+        echo is-bump=$IS_BUMP >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -20,7 +20,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/service-test.yaml
+++ b/.github/workflows/service-test.yaml
@@ -36,7 +36,7 @@ jobs:
           PGPASSWORD: postgres
         run: psql -h 127.0.0.1 -U postgres -f ./service/local-dev/local-postgres-init.sql
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/service-test.yaml
+++ b/.github/workflows/service-test.yaml
@@ -25,7 +25,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: psql -h 127.0.0.1 -U postgres -f ./service/local-dev/local-postgres-init.sql
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -81,14 +81,14 @@ jobs:
       # thus we store screenshots only on failures
       # Alternative: create and commit an empty cypress/screenshots folder
       # to always have something to upload
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: ui/cypress/screenshots
 
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up AdoptOpenJDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -20,7 +20,7 @@ jobs:
         node-version: [15.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/underlay-test.yaml
+++ b/.github/workflows/underlay-test.yaml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/underlay-test.yaml
+++ b/.github/workflows/underlay-test.yaml
@@ -20,7 +20,7 @@ jobs:
           java-version: 11
           distribution: 'temurin'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up AdoptOpenJDK 11
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- use actions/cache@v3 instead of v2
- use actions/upload-artifact@v3 instead of v2
- use setup-node@v3 instead of v2
- replace 'set-output' command