### PR TITLE
Tests for listing review instances.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/FromApiConversionService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FromApiConversionService.java
@@ -153,7 +153,7 @@ public final class FromApiConversionService {
     }
   }
 
-  public ReviewQueryRequest.Builder fromApiObject(
+  public ReviewQueryRequest fromApiObject(
       ApiReviewQueryV2 apiObj, String studyId, String cohortId) {
     ValidationUtils.validateApiFilter(apiObj.getEntityFilter());
 
@@ -209,13 +209,12 @@ public final class FromApiConversionService {
                 }
               });
     }
-    return new ReviewQueryRequest.Builder()
-        .entity(entity)
-        .mappingType(Underlay.MappingType.INDEX)
+    return ReviewQueryRequest.builder()
         .attributes(attributes)
         .entityFilter(entityFilter)
         .annotationFilter(annotationFilter)
-        .orderBys(orderBys);
+        .orderBys(orderBys)
+        .build();
   }
 
   public static Literal fromApiObject(ApiLiteralV2 apiLiteral) {

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/AnnotationValue.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/AnnotationValue.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.service.artifact;
 
 import bio.terra.tanagra.query.Literal;
+import java.util.Objects;
 
 public class AnnotationValue {
   private final Literal literal;
@@ -51,6 +52,34 @@ public class AnnotationValue {
 
   public boolean isPartOfSelectedReview() {
     return isPartOfSelectedReview;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AnnotationValue that = (AnnotationValue) o;
+    return cohortRevisionVersion == that.cohortRevisionVersion
+        && isMostRecent == that.isMostRecent
+        && isPartOfSelectedReview == that.isPartOfSelectedReview
+        && literal.equals(that.literal)
+        && annotationKeyId.equals(that.annotationKeyId)
+        && instanceId.equals(that.instanceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        literal,
+        cohortRevisionVersion,
+        annotationKeyId,
+        instanceId,
+        isMostRecent,
+        isPartOfSelectedReview);
   }
 
   public static class Builder {

--- a/service/src/main/java/bio/terra/tanagra/service/instances/ReviewQueryRequest.java
+++ b/service/src/main/java/bio/terra/tanagra/service/instances/ReviewQueryRequest.java
@@ -1,46 +1,31 @@
 package bio.terra.tanagra.service.instances;
 
-import bio.terra.tanagra.query.Literal;
-import bio.terra.tanagra.service.artifact.AnnotationValue;
 import bio.terra.tanagra.service.instances.filter.AnnotationFilter;
 import bio.terra.tanagra.service.instances.filter.EntityFilter;
 import bio.terra.tanagra.underlay.Attribute;
-import bio.terra.tanagra.underlay.Entity;
-import bio.terra.tanagra.underlay.Underlay;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class ReviewQueryRequest {
-  private final Entity entity;
-  private final Underlay.MappingType mappingType;
   private final List<Attribute> attributes;
   private final EntityFilter entityFilter;
   private final AnnotationFilter annotationFilter;
-  private final List<Literal> entityInstanceIds;
-  private final List<AnnotationValue> annotationValues;
   private final List<ReviewQueryOrderBy> orderBys;
 
   private ReviewQueryRequest(Builder builder) {
-    this.entity = builder.entity;
-    this.mappingType = builder.mappingType;
     this.attributes = builder.attributes;
     this.entityFilter = builder.entityFilter;
     this.annotationFilter = builder.annotationFilter;
-    this.entityInstanceIds = builder.entityInstanceIds;
-    this.annotationValues = builder.annotationValues;
     this.orderBys = builder.orderBys;
   }
 
-  public Entity getEntity() {
-    return entity;
-  }
-
-  public Underlay.MappingType getMappingType() {
-    return mappingType;
+  public static Builder builder() {
+    return new Builder();
   }
 
   public List<Attribute> getAttributes() {
-    return attributes == null ? Collections.emptyList() : Collections.unmodifiableList(attributes);
+    return attributes;
   }
 
   public EntityFilter getEntityFilter() {
@@ -55,14 +40,6 @@ public class ReviewQueryRequest {
     return annotationFilter != null;
   }
 
-  public List<Literal> getEntityInstanceIds() {
-    return Collections.unmodifiableList(entityInstanceIds);
-  }
-
-  public List<AnnotationValue> getAnnotationValues() {
-    return Collections.unmodifiableList(annotationValues);
-  }
-
   public List<ReviewQueryOrderBy> getOrderBys() {
     return orderBys == null ? Collections.emptyList() : Collections.unmodifiableList(orderBys);
   }
@@ -72,24 +49,10 @@ public class ReviewQueryRequest {
   }
 
   public static class Builder {
-    private Entity entity;
-    private Underlay.MappingType mappingType;
     private List<Attribute> attributes;
     private EntityFilter entityFilter;
     private AnnotationFilter annotationFilter;
-    private List<Literal> entityInstanceIds;
-    private List<AnnotationValue> annotationValues;
     private List<ReviewQueryOrderBy> orderBys;
-
-    public Builder entity(Entity entity) {
-      this.entity = entity;
-      return this;
-    }
-
-    public Builder mappingType(Underlay.MappingType mappingType) {
-      this.mappingType = mappingType;
-      return this;
-    }
 
     public Builder attributes(List<Attribute> attributes) {
       this.attributes = attributes;
@@ -106,22 +69,13 @@ public class ReviewQueryRequest {
       return this;
     }
 
-    public Builder entityInstanceIds(List<Literal> entityInstanceIds) {
-      this.entityInstanceIds = entityInstanceIds;
-      return this;
-    }
-
-    public Builder annotationValues(List<AnnotationValue> annotationValues) {
-      this.annotationValues = annotationValues;
-      return this;
-    }
-
     public Builder orderBys(List<ReviewQueryOrderBy> orderBys) {
       this.orderBys = orderBys;
       return this;
     }
 
     public ReviewQueryRequest build() {
+      attributes = attributes == null ? new ArrayList<>() : new ArrayList<>(attributes);
       return new ReviewQueryRequest(this);
     }
   }

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewInstanceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewInstanceTest.java
@@ -1,0 +1,882 @@
+package bio.terra.tanagra.service;
+
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.tanagra.app.Main;
+import bio.terra.tanagra.query.*;
+import bio.terra.tanagra.query.filtervariable.BinaryFilterVariable;
+import bio.terra.tanagra.query.inmemory.InMemoryRowResult;
+import bio.terra.tanagra.service.artifact.*;
+import bio.terra.tanagra.service.instances.ReviewInstance;
+import bio.terra.tanagra.service.instances.ReviewQueryOrderBy;
+import bio.terra.tanagra.service.instances.ReviewQueryRequest;
+import bio.terra.tanagra.service.instances.filter.AnnotationFilter;
+import bio.terra.tanagra.service.instances.filter.AttributeFilter;
+import bio.terra.tanagra.underlay.Attribute;
+import bio.terra.tanagra.underlay.Entity;
+import bio.terra.tanagra.underlay.ValueDisplay;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+@ActiveProfiles("test")
+public class ReviewInstanceTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReviewInstanceTest.class);
+  private static final String UNDERLAY_NAME = "cms_synpuf";
+
+  @Autowired private StudyService studyService;
+  @Autowired private CohortService cohortService;
+  @Autowired private AnnotationService annotationService;
+  @Autowired private ReviewService reviewService;
+  @Autowired private UnderlaysService underlaysService;
+
+  private Study study1;
+  private Cohort cohort1;
+  private Review review1;
+  private Review review2;
+  private Review review3;
+  private Review review4;
+  private AnnotationKey annotationKey1;
+  private AnnotationKey annotationKey2;
+
+  @BeforeEach
+  void createReviewsAndAnnotations() {
+    String userEmail = "abc@123.com";
+
+    // Create study1.
+    study1 = studyService.createStudy(Study.builder().displayName("study 1"), userEmail);
+    assertNotNull(study1);
+    LOGGER.info("Created study1 {} at {}", study1.getId(), study1.getCreated());
+
+    // Create cohort1 with criteria.
+    cohort1 =
+        cohortService.createCohort(
+            study1.getId(),
+            Cohort.builder()
+                .underlay(UNDERLAY_NAME)
+                .displayName("cohort 2")
+                .description("first cohort"),
+            userEmail,
+            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+    assertNotNull(cohort1);
+    LOGGER.info("Created cohort1 {} at {}", cohort1.getId(), cohort1.getCreated());
+
+    // Create review1, review2, review3, review4 for cohort1.
+    // r1: 2014950, 1858841, 2180409
+    // r2: 1858841, 2180409, 1131436, 1838382
+    // r3: 1858841, 2180409, 1838382
+    // r4: 1858841, 1838382, 799353, 2104705
+    ColumnHeaderSchema columnHeaderSchema =
+        new ColumnHeaderSchema(List.of(new ColumnSchema("id", CellValue.SQLDataType.INT64)));
+    QueryResult queryResult =
+        new QueryResult(
+            List.of(2_014_950L, 1_858_841L, 2_180_409L).stream()
+                .map(id -> new InMemoryRowResult(List.of(id), columnHeaderSchema))
+                .collect(Collectors.toList()),
+            columnHeaderSchema);
+    review1 =
+        reviewService.createReviewHelper(
+            study1.getId(), cohort1.getId(), Review.builder().size(11), userEmail, queryResult);
+    assertNotNull(review1);
+    LOGGER.info("Created review1 {} at {}", review1.getId(), review1.getCreated());
+
+    queryResult =
+        new QueryResult(
+            List.of(1_858_841L, 2_180_409L, 1_131_436L, 1_838_382L).stream()
+                .map(id -> new InMemoryRowResult(List.of(id), columnHeaderSchema))
+                .collect(Collectors.toList()),
+            columnHeaderSchema);
+    review2 =
+        reviewService.createReviewHelper(
+            study1.getId(), cohort1.getId(), Review.builder().size(14), userEmail, queryResult);
+    assertNotNull(review2);
+    LOGGER.info("Created review2 {} at {}", review2.getId(), review2.getCreated());
+
+    queryResult =
+        new QueryResult(
+            List.of(1_858_841L, 2_180_409L, 1_838_382L).stream()
+                .map(id -> new InMemoryRowResult(List.of(id), columnHeaderSchema))
+                .collect(Collectors.toList()),
+            columnHeaderSchema);
+    review3 =
+        reviewService.createReviewHelper(
+            study1.getId(), cohort1.getId(), Review.builder().size(3), userEmail, queryResult);
+    assertNotNull(review3);
+    LOGGER.info("Created review3 {} at {}", review3.getId(), review3.getCreated());
+
+    queryResult =
+        new QueryResult(
+            List.of(1_858_841L, 1_838_382L, 799_353L, 2_104_705L).stream()
+                .map(id -> new InMemoryRowResult(List.of(id), columnHeaderSchema))
+                .collect(Collectors.toList()),
+            columnHeaderSchema);
+    review4 =
+        reviewService.createReviewHelper(
+            study1.getId(), cohort1.getId(), Review.builder().size(4), userEmail, queryResult);
+    assertNotNull(review4);
+    LOGGER.info("Created review4 {} at {}", review4.getId(), review4.getCreated());
+
+    // Create annotationKey1 for cohort1.
+    annotationKey1 =
+        annotationService.createAnnotationKey(
+            study1.getId(),
+            cohort1.getId(),
+            AnnotationKey.builder().dataType(Literal.DataType.INT64).displayName("key1"));
+    assertNotNull(annotationKey1);
+    LOGGER.info("Created annotationKey1 {}", annotationKey1.getId());
+
+    // Create annotationKey2 for cohort1.
+    annotationKey2 =
+        annotationService.createAnnotationKey(
+            study1.getId(),
+            cohort1.getId(),
+            AnnotationKey.builder().dataType(Literal.DataType.STRING).displayName("key2"));
+    assertNotNull(annotationKey2);
+    LOGGER.info("Created annotationKey2 {}", annotationKey2.getId());
+
+    // Create annotation values.
+    // 2014950: (r1, k1)
+    // 1858841: (r1, k1), (r2, k1), (r3, k1), (r4, k1), (r1, k2), (r2, k2), (r3, k2)
+    // 2180409: (r2, k1), (r3, k1), (r1, k2), (r3, k2)
+    // 1131436: (r2, k1)
+    // 1838382: (r2, k2), (r3, k2), (r4, k2)
+    // 799353:
+    // 2104705: (r4, k1), (r4, k2)
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review1.getId(),
+        "2014950",
+        List.of(new Literal(111L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review1.getId(),
+        "1858841",
+        List.of(new Literal(112L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review2.getId(),
+        "1858841",
+        List.of(new Literal(113L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review3.getId(),
+        "1858841",
+        List.of(new Literal(114L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review4.getId(),
+        "1858841",
+        List.of(new Literal(115L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review1.getId(),
+        "1858841",
+        List.of(new Literal("str116")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review2.getId(),
+        "1858841",
+        List.of(new Literal("str117")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review3.getId(),
+        "1858841",
+        List.of(new Literal("str118")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review2.getId(),
+        "2180409",
+        List.of(new Literal(119L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review3.getId(),
+        "2180409",
+        List.of(new Literal(120L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review1.getId(),
+        "2180409",
+        List.of(new Literal("str121")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review3.getId(),
+        "2180409",
+        List.of(new Literal("str122")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review2.getId(),
+        "1131436",
+        List.of(new Literal(123L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review2.getId(),
+        "1838382",
+        List.of(new Literal("str124")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review3.getId(),
+        "1838382",
+        List.of(new Literal("str125")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review4.getId(),
+        "1838382",
+        List.of(new Literal("str126")));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey1.getId(),
+        review4.getId(),
+        "2104705",
+        List.of(new Literal(115L)));
+    annotationService.updateAnnotationValues(
+        study1.getId(),
+        cohort1.getId(),
+        annotationKey2.getId(),
+        review4.getId(),
+        "2104705",
+        List.of(new Literal("str128")));
+  }
+
+  @AfterEach
+  void deleteReviewsAndAnnotations() {
+    try {
+      studyService.deleteStudy(study1.getId());
+      LOGGER.info("Deleted study1 {}", study1.getId());
+    } catch (Exception ex) {
+      LOGGER.error("Error deleting study1", ex);
+    }
+  }
+
+  @Test
+  void entityAttributes() {
+    Entity primaryEntity = underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity();
+    Attribute idAttr = primaryEntity.getIdAttribute();
+
+    // List instances for review2. Request only the gender attribute.
+    List<ReviewInstance> reviewInstances2 =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review2.getId(),
+            ReviewQueryRequest.builder()
+                .attributes(List.of(primaryEntity.getAttribute("gender")))
+                .build());
+    checkEntityInstances(
+        List.of(1_858_841L, 2_180_409L, 1_131_436L, 1_838_382L), idAttr, reviewInstances2);
+
+    // Check that the id attribute was fetched automatically to each review instance.
+    reviewInstances2.stream().forEach(ri -> assertNotNull(ri.getAttributeValues().get(idAttr)));
+
+    // Check that the gender attribute values are correct.
+    Attribute genderAttr = primaryEntity.getAttribute("gender");
+    checkAttributeValue(genderAttr, 8_532L, 1_858_841L, idAttr, reviewInstances2);
+    checkAttributeValue(genderAttr, 8_532L, 2_180_409L, idAttr, reviewInstances2);
+    checkAttributeValue(genderAttr, 8_532L, 1_131_436L, idAttr, reviewInstances2);
+    checkAttributeValue(genderAttr, 8_507L, 1_838_382L, idAttr, reviewInstances2);
+  }
+
+  @Test
+  void annotationValues() {
+    // List instances for reviews 1-4. For each, check that:
+    //   - The correct entity instances (ids) are included.
+    //   - The correct annotation values are included.
+    //   - The isMostRecent and isPartOfSelectedReview flags are set correctly.
+    Attribute primaryEntityIdAttribute =
+        underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity().getIdAttribute();
+
+    // List instances for review1.
+    List<ReviewInstance> reviewInstances1 =
+        reviewService.listReviewInstances(
+            study1.getId(), cohort1.getId(), review1.getId(), ReviewQueryRequest.builder().build());
+    checkEntityInstances(
+        List.of(2_014_950L, 1_858_841L, 2_180_409L), primaryEntityIdAttribute, reviewInstances1);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(111L))
+                .cohortRevisionVersion(0)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("2014950")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build()),
+        2_014_950L,
+        primaryEntityIdAttribute,
+        reviewInstances1);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(112L))
+                .cohortRevisionVersion(0)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal(115L))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str116"))
+                .cohortRevisionVersion(0)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1858841")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str118"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        1_858_841L,
+        primaryEntityIdAttribute,
+        reviewInstances1);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(120L))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("2180409")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str121"))
+                .cohortRevisionVersion(0)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("2180409")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str122"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("2180409")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        2_180_409L,
+        primaryEntityIdAttribute,
+        reviewInstances1);
+
+    // List instances for review2.
+    List<ReviewInstance> reviewInstances2 =
+        reviewService.listReviewInstances(
+            study1.getId(), cohort1.getId(), review2.getId(), ReviewQueryRequest.builder().build());
+    checkEntityInstances(
+        List.of(1_858_841L, 2_180_409L, 1_131_436L, 1_838_382L),
+        primaryEntityIdAttribute,
+        reviewInstances2);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(113L))
+                .cohortRevisionVersion(1)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal(115L))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str117"))
+                .cohortRevisionVersion(1)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1858841")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str118"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        1_858_841L,
+        primaryEntityIdAttribute,
+        reviewInstances2);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(119L))
+                .cohortRevisionVersion(1)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("2180409")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal(120L))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("2180409")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str122"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("2180409")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        2_180_409L,
+        primaryEntityIdAttribute,
+        reviewInstances2);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(123L))
+                .cohortRevisionVersion(1)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1131436")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build()),
+        1_131_436L,
+        primaryEntityIdAttribute,
+        reviewInstances2);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal("str124"))
+                .cohortRevisionVersion(1)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1838382")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str126"))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1838382")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        1_838_382L,
+        primaryEntityIdAttribute,
+        reviewInstances2);
+
+    // List instances for review3.
+    List<ReviewInstance> reviewInstances3 =
+        reviewService.listReviewInstances(
+            study1.getId(), cohort1.getId(), review3.getId(), ReviewQueryRequest.builder().build());
+    checkEntityInstances(
+        List.of(1_858_841L, 2_180_409L, 1_838_382L), primaryEntityIdAttribute, reviewInstances3);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(114L))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal(115L))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str118"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build()),
+        1_858_841L,
+        primaryEntityIdAttribute,
+        reviewInstances3);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(120L))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("2180409")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str122"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("2180409")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build()),
+        2_180_409L,
+        primaryEntityIdAttribute,
+        reviewInstances3);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal("str125"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1838382")
+                .isMostRecent(false)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str126"))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1838382")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        1_838_382L,
+        primaryEntityIdAttribute,
+        reviewInstances3);
+
+    // List instances for review4.
+    List<ReviewInstance> reviewInstances4 =
+        reviewService.listReviewInstances(
+            study1.getId(), cohort1.getId(), review4.getId(), ReviewQueryRequest.builder().build());
+    checkEntityInstances(
+        List.of(1_858_841L, 1_838_382L, 799_353L, 2_104_705L),
+        primaryEntityIdAttribute,
+        reviewInstances4);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(115L))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str118"))
+                .cohortRevisionVersion(2)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1858841")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(false)
+                .build()),
+        1_858_841L,
+        primaryEntityIdAttribute,
+        reviewInstances4);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal("str126"))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("1838382")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build()),
+        1_838_382L,
+        primaryEntityIdAttribute,
+        reviewInstances4);
+    checkAnnotationValues(
+        Collections.emptyList(), 799_353L, primaryEntityIdAttribute, reviewInstances4);
+    checkAnnotationValues(
+        List.of(
+            AnnotationValue.builder()
+                .literal(new Literal(115L))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey1.getId())
+                .instanceId("2104705")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build(),
+            AnnotationValue.builder()
+                .literal(new Literal("str128"))
+                .cohortRevisionVersion(3)
+                .annotationKeyId(annotationKey2.getId())
+                .instanceId("2104705")
+                .isMostRecent(true)
+                .isPartOfSelectedReview(true)
+                .build()),
+        2_104_705L,
+        primaryEntityIdAttribute,
+        reviewInstances4);
+  }
+
+  @Test
+  void orderBys() {
+    Attribute primaryEntityIdAttribute =
+        underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity().getIdAttribute();
+
+    // Order by an entity attribute.
+    List<ReviewInstance> reviewInstancesByAttr =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review4.getId(),
+            ReviewQueryRequest.builder()
+                .orderBys(
+                    List.of(
+                        new ReviewQueryOrderBy(
+                            primaryEntityIdAttribute, OrderByDirection.DESCENDING)))
+                .build());
+    assertEquals(
+        List.of(2_104_705L, 1_858_841L, 1_838_382L, 799_353L),
+        reviewInstancesByAttr.stream()
+            .map(
+                ri ->
+                    ri.getAttributeValues().get(primaryEntityIdAttribute).getValue().getInt64Val())
+            .collect(Collectors.toList()));
+
+    // Order by an annotation key.
+    List<ReviewInstance> reviewInstancesByAnn =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review4.getId(),
+            ReviewQueryRequest.builder()
+                .orderBys(
+                    List.of(new ReviewQueryOrderBy(annotationKey2, OrderByDirection.DESCENDING)))
+                .build());
+    assertEquals(
+        List.of(2_104_705L, 1_838_382L, 1_858_841L, 799_353L),
+        reviewInstancesByAnn.stream()
+            .map(
+                ri ->
+                    ri.getAttributeValues().get(primaryEntityIdAttribute).getValue().getInt64Val())
+            .collect(Collectors.toList()));
+
+    // Order by both.
+    List<ReviewInstance> reviewInstancesByBoth =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review4.getId(),
+            ReviewQueryRequest.builder()
+                .orderBys(
+                    List.of(
+                        new ReviewQueryOrderBy(annotationKey1, OrderByDirection.ASCENDING),
+                        new ReviewQueryOrderBy(
+                            primaryEntityIdAttribute, OrderByDirection.ASCENDING)))
+                .build());
+    assertEquals(
+        List.of(799_353L, 1_838_382L, 1_858_841L, 2_104_705L),
+        reviewInstancesByBoth.stream()
+            .map(
+                ri ->
+                    ri.getAttributeValues().get(primaryEntityIdAttribute).getValue().getInt64Val())
+            .collect(Collectors.toList()));
+  }
+
+  @Test
+  void filters() {
+    Entity primaryEntity = underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity();
+
+    // Filter by an entity attribute.
+    List<ReviewInstance> reviewInstancesByAttr =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review4.getId(),
+            ReviewQueryRequest.builder()
+                .entityFilter(
+                    new AttributeFilter(
+                        primaryEntity.getAttribute("gender"),
+                        BinaryFilterVariable.BinaryOperator.EQUALS,
+                        new Literal(8_532L)))
+                .build());
+    assertEquals(
+        List.of(1_858_841L),
+        reviewInstancesByAttr.stream()
+            .map(
+                ri ->
+                    ri.getAttributeValues()
+                        .get(primaryEntity.getIdAttribute())
+                        .getValue()
+                        .getInt64Val())
+            .collect(Collectors.toList()));
+
+    // Filter by an annotation key.
+    List<ReviewInstance> reviewInstancesByAnn =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review4.getId(),
+            ReviewQueryRequest.builder()
+                .annotationFilter(
+                    new AnnotationFilter(
+                        annotationKey2,
+                        BinaryFilterVariable.BinaryOperator.EQUALS,
+                        new Literal("str128")))
+                .build());
+    assertEquals(
+        List.of(2_104_705L),
+        reviewInstancesByAnn.stream()
+            .map(
+                ri ->
+                    ri.getAttributeValues()
+                        .get(primaryEntity.getIdAttribute())
+                        .getValue()
+                        .getInt64Val())
+            .collect(Collectors.toList()));
+
+    // Filter by both.
+    List<ReviewInstance> reviewInstancesByBoth =
+        reviewService.listReviewInstances(
+            study1.getId(),
+            cohort1.getId(),
+            review4.getId(),
+            ReviewQueryRequest.builder()
+                .entityFilter(
+                    new AttributeFilter(
+                        primaryEntity.getAttribute("gender"),
+                        BinaryFilterVariable.BinaryOperator.EQUALS,
+                        new Literal(8_507L)))
+                .annotationFilter(
+                    new AnnotationFilter(
+                        annotationKey1,
+                        BinaryFilterVariable.BinaryOperator.EQUALS,
+                        new Literal(115L)))
+                .build());
+    assertEquals(
+        List.of(2_104_705L),
+        reviewInstancesByBoth.stream()
+            .map(
+                ri ->
+                    ri.getAttributeValues()
+                        .get(primaryEntity.getIdAttribute())
+                        .getValue()
+                        .getInt64Val())
+            .collect(Collectors.toList()));
+  }
+
+  private void checkEntityInstances(
+      List<Long> instanceIds, Attribute idAttribute, List<ReviewInstance> reviewInstances) {
+    for (Long instanceId : instanceIds) {
+      assertTrue(
+          reviewInstances.stream()
+              .filter(
+                  ri ->
+                      ri.getAttributeValues()
+                          .get(idAttribute)
+                          .getValue()
+                          .equals(new Literal(instanceId)))
+              .findFirst()
+              .isPresent());
+    }
+  }
+
+  private void checkAttributeValue(
+      Attribute attribute,
+      Long expectedAttributeValue,
+      Long instanceId,
+      Attribute idAttribute,
+      List<ReviewInstance> reviewInstances) {
+    ReviewInstance reviewInstance =
+        reviewInstances.stream()
+            .filter(
+                ri ->
+                    ri.getAttributeValues()
+                        .get(idAttribute)
+                        .getValue()
+                        .getInt64Val()
+                        .equals(instanceId))
+            .findFirst()
+            .get();
+    ValueDisplay actualAttributeValue = reviewInstance.getAttributeValues().get(attribute);
+    assertNotNull(actualAttributeValue);
+    assertEquals(expectedAttributeValue, actualAttributeValue.getValue().getInt64Val());
+  }
+
+  private void checkAnnotationValues(
+      List<AnnotationValue> annotationValues,
+      Long instanceId,
+      Attribute idAttribute,
+      List<ReviewInstance> reviewInstances) {
+    ReviewInstance reviewInstance =
+        reviewInstances.stream()
+            .filter(
+                ri ->
+                    ri.getAttributeValues()
+                        .get(idAttribute)
+                        .getValue()
+                        .getInt64Val()
+                        .equals(instanceId))
+            .findFirst()
+            .get();
+    assertEquals(annotationValues.size(), reviewInstance.getAnnotationValues().size());
+    for (AnnotationValue annotationValue : annotationValues) {
+      assertTrue(reviewInstance.getAnnotationValues().contains(annotationValue));
+    }
+  }
+}


### PR DESCRIPTION
- Tests check for correct annotation values across reviews, correct attribute values, ordering by annotation and/or attribute, filtering on annotation and/or attribute.
- Also removed the primary entity ids and annotation values from the request object, since those are now private methods in the same service class.