### PR TITLE
Switch VUMC primary user identifier back to email address

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/VumcAdminService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/VumcAdminService.java
@@ -69,6 +69,7 @@ public class VumcAdminService {
   }
 
   @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  // uses email as the primary user identifier
   public boolean isAuthorized(
       String userId, ResourceAction resourceAction, ResourceType resourceType, String resourceId) {
     AuthorizationApi authorizationApi = new AuthorizationApi(getApiClientAuthenticated());
@@ -83,6 +84,7 @@ public class VumcAdminService {
     }
   }
 
+  // uses email as the primary user identifier
   public ResourceList listAuthorizedResources(String userId, ResourceTypeList resourceTypeList) {
     AuthorizationApi authorizationApi = new AuthorizationApi(getApiClientAuthenticated());
     try {

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
@@ -29,7 +29,7 @@ public class VumcAdminAccessControl implements AccessControl {
   public boolean isAuthorized(
       UserId userId, Action action, ResourceType resourceType, @Nullable ResourceId resourceId) {
     return vumcAdminService.isAuthorized(
-        userId.getSubject(),
+        userId.getEmail(),
         ResourceAction.valueOf(action.toString()),
         org.vumc.vda.tanagra.admin.model.ResourceType.valueOf(resourceType.toString()),
         resourceId == null ? null : resourceId.toString());
@@ -42,7 +42,7 @@ public class VumcAdminAccessControl implements AccessControl {
     resourceTypeList.add(
         org.vumc.vda.tanagra.admin.model.ResourceType.valueOf(resourceType.toString()));
     ResourceList resourceList =
-        vumcAdminService.listAuthorizedResources(userId.getSubject(), resourceTypeList);
+        vumcAdminService.listAuthorizedResources(userId.getEmail(), resourceTypeList);
     return ResourceIdCollection.forCollection(
         resourceList.stream()
             .map(resource -> new ResourceId(resource.getId()))


### PR DESCRIPTION
It looks like we're going to have to switch back to using user emails at least temporarily as we are unable to retrieve user profile information from the Google Directory API for users that are not a member of the organization.