### PR TITLE
Make annotation_value PK id -> review + id.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -9,14 +9,7 @@ import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT_REVIEW
 
 import bio.terra.tanagra.app.auth.SpringAuthentication;
 import bio.terra.tanagra.generated.controller.AnnotationsV2Api;
-import bio.terra.tanagra.generated.model.ApiAnnotationCreateInfoV2;
-import bio.terra.tanagra.generated.model.ApiAnnotationListV2;
-import bio.terra.tanagra.generated.model.ApiAnnotationUpdateInfoV2;
-import bio.terra.tanagra.generated.model.ApiAnnotationV2;
-import bio.terra.tanagra.generated.model.ApiAnnotationValueCreateUpdateInfoV2;
-import bio.terra.tanagra.generated.model.ApiAnnotationValueV2;
-import bio.terra.tanagra.generated.model.ApiDataTypeV2;
-import bio.terra.tanagra.generated.model.ApiExportFile;
+import bio.terra.tanagra.generated.model.*;
 import bio.terra.tanagra.query.Literal;
 import bio.terra.tanagra.service.AccessControlService;
 import bio.terra.tanagra.service.AnnotationService;
@@ -148,12 +141,13 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
       String cohortId,
       String annotationId,
       String reviewId,
-      ApiAnnotationValueCreateUpdateInfoV2 body) {
+      ApiAnnotationValueCreateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
         SpringAuthentication.getCurrentUser(), UPDATE, COHORT_REVIEW, new ResourceId(reviewId));
 
-    // Generate a random 10-character alphanumeric string for the new annotation value ID.
-    String newAnnotationValueId = RandomStringUtils.randomAlphanumeric(10);
+    // If the caller did not specify the annotation value id, then default to the entity instance
+    // id.
+    String newAnnotationValueId = body.getId() == null ? body.getInstanceId() : body.getId();
 
     AnnotationValue annotationValueToCreate =
         AnnotationValue.builder()
@@ -186,7 +180,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
       String annotationId,
       String reviewId,
       String valueId,
-      ApiAnnotationValueCreateUpdateInfoV2 body) {
+      ApiLiteralV2 body) {
     accessControlService.throwIfUnauthorized(
         SpringAuthentication.getCurrentUser(), UPDATE, COHORT_REVIEW, new ResourceId(reviewId));
     AnnotationValue updatedAnnotationValue =
@@ -196,7 +190,7 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
             annotationId,
             reviewId,
             valueId,
-            FromApiConversionService.fromApiObject(body.getValue()));
+            FromApiConversionService.fromApiObject(body));
     return ResponseEntity.ok(ToApiConversionUtils.toApiObject(updatedAnnotationValue));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/db/AnnotationValueDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/AnnotationValueDao.java
@@ -108,10 +108,12 @@ public class AnnotationValueDao {
       String reviewId,
       String annotationValueId) {
     final String sql =
-        "DELETE FROM annotation_value WHERE annotation_value_id = :annotation_value_id";
+        "DELETE FROM annotation_value WHERE review_id = :review_id AND annotation_value_id = :annotation_value_id";
 
     MapSqlParameterSource params =
-        new MapSqlParameterSource().addValue("annotation_value_id", annotationValueId);
+        new MapSqlParameterSource()
+            .addValue("annotation_value_id", annotationValueId)
+            .addValue("review_id", reviewId);
     int rowsAffected = jdbcTemplate.update(sql, params);
     boolean deleted = rowsAffected > 0;
 

--- a/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
@@ -166,6 +166,27 @@ public class AnnotationService {
         studyId, cohortRevisionGroupId, annotationId, reviewId, annotationValueId);
   }
 
+  /** Create or update an annotation value. Only the annotation value's literal can be updated. */
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  public AnnotationValue createUpdateAnnotationValue(
+      String studyId,
+      String cohortRevisionGroupId,
+      String annotationId,
+      String reviewId,
+      AnnotationValue annotationValue) {
+    featureConfiguration.artifactStorageEnabledCheck();
+    validateAnnotationValueDataType(
+        studyId, cohortRevisionGroupId, annotationId, annotationValue.getLiteral());
+    annotationValueDao.createUpdateAnnotationValue(
+        studyId, cohortRevisionGroupId, annotationId, reviewId, annotationValue);
+    return annotationValueDao.getAnnotationValue(
+        studyId,
+        cohortRevisionGroupId,
+        annotationId,
+        reviewId,
+        annotationValue.getAnnotationValueId());
+  }
+
   /** Retrieves a list of all annotation values for a review. */
   public List<AnnotationValue> getAnnotationValues(String reviewId) {
     featureConfiguration.artifactStorageEnabledCheck();

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -728,7 +728,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AnnotationValueCreateUpdateInfoV2"
+              $ref: "#/components/schemas/AnnotationValueCreateInfoV2"
       responses:
         200:
           description: OK
@@ -755,7 +755,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AnnotationValueCreateUpdateInfoV2'
+              $ref: '#/components/schemas/LiteralV2'
       responses:
         200:
           description: OK
@@ -2114,9 +2114,12 @@ components:
         - value
         - review
 
-    AnnotationValueCreateUpdateInfoV2:
+    AnnotationValueCreateInfoV2:
       type: object
       properties:
+        id:
+          description: ID of the annotation value, immutable. Defaults to the entity instance id.
+          type: string
         instanceId:
           description: ID of the entity instance this annotation value is associated with
           type: string
@@ -2130,7 +2133,8 @@ components:
       type: object
       properties:
         attributes:
-          description: A map of entity attribute names to their value for this instance
+          description: |
+            A map of entity attribute names to their value for this instance. The id attribute will always be included.
           type: object
           additionalProperties:
             type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -713,32 +713,6 @@ paths:
         500:
           $ref: '#/components/responses/ServerError'
 
-  "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/reviews/{reviewId}/values":
-    parameters:
-      - $ref: '#/components/parameters/StudyIdV2'
-      - $ref: '#/components/parameters/CohortIdV2'
-      - $ref: '#/components/parameters/AnnotationIdV2'
-      - $ref: '#/components/parameters/ReviewIdV2'
-    post:
-      summary: Create a new annotation value
-      operationId: createAnnotationValue
-      tags: [AnnotationsV2]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AnnotationValueCreateInfoV2"
-      responses:
-        200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnnotationValueV2"
-        500:
-          $ref: "#/components/responses/ServerError"
-
   "/v2/studies/{studyId}/cohorts/{cohortId}/annotations/{annotationId}/reviews/{reviewId}/values/{valueId}":
     parameters:
       - $ref: '#/components/parameters/StudyIdV2'
@@ -746,9 +720,9 @@ paths:
       - $ref: '#/components/parameters/AnnotationIdV2'
       - $ref: '#/components/parameters/ReviewIdV2'
       - $ref: '#/components/parameters/AnnotationValueIdV2'
-    patch:
-      summary: Update an existing annotation value
-      operationId: updateAnnotationValue
+    post:
+      summary: Create or update an annotation value
+      operationId: createUpdateAnnotationValue
       tags: [AnnotationsV2]
       requestBody:
         required: true
@@ -2117,9 +2091,6 @@ components:
     AnnotationValueCreateInfoV2:
       type: object
       properties:
-        id:
-          description: ID of the annotation value, immutable. Defaults to the entity instance id.
-          type: string
         instanceId:
           description: ID of the entity instance this annotation value is associated with
           type: string

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2088,18 +2088,6 @@ components:
         - value
         - review
 
-    AnnotationValueCreateInfoV2:
-      type: object
-      properties:
-        instanceId:
-          description: ID of the entity instance this annotation value is associated with
-          type: string
-        value:
-          $ref: "#/components/schemas/LiteralV2"
-      required:
-        - instanceId
-        - value
-
     ReviewInstanceV2:
       type: object
       properties:

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -7,4 +7,5 @@
     <include file="changesets/20221202_annotation_value_table.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20221215_annotation_value_instance_col.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20221219_created_columns.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230331_annotation_value_pk.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230331_annotation_value_pk.yaml
+++ b/service/src/main/resources/db/changesets/20230331_annotation_value_pk.yaml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+  - changeSet:
+      id: annotation_value_pk
+      author: marikomedlock
+      changes:
+        - dropPrimaryKey:
+            tableName: annotation_value
+        - addUniqueConstraint:
+            tableName: annotation_value
+            columnNames: review_id, annotation_value_id

--- a/service/src/main/resources/db/changesets/20230331_annotation_value_pk.yaml
+++ b/service/src/main/resources/db/changesets/20230331_annotation_value_pk.yaml
@@ -6,5 +6,6 @@ databaseChangeLog:
         - dropPrimaryKey:
             tableName: annotation_value
         - addUniqueConstraint:
+            constraintName: pk_annotation_value
             tableName: annotation_value
             columnNames: review_id, annotation_value_id


### PR DESCRIPTION
- Merged the annotation value create + update endpoints, and forced the annotation value id = entity instance id.
- The update annotation value endpoint now only allows the caller to update the literal value itself. Previously, it also allowed updating the entity instance id, but I think it's less confusing to just delete and create a new one, in that case.
- Changed the primary key of the annotation value table from just the `annotation_value_id` field, to `annotation_value_id + review_id`. This accommodates the caller specifying the `annotation_value_id` without requiring it to be unique across all reviews.