### PR TITLE
Groundwork for modifiers and source hierarchies

### DIFF
--- a/ui/src/cohortReview/cohortReview.tsx
+++ b/ui/src/cohortReview/cohortReview.tsx
@@ -176,7 +176,7 @@ export function CohortReview() {
             id,
             {
               type: FilterType.Attribute,
-              occurrenceID: "",
+              occurrenceId: "",
               attribute: "id",
               values: [instance?.data?.[primaryKey]],
             },

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -101,14 +101,13 @@ class _ implements CriteriaPlugin<Data> {
   generateFilter() {
     return {
       type: FilterType.Attribute,
-      occurrenceID: "",
       attribute: this.config.attribute,
       values: this.data.selected?.map(({ value }) => value),
       ranges: this.data.dataRanges,
     };
   }
 
-  occurrenceID() {
+  filterOccurrenceId() {
     return "";
   }
 }

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -121,13 +121,13 @@ class _ implements CriteriaPlugin<Data> {
   generateFilter() {
     return {
       type: FilterType.Classification,
-      occurrenceID: this.config.occurrence,
-      classificationID: this.config.classification,
+      occurrenceId: this.config.occurrence,
+      classificationId: this.config.classification,
       keys: this.data.selected.map(({ key }) => key),
     };
   }
 
-  occurrenceID() {
+  filterOccurrenceId() {
     return this.config.occurrence;
   }
 }

--- a/ui/src/criteria/textSearch.tsx
+++ b/ui/src/criteria/textSearch.tsx
@@ -95,20 +95,18 @@ class _ implements CriteriaPlugin<Data> {
     return makeArrayFilter({}, [
       {
         type: FilterType.Text,
-        occurrenceID: this.config.occurrenceId,
         attribute: this.config.searchAttribute,
         text: this.data.query,
       },
       {
         type: FilterType.Attribute,
-        occurrenceID: this.config.occurrenceId,
         attribute: this.config.searchAttribute,
         values: this.data.categories.map((c) => c.value),
       },
     ]);
   }
 
-  occurrenceID() {
+  filterOccurrenceId() {
     return this.config.occurrenceId;
   }
 }

--- a/ui/src/data/filter.ts
+++ b/ui/src/data/filter.ts
@@ -7,6 +7,7 @@ export enum FilterType {
   Classification = "CLASSIFICATION",
   Attribute = "ATTRIBUTE",
   Text = "TEXT",
+  Relationship = "RELATIONSHIP",
 }
 
 type BaseFilter = {
@@ -59,7 +60,6 @@ export function makeArrayFilter(
 }
 
 export type AttributeFilter = BaseFilter & {
-  occurrenceID: string;
   attribute: string;
   values?: DataValue[];
   ranges?: { min: number; max: number }[];
@@ -70,7 +70,6 @@ export function isAttributeFilter(filter: Filter): filter is AttributeFilter {
 }
 
 export type TextFilter = BaseFilter & {
-  occurrenceID: string;
   text: string;
   attribute?: string;
 };
@@ -79,9 +78,20 @@ export function isTextFilter(filter: Filter): filter is TextFilter {
   return filter.type == FilterType.Text;
 }
 
+export type RelationshipFilter = BaseFilter & {
+  entityId: string;
+  subfilter: Filter;
+};
+
+export function isRelationshipFilter(
+  filter: Filter
+): filter is RelationshipFilter {
+  return filter.type == FilterType.Relationship;
+}
+
 export type ClassificationFilter = BaseFilter & {
-  occurrenceID: string;
-  classificationID: string;
+  occurrenceId: string;
+  classificationId: string;
   keys: DataKey[];
 };
 
@@ -96,4 +106,5 @@ export type Filter =
   | ArrayFilter
   | AttributeFilter
   | ClassificationFilter
-  | TextFilter;
+  | TextFilter
+  | RelationshipFilter;

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -397,7 +397,12 @@ function useConceptSetOccurrences(
       ?.filter((cs) => selectedConceptSets.has(cs.id))
       ?.forEach((conceptSet) => {
         const plugin = getCriteriaPlugin(conceptSet.criteria);
-        addFilter(plugin.occurrenceID(), plugin.generateFilter());
+        const occurrenceIds = plugin.outputOccurrenceIds?.() ?? [
+          plugin.filterOccurrenceId(),
+        ];
+        occurrenceIds.forEach((o) => {
+          addFilter(o, plugin.generateFilter());
+        });
       });
 
     return Array.from(occurrences)


### PR DESCRIPTION
* Differentiate between criteria occurrences used for filters and those used for outputs to allow for multiple outputs or outputs from alternate hierarchies.
* Separate relationship filters into their own object. This allow on relationship filter to apply to a set of criteria (i.e. modifiers).
* Temporarily insert relationship filters based on each criteria until CriteriaGroups are ready.