### PR TITLE
Store resource id parts separately. Use study id for all child artifacts for VUMC access control.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/AnnotationsV2ApiController.java
@@ -44,7 +44,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiAnnotationV2> createAnnotationKey(
       String studyId, String cohortId, ApiAnnotationCreateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), CREATE, ANNOTATION, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        CREATE,
+        ANNOTATION,
+        ResourceId.forCohort(studyId, cohortId));
     AnnotationKey createdAnnotationKey =
         annotationService.createAnnotationKey(
             studyId,
@@ -61,7 +64,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<Void> deleteAnnotationKey(
       String studyId, String cohortId, String annotationKeyId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), DELETE, ANNOTATION, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        DELETE,
+        ANNOTATION,
+        ResourceId.forAnnotationKey(studyId, cohortId, annotationKeyId));
     annotationService.deleteAnnotationKey(studyId, cohortId, annotationKeyId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -70,7 +76,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiAnnotationV2> getAnnotationKey(
       String studyId, String cohortId, String annotationKeyId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, ANNOTATION, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        ANNOTATION,
+        ResourceId.forAnnotationKey(studyId, cohortId, annotationKeyId));
     return ResponseEntity.ok(
         toApiObject(annotationService.getAnnotationKey(studyId, cohortId, annotationKeyId)));
   }
@@ -92,7 +101,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<ApiAnnotationV2> updateAnnotationKey(
       String studyId, String cohortId, String annotationKeyId, ApiAnnotationUpdateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, ANNOTATION, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        UPDATE,
+        ANNOTATION,
+        ResourceId.forAnnotationKey(studyId, cohortId, annotationKeyId));
     AnnotationKey updatedAnnotationKey =
         annotationService.updateAnnotationKey(
             studyId, cohortId, annotationKeyId, body.getDisplayName(), body.getDescription());
@@ -108,7 +120,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
       String instanceId,
       ApiLiteralV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, COHORT_REVIEW, new ResourceId(reviewId));
+        SpringAuthentication.getCurrentUser(),
+        UPDATE,
+        COHORT_REVIEW,
+        ResourceId.forReview(studyId, cohortId, reviewId));
     // The API currently restricts the caller to a single annotation value per review instance per
     // annotation key, but the backend can handle a list.
     annotationService.updateAnnotationValues(
@@ -125,7 +140,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   public ResponseEntity<Void> deleteAnnotationValues(
       String studyId, String cohortId, String annotationKeyId, String reviewId, String instanceId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, COHORT_REVIEW, new ResourceId(reviewId));
+        SpringAuthentication.getCurrentUser(),
+        UPDATE,
+        COHORT_REVIEW,
+        ResourceId.forReview(studyId, cohortId, reviewId));
     annotationService.deleteAnnotationValues(
         studyId, cohortId, annotationKeyId, reviewId, instanceId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -134,7 +152,10 @@ public class AnnotationsV2ApiController implements AnnotationsV2Api {
   @Override
   public ResponseEntity<ApiExportFile> exportAnnotationValues(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, COHORT_REVIEW, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        COHORT,
+        ResourceId.forCohort(studyId, cohortId));
     String gcsSignedUrl = reviewService.exportAnnotationValuesToGcs(studyId, cohortId);
     return ResponseEntity.ok(new ApiExportFile().gcsSignedUrl(gcsSignedUrl));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsV2ApiController.java
@@ -41,7 +41,7 @@ public class CohortsV2ApiController implements CohortsV2Api {
   @Override
   public ResponseEntity<ApiCohortV2> createCohort(String studyId, ApiCohortCreateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), CREATE, COHORT, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), CREATE, COHORT, ResourceId.forStudy(studyId));
     Cohort createdCohort =
         cohortService.createCohort(
             studyId,
@@ -56,7 +56,10 @@ public class CohortsV2ApiController implements CohortsV2Api {
   @Override
   public ResponseEntity<Void> deleteCohort(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), DELETE, COHORT, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        DELETE,
+        COHORT,
+        ResourceId.forCohort(studyId, cohortId));
     cohortService.deleteCohort(studyId, cohortId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -64,7 +67,10 @@ public class CohortsV2ApiController implements CohortsV2Api {
   @Override
   public ResponseEntity<ApiCohortV2> getCohort(String studyId, String cohortId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, COHORT, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        COHORT,
+        ResourceId.forCohort(studyId, cohortId));
     return ResponseEntity.ok(
         ToApiConversionUtils.toApiObject(cohortService.getCohort(studyId, cohortId)));
   }
@@ -85,7 +91,10 @@ public class CohortsV2ApiController implements CohortsV2Api {
   public ResponseEntity<ApiCohortV2> updateCohort(
       String studyId, String cohortId, ApiCohortUpdateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, COHORT, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        UPDATE,
+        COHORT,
+        ResourceId.forCohort(studyId, cohortId));
     List<CohortRevision.CriteriaGroupSection> sections =
         body.getCriteriaGroupSections().stream()
             .map(CohortsV2ApiController::fromApiObject)

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsV2ApiController.java
@@ -37,7 +37,7 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
   public ResponseEntity<ApiConceptSetV2> createConceptSet(
       String studyId, ApiConceptSetCreateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), CREATE, CONCEPT_SET, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), CREATE, CONCEPT_SET, ResourceId.forStudy(studyId));
     Criteria singleCriteria =
         body.getCriteria() == null
             ? null
@@ -58,7 +58,10 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
   @Override
   public ResponseEntity<Void> deleteConceptSet(String studyId, String conceptSetId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), DELETE, CONCEPT_SET, new ResourceId(conceptSetId));
+        SpringAuthentication.getCurrentUser(),
+        DELETE,
+        CONCEPT_SET,
+        ResourceId.forConceptSet(studyId, conceptSetId));
     conceptSetService.deleteConceptSet(studyId, conceptSetId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -66,7 +69,10 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
   @Override
   public ResponseEntity<ApiConceptSetV2> getConceptSet(String studyId, String conceptSetId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, CONCEPT_SET, new ResourceId(conceptSetId));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        CONCEPT_SET,
+        ResourceId.forConceptSet(studyId, conceptSetId));
     return ResponseEntity.ok(toApiObject(conceptSetService.getConceptSet(studyId, conceptSetId)));
   }
 
@@ -86,7 +92,10 @@ public class ConceptSetsV2ApiController implements ConceptSetsV2Api {
   public ResponseEntity<ApiConceptSetV2> updateConceptSet(
       String studyId, String conceptSetId, ApiConceptSetUpdateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, CONCEPT_SET, new ResourceId(conceptSetId));
+        SpringAuthentication.getCurrentUser(),
+        UPDATE,
+        CONCEPT_SET,
+        ResourceId.forConceptSet(studyId, conceptSetId));
     Criteria singleCriteria =
         body.getCriteria() == null
             ? null

--- a/service/src/main/java/bio/terra/tanagra/app/controller/EntitiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/EntitiesV2ApiController.java
@@ -33,7 +33,10 @@ public class EntitiesV2ApiController implements EntitiesV2Api {
   @Override
   public ResponseEntity<ApiEntityListV2> listEntities(String underlayName) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, UNDERLAY, new ResourceId(underlayName));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        UNDERLAY,
+        ResourceId.forUnderlay(underlayName));
     ApiEntityListV2 apiEntities = new ApiEntityListV2();
     List<Entity> entities = underlaysService.listEntities(underlayName);
     entities.stream().forEach(entity -> apiEntities.addEntitiesItem(toApiObject(entity)));
@@ -43,7 +46,10 @@ public class EntitiesV2ApiController implements EntitiesV2Api {
   @Override
   public ResponseEntity<ApiEntityV2> getEntity(String underlayName, String entityName) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, UNDERLAY, new ResourceId(underlayName));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        UNDERLAY,
+        ResourceId.forUnderlay(underlayName));
     Entity entity = underlaysService.getEntity(underlayName, entityName);
     return ResponseEntity.ok(toApiObject(entity));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/HintsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/HintsV2ApiController.java
@@ -57,7 +57,7 @@ public class HintsV2ApiController implements HintsV2Api {
         SpringAuthentication.getCurrentUser(),
         QUERY_COUNTS,
         UNDERLAY,
-        new ResourceId(underlayName));
+        ResourceId.forUnderlay(underlayName));
     Entity entity = underlaysService.getEntity(underlayName, entityName);
 
     if (body == null || body.getRelatedEntity() == null) {

--- a/service/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/InstancesV2ApiController.java
@@ -74,7 +74,7 @@ public class InstancesV2ApiController implements InstancesV2Api {
         SpringAuthentication.getCurrentUser(),
         QUERY_INSTANCES,
         UNDERLAY,
-        new ResourceId(underlayName));
+        ResourceId.forUnderlay(underlayName));
 
     ValidationUtils.validateApiFilter(body.getFilter());
 
@@ -213,7 +213,7 @@ public class InstancesV2ApiController implements InstancesV2Api {
         SpringAuthentication.getCurrentUser(),
         QUERY_COUNTS,
         UNDERLAY,
-        new ResourceId(underlayName));
+        ResourceId.forUnderlay(underlayName));
     Entity entity = underlaysService.getEntity(underlayName, entityName);
 
     ValidationUtils.validateApiFilter(body.getFilter());
@@ -258,7 +258,7 @@ public class InstancesV2ApiController implements InstancesV2Api {
         SpringAuthentication.getCurrentUser(),
         QUERY_INSTANCES,
         UNDERLAY,
-        new ResourceId(underlayName));
+        ResourceId.forUnderlay(underlayName));
 
     ValidationUtils.validateApiFilter(body.getFilter());
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsV2ApiController.java
@@ -62,7 +62,10 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
   public ResponseEntity<ApiReviewV2> createReview(
       String studyId, String cohortId, ApiReviewCreateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), CREATE, COHORT_REVIEW, new ResourceId(cohortId));
+        SpringAuthentication.getCurrentUser(),
+        CREATE,
+        COHORT_REVIEW,
+        ResourceId.forCohort(studyId, cohortId));
 
     // TODO: Remove the entity filter from here once we store it for the cohort.
     ValidationUtils.validateApiFilter(body.getFilter());
@@ -86,7 +89,10 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
   @Override
   public ResponseEntity<Void> deleteReview(String studyId, String cohortId, String reviewId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), DELETE, COHORT_REVIEW, new ResourceId(reviewId));
+        SpringAuthentication.getCurrentUser(),
+        DELETE,
+        COHORT_REVIEW,
+        ResourceId.forReview(studyId, cohortId, reviewId));
     reviewService.deleteReview(studyId, cohortId, reviewId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -94,7 +100,10 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
   @Override
   public ResponseEntity<ApiReviewV2> getReview(String studyId, String cohortId, String reviewId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, COHORT_REVIEW, new ResourceId(reviewId));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        COHORT_REVIEW,
+        ResourceId.forReview(studyId, cohortId, reviewId));
     return ResponseEntity.ok(
         toApiObject(
             reviewService.getReview(studyId, cohortId, reviewId),
@@ -119,7 +128,10 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
   public ResponseEntity<ApiReviewV2> updateReview(
       String studyId, String cohortId, String reviewId, ApiReviewUpdateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, COHORT_REVIEW, new ResourceId(reviewId));
+        SpringAuthentication.getCurrentUser(),
+        UPDATE,
+        COHORT_REVIEW,
+        ResourceId.forReview(studyId, cohortId, reviewId));
     Review updatedReview =
         reviewService.updateReview(
             studyId,
@@ -139,7 +151,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
         SpringAuthentication.getCurrentUser(),
         QUERY_INSTANCES,
         COHORT_REVIEW,
-        new ResourceId(reviewId));
+        ResourceId.forReview(studyId, cohortId, reviewId));
     ApiReviewInstanceListV2 apiReviewInstances = new ApiReviewInstanceListV2();
     reviewService
         .listReviewInstances(
@@ -159,7 +171,7 @@ public class ReviewsV2ApiController implements ReviewsV2Api {
         SpringAuthentication.getCurrentUser(),
         QUERY_COUNTS,
         COHORT_REVIEW,
-        new ResourceId(reviewId));
+        ResourceId.forReview(studyId, cohortId, reviewId));
     Pair<String, List<EntityInstanceCount>> countResult =
         reviewService.countReviewInstances(studyId, cohortId, reviewId, body.getAttributes());
     ApiInstanceCountListV2 apiCounts = new ApiInstanceCountListV2().sql(countResult.getKey());

--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
@@ -57,7 +57,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
   @Override
   public ResponseEntity<Void> deleteStudy(String studyId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), DELETE, STUDY, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), DELETE, STUDY, ResourceId.forStudy(studyId));
     studyService.deleteStudy(studyId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
@@ -65,7 +65,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
   @Override
   public ResponseEntity<ApiStudyV2> getStudy(String studyId) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, STUDY, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), READ, STUDY, ResourceId.forStudy(studyId));
     return ResponseEntity.ok(toApiObject(studyService.getStudy(studyId)));
   }
 
@@ -83,7 +83,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
   @Override
   public ResponseEntity<ApiStudyV2> updateStudy(String studyId, ApiStudyUpdateInfoV2 body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, STUDY, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), UPDATE, STUDY, ResourceId.forStudy(studyId));
     Study updatedStudy =
         studyService.updateStudy(
             studyId,
@@ -97,7 +97,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
   public ResponseEntity<Void> updateStudyProperties(
       String studyId, List<ApiPropertyKeyValueV2> body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, STUDY, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), UPDATE, STUDY, ResourceId.forStudy(studyId));
     studyService.updateStudyProperties(
         studyId, SpringAuthentication.getCurrentUser().getEmail(), fromApiObject(body));
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -106,7 +106,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
   @Override
   public ResponseEntity<Void> deleteStudyProperties(String studyId, List<String> body) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), UPDATE, STUDY, new ResourceId(studyId));
+        SpringAuthentication.getCurrentUser(), UPDATE, STUDY, ResourceId.forStudy(studyId));
     studyService.deleteStudyProperties(
         studyId, SpringAuthentication.getCurrentUser().getEmail(), body);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
@@ -43,7 +43,10 @@ public class UnderlaysV2ApiController implements UnderlaysV2Api {
   @Override
   public ResponseEntity<ApiUnderlayV2> getUnderlay(String underlayName) {
     accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(), READ, UNDERLAY, new ResourceId(underlayName));
+        SpringAuthentication.getCurrentUser(),
+        READ,
+        UNDERLAY,
+        ResourceId.forUnderlay(underlayName));
     return ResponseEntity.ok(toApiObject(underlaysService.getUnderlay(underlayName)));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/AnnotationService.java
@@ -50,7 +50,7 @@ public class AnnotationService {
       return annotationDao.getAnnotationKeysMatchingList(
           cohortId,
           authorizedAnnotationKeyIds.getResourceIds().stream()
-              .map(ResourceId::getId)
+              .map(ResourceId::getAnnotationKey)
               .collect(Collectors.toSet()),
           offset,
           limit);

--- a/service/src/main/java/bio/terra/tanagra/service/CohortService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/CohortService.java
@@ -80,7 +80,7 @@ public class CohortService {
     } else {
       return cohortDao.getCohortsMatchingList(
           authorizedCohortIds.getResourceIds().stream()
-              .map(ResourceId::getId)
+              .map(ResourceId::getCohort)
               .collect(Collectors.toSet()),
           offset,
           limit);

--- a/service/src/main/java/bio/terra/tanagra/service/ConceptSetService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/ConceptSetService.java
@@ -57,7 +57,7 @@ public class ConceptSetService {
     } else {
       return conceptSetDao.getConceptSetsMatchingList(
           authorizedConceptSetIds.getResourceIds().stream()
-              .map(ResourceId::getId)
+              .map(ResourceId::getConceptSet)
               .collect(Collectors.toSet()),
           offset,
           limit);

--- a/service/src/main/java/bio/terra/tanagra/service/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/ReviewService.java
@@ -151,7 +151,7 @@ public class ReviewService {
     } else {
       return reviewDao.getReviewsMatchingList(
           authorizedReviewIds.getResourceIds().stream()
-              .map(ResourceId::getId)
+              .map(ResourceId::getReview)
               .collect(Collectors.toSet()),
           offset,
           limit);

--- a/service/src/main/java/bio/terra/tanagra/service/StudyService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/StudyService.java
@@ -49,7 +49,7 @@ public class StudyService {
       }
       return studyDao.getStudiesMatchingList(
           authorizedIds.getResourceIds().stream()
-              .map(ResourceId::getId)
+              .map(ResourceId::getStudy)
               .collect(Collectors.toSet()),
           offset,
           limit);

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlaysService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlaysService.java
@@ -53,7 +53,7 @@ public class UnderlaysService {
       }
       List<String> authorizedNames =
           authorizedIds.getResourceIds().stream()
-              .map(ResourceId::getId)
+              .map(ResourceId::getUnderlay)
               .collect(Collectors.toList());
       return underlaysMap.values().stream()
           .filter(underlay -> authorizedNames.contains(underlay.getName()))

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/AccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/AccessControl.java
@@ -19,5 +19,11 @@ public interface AccessControl {
   boolean isAuthorized(
       UserId userId, Action action, ResourceType resourceType, ResourceId resourceId);
 
-  ResourceIdCollection listResourceIds(UserId userId, ResourceType type, int offset, int limit);
+  default ResourceIdCollection listResourceIds(
+      UserId userId, ResourceType type, int offset, int limit) {
+    return listResourceIds(userId, type, null, offset, limit);
+  }
+
+  ResourceIdCollection listResourceIds(
+      UserId userId, ResourceType type, ResourceId parentResourceId, int offset, int limit);
 }

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceId.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceId.java
@@ -1,19 +1,196 @@
 package bio.terra.tanagra.service.accesscontrol;
 
-/**
- * Strongly typed wrapper around a String identifying a Tanagra resource (e.g. underlay, study,
- * cohort). In the future, we may need to support other data types.
- *
- * <p>Strongly instead of Stringly typing this makes its usage clearer and more type safe.
- */
-public class ResourceId {
-  private final String id;
+import static bio.terra.tanagra.service.accesscontrol.ResourceType.*;
 
-  public ResourceId(String id) {
-    this.id = id;
+import bio.terra.tanagra.exception.SystemException;
+import java.util.List;
+import org.apache.logging.log4j.util.Strings;
+
+public final class ResourceId {
+  private static final char COMPOSITE_ID_SEPARATOR = '-';
+  private final ResourceType type;
+  private final String underlay;
+  private final String study;
+  private final String cohort;
+  private final String conceptSet;
+  private final String dataset;
+  private final String review;
+  private final String annotationKey;
+
+  private ResourceId(Builder builder) {
+    this.type = builder.type;
+    this.underlay = builder.underlay;
+    this.study = builder.study;
+    this.cohort = builder.cohort;
+    this.conceptSet = builder.conceptSet;
+    this.dataset = builder.dataset;
+    this.review = builder.review;
+    this.annotationKey = builder.annotationKey;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static ResourceId forUnderlay(String underlay) {
+    return builder().type(UNDERLAY).underlay(underlay).build();
+  }
+
+  public static ResourceId forStudy(String study) {
+    return builder().type(STUDY).study(study).build();
+  }
+
+  public static ResourceId forCohort(String study, String cohort) {
+    return builder().type(COHORT).study(study).cohort(cohort).build();
+  }
+
+  public static ResourceId forConceptSet(String study, String conceptSet) {
+    return builder().type(CONCEPT_SET).study(study).conceptSet(conceptSet).build();
+  }
+
+  public static ResourceId forDataset(String study, String dataset) {
+    return builder().type(DATASET).study(study).dataset(dataset).build();
+  }
+
+  public static ResourceId forReview(String study, String cohort, String review) {
+    return builder().type(COHORT_REVIEW).study(study).cohort(cohort).review(review).build();
+  }
+
+  public static ResourceId forAnnotationKey(String study, String cohort, String annotationKey) {
+    return builder()
+        .type(ANNOTATION)
+        .study(study)
+        .cohort(cohort)
+        .annotationKey(annotationKey)
+        .build();
   }
 
   public String getId() {
-    return id;
+    switch (type) {
+      case UNDERLAY:
+        return underlay;
+      case STUDY:
+        return study;
+      case COHORT:
+        return buildCompositeId(List.of(study, cohort));
+      case CONCEPT_SET:
+        return buildCompositeId(List.of(study, conceptSet));
+      case DATASET:
+        return buildCompositeId(List.of(study, dataset));
+      case COHORT_REVIEW:
+        return buildCompositeId(List.of(study, cohort, review));
+      case ANNOTATION:
+        return buildCompositeId(List.of(study, cohort, annotationKey));
+      default:
+        throw new IllegalArgumentException("Unknown resource type: " + type);
+    }
+  }
+
+  private static String buildCompositeId(List<String> ids) {
+    return Strings.join(ids, COMPOSITE_ID_SEPARATOR);
+  }
+
+  public String getUnderlay() {
+    if (type != UNDERLAY) {
+      throw new SystemException("Underlay id is not set for resource type: " + type);
+    }
+    return underlay;
+  }
+
+  public String getStudy() {
+    if (type == UNDERLAY) {
+      throw new SystemException("Study id is not set for resource type: " + type);
+    }
+    return study;
+  }
+
+  public String getCohort() {
+    if (!List.of(COHORT, COHORT_REVIEW, ANNOTATION).contains(type)) {
+      throw new SystemException("Cohort id is not set for resource type: " + type);
+    }
+    return cohort;
+  }
+
+  public String getConceptSet() {
+    if (type != CONCEPT_SET) {
+      throw new SystemException("Concept set id is not set for resource type: " + type);
+    }
+    return conceptSet;
+  }
+
+  public String getDataset() {
+    if (type != DATASET) {
+      throw new SystemException("Dataset id is not set for resource type: " + type);
+    }
+    return dataset;
+  }
+
+  public String getReview() {
+    if (type != COHORT_REVIEW) {
+      throw new SystemException("Review id is not set for resource type: " + type);
+    }
+    return review;
+  }
+
+  public String getAnnotationKey() {
+    if (type != ANNOTATION) {
+      throw new SystemException("Annotation key id is not set for resource type: " + type);
+    }
+    return annotationKey;
+  }
+
+  public static class Builder {
+    private ResourceType type;
+    private String underlay;
+    private String study;
+    private String cohort;
+    private String conceptSet;
+    private String dataset;
+    private String review;
+    private String annotationKey;
+
+    public Builder type(ResourceType type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder underlay(String underlay) {
+      this.underlay = underlay;
+      return this;
+    }
+
+    public Builder study(String study) {
+      this.study = study;
+      return this;
+    }
+
+    public Builder cohort(String cohort) {
+      this.cohort = cohort;
+      return this;
+    }
+
+    public Builder conceptSet(String conceptSet) {
+      this.conceptSet = conceptSet;
+      return this;
+    }
+
+    public Builder dataset(String dataset) {
+      this.dataset = dataset;
+      return this;
+    }
+
+    public Builder review(String review) {
+      this.review = review;
+      return this;
+    }
+
+    public Builder annotationKey(String annotationKey) {
+      this.annotationKey = annotationKey;
+      return this;
+    }
+
+    public ResourceId build() {
+      return new ResourceId(this);
+    }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceIdCollection.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceIdCollection.java
@@ -25,6 +25,10 @@ public final class ResourceIdCollection {
     return new ResourceIdCollection(true, null);
   }
 
+  public static ResourceIdCollection empty() {
+    return new ResourceIdCollection(false, null);
+  }
+
   public boolean isAllResourceIds() {
     return isAllResourceIds;
   }
@@ -36,6 +40,6 @@ public final class ResourceIdCollection {
   }
 
   public boolean isEmpty() {
-    return resourceIds.isEmpty();
+    return !isAllResourceIds && (resourceIds == null || resourceIds.isEmpty());
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/OpenAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/OpenAccessControl.java
@@ -27,7 +27,7 @@ public class OpenAccessControl implements AccessControl {
 
   @Override
   public ResourceIdCollection listResourceIds(
-      UserId userId, ResourceType type, int offset, int limit) {
+      UserId userId, ResourceType type, ResourceId parentResourceId, int offset, int limit) {
     // Everyone can list everything.
     return ResourceIdCollection.allResourceIds();
   }

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.service.accesscontrol.impl;
 
+import static bio.terra.tanagra.service.accesscontrol.Action.*;
+
 import bio.terra.tanagra.service.VumcAdminService;
 import bio.terra.tanagra.service.accesscontrol.AccessControl;
 import bio.terra.tanagra.service.accesscontrol.Action;
@@ -7,6 +9,7 @@ import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.accesscontrol.ResourceIdCollection;
 import bio.terra.tanagra.service.accesscontrol.ResourceType;
 import bio.terra.tanagra.service.auth.UserId;
+import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.vumc.vda.tanagra.admin.model.ResourceAction;
@@ -28,24 +31,73 @@ public class VumcAdminAccessControl implements AccessControl {
   @Override
   public boolean isAuthorized(
       UserId userId, Action action, ResourceType resourceType, @Nullable ResourceId resourceId) {
-    return vumcAdminService.isAuthorized(
-        userId.getEmail(),
-        ResourceAction.valueOf(action.toString()),
-        org.vumc.vda.tanagra.admin.model.ResourceType.valueOf(resourceType.toString()),
-        resourceId == null ? null : resourceId.toString());
+    if (resourceType == ResourceType.UNDERLAY) {
+      // For underlays, check authorization with the underlay id.
+      String underlayId = resourceId == null ? null : resourceId.getUnderlay();
+      return vumcAdminService.isAuthorized(
+          userId.getEmail(),
+          ResourceAction.valueOf(action.toString()),
+          org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY,
+          underlayId);
+    } else if (resourceType == ResourceType.STUDY) {
+      // For studies, check authorization with the study id.
+      String studyId = resourceId == null ? null : resourceId.getStudy();
+      return vumcAdminService.isAuthorized(
+          userId.getEmail(),
+          ResourceAction.valueOf(action.toString()),
+          org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+          studyId);
+    } else {
+      // For artifacts that are children of a study (e.g. cohort):
+      //   - Map the action type to the action on the study (e.g. create cohort -> update study).
+      //   - Check authorization with the parent study id.
+      String studyId = resourceId == null ? null : resourceId.getStudy();
+      Action actionOnStudy =
+          List.of(READ, QUERY_INSTANCES, QUERY_COUNTS).contains(action) ? READ : UPDATE;
+      return vumcAdminService.isAuthorized(
+          userId.getEmail(),
+          ResourceAction.valueOf(actionOnStudy.toString()),
+          org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+          studyId);
+    }
   }
 
   @Override
   public ResourceIdCollection listResourceIds(
-      UserId userId, ResourceType resourceType, int offset, int limit) {
+      UserId userId,
+      ResourceType resourceType,
+      ResourceId parentResourceId,
+      int offset,
+      int limit) {
     ResourceTypeList resourceTypeList = new ResourceTypeList();
-    resourceTypeList.add(
-        org.vumc.vda.tanagra.admin.model.ResourceType.valueOf(resourceType.toString()));
-    ResourceList resourceList =
-        vumcAdminService.listAuthorizedResources(userId.getEmail(), resourceTypeList);
-    return ResourceIdCollection.forCollection(
-        resourceList.stream()
-            .map(resource -> new ResourceId(resource.getId()))
-            .collect(Collectors.toList()));
+    if (resourceType == ResourceType.UNDERLAY) {
+      // For underlays, list authorized underlay ids.
+      resourceTypeList.add(org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY);
+      ResourceList resourceList =
+          vumcAdminService.listAuthorizedResources(userId.getEmail(), resourceTypeList);
+      return ResourceIdCollection.forCollection(
+          resourceList.stream()
+              .map(resource -> ResourceId.forUnderlay(resource.getId()))
+              .collect(Collectors.toList()));
+    } else if (resourceType == ResourceType.STUDY) {
+      // For studies, list authorized study ids.
+      resourceTypeList.add(org.vumc.vda.tanagra.admin.model.ResourceType.STUDY);
+      ResourceList resourceList =
+          vumcAdminService.listAuthorizedResources(userId.getEmail(), resourceTypeList);
+      return ResourceIdCollection.forCollection(
+          resourceList.stream()
+              .map(resource -> ResourceId.forStudy(resource.getId()))
+              .collect(Collectors.toList()));
+    } else {
+      // For artifacts that are children of a study (e.g. cohort), check if the user is authorized
+      // to read the parent study.
+      //   - If yes, they can see all children artifacts in it (e.g. cohorts).
+      //   - If no, they can see no children artifacts in it.
+      if (isAuthorized(userId, READ, ResourceType.STUDY, parentResourceId)) {
+        return ResourceIdCollection.allResourceIds();
+      } else {
+        return ResourceIdCollection.empty();
+      }
+    }
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
@@ -238,7 +238,10 @@ public class AnnotationServiceTest {
     // List selected annotation key for cohort2.
     List<AnnotationKey> selectedAnnotationKeys =
         annotationService.listAnnotationKeys(
-            ResourceIdCollection.forCollection(List.of(new ResourceId(annotationKey3.getId()))),
+            ResourceIdCollection.forCollection(
+                List.of(
+                    ResourceId.forAnnotationKey(
+                        study1.getId(), cohort2.getId(), annotationKey3.getId()))),
             study1.getId(),
             cohort2.getId(),
             0,
@@ -257,7 +260,8 @@ public class AnnotationServiceTest {
     // List selected.
     List<AnnotationKey> selectedAnnotationKeys =
         annotationService.listAnnotationKeys(
-            ResourceIdCollection.forCollection(List.of(new ResourceId("123"))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forAnnotationKey(study1.getId(), cohort1.getId(), "123"))),
             study1.getId(),
             cohort1.getId(),
             0,

--- a/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
@@ -164,7 +164,8 @@ public class CohortServiceTest {
     // List selected cohort in study2.
     List<Cohort> selectedCohorts =
         cohortService.listCohorts(
-            ResourceIdCollection.forCollection(List.of(new ResourceId(cohort3.getId()))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forCohort(study2.getId(), cohort3.getId()))),
             study2.getId(),
             0,
             10);
@@ -181,7 +182,8 @@ public class CohortServiceTest {
     // List selected.
     List<Cohort> selectedCohorts =
         cohortService.listCohorts(
-            ResourceIdCollection.forCollection(List.of(new ResourceId("123"))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forCohort(study1.getId(), "123"))),
             study1.getId(),
             0,
             10);

--- a/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
@@ -184,7 +184,8 @@ public class ConceptSetServiceTest {
     // List selected concept set in study2.
     List<ConceptSet> selectedConceptSets =
         conceptSetService.listConceptSets(
-            ResourceIdCollection.forCollection(List.of(new ResourceId(conceptSet3.getId()))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forConceptSet(study2.getId(), conceptSet3.getId()))),
             study2.getId(),
             0,
             10);
@@ -202,7 +203,8 @@ public class ConceptSetServiceTest {
     // List selected.
     List<ConceptSet> selectedConceptSets =
         conceptSetService.listConceptSets(
-            ResourceIdCollection.forCollection(List.of(new ResourceId("123"))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forConceptSet(study1.getId(), "123"))),
             study1.getId(),
             0,
             10);

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
@@ -203,7 +203,8 @@ public class ReviewServiceTest {
     // List selected review for cohort2.
     List<Review> selectedReviews =
         reviewService.listReviews(
-            ResourceIdCollection.forCollection(List.of(new ResourceId(review3.getId()))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forReview(study1.getId(), cohort2.getId(), review3.getId()))),
             study1.getId(),
             cohort2.getId(),
             0,
@@ -222,7 +223,8 @@ public class ReviewServiceTest {
     // List selected.
     List<Review> selectedReviews =
         reviewService.listReviews(
-            ResourceIdCollection.forCollection(List.of(new ResourceId("123"))),
+            ResourceIdCollection.forCollection(
+                List.of(ResourceId.forReview(study1.getId(), cohort1.getId(), "123"))),
             study1.getId(),
             cohort1.getId(),
             0,

--- a/service/src/test/java/bio/terra/tanagra/service/StudyServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/StudyServiceTest.java
@@ -96,7 +96,9 @@ public class StudyServiceTest {
     // List selected.
     List<Study> selectedStudies =
         studyService.listStudies(
-            ResourceIdCollection.forCollection(List.of(new ResourceId(study2.getId()))), 0, 10);
+            ResourceIdCollection.forCollection(List.of(ResourceId.forStudy(study2.getId()))),
+            0,
+            10);
     assertEquals(1, selectedStudies.size());
     assertEquals(study2.getId(), selectedStudies.get(0).getId());
   }
@@ -110,7 +112,7 @@ public class StudyServiceTest {
     // List selected.
     List<Study> selectedStudies =
         studyService.listStudies(
-            ResourceIdCollection.forCollection(List.of(new ResourceId("123"))), 0, 10);
+            ResourceIdCollection.forCollection(List.of(ResourceId.forStudy("123"))), 0, 10);
     assertTrue(selectedStudies.isEmpty());
 
     // Get invalid.

--- a/service/src/test/java/bio/terra/tanagra/service/UnderlaysServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/UnderlaysServiceTest.java
@@ -35,7 +35,7 @@ public class UnderlaysServiceTest {
 
     List<Underlay> oneUnderlay =
         underlaysService.listUnderlays(
-            ResourceIdCollection.forCollection(List.of(new ResourceId(underlayName))));
+            ResourceIdCollection.forCollection(List.of(ResourceId.forUnderlay(underlayName))));
     assertEquals(1, oneUnderlay.size());
     assertEquals(underlayName, oneUnderlay.get(0).getName());
 


### PR DESCRIPTION
- Changed the `ResourceId` field to store different parts of the ID separately (e.g. review id = study-cohort-review), instead of just a single string.
- Added named `ResourceId` constructors to make it clearer which type of resource the id refers to.
- Added a dedicated `ResourceIdCollcetion.empty` constructor to replace the special  null handling.
- Updated the `VUMCAccessControl` class to just use the study id for all children artifacts (e.g. cohorts).