### PR TITLE
Clean up table header rendering

### DIFF
--- a/ui/src/cohortReview/plugins/occurrenceTable.tsx
+++ b/ui/src/cohortReview/plugins/occurrenceTable.tsx
@@ -58,7 +58,6 @@ function OccurrenceTable({ config }: { config: Config }) {
     <GridBox
       sx={{
         width: "100%",
-        p: 1,
       }}
     >
       <TreeGrid columns={config.columns} data={data} />

--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -1,29 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table renders correctly 1`] = `
-Array [
+<div
+  className="css-o1f3wd"
+>
   <table
     style={
       Object {
+        "borderCollapse": "collapse",
         "tableLayout": "fixed",
+        "textAlign": "left",
         "width": "100%",
       }
     }
   >
-    <thead
-      style={
-        Object {
-          "display": "block",
-        }
-      }
-    >
+    <thead>
       <tr>
-        <td
+        <th
           style={
             Object {
+              "backgroundColor": "#fff",
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
               "maxWidth": "100%",
               "minWidth": "100%",
+              "position": "sticky",
+              "top": 0,
               "width": "100%",
+              "zIndex": 1,
             }
           }
         >
@@ -37,13 +40,18 @@ Array [
               Column 1
             </span>
           </div>
-        </td>
-        <td
+        </th>
+        <th
           style={
             Object {
+              "backgroundColor": "#fff",
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
               "maxWidth": 150,
               "minWidth": 150,
+              "position": "sticky",
+              "top": 0,
               "width": 150,
+              "zIndex": 1,
             }
           }
         >
@@ -57,13 +65,18 @@ Array [
               Column 2
             </span>
           </div>
-        </td>
-        <td
+        </th>
+        <th
           style={
             Object {
+              "backgroundColor": "#fff",
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
               "maxWidth": 50,
               "minWidth": 50,
+              "position": "sticky",
+              "top": 0,
               "width": 50,
+              "zIndex": 1,
             }
           }
         >
@@ -87,299 +100,278 @@ Array [
               </svg>
             </span>
           </div>
-        </td>
+        </th>
       </tr>
     </thead>
-  </table>,
-  <hr
-    className="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-  />,
-  <div
-    style={
-      Object {
-        "display": "inline-block",
-        "overflowY": "auto",
-      }
-    }
-  >
-    <table
-      style={
-        Object {
-          "tableLayout": "fixed",
-          "width": "100%",
-        }
-      }
-    >
-      <tbody>
-        <tr
-          style={Object {}}
-        >
-          <td
-            style={
-              Object {
-                "maxWidth": "100%",
-                "minWidth": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div
-              className="MuiStack-root css-1sg8hwy-MuiStack-root"
-            >
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex={0}
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                  data-testid="KeyboardArrowRightIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
-                  />
-                </svg>
-              </button>
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="1-col1"
-              >
-                1-col1
-              </p>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "maxWidth": 150,
-                "minWidth": 150,
-                "width": 150,
-              }
-            }
-          >
-            <div
-              className="MuiStack-root css-1d9cypr-MuiStack-root"
-            >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="1-col2"
-              >
-                1-col2
-              </p>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "maxWidth": 50,
-                "minWidth": 50,
-                "width": 50,
-              }
-            }
-          >
-            <div
-              className="MuiStack-root css-1d9cypr-MuiStack-root"
-            >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title=""
-              >
-                
-              </p>
-            </div>
-          </td>
-        </tr>
-        <tr
+    <tbody>
+      <tr
+        style={Object {}}
+      >
+        <td
           style={
             Object {
-              "visibility": "collapse",
+              "maxWidth": "100%",
+              "minWidth": "100%",
+              "width": "100%",
             }
           }
         >
-          <td
-            style={
-              Object {
-                "maxWidth": "100%",
-                "minWidth": "100%",
-                "width": "100%",
-              }
-            }
+          <div
+            className="MuiStack-root css-1sg8hwy-MuiStack-root"
           >
-            <div
-              className="MuiStack-root css-kv8qlv-MuiStack-root"
+            <button
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
             >
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-                disabled={false}
-                onBlur={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                tabIndex={0}
-                type="button"
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="KeyboardArrowRightIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                  data-testid="CheckBoxIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                  />
-                </svg>
-              </button>
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="2-col1"
-              >
-                2-col1
-              </p>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "maxWidth": 150,
-                "minWidth": 150,
-                "width": 150,
-              }
+                <path
+                  d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"
+                />
+              </svg>
+            </button>
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="1-col1"
+            >
+              1-col1
+            </p>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "maxWidth": 150,
+              "minWidth": 150,
+              "width": 150,
             }
-          >
-            <div
-              className="MuiStack-root css-1d9cypr-MuiStack-root"
-            >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="2-col2"
-              >
-                2-col2
-              </p>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "maxWidth": 50,
-                "minWidth": 50,
-                "width": 50,
-              }
-            }
-          >
-            <div
-              className="MuiStack-root css-1d9cypr-MuiStack-root"
-            >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="2-col3"
-              >
-                2-col3
-              </p>
-            </div>
-          </td>
-        </tr>
-        <tr
-          style={Object {}}
+          }
         >
-          <td
-            style={
-              Object {
-                "maxWidth": "100%",
-                "minWidth": "100%",
-                "width": "100%",
-              }
-            }
+          <div
+            className="MuiStack-root css-1d9cypr-MuiStack-root"
           >
-            <div
-              className="MuiStack-root css-1sg8hwy-MuiStack-root"
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="1-col2"
             >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="3-col1"
-              >
-                3-col1
-              </p>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "maxWidth": 150,
-                "minWidth": 150,
-                "width": 150,
-              }
+              1-col2
+            </p>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "maxWidth": 50,
+              "minWidth": 50,
+              "width": 50,
             }
+          }
+        >
+          <div
+            className="MuiStack-root css-1d9cypr-MuiStack-root"
           >
-            <div
-              className="MuiStack-root css-1d9cypr-MuiStack-root"
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title=""
             >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title="3-col2"
-              >
-                3-col2
-              </p>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "maxWidth": 50,
-                "minWidth": 50,
-                "width": 50,
-              }
+              
+            </p>
+          </div>
+        </td>
+      </tr>
+      <tr
+        style={
+          Object {
+            "visibility": "collapse",
+          }
+        }
+      >
+        <td
+          style={
+            Object {
+              "maxWidth": "100%",
+              "minWidth": "100%",
+              "width": "100%",
             }
+          }
+        >
+          <div
+            className="MuiStack-root css-kv8qlv-MuiStack-root"
           >
-            <div
-              className="MuiStack-root css-1d9cypr-MuiStack-root"
+            <button
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+              disabled={false}
+              onBlur={[Function]}
+              onContextMenu={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
             >
-              <p
-                className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
-                title=""
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="CheckBoxIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                  data-testid="AccountTreeIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
-                  />
-                </svg>
-              </p>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>,
-]
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </button>
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="2-col1"
+            >
+              2-col1
+            </p>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "maxWidth": 150,
+              "minWidth": 150,
+              "width": 150,
+            }
+          }
+        >
+          <div
+            className="MuiStack-root css-1d9cypr-MuiStack-root"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="2-col2"
+            >
+              2-col2
+            </p>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "maxWidth": 50,
+              "minWidth": 50,
+              "width": 50,
+            }
+          }
+        >
+          <div
+            className="MuiStack-root css-1d9cypr-MuiStack-root"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="2-col3"
+            >
+              2-col3
+            </p>
+          </div>
+        </td>
+      </tr>
+      <tr
+        style={Object {}}
+      >
+        <td
+          style={
+            Object {
+              "maxWidth": "100%",
+              "minWidth": "100%",
+              "width": "100%",
+            }
+          }
+        >
+          <div
+            className="MuiStack-root css-1sg8hwy-MuiStack-root"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="3-col1"
+            >
+              3-col1
+            </p>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "maxWidth": 150,
+              "minWidth": 150,
+              "width": 150,
+            }
+          }
+        >
+          <div
+            className="MuiStack-root css-1d9cypr-MuiStack-root"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title="3-col2"
+            >
+              3-col2
+            </p>
+          </div>
+        </td>
+        <td
+          style={
+            Object {
+              "maxWidth": 50,
+              "minWidth": 50,
+              "width": 50,
+            }
+          }
+        >
+          <div
+            className="MuiStack-root css-1d9cypr-MuiStack-root"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1 css-rxttw8-MuiTypography-root"
+              title=""
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                data-testid="AccountTreeIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
+                />
+              </svg>
+            </p>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -3,11 +3,12 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
-import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import { GridBox } from "layout/gridBox";
 import { ReactNode, useEffect, useRef } from "react";
 import { useImmer } from "use-immer";
 
@@ -57,11 +58,13 @@ export type TreeGridProps = {
     data: TreeGridRowData
   ) => ColumnCustomization[] | undefined;
   loadChildren?: (id: TreeGridId) => Promise<void>;
-  variableWidth?: boolean;
+  minWidth?: boolean;
   wrapBodyText?: boolean;
 };
 
 export function TreeGrid(props: TreeGridProps) {
+  const theme = useTheme();
+
   const [state, updateState] = useImmer<TreeGridState>(
     new Map<TreeGridId, TreeGridItemState>()
   );
@@ -126,29 +129,35 @@ export function TreeGrid(props: TreeGridProps) {
     }
   }, [props.defaultExpanded]);
 
+  const paperColor = theme.palette.background.paper;
+  const dividerColor = theme.palette.divider;
+
   return (
-    <>
+    <GridBox sx={{ overflowY: "auto", px: 1 }}>
       <table
         style={{
           tableLayout: "fixed",
-          ...(!props.variableWidth ? { width: "100%" } : undefined),
+          ...(props.minWidth ? { minWidth: "100%" } : { width: "100%" }),
+          textAlign: "left",
+          borderCollapse: "collapse",
         }}
       >
-        <thead
-          style={{
-            display: "block",
-          }}
-        >
+        <thead>
           <tr>
             {props.columns.map((col, i) => (
-              <td
+              <th
                 key={i}
                 style={{
+                  position: "sticky",
+                  top: 0,
                   ...(col.width && {
                     maxWidth: col.width,
                     width: col.width,
                     minWidth: col.width,
                   }),
+                  backgroundColor: paperColor,
+                  boxShadow: `inset 0 -1px 0 ${dividerColor}`,
+                  zIndex: 1,
                 }}
               >
                 <Box
@@ -168,38 +177,23 @@ export function TreeGrid(props: TreeGridProps) {
                     {col.title}
                   </Typography>
                 </Box>
-              </td>
+              </th>
             ))}
           </tr>
         </thead>
+        <tbody>
+          {renderChildren(
+            props,
+            state,
+            (id: TreeGridId) =>
+              updateState((draft) => toggleExpanded(draft, id)),
+            "root",
+            0,
+            false
+          )}
+        </tbody>
       </table>
-      <Divider />
-      <div
-        style={{
-          overflowY: "auto",
-          display: "inline-block",
-        }}
-      >
-        <table
-          style={{
-            tableLayout: "fixed",
-            width: "100%",
-          }}
-        >
-          <tbody>
-            {renderChildren(
-              props,
-              state,
-              (id: TreeGridId) =>
-                updateState((draft) => toggleExpanded(draft, id)),
-              "root",
-              0,
-              false
-            )}
-          </tbody>
-        </table>
-      </div>
-    </>
+    </GridBox>
   );
 }
 

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -1,5 +1,4 @@
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
-import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import { CriteriaPlugin, registerCriteriaPlugin } from "cohort";
@@ -25,6 +24,8 @@ import {
 import { DataEntry, DataKey } from "data/types";
 import { useUpdateCriteria } from "hooks";
 import produce from "immer";
+import { GridBox } from "layout/gridBox";
+import GridLayout from "layout/gridLayout";
 import React, { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import useSWRImmutable from "swr/immutable";
@@ -273,172 +274,172 @@ function ClassificationEdit(props: ClassificationEditProps) {
   const nameColumnIndex = props.config.nameColumnIndex ?? 0;
 
   return (
-    <Box
+    <GridBox
       sx={{
-        p: 1,
-        minHeight: "100%",
         backgroundColor: (theme) => theme.palette.background.paper,
       }}
     >
-      {!searchData?.hierarchy && (
-        <Search
-          placeholder="Search by code or description"
-          onSearch={(query: string) => {
-            updateSearchData((data: SearchData) => {
-              data.query = query;
-            });
-          }}
-          initialValue={searchData?.query}
-        />
-      )}
-      <Loading status={classificationState}>
-        {!classificationState.data?.root?.children?.length ? (
-          <Empty
-            minHeight="300px"
-            image="/empty.png"
-            title="No matches found"
+      <GridLayout rows>
+        {!searchData?.hierarchy && (
+          <Search
+            placeholder="Search by code or description"
+            onSearch={(query: string) => {
+              updateSearchData((data: SearchData) => {
+                data.query = query;
+              });
+            }}
+            initialValue={searchData?.query}
           />
-        ) : (
-          <TreeGrid
-            columns={!!searchData?.hierarchy ? hierarchyColumns : allColumns}
-            data={classificationState?.data ?? {}}
-            defaultExpanded={searchData?.hierarchy}
-            rowCustomization={(id: TreeGridId, rowData: TreeGridRowData) => {
-              if (!classificationState.data) {
-                return undefined;
-              }
+        )}
+        <Loading status={classificationState}>
+          {!classificationState.data?.root?.children?.length ? (
+            <Empty
+              minHeight="300px"
+              image="/empty.png"
+              title="No matches found"
+            />
+          ) : (
+            <TreeGrid
+              columns={!!searchData?.hierarchy ? hierarchyColumns : allColumns}
+              data={classificationState?.data ?? {}}
+              defaultExpanded={searchData?.hierarchy}
+              rowCustomization={(id: TreeGridId, rowData: TreeGridRowData) => {
+                if (!classificationState.data) {
+                  return undefined;
+                }
 
-              // TODO(tjennison): Make TreeGridData's type generic so we can avoid
-              // this type assertion. Also consider passing the TreeGridItem to
-              // the callback instead of the TreeGridRowData.
-              const item = classificationState.data[
-                id
-              ] as ClassificationNodeItem;
-              if (!item || item.node.grouping) {
-                return undefined;
-              }
+                // TODO(tjennison): Make TreeGridData's type generic so we can avoid
+                // this type assertion. Also consider passing the TreeGridItem to
+                // the callback instead of the TreeGridRowData.
+                const item = classificationState.data[
+                  id
+                ] as ClassificationNodeItem;
+                if (!item || item.node.grouping) {
+                  return undefined;
+                }
 
-              const column = props.config.columns[nameColumnIndex];
-              const name = rowData[column.key];
-              const newItem = {
-                key: item.node.data.key,
-                name: !!name ? String(name) : "",
-              };
+                const column = props.config.columns[nameColumnIndex];
+                const name = rowData[column.key];
+                const newItem = {
+                  key: item.node.data.key,
+                  name: !!name ? String(name) : "",
+                };
 
-              const viewHierarchyContent =
-                !searchData?.hierarchy && classification.hierarchy
-                  ? [
-                      {
-                        column: props.config.columns.length,
-                        content: (
-                          <Stack alignItems="center">
-                            <IconButton
-                              size="small"
-                              onClick={() => {
-                                updateSearchData((data: SearchData) => {
-                                  if (rowData.view_hierarchy) {
-                                    data.hierarchy =
-                                      rowData.view_hierarchy as DataKey[];
-                                  }
-                                });
-                              }}
-                            >
-                              <AccountTreeIcon fontSize="inherit" />
-                            </IconButton>
-                          </Stack>
-                        ),
-                      },
-                    ]
-                  : [];
+                const viewHierarchyContent =
+                  !searchData?.hierarchy && classification.hierarchy
+                    ? [
+                        {
+                          column: props.config.columns.length,
+                          content: (
+                            <Stack alignItems="center">
+                              <IconButton
+                                size="small"
+                                onClick={() => {
+                                  updateSearchData((data: SearchData) => {
+                                    if (rowData.view_hierarchy) {
+                                      data.hierarchy =
+                                        rowData.view_hierarchy as DataKey[];
+                                    }
+                                  });
+                                }}
+                              >
+                                <AccountTreeIcon fontSize="inherit" />
+                              </IconButton>
+                            </Stack>
+                          ),
+                        },
+                      ]
+                    : [];
 
-              if (props.config.multiSelect) {
-                const index = props.data.selected.findIndex(
-                  (sel) => item.node.data.key === sel.key
-                );
+                if (props.config.multiSelect) {
+                  const index = props.data.selected.findIndex(
+                    (sel) => item.node.data.key === sel.key
+                  );
+
+                  return [
+                    {
+                      column: nameColumnIndex,
+                      prefixElements: (
+                        <Checkbox
+                          size="small"
+                          fontSize="inherit"
+                          checked={index > -1}
+                          onChange={() => {
+                            updateCriteria(
+                              produce(props.data, (data) => {
+                                if (index > -1) {
+                                  data.selected.splice(index, 1);
+                                } else {
+                                  data.selected.push(newItem);
+                                }
+                              })
+                            );
+                          }}
+                        />
+                      ),
+                    },
+                    ...viewHierarchyContent,
+                  ];
+                }
 
                 return [
                   {
                     column: nameColumnIndex,
-                    prefixElements: (
-                      <Checkbox
-                        size="small"
-                        fontSize="inherit"
-                        checked={index > -1}
-                        onChange={() => {
-                          updateCriteria(
-                            produce(props.data, (data) => {
-                              if (index > -1) {
-                                data.selected.splice(index, 1);
-                              } else {
-                                data.selected.push(newItem);
-                              }
-                            })
-                          );
-                        }}
-                      />
-                    ),
+                    onClick: () => {
+                      updateCriteria(
+                        produce(props.data, (data) => {
+                          data.selected = [newItem];
+                        })
+                      );
+                      navigate(props.doneURL);
+                    },
                   },
                   ...viewHierarchyContent,
                 ];
-              }
+              }}
+              loadChildren={(id: TreeGridId) => {
+                const data = classificationState.data;
+                if (!data) {
+                  return Promise.resolve();
+                }
 
-              return [
-                {
-                  column: nameColumnIndex,
-                  onClick: () => {
-                    updateCriteria(
-                      produce(props.data, (data) => {
-                        data.selected = [newItem];
-                      })
-                    );
-                    navigate(props.doneURL);
-                  },
-                },
-                ...viewHierarchyContent,
-              ];
-            }}
-            loadChildren={(id: TreeGridId) => {
-              const data = classificationState.data;
-              if (!data) {
-                return Promise.resolve();
-              }
-
-              const item = data[id] as ClassificationNodeItem;
-              const key = item?.node ? keyForNode(item.node) : id;
-              if (item?.node.grouping) {
-                return source
-                  .searchGrouping(
-                    attributes,
-                    occurrence.id,
-                    classification.id,
-                    item.node
-                  )
-                  .then((res) => {
-                    updateData(
-                      processEntities(res, searchData?.hierarchy, key, data)
-                    );
-                  });
-              } else {
-                return source
-                  .searchClassification(
-                    attributes,
-                    occurrence.id,
-                    classification.id,
-                    {
-                      parent: key,
-                    }
-                  )
-                  .then((res) => {
-                    updateData(
-                      processEntities(res, searchData?.hierarchy, key, data)
-                    );
-                  });
-              }
-            }}
-          />
-        )}
-      </Loading>
-    </Box>
+                const item = data[id] as ClassificationNodeItem;
+                const key = item?.node ? keyForNode(item.node) : id;
+                if (item?.node.grouping) {
+                  return source
+                    .searchGrouping(
+                      attributes,
+                      occurrence.id,
+                      classification.id,
+                      item.node
+                    )
+                    .then((res) => {
+                      updateData(
+                        processEntities(res, searchData?.hierarchy, key, data)
+                      );
+                    });
+                } else {
+                  return source
+                    .searchClassification(
+                      attributes,
+                      occurrence.id,
+                      classification.id,
+                      {
+                        parent: key,
+                      }
+                    )
+                    .then((res) => {
+                      updateData(
+                        processEntities(res, searchData?.hierarchy, key, data)
+                      );
+                    });
+                }
+              }}
+            />
+          )}
+        </Loading>
+      </GridLayout>
+    </GridBox>
   );
 }
 

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -578,10 +578,10 @@ function Preview(props: PreviewProps) {
                       )
                       .map((attribute) => ({
                         key: attribute,
-                        width: 120,
+                        width: 140,
                         title: attribute,
                       }))}
-                    variableWidth
+                    minWidth
                     wrapBodyText
                   />
                 ) : (


### PR DESCRIPTION
* Switch to "sticky" headers. This ensures header and cell widths are consistent and that headers are always visible.
* Scroll only tables instead of entire pages.