### PR TITLE
Align headers, clean up datasets text and tooltips

### DIFF
--- a/ui/src/actionBar.tsx
+++ b/ui/src/actionBar.tsx
@@ -1,71 +1,70 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import AppBar from "@mui/material/AppBar";
 import IconButton from "@mui/material/IconButton";
-import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
-import { useAppSelector } from "hooks";
-import { Link as RouterLink, useParams } from "react-router-dom";
+import { GridBox } from "layout/gridBox";
+import GridLayout from "layout/gridLayout";
+import { Link as RouterLink } from "react-router-dom";
 
 type ActionBarProps = {
   title: string;
+  subtitle?: string | JSX.Element;
+  height?: number | string;
   backURL?: string | null; // null hides the back button.
   extraControls?: JSX.Element;
 };
 
 export default function ActionBar(props: ActionBarProps) {
-  const { underlayName } = useParams<{ underlayName: string }>();
-  const underlay = useAppSelector((state) =>
-    state.present.underlays.find((underlay) => underlay.name === underlayName)
-  );
-
   return (
-    <AppBar
-      position="fixed"
+    <GridLayout
+      rows
       sx={{
-        zIndex: (theme) => theme.zIndex.drawer + 1,
+        px: 4,
+        py: 2,
+        backgroundColor: (theme) => theme.palette.background.paper,
         borderBottomColor: (theme) => theme.palette.divider,
         borderBottomStyle: "solid",
         borderBottomWidth: "1px",
       }}
     >
-      <Toolbar disableGutters>
+      <GridLayout
+        cols={4}
+        rows={props.subtitle ? 2 : undefined}
+        fillCol={2}
+        rowAlign="middle"
+        height="auto"
+      >
         <IconButton
-          color="primary"
           aria-label="back"
           component={RouterLink}
           to={props.backURL ?? ".."}
           sx={{
-            mx: 1,
+            mr: 2,
             visibility: props.backURL === null ? "hidden" : "visible",
-            "&.MuiIconButton-root": {
-              backgroundColor: (theme) => theme.palette.primary.main,
-              color: (theme) => theme.palette.primary.contrastText,
-            },
-            "&.MuiIconButton-root:hover": {
-              backgroundColor: (theme) => theme.palette.primary.dark,
-            },
           }}
         >
           <ArrowBackIcon />
         </IconButton>
-        <Typography
-          variant="h6"
-          sx={{
-            flexGrow: 1,
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-          }}
-        >
-          {props.title}
-        </Typography>
-        {props.extraControls}
-        {underlay ? (
-          <Typography variant="body1" sx={{ mx: 1 }}>
-            Dataset: {underlay.name}
+        <GridLayout rows height="auto">
+          <Typography
+            variant="h6"
+            sx={{
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+            }}
+          >
+            {props.title}
           </Typography>
+        </GridLayout>
+        <GridBox />
+        {props.extraControls ?? <GridBox />}
+
+        {props.subtitle ? <GridBox /> : null}
+        {props.subtitle ? (
+          <Typography variant="body2">{props.subtitle}</Typography>
         ) : null}
-      </Toolbar>
-    </AppBar>
+        {props.subtitle ? <GridBox /> : null}
+      </GridLayout>
+    </GridLayout>
   );
 }

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -198,7 +198,8 @@ function AddCriteria(props: AddCriteriaProps) {
   );
 
   return (
-    <GridBox
+    <GridLayout
+      rows
       sx={{
         backgroundColor: (theme) => theme.palette.background.paper,
       }}
@@ -348,7 +349,7 @@ function AddCriteria(props: AddCriteriaProps) {
           )}
         </Loading>
       </GridLayout>
-    </GridBox>
+    </GridLayout>
   );
 }
 

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,4 +1,3 @@
-import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
 import { EntitiesApiContext, UnderlaysApiContext } from "apiContext";
@@ -60,28 +59,7 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Loading status={underlaysState}>
-        <Box
-          sx={{
-            display: "grid",
-            width: "100%",
-            height: "100%",
-            gridTemplateColumns: "1fr",
-            gridTemplateRows: (theme) => `${theme.spacing(6)} 1fr`,
-            gridTemplateAreas: "'actionBar' 'content'",
-          }}
-        >
-          <Box
-            sx={{
-              gridArea: "content",
-              width: "100%",
-              minWidth: "100%",
-              height: "100%",
-              minHeight: "100%",
-            }}
-          >
-            <RouterProvider router={createAppRouter()} />
-          </Box>
-        </Box>
+        <RouterProvider router={createAppRouter()} />
       </Loading>
     </ThemeProvider>
   );

--- a/ui/src/cohortReview/cohortReview.tsx
+++ b/ui/src/cohortReview/cohortReview.tsx
@@ -196,7 +196,7 @@ export function CohortReview() {
     useParticipantsListDialog({ count });
 
   return (
-    <GridBox>
+    <GridLayout rows>
       <ActionBar
         title={
           reviewState?.data?.displayName
@@ -370,7 +370,7 @@ export function CohortReview() {
         {newAnnotationDialog}
         {participantsListDialog}
       </Loading>
-    </GridBox>
+    </GridLayout>
   );
 }
 

--- a/ui/src/cohortReview/cohortReviewList.tsx
+++ b/ui/src/cohortReview/cohortReviewList.tsx
@@ -197,7 +197,7 @@ export function CohortReviewList() {
   });
 
   return (
-    <>
+    <GridLayout rows>
       <ActionBar
         title={`Reviews of ${cohort.name}`}
         backURL={absoluteCohortURL(params, cohort.id)}
@@ -218,60 +218,69 @@ export function CohortReviewList() {
             p: 1,
           }}
         >
-          <Stack direction="row">
-            <Typography variant="h6" sx={{ mr: 1 }}>
-              Reviews
-            </Typography>
-            <IconButton onClick={showNewReviewDialog}>
-              <AddIcon />
-            </IconButton>
-          </Stack>
-          {!!reviewsState.data?.length ? (
-            <List sx={{ p: 0 }}>
-              {reviewsState.data?.map((item) => (
-                <ListItemButton
-                  sx={{ p: 0, mt: 1 }}
-                  component={RouterLink}
-                  key={item.id()}
-                  to={absoluteCohortReviewListURL(params, cohort.id, item.id())}
-                  disabled={!!item.pending}
-                >
-                  <SelectablePaper selected={item.id() === selectedReview?.id}>
-                    <Stack
-                      direction="row"
-                      justifyContent="space-between"
-                      sx={{ p: 1 }}
+          <GridLayout rows>
+            <GridLayout cols height="auto">
+              <Typography variant="h6" sx={{ mr: 1 }}>
+                Reviews
+              </Typography>
+              <IconButton onClick={showNewReviewDialog}>
+                <AddIcon />
+              </IconButton>
+              <GridBox />
+            </GridLayout>
+            {!!reviewsState.data?.length ? (
+              <List sx={{ p: 0 }}>
+                {reviewsState.data?.map((item) => (
+                  <ListItemButton
+                    sx={{ p: 0, mt: 1 }}
+                    component={RouterLink}
+                    key={item.id()}
+                    to={absoluteCohortReviewListURL(
+                      params,
+                      cohort.id,
+                      item.id()
+                    )}
+                    disabled={!!item.pending}
+                  >
+                    <SelectablePaper
+                      selected={item.id() === selectedReview?.id}
                     >
-                      <Stack>
-                        <Typography variant="body1em">
-                          {item.displayName()}
-                        </Typography>
+                      <Stack
+                        direction="row"
+                        justifyContent="space-between"
+                        sx={{ p: 1 }}
+                      >
+                        <Stack>
+                          <Typography variant="body1em">
+                            {item.displayName()}
+                          </Typography>
+                          <Typography variant="body1">
+                            {item.created()?.toLocaleString()}
+                          </Typography>
+                          <Typography variant="body1">
+                            {`Participants: ${item.size()}`}
+                          </Typography>
+                        </Stack>
                         <Typography variant="body1">
-                          {item.created()?.toLocaleString()}
-                        </Typography>
-                        <Typography variant="body1">
-                          {`Participants: ${item.size()}`}
+                          {!!item.pending ? (
+                            <CircularProgress
+                              sx={{ maxWidth: "1em", maxHeight: "1em" }}
+                            />
+                          ) : null}
                         </Typography>
                       </Stack>
-                      <Typography variant="body1">
-                        {!!item.pending ? (
-                          <CircularProgress
-                            sx={{ maxWidth: "1em", maxHeight: "1em" }}
-                          />
-                        ) : null}
-                      </Typography>
-                    </Stack>
-                  </SelectablePaper>
-                </ListItemButton>
-              ))}
-            </List>
-          ) : (
-            <Empty
-              maxWidth="90%"
-              minHeight="200px"
-              title="No reviews created"
-            />
-          )}
+                    </SelectablePaper>
+                  </ListItemButton>
+                ))}
+              </List>
+            ) : (
+              <Empty
+                maxWidth="90%"
+                minHeight="200px"
+                title="No reviews created"
+              />
+            )}
+          </GridLayout>
         </Box>
         <Box
           sx={{
@@ -308,10 +317,10 @@ export function CohortReviewList() {
         <Box sx={{ gridArea: "1/1/-1/-1" }}>
           {reviewsState.isLoading ? <LoadingOverlay /> : undefined}
         </Box>
+        {newReviewDialog}
+        {renameReviewDialog}
       </Box>
-      {newReviewDialog}
-      {renameReviewDialog}
-    </>
+    </GridLayout>
   );
 }
 

--- a/ui/src/cohortToolbar.tsx
+++ b/ui/src/cohortToolbar.tsx
@@ -1,21 +1,11 @@
 import RedoIcon from "@mui/icons-material/Redo";
 import UndoIcon from "@mui/icons-material/Undo";
 import Button from "@mui/material/Button";
-import Divider from "@mui/material/Divider";
 import Stack from "@mui/material/Stack";
-import {
-  useCohort,
-  useRedoAction,
-  useUndoAction,
-  useUndoRedoUrls,
-} from "hooks";
+import { useRedoAction, useUndoAction, useUndoRedoUrls } from "hooks";
 import { Link as RouterLink } from "react-router-dom";
-import { absoluteCohortReviewListURL, useBaseParams } from "router";
 
 export default function CohortToolbar() {
-  const cohort = useCohort();
-  const params = useBaseParams();
-
   const [undoUrlPath, redoUrlPath] = useUndoRedoUrls();
   const undo = useUndoAction();
   const redo = useRedoAction();
@@ -39,14 +29,6 @@ export default function CohortToolbar() {
         to={redoUrlPath}
       >
         Redo
-      </Button>
-      <Divider orientation="vertical" flexItem />
-      <Button
-        variant="outlined"
-        component={RouterLink}
-        to={absoluteCohortReviewListURL(params, cohort.id)}
-      >
-        Review cohort
       </Button>
     </Stack>
   );

--- a/ui/src/criteriaHolder.tsx
+++ b/ui/src/criteriaHolder.tsx
@@ -1,5 +1,6 @@
 import ActionBar from "actionBar";
 import { CriteriaPlugin } from "cohort";
+import GridLayout from "layout/gridLayout";
 import { useState } from "react";
 
 export type CriteriaHolderProps = {
@@ -14,12 +15,12 @@ export default function CriteriaHolder(props: CriteriaHolderProps) {
   const [backURL, setBackURL] = useState<string | undefined>();
 
   return (
-    <>
+    <GridLayout rows>
       <ActionBar
         title={props.title}
         backURL={backURL ?? props.defaultBackURL}
       />
       {props.plugin.renderEdit?.(props.doneURL ?? "..", setBackURL)}
-    </>
+    </GridLayout>
   );
 }

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -1,4 +1,5 @@
 import AddIcon from "@mui/icons-material/Add";
+import InfoIcon from "@mui/icons-material/Info";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
@@ -14,6 +15,7 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
 import {
@@ -39,7 +41,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { Link as RouterLink, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   absoluteCohortURL,
   absoluteConceptSetURL,
@@ -171,304 +173,275 @@ export function Datasets() {
   );
 
   return (
-    <GridBox sx={{ overflowY: "auto" }}>
-      <ActionBar title="Datasets" backURL={"/underlays/" + underlay.name} />
-      <GridLayout height="auto" sx={{ py: 1, px: 5 }}>
-        <GridLayout cols="1fr 2fr" spacing={2}>
-          <GridLayout rows="auto 320px">
-            <GridLayout cols={3} fillCol={1} rowAlign="middle">
-              <GridBox sx={{ py: 2 }}>
-                <Typography variant="body1em">Cohorts</Typography>
-              </GridBox>
-              <GridBox />
-              <Button
-                startIcon={<AddIcon />}
-                variant="contained"
-                onClick={showNewCohort}
-              >
-                New cohort
-              </Button>
-              {dialog}
-            </GridLayout>
-            <Paper
-              sx={{
-                py: 2,
-                overflowY: "auto",
-                display: "block",
-                width: "100%",
-                height: "100%",
-              }}
-            >
-              <GridBox sx={{ px: 1, overflowY: "auto" }}>
-                {cohorts.length === 0 ? (
-                  <Empty
-                    maxWidth="80%"
-                    title="Cohorts are groups of people with common traits"
-                    subtitle={
-                      <>
-                        <Link
-                          variant="link"
-                          underline="hover"
-                          onClick={showNewCohort}
-                          sx={{ cursor: "pointer" }}
-                        >
-                          Create a new cohort
-                        </Link>{" "}
-                        to define criteria
-                      </>
-                    }
-                  />
-                ) : (
-                  cohorts
-                    .filter((cohort) => cohort.underlayName === underlay.name)
-                    .map((cohort, i) => (
-                      <GridLayout
-                        key={cohort.id}
-                        cols
-                        fillCol={2}
-                        rowAlign="middle"
-                        height="auto"
-                        sx={{
-                          boxShadow:
-                            i !== 0
-                              ? (theme) => `0 -1px 0 ${theme.palette.divider}`
-                              : undefined,
-                        }}
-                      >
-                        <Checkbox
-                          name={cohort.name}
-                          checked={selectedCohorts.has(cohort.id)}
-                          onChange={() =>
-                            onToggle(updateSelectedCohorts, cohort.id)
-                          }
-                        />
-                        <Typography variant="body2">{cohort.name}</Typography>
-                        <GridBox />
-                        <Button
-                          data-testid={cohort.name}
-                          variant="outlined"
-                          onClick={() =>
-                            navigate(
-                              absoluteCohortURL(
-                                params,
-                                cohort.id,
-                                cohort.groupSections[0].id
-                              )
-                            )
-                          }
-                          sx={{ minWidth: "auto" }}
-                        >
-                          Edit
-                        </Button>
-                      </GridLayout>
-                    ))
-                )}
-              </GridBox>
-            </Paper>
-          </GridLayout>
-          <GridLayout rows="auto 320px">
-            <GridLayout cols={3} fillCol={1} rowAlign="middle">
-              <GridBox sx={{ py: 2 }}>
-                <Typography variant="body1em" sx={{ py: 2 }}>
-                  Data features
-                </Typography>
-              </GridBox>
-              <GridBox />
-              <Button
-                startIcon={<AddIcon />}
-                variant="contained"
-                onClick={() => {
-                  navigate(absoluteNewConceptSetURL(params));
+    <GridLayout rows>
+      <ActionBar
+        title="Datasets"
+        subtitle={`Data source: ${underlay.name}`}
+        backURL={"/underlays/" + underlay.name}
+      />
+      <GridBox sx={{ overflowY: "auto" }}>
+        <GridLayout height="auto" sx={{ py: 1, px: 5 }}>
+          <GridLayout cols="1fr 2fr" spacing={2}>
+            <GridLayout rows="auto 320px">
+              <GridLayout cols fillCol={2} spacing={1} rowAlign="middle">
+                <GridBox sx={{ py: 2 }}>
+                  <Typography variant="body1em">Cohorts</Typography>
+                </GridBox>
+                <Tooltip title="Cohorts are groups of people with common traits">
+                  <InfoIcon sx={{ display: "flex" }} />
+                </Tooltip>
+                <GridBox />
+                <Button
+                  startIcon={<AddIcon />}
+                  variant="contained"
+                  onClick={showNewCohort}
+                >
+                  New cohort
+                </Button>
+                {dialog}
+              </GridLayout>
+              <Paper
+                sx={{
+                  py: 2,
+                  overflowY: "auto",
+                  display: "block",
+                  width: "100%",
+                  height: "100%",
                 }}
               >
-                New data feature
-              </Button>
-            </GridLayout>
-            <Paper
-              sx={{
-                p: 2,
-                display: "block",
-                width: "100%",
-                height: "100%",
-              }}
-            >
-              <GridLayout cols="1fr 1fr" spacing={2}>
-                <GridLayout rows spacing={2}>
-                  <GridLayout cols>
-                    <Step
-                      index={0}
-                      active={conceptSetOccurrences.length === 0}
-                      completed={conceptSetOccurrences.length > 0}
-                    >
-                      <StepLabel>Select data features</StepLabel>
-                    </Step>
-                    <StepConnector />
-                  </GridLayout>
-                  <Paper
-                    variant="outlined"
-                    sx={{
-                      py: 2,
-                      display: "block",
-                      width: "100%",
-                      height: "100%",
-                    }}
-                  >
-                    <GridBox sx={{ px: 1, overflowY: "auto" }}>
-                      {workspaceConceptSets.data?.length === 0 ? (
-                        <GridLayout rows="1fr 70% 1fr">
-                          {underlay.uiConfiguration.prepackagedConceptSets ? (
-                            <GridLayout rows height="auto">
-                              {listConceptSets(
-                                false,
-                                underlay.uiConfiguration.prepackagedConceptSets
-                              )}
-                            </GridLayout>
-                          ) : (
-                            <GridBox />
-                          )}
-                          <GridBox
-                            sx={{
-                              boxShadow: (theme) =>
-                                `0 -1px 0 ${theme.palette.divider}`,
-                            }}
-                          >
-                            <Empty
-                              maxWidth="80%"
-                              title="Data features are categories of data to export"
-                              subtitle={
-                                <>
-                                  <Link
-                                    variant="link"
-                                    underline="hover"
-                                    component={RouterLink}
-                                    to={absoluteNewConceptSetURL(params)}
-                                  >
-                                    Create a new data feature
-                                  </Link>{" "}
-                                  to define more criteria
-                                </>
-                              }
-                            />
-                          </GridBox>
-                          <GridBox />
-                        </GridLayout>
-                      ) : (
+                <GridBox sx={{ px: 1, overflowY: "auto" }}>
+                  {cohorts.length === 0 ? (
+                    <Empty
+                      maxWidth="80%"
+                      title="Cohorts are groups of people with common traits"
+                      subtitle={
                         <>
-                          {underlay.uiConfiguration.prepackagedConceptSets && (
-                            <>
-                              {listConceptSets(
-                                false,
-                                underlay.uiConfiguration.prepackagedConceptSets
-                              )}
-                            </>
-                          )}
-                          {workspaceConceptSets.data?.length &&
-                            listConceptSets(
+                          <Link
+                            variant="link"
+                            underline="hover"
+                            onClick={showNewCohort}
+                            sx={{ cursor: "pointer" }}
+                          >
+                            Create a new cohort
+                          </Link>{" "}
+                          to define criteria
+                        </>
+                      }
+                    />
+                  ) : (
+                    cohorts
+                      .filter((cohort) => cohort.underlayName === underlay.name)
+                      .map((cohort, i) => (
+                        <GridLayout
+                          key={cohort.id}
+                          cols
+                          fillCol={2}
+                          rowAlign="middle"
+                          height="auto"
+                          sx={{
+                            boxShadow:
+                              i !== 0
+                                ? (theme) => `0 -1px 0 ${theme.palette.divider}`
+                                : undefined,
+                          }}
+                        >
+                          <Checkbox
+                            name={cohort.name}
+                            checked={selectedCohorts.has(cohort.id)}
+                            onChange={() =>
+                              onToggle(updateSelectedCohorts, cohort.id)
+                            }
+                          />
+                          <Typography variant="body2">{cohort.name}</Typography>
+                          <GridBox />
+                          <Button
+                            data-testid={cohort.name}
+                            variant="outlined"
+                            onClick={() =>
+                              navigate(
+                                absoluteCohortURL(
+                                  params,
+                                  cohort.id,
+                                  cohort.groupSections[0].id
+                                )
+                              )
+                            }
+                            sx={{ minWidth: "auto" }}
+                          >
+                            Edit
+                          </Button>
+                        </GridLayout>
+                      ))
+                  )}
+                </GridBox>
+              </Paper>
+            </GridLayout>
+            <GridLayout rows="auto 320px">
+              <GridLayout cols fillCol={2} spacing={1} rowAlign="middle">
+                <GridBox sx={{ py: 2 }}>
+                  <Typography variant="body1em" sx={{ py: 2 }}>
+                    Data features
+                  </Typography>
+                </GridBox>
+                <Tooltip title="Data features are categories of data to export">
+                  <InfoIcon sx={{ display: "flex" }} />
+                </Tooltip>
+                <GridBox />
+                <Button
+                  startIcon={<AddIcon />}
+                  variant="contained"
+                  onClick={() => {
+                    navigate(absoluteNewConceptSetURL(params));
+                  }}
+                >
+                  New data feature
+                </Button>
+              </GridLayout>
+              <Paper
+                sx={{
+                  p: 2,
+                  display: "block",
+                  width: "100%",
+                  height: "100%",
+                }}
+              >
+                <GridLayout cols="1fr 1fr" spacing={2}>
+                  <GridLayout rows spacing={2}>
+                    <GridLayout cols>
+                      <Step
+                        index={0}
+                        active={conceptSetOccurrences.length === 0}
+                        completed={conceptSetOccurrences.length > 0}
+                      >
+                        <StepLabel>Select data features</StepLabel>
+                      </Step>
+                      <StepConnector />
+                    </GridLayout>
+                    <Paper
+                      variant="outlined"
+                      sx={{
+                        py: 2,
+                        display: "block",
+                        width: "100%",
+                        height: "100%",
+                      }}
+                    >
+                      <GridBox sx={{ px: 1, overflowY: "auto" }}>
+                        {underlay.uiConfiguration.prepackagedConceptSets ? (
+                          <>
+                            {listConceptSets(
+                              false,
+                              underlay.uiConfiguration.prepackagedConceptSets
+                            )}
+                          </>
+                        ) : null}
+                        {workspaceConceptSets.data?.length
+                          ? listConceptSets(
                               true,
                               (workspaceConceptSets.data ?? []).map((cs) => ({
                                 id: cs.id,
                                 name: getCriteriaTitle(cs.criteria),
                               }))
-                            )}
-                        </>
-                      )}
-                    </GridBox>
-                  </Paper>
-                </GridLayout>
-                <GridLayout rows spacing={2}>
-                  <Step index={1} active={conceptSetOccurrences.length > 0}>
-                    <StepLabel>Select feature values</StepLabel>
-                  </Step>
-                  <Paper
-                    variant="outlined"
-                    sx={{
-                      py: 2,
-                      display: "block",
-                      width: "100%",
-                      height: "100%",
-                    }}
-                  >
-                    <GridBox sx={{ px: 1, overflowY: "auto" }}>
-                      {conceptSetOccurrences.length === 0 && (
-                        <Empty
-                          maxWidth="80%"
-                          title="No data features selected"
-                          subtitle="Select at least one data feature to pick values"
-                        />
-                      )}
-                      {conceptSetOccurrences.map((occurrence) => (
-                        <Fragment key={occurrence.id}>
-                          <GridBox
-                            sx={{
-                              position: "sticky",
-                              top: 0,
-                              zIndex: 1,
-                              backgroundColor: (theme) =>
-                                theme.palette.background.paper,
-                              boxShadow: (theme) =>
-                                `inset 0 -1px 0 ${theme.palette.divider}`,
-                              height: "auto",
-                            }}
-                          >
-                            <Typography variant="body2em">
-                              {occurrence.name}
-                            </Typography>
-                          </GridBox>
-                          {occurrence.attributes.map((attribute) => (
-                            <Stack
-                              key={attribute}
-                              direction="row"
-                              alignItems="center"
+                            )
+                          : null}
+                      </GridBox>
+                    </Paper>
+                  </GridLayout>
+                  <GridLayout rows spacing={2}>
+                    <Step index={1} active={conceptSetOccurrences.length > 0}>
+                      <StepLabel>Select feature values</StepLabel>
+                    </Step>
+                    <Paper
+                      variant="outlined"
+                      sx={{
+                        py: 2,
+                        display: "block",
+                        width: "100%",
+                        height: "100%",
+                      }}
+                    >
+                      <GridBox sx={{ px: 1, overflowY: "auto" }}>
+                        {conceptSetOccurrences.length === 0 && (
+                          <Empty
+                            maxWidth="80%"
+                            title="No data features selected"
+                            subtitle="Select at least one data feature to pick values"
+                          />
+                        )}
+                        {conceptSetOccurrences.map((occurrence) => (
+                          <Fragment key={occurrence.id}>
+                            <GridBox
+                              sx={{
+                                position: "sticky",
+                                top: 0,
+                                zIndex: 1,
+                                backgroundColor: (theme) =>
+                                  theme.palette.background.paper,
+                                boxShadow: (theme) =>
+                                  `inset 0 -1px 0 ${theme.palette.divider}`,
+                                height: "auto",
+                              }}
                             >
-                              <Checkbox
-                                name={occurrence.id + "-" + attribute}
-                                checked={
-                                  !excludedAttributes
-                                    .get(occurrence.id)
-                                    ?.has(attribute)
-                                }
-                                onChange={() =>
-                                  updateExcludedAttributes((selection) => {
-                                    if (!selection?.get(occurrence.id)) {
-                                      selection?.set(
-                                        occurrence.id,
-                                        new Set<string>()
-                                      );
-                                    }
-
-                                    const attributes = selection?.get(
-                                      occurrence.id
-                                    );
-                                    if (attributes?.has(attribute)) {
-                                      attributes?.delete(attribute);
-                                    } else {
-                                      attributes?.add(attribute);
-                                    }
-                                  })
-                                }
-                              />
-                              <Typography variant="body2">
-                                {attribute}
+                              <Typography variant="body2em">
+                                {occurrence.name}
                               </Typography>
-                            </Stack>
-                          ))}
-                        </Fragment>
-                      ))}
-                    </GridBox>
-                  </Paper>
+                            </GridBox>
+                            {occurrence.attributes.map((attribute) => (
+                              <Stack
+                                key={attribute}
+                                direction="row"
+                                alignItems="center"
+                              >
+                                <Checkbox
+                                  name={occurrence.id + "-" + attribute}
+                                  checked={
+                                    !excludedAttributes
+                                      .get(occurrence.id)
+                                      ?.has(attribute)
+                                  }
+                                  onChange={() =>
+                                    updateExcludedAttributes((selection) => {
+                                      if (!selection?.get(occurrence.id)) {
+                                        selection?.set(
+                                          occurrence.id,
+                                          new Set<string>()
+                                        );
+                                      }
+
+                                      const attributes = selection?.get(
+                                        occurrence.id
+                                      );
+                                      if (attributes?.has(attribute)) {
+                                        attributes?.delete(attribute);
+                                      } else {
+                                        attributes?.add(attribute);
+                                      }
+                                    })
+                                  }
+                                />
+                                <Typography variant="body2">
+                                  {attribute}
+                                </Typography>
+                              </Stack>
+                            ))}
+                          </Fragment>
+                        ))}
+                      </GridBox>
+                    </Paper>
+                  </GridLayout>
                 </GridLayout>
-              </GridLayout>
-            </Paper>
+              </Paper>
+            </GridLayout>
           </GridLayout>
+          <Preview
+            selectedCohorts={selectedCohorts}
+            selectedConceptSets={selectedConceptSets}
+            conceptSetOccurrences={conceptSetOccurrences}
+            excludedAttributes={excludedAttributes}
+          />
         </GridLayout>
-        <Preview
-          selectedCohorts={selectedCohorts}
-          selectedConceptSets={selectedConceptSets}
-          conceptSetOccurrences={conceptSetOccurrences}
-          excludedAttributes={excludedAttributes}
-        />
-      </GridLayout>
-    </GridBox>
+      </GridBox>
+    </GridLayout>
   );
 }
 

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -36,7 +36,13 @@ import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
 import { useCallback, useMemo } from "react";
 import { Link as RouterLink, useNavigate } from "react-router-dom";
-import { cohortURL, criteriaURL, exitURL, useBaseParams } from "router";
+import {
+  absoluteCohortReviewListURL,
+  cohortURL,
+  criteriaURL,
+  exitURL,
+  useBaseParams,
+} from "router";
 import useSWRImmutable from "swr/immutable";
 import * as tanagra from "tanagra-api";
 import {
@@ -50,24 +56,42 @@ import {
 
 export function Overview() {
   const cohort = useCohort();
+  const params = useBaseParams();
 
   return (
-    <GridLayout
-      rows="minmax(max-content, 100%)"
-      cols="auto 380px"
-      spacing={2}
-      sx={{ px: 5, overflowY: "auto" }}
-    >
-      <GroupList />
-      <GridBox
-        sx={{
-          leftBorderStyle: "solid",
-          borderColor: (theme) => theme.palette.divider,
-          borderWidth: "1px",
-        }}
+    <GridLayout rows>
+      <ActionBar
+        height={8}
+        title={cohort.name}
+        subtitle={<SaveStatus />}
+        extraControls={
+          <Button
+            variant="outlined"
+            component={RouterLink}
+            to={absoluteCohortReviewListURL(params, cohort.id)}
+          >
+            Review cohort
+          </Button>
+        }
+        backURL={exitURL(params)}
+      />
+      <GridLayout
+        rows="minmax(max-content, 100%)"
+        cols="auto 380px"
+        spacing={2}
+        sx={{ px: 5, overflowY: "auto" }}
       >
-        <DemographicCharts cohort={cohort} />
-      </GridBox>
+        <GroupList />
+        <GridBox
+          sx={{
+            leftBorderStyle: "solid",
+            borderColor: (theme) => theme.palette.divider,
+            borderWidth: "1px",
+          }}
+        >
+          <DemographicCharts cohort={cohort} />
+        </GridBox>
+      </GridLayout>
     </GridLayout>
   );
 }
@@ -83,15 +107,9 @@ function GroupDivider() {
 function GroupList() {
   const context = useCohortContext();
   const cohort = useCohort();
-  const params = useBaseParams();
 
   return (
     <GridBox sx={{ pb: 2 }}>
-      <ActionBar
-        title={cohort.name}
-        extraControls={<SaveStatus />}
-        backURL={exitURL(params)}
-      />
       <GridLayout rows height="auto">
         <GridBox sx={{ py: 3 }}>
           <GridLayout cols fillCol={1} rowAlign="middle">

--- a/ui/src/studiesList.tsx
+++ b/ui/src/studiesList.tsx
@@ -12,6 +12,7 @@ import Empty from "components/empty";
 import Loading from "components/loading";
 import { useTextInputDialog } from "components/textInputDialog";
 import { useSource } from "data/source";
+import GridLayout from "layout/gridLayout";
 import { Link as RouterLink } from "react-router-dom";
 import useSWR from "swr";
 
@@ -44,7 +45,7 @@ export function StudiesList() {
   });
 
   return (
-    <>
+    <GridLayout rows>
       <ActionBar title={"Studies"} />
       <Loading status={studiesState}>
         <Box sx={{ p: 1 }}>
@@ -94,6 +95,6 @@ export function StudiesList() {
           {newStudyDialog}
         </Box>
       </Loading>
-    </>
+    </GridLayout>
   );
 }

--- a/ui/src/underlaySelect.tsx
+++ b/ui/src/underlaySelect.tsx
@@ -4,6 +4,7 @@ import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
 import ActionBar from "actionBar";
 import { useAppSelector } from "hooks";
+import GridLayout from "layout/gridLayout";
 import { Link as RouterLink } from "react-router-dom";
 import { underlayURL } from "router";
 
@@ -11,7 +12,7 @@ export function UnderlaySelect() {
   const underlays = useAppSelector((state) => state.present.underlays);
 
   return (
-    <>
+    <GridLayout rows>
       <ActionBar title="Select Dataset" backURL={null} />
       <List>
         {underlays.map((underlay) => (
@@ -25,6 +26,6 @@ export function UnderlaySelect() {
           </ListItem>
         ))}
       </List>
-    </>
+    </GridLayout>
   );
 }


### PR DESCRIPTION
* Convert headers to use standard layout components.
* Add support for header subtitles and rearrange components to use them.
* Add tooltips to datasets page and remove "empty" message from data features list.