### PR TITLE
Restyle tables to match new UX designs

### DIFF
--- a/ui/cypress/e2e/cohortReview.cy.js
+++ b/ui/cypress/e2e/cohortReview.cy.js
@@ -12,9 +12,7 @@ describe("Basic tests", () => {
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("[data-testid='tanagra-procedures']").click();
     cy.get("input").type("Retrograde pyelogram");
-    cy.get("button:Contains(Retrograde pyelogram)", { timeout: 20000 })
-      .first()
-      .click();
+    cy.get("[data-testid='Retrograde pyelogram']", { timeout: 20000 }).click();
 
     cy.contains("Review").click();
 

--- a/ui/cypress/e2e/export.cy.js
+++ b/ui/cypress/e2e/export.cy.js
@@ -13,7 +13,7 @@ describe("Basic tests", () => {
     cy.get("button[id=insert-concept-set]").click();
     cy.get("[data-testid='tanagra-conditions']").click();
     cy.get("input").type("Red color");
-    cy.get("button:Contains(Red color)").click();
+    cy.get("[data-testid='Red color']").click();
 
     cy.get(`button[name='${cohort1}']`).click();
     cy.get(`button[name='${cohort2}']`).click();

--- a/ui/cypress/e2e/tests.cy.js
+++ b/ui/cypress/e2e/tests.cy.js
@@ -12,7 +12,7 @@ describe("Basic tests", () => {
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("[data-testid='tanagra-conditions']").click();
     cy.get("[data-testid='AccountTreeIcon']").first().click();
-    cy.get("button:Contains(Clinical finding)").click();
+    cy.get("[data-testid='Clinical finding']").click();
 
     cy.get("button:Contains(Add criteria)").first().click();
     cy.get("[data-testid='tanagra-race']").click();
@@ -28,18 +28,18 @@ describe("Basic tests", () => {
 
     cy.get("button:Contains(Add criteria)").last().click();
     cy.get("[data-testid='tanagra-observations']").click();
-    cy.get("button:Contains(Marital status)", { timeout: 20000 }).click();
+    cy.get("[data-testid='Marital status']", { timeout: 20000 }).click();
 
     cy.get("button:Contains(Add criteria)").last().click();
     cy.get("input").type("clinical");
-    cy.get("button:Contains(Imaging)", { timeout: 20000 }).first().click();
+    cy.get("[data-testid='Imaging']", { timeout: 20000 }).first().click();
 
     cy.get("a[aria-label=back]").click();
 
     cy.get("button[id=insert-concept-set]").click();
     cy.get("[data-testid='tanagra-conditions']").click();
     cy.get("[data-testid='AccountTreeIcon']").first().click();
-    cy.get("button:Contains(Clinical finding)").click();
+    cy.get("[data-testid='Clinical finding']").click();
 
     cy.get(`button[name='${cohortName}']`).click();
     cy.get("button[name='Condition: Clinical finding']").click();

--- a/ui/cypress/support/e2e.js
+++ b/ui/cypress/support/e2e.js
@@ -20,6 +20,6 @@ Cypress.Commands.add("createCohortFromSearch", (name, search, domain) => {
     cy.get(`[data-testid='${domain}']`).click();
   }
   cy.get("input").type(search);
-  cy.get(`button:Contains(${search})`, { timeout: 20000 }).first().click();
+  cy.get(`[data-testid='${search}']`, { timeout: 20000 }).first().click();
   cy.get("a[aria-label=back]").click();
 });

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -1,8 +1,7 @@
-import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
-import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
 import { insertCohortCriteria, useCohortContext } from "cohortContext";
@@ -14,6 +13,7 @@ import {
   TreeGridData,
   TreeGridId,
   TreeGridItem,
+  TreeGridRowData,
 } from "components/treegrid";
 import { createConceptSet, useConceptSetContext } from "conceptSetContext";
 import { MergedDataEntry, useSource } from "data/source";
@@ -80,6 +80,7 @@ type AddCriteriaProps = {
 };
 
 function AddCriteria(props: AddCriteriaProps) {
+  const theme = useTheme();
   const underlay = useUnderlay();
   const source = useSource();
   const navigate = useNavigate();
@@ -123,6 +124,10 @@ function AddCriteria(props: AddCriteriaProps) {
         title: "Criteria type",
       },
       ...searchConfig.columns,
+      {
+        key: "t_add_button",
+        width: 80,
+      },
     ],
     [underlay]
   );
@@ -196,14 +201,13 @@ function AddCriteria(props: AddCriteriaProps) {
     <GridBox
       sx={{
         backgroundColor: (theme) => theme.palette.background.paper,
-        overflowY: "auto",
-        px: 5,
-        py: 3,
       }}
     >
       <ActionBar title={props.title} backURL={props.backURL} />
-      <GridLayout rows spacing={3}>
-        <Search placeholder="Search by code or description" />
+      <GridLayout rows>
+        <GridBox sx={{ px: 5, py: 3 }}>
+          <Search placeholder="Search by code or description" />
+        </GridBox>
         <Loading status={searchState}>
           {!searchState.data?.root?.children?.length ? (
             query !== "" ? (
@@ -213,75 +217,104 @@ function AddCriteria(props: AddCriteriaProps) {
                 title="No matches found"
               />
             ) : (
-              <GridLayout rows height="auto">
-                {categories.map((category) => (
-                  <GridLayout key={category[0].category} rows height="auto">
-                    <GridBox
-                      key={category[0].category}
-                      sx={{
-                        p: 1.5,
-                        backgroundColor: (theme) => theme.palette.info.main,
-                        borderBottomStyle: "solid",
-                        borderColor: (theme) => theme.palette.divider,
-                        borderWidth: "2px",
-                        height: "auto",
+              <GridBox sx={{ px: 5, overflowY: "auto" }}>
+                <table
+                  style={{
+                    tableLayout: "fixed",
+                    width: "100%",
+                    textAlign: "left",
+                    borderCollapse: "collapse",
+                  }}
+                >
+                  <colgroup>
+                    <col
+                      style={{
+                        width: "100%",
+                        minWidth: "100%",
+                        maxWidth: "100%",
+                        verticalAlign: "center",
                       }}
-                    >
-                      <Typography key="" variant="overline">
-                        {category[0].category ?? "Uncategorized"}
-                      </Typography>
-                    </GridBox>
-                    {category.map((config) => (
-                      <GridLayout
-                        key={config.id}
-                        cols
-                        fillCol={1}
-                        rowAlign="middle"
-                        sx={{
-                          p: 1.5,
-                          borderBottomStyle: "solid",
-                          borderColor: (theme) => theme.palette.divider,
-                          borderWidth: "1px",
-                          height: "auto",
-                        }}
-                      >
-                        <Typography variant="body2">{config.title}</Typography>
-                        <GridBox />
-                        <GridLayout
-                          colAlign="center"
-                          width="100px"
-                          height="auto"
+                    />
+                    <col
+                      style={{
+                        width: "80px",
+                        minWidth: "80px",
+                        maxWidth: "80px",
+                        verticalAlign: "center",
+                      }}
+                    />
+                  </colgroup>
+                  <tbody>
+                    {categories.map((category) => [
+                      <tr key={category[0].category}>
+                        <th
+                          colSpan={2}
+                          style={{
+                            position: "sticky",
+                            top: 0,
+                            backgroundColor: theme.palette.info.main,
+                            boxShadow: `inset 0 -2px 0 ${theme.palette.divider}`,
+                            zIndex: 1,
+                            height: theme.spacing(6),
+                          }}
                         >
-                          {criteriaConfigMap.get(config.id)?.showMore ? (
-                            <IconButton
-                              key={config.id}
-                              data-testid={config.id}
-                              onClick={() => onClick(config)}
-                            >
-                              <NavigateNextIcon />
-                            </IconButton>
-                          ) : (
-                            <Button
-                              key={config.id}
-                              data-testid={config.id}
-                              onClick={() => onClick(config)}
-                              variant="outlined"
-                            >
-                              Add
-                            </Button>
-                          )}
-                        </GridLayout>
-                      </GridLayout>
-                    ))}
-                  </GridLayout>
-                ))}
-              </GridLayout>
+                          <Typography key="" variant="overline">
+                            {category[0].category}
+                          </Typography>
+                        </th>
+                      </tr>,
+                      ...category.map((config) => (
+                        <tr key={config.id}>
+                          <td
+                            style={{
+                              boxShadow: `inset 0 -1px 0 ${theme.palette.divider}`,
+                              height: theme.spacing(6),
+                            }}
+                          >
+                            <Typography key="" variant="body2">
+                              {config.title}
+                            </Typography>
+                          </td>
+                          <td
+                            style={{
+                              boxShadow: `inset 0 -1px 0 ${theme.palette.divider}`,
+                            }}
+                          >
+                            <GridLayout colAlign="center">
+                              {criteriaConfigMap.get(config.id)?.showMore ? (
+                                <Button
+                                  key={config.id}
+                                  data-testid={config.id}
+                                  onClick={() => onClick(config)}
+                                  variant="outlined"
+                                >
+                                  Explore
+                                </Button>
+                              ) : (
+                                <Button
+                                  key={config.id}
+                                  data-testid={config.id}
+                                  onClick={() => onClick(config)}
+                                  variant="outlined"
+                                  sx={{ minWidth: "auto" }}
+                                >
+                                  Add
+                                </Button>
+                              )}
+                            </GridLayout>
+                          </td>
+                        </tr>
+                      )),
+                    ])}
+                  </tbody>
+                </table>
+              </GridBox>
             )
           ) : (
             <TreeGrid
               columns={columns}
               data={searchState.data ?? {}}
-              rowCustomization={(id: TreeGridId) => {
+              rowCustomization={(id: TreeGridId, rowData: TreeGridRowData) => {
                 if (!searchState.data) {
                   return undefined;
                 }
@@ -296,8 +329,18 @@ function AddCriteria(props: AddCriteriaProps) {
 
                 return [
                   {
-                    column: 1,
-                    onClick: () => onClick(config, item.entry.data),
+                    column: columns.length - 1,
+                    content: (
+                      <GridLayout colAlign="center">
+                        <Button
+                          data-testid={rowData[searchConfig.columns[0].key]}
+                          onClick={() => onClick(config, item.entry.data)}
+                          variant="outlined"
+                        >
+                          Add
+                        </Button>
+                      </GridLayout>
+                    ),
                   },
                 ];
               }}

--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Table renders correctly 1`] = `
 <div
-  className="css-o1f3wd"
+  className="css-1qqflhf"
 >
   <table
     style={
@@ -20,7 +20,8 @@ exports[`Table renders correctly 1`] = `
           style={
             Object {
               "backgroundColor": "#fff",
-              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "boxShadow": "inset 0 -2px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": "100%",
               "minWidth": "100%",
               "position": "sticky",
@@ -45,7 +46,8 @@ exports[`Table renders correctly 1`] = `
           style={
             Object {
               "backgroundColor": "#fff",
-              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "boxShadow": "inset 0 -2px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 150,
               "minWidth": 150,
               "position": "sticky",
@@ -70,7 +72,8 @@ exports[`Table renders correctly 1`] = `
           style={
             Object {
               "backgroundColor": "#fff",
-              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "boxShadow": "inset 0 -2px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 50,
               "minWidth": 50,
               "position": "sticky",
@@ -110,6 +113,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": "100%",
               "minWidth": "100%",
               "width": "100%",
@@ -161,6 +166,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 150,
               "minWidth": 150,
               "width": 150,
@@ -181,6 +188,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 50,
               "minWidth": 50,
               "width": 50,
@@ -209,6 +218,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": "100%",
               "minWidth": "100%",
               "width": "100%",
@@ -259,6 +270,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 150,
               "minWidth": 150,
               "width": 150,
@@ -279,6 +292,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 50,
               "minWidth": 50,
               "width": 50,
@@ -303,6 +318,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": "100%",
               "minWidth": "100%",
               "width": "100%",
@@ -323,6 +340,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 150,
               "minWidth": 150,
               "width": 150,
@@ -343,6 +362,8 @@ exports[`Table renders correctly 1`] = `
         <td
           style={
             Object {
+              "boxShadow": "inset 0 -1px 0 rgba(0, 0, 0, 0.12)",
+              "height": "48px",
               "maxWidth": 50,
               "minWidth": 50,
               "width": 50,

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -6,11 +6,12 @@ import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
-import { useTheme } from "@mui/material/styles";
+import { Theme, useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { GridBox } from "layout/gridBox";
 import { ReactNode, useEffect, useRef } from "react";
 import { useImmer } from "use-immer";
+import { spacing } from "util/spacing";
 
 export type TreeGridId = string | number;
 export type TreeGridValue =
@@ -60,6 +61,8 @@ export type TreeGridProps = {
   loadChildren?: (id: TreeGridId) => Promise<void>;
   minWidth?: boolean;
   wrapBodyText?: boolean;
+  rowHeight?: number | string;
+  padding?: number | string;
 };
 
 export function TreeGrid(props: TreeGridProps) {
@@ -130,10 +133,9 @@ export function TreeGrid(props: TreeGridProps) {
   }, [props.defaultExpanded]);
 
   const paperColor = theme.palette.background.paper;
-  const dividerColor = theme.palette.divider;
 
   return (
-    <GridBox sx={{ overflowY: "auto", px: 1 }}>
+    <GridBox sx={{ overflowY: "auto", px: spacing(theme, props.padding ?? 5) }}>
       <table
         style={{
           tableLayout: "fixed",
@@ -155,8 +157,9 @@ export function TreeGrid(props: TreeGridProps) {
                     width: col.width,
                     minWidth: col.width,
                   }),
+                  height: spacing(theme, props.rowHeight ?? 6),
                   backgroundColor: paperColor,
-                  boxShadow: `inset 0 -1px 0 ${dividerColor}`,
+                  boxShadow: `inset 0 -2px 0 ${theme.palette.divider}`,
                   zIndex: 1,
                 }}
               >
@@ -183,6 +186,7 @@ export function TreeGrid(props: TreeGridProps) {
         </thead>
         <tbody>
           {renderChildren(
+            theme,
             props,
             state,
             (id: TreeGridId) =>
@@ -198,6 +202,7 @@ export function TreeGrid(props: TreeGridProps) {
 }
 
 function renderChildren(
+  theme: Theme,
   props: TreeGridProps,
   state: TreeGridState,
   toggleExpanded: (id: TreeGridId) => void,
@@ -311,6 +316,8 @@ function renderChildren(
                   width: col.width,
                   minWidth: col.width,
                 }),
+                height: spacing(theme, props.rowHeight ?? 6),
+                boxShadow: `inset 0 -1px 0 ${theme.palette.divider}`,
               }}
             >
               <Stack
@@ -340,6 +347,7 @@ function renderChildren(
 
     results.push(
       ...renderChildren(
+        theme,
         props,
         state,
         toggleExpanded,

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -585,6 +585,8 @@ function Preview(props: PreviewProps) {
                       }))}
                     minWidth
                     wrapBodyText
+                    rowHeight="auto"
+                    padding={0}
                   />
                 ) : (
                   <Empty

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -110,6 +110,10 @@ export function useNewCriteria() {
   return useOptionalNewCriteria(true) as NonNullable<tanagra.Criteria>;
 }
 
+export function useIsNewCriteria() {
+  return !!useOptionalNewCriteria(false);
+}
+
 export function useGroupSectionAndGroup() {
   const { section, group } = useOptionalGroupSectionAndGroup(true);
   return {

--- a/ui/src/layout/gridLayout.tsx
+++ b/ui/src/layout/gridLayout.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import { SxProps, Theme, useTheme } from "@mui/material/styles";
 import { Children, PropsWithChildren } from "react";
+import { spacing } from "util/spacing";
 import { isValid } from "util/valid";
 
 type axisDesc = undefined | number | string | ((theme: Theme) => string) | true;
@@ -116,8 +117,4 @@ export default function GridLayout(props: PropsWithChildren<GridLayoutProps>) {
       ))}
     </Box>
   );
-}
-
-function spacing(theme: Theme, value?: string | number) {
-  return typeof value === "number" ? theme.spacing(value) : value;
 }

--- a/ui/src/studiesList.tsx
+++ b/ui/src/studiesList.tsx
@@ -60,7 +60,7 @@ export function StudiesList() {
                   <Paper sx={{ p: 1 }}>
                     <Stack direction="row">
                       <Stack>
-                        <Typography variant="h4">
+                        <Typography variant="body1em">
                           {study.displayName}
                         </Typography>
                         <Typography variant="body2">

--- a/ui/src/util/spacing.ts
+++ b/ui/src/util/spacing.ts
@@ -1,0 +1,5 @@
+import { Theme } from "@mui/material/styles";
+
+export function spacing(theme: Theme, value?: string | number) {
+  return typeof value === "number" ? theme.spacing(value) : value;
+}


### PR DESCRIPTION
* Use buttons for adding criteria instead of clicking on names. Show different text depending on whether the criteria is being added.
* Convert add criteria page to a table and tweak styling.
* Shrink study list text.
* Refactor spacing helper to a shared location.