### PR TITLE
Show top results for empty queries instead of root items

### DIFF
--- a/ui/cypress/e2e/tests.cy.js
+++ b/ui/cypress/e2e/tests.cy.js
@@ -11,7 +11,7 @@ describe("Basic tests", () => {
     cy.get("button:Contains(Create)").click();
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("button:Contains(Condition)").click();
-    cy.get("[data-testid='AccountTreeIcon']").click();
+    cy.get("[data-testid='AccountTreeIcon']").first().click();
     cy.get("button:Contains(Clinical finding)").click();
 
     cy.get("button:Contains(Add criteria)").first().click();
@@ -38,7 +38,7 @@ describe("Basic tests", () => {
 
     cy.get("button[id=insert-concept-set]").click();
     cy.get("button:Contains(Condition)").click();
-    cy.get("[data-testid='AccountTreeIcon']").click();
+    cy.get("[data-testid='AccountTreeIcon']").first().click();
     cy.get("button:Contains(Clinical finding)").click();
 
     cy.get(`button[name='${cohortName}']`).click();

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -232,10 +232,7 @@ function ClassificationEdit(props: ClassificationEditProps) {
   const fetchClassification = useCallback(() => {
     return source
       .searchClassification(attributes, occurrence.id, classification.id, {
-        query:
-          !searchData?.hierarchy && !!searchData?.query
-            ? searchData?.query
-            : undefined,
+        query: !searchData?.hierarchy ? searchData?.query ?? "" : undefined,
         includeGroupings: !searchData?.hierarchy,
       })
       .then((res) => processEntities(res, searchData?.hierarchy));

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -360,8 +360,6 @@ export class BackendSource implements Source {
       classificationID
     );
 
-    const query = !options?.parent ? options?.query || "" : undefined;
-
     const promises = [
       this.instancesApi.queryInstances(
         searchRequest(
@@ -370,7 +368,7 @@ export class BackendSource implements Source {
           occurrenceID,
           classification,
           undefined,
-          query,
+          options?.query,
           options?.parent
         )
       ),
@@ -386,7 +384,7 @@ export class BackendSource implements Source {
               occurrenceID,
               classification,
               grouping,
-              query,
+              options?.query,
               options?.parent
             )
           )
@@ -1140,16 +1138,18 @@ function searchRequest(
         },
       },
     });
-  } else if (query) {
-    operands.push({
-      filterType: tanagra.FilterV2FilterTypeEnum.Text,
-      filterUnion: {
-        textFilter: {
-          matchType: tanagra.TextFilterV2MatchTypeEnum.ExactMatch,
-          text: query,
+  } else if (isValid(query)) {
+    if (query !== "") {
+      operands.push({
+        filterType: tanagra.FilterV2FilterTypeEnum.Text,
+        filterUnion: {
+          textFilter: {
+            matchType: tanagra.TextFilterV2MatchTypeEnum.ExactMatch,
+            text: query,
+          },
         },
-      },
-    });
+      });
+    }
   } else if (classification.hierarchy && !grouping) {
     operands.push({
       filterType: tanagra.FilterV2FilterTypeEnum.Hierarchy,


### PR DESCRIPTION
Unlike AoU, this currently leaves the root nodes visible in the list view but the UI can't globablly exclude them because they should be visible in some places (e.g. genotyping platform). Configuration for that behavior can be added in a future PR but given the varying behavior of top level nodes in AoU hierarchies it may go beyond a UI config flag.