### PR TITLE
Revert changeset modifications.

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-    <!-- define global column types for dbms -->
-    <property global="true" dbms="postgresql" name="id.type" value="text"/>
-    <property global="true" dbms="postgresql" name="text.type" value="text"/>
-    <property global="true" dbms="postgresql" name="long.text.type" value="text"/>
-    <property global="true" dbms="postgresql" name="text.array.type" value="text[]"/>
-    <property global="true" dbms="postgresql" name="jsonb.type" value="jsonb"/>
-    <property global="true" dbms="mariadb,mysql" name="id.type" value="varchar(50)"/>
-    <property global="true" dbms="mariadb,mysql" name="text.type" value="varchar(255)"/>
-    <property global="true" dbms="mariadb,mysql" name="long.text.type" value="longtext"/>
-    <property global="true" dbms="mariadb,mysql" name="text.array.type" value="longtext"/>
-    <property global="true" dbms="mariadb,mysql" name="jsonb.type" value="longtext"/>
-    <!-- define changesets -->
     <include file="changesets/20230410_schema_reset.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230530_avoid_postgres_specific_features.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230410_schema_reset.yaml
+++ b/service/src/main/resources/db/changesets/20230410_schema_reset.yaml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: schema_reset
       author: marikomedlock
+      dbms: postgresql
       changes:
         - createTable:
             tableName: study

--- a/service/src/main/resources/db/changesets/20230410_schema_reset.yaml
+++ b/service/src/main/resources/db/changesets/20230410_schema_reset.yaml
@@ -1,31 +1,31 @@
 databaseChangeLog:
   - changeSet:
       id: schema_reset
-      author: marikomedlock, chenchalsubraveti
+      author: marikomedlock
       changes:
         - createTable:
             tableName: study
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     primaryKey: true
                     nullable: false
                     unique: true
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: description
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: properties
-                  type: ${jsonb.type}
+                  type: jsonb
                   constraints:
                     nullable: true
               - column:
@@ -36,7 +36,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: created_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -47,7 +47,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: last_modified_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
 
@@ -56,14 +56,14 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type:  ${id.type}
+                  type: text
                   constraints:
                     primaryKey: true
                     nullable: false
                     unique: true
               - column:
                   name: study_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: study(id)
                     foreignKeyName: fk_cs_s
@@ -72,22 +72,22 @@ databaseChangeLog:
                   remarks: Deleting a study will cascade to delete the concept sets contained in it
               - column:
                   name: underlay
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: entity
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: description
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
@@ -98,7 +98,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: created_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -109,7 +109,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: last_modified_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
 
@@ -118,14 +118,14 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     primaryKey: true
                     nullable: false
                     unique: true
               - column:
                   name: study_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: study(id)
                     foreignKeyName: fk_c_s
@@ -134,17 +134,17 @@ databaseChangeLog:
                   remarks: Deleting a study will cascade to delete the cohorts contained in it
               - column:
                   name: underlay
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: description
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
@@ -155,7 +155,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: created_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -166,7 +166,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: last_modified_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
 
@@ -175,14 +175,14 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     primaryKey: true
                     nullable: false
                     unique: true
               - column:
                   name: cohort_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort(id)
                     foreignKeyName: fk_r_c
@@ -191,12 +191,12 @@ databaseChangeLog:
                   remarks: Deleting a cohort will cascade to delete the reviews associated with it
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: description
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
@@ -212,7 +212,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: created_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -223,7 +223,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: last_modified_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
         - addUniqueConstraint:
@@ -236,7 +236,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: review_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: review(id)
                     foreignKeyName: fk_pei_r
@@ -245,7 +245,7 @@ databaseChangeLog:
                   remarks: Deleting a review will cascade to delete the entity instances contained in it
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
                     unique: false
@@ -260,14 +260,14 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     primaryKey: true
                     nullable: false
                     unique: true
               - column:
                   name: cohort_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort(id)
                     foreignKeyName: fk_cr_c
@@ -276,7 +276,7 @@ databaseChangeLog:
                   remarks: Deleting a cohort will cascade to delete the cohort revisions associated with it
               - column:
                   name: review_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: review(id)
                     foreignKeyName: fk_cr_r
@@ -306,7 +306,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: created_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -317,7 +317,7 @@ databaseChangeLog:
                   defaultValueComputed: now()
               - column:
                   name: last_modified_by
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
 
@@ -326,12 +326,12 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: cohort_revision_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort_revision(id)
                     foreignKeyName: fk_cgs_cr
@@ -340,10 +340,10 @@ databaseChangeLog:
                   remarks: Deleting a cohort revision will cascade to delete the criteria group sections contained in it
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
               - column:
                   name: operator
-                  type: ${text.type}
+                  type: text
               - column:
                   name: is_excluded
                   type: boolean
@@ -364,17 +364,17 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: criteria_group_section_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: cohort_revision_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort_revision(id)
                     foreignKeyName: fk_cg_cr
@@ -383,13 +383,13 @@ databaseChangeLog:
                   remarks: Deleting a cohort revision will cascade to delete the criteria groups contained in it
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
               - column:
                   name: entity
-                  type: ${text.type}
+                  type: text
               - column:
                   name: group_by_count_operator
-                  type: ${text.type}
+                  type: text
               - column:
                   name: group_by_count_value
                   type: integer
@@ -408,22 +408,22 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: criteria_group_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: criteria_group_section_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: cohort_revision_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort_revision(id)
                     foreignKeyName: ck_crit_cr
@@ -432,7 +432,7 @@ databaseChangeLog:
                   remarks: Deleting a cohort revision will cascade to delete the criteria contained in it
               - column:
                   name: concept_set_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: concept_set(id)
                     foreignKeyName: fk_crit_cs
@@ -441,25 +441,25 @@ databaseChangeLog:
                   remarks: Deleting a concept set will cascade to delete the criteria contained in it
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
               - column:
                   name: plugin_name
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: selection_data
-                  type: ${long.text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: ui_config
-                  type: ${long.text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: tags
-                  type: ${text.array.type}
+                  type: text[]
                   constraints:
                     nullable: false
               - column:
@@ -477,12 +477,12 @@ databaseChangeLog:
             columns:
               - column:
                   name: id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: cohort_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort(id)
                     foreignKeyName: fk_ak_c
@@ -491,22 +491,22 @@ databaseChangeLog:
                   remarks: Deleting a cohort will cascade to delete the annotation keys associated with it
               - column:
                   name: display_name
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: description
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: data_type
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: enum_vals
-                  type: ${text.array.type}
+                  type: text[]
                   constraints:
                     nullable: false
         - addUniqueConstraint:
@@ -519,22 +519,22 @@ databaseChangeLog:
             columns:
               - column:
                   name: cohort_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: annotation_key_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: review_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: primary_entity_instance_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
@@ -549,7 +549,7 @@ databaseChangeLog:
                     nullable: true
               - column:
                   name: string_val
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:

--- a/service/src/main/resources/db/changesets/20230530_avoid_postgres_specific_features.yaml
+++ b/service/src/main/resources/db/changesets/20230530_avoid_postgres_specific_features.yaml
@@ -1,7 +1,7 @@
 databaseChangeLog:
   - changeSet:
       id: avoid_postgres_specific_features
-      author: marikomedlock, chenchalsubraveti
+      author: marikomedlock
       # TODO: Remove the jsonb and 2 text[] columns in a follow-on changeset, once we're sure this migration was successful.
       # study.properties, criteria.tags, annotation_key.enumVals
       changes:
@@ -10,7 +10,7 @@ databaseChangeLog:
             columns:
               - column:
                   name: study_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: study(id)
                     foreignKeyName: fk_sp_s
@@ -19,12 +19,12 @@ databaseChangeLog:
                   remarks: Deleting a study will cascade to delete its properties
               - column:
                   name: key
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: value
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: true
         - addUniqueConstraint:
@@ -43,22 +43,22 @@ databaseChangeLog:
             columns:
               - column:
                   name: criteria_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: criteria_group_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: criteria_group_section_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: true
               - column:
                   name: cohort_revision_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: cohort_revision(id)
                     foreignKeyName: ck_crit_cr
@@ -67,7 +67,7 @@ databaseChangeLog:
                   remarks: Deleting a cohort revision will cascade to delete the criteria contained in it
               - column:
                   name: concept_set_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     references: concept_set(id)
                     foreignKeyName: fk_crit_cs
@@ -76,12 +76,12 @@ databaseChangeLog:
                   remarks: Deleting a concept set will cascade to delete the criteria contained in it
               - column:
                   name: key
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: value
-                  type: ${text.type}
+                  type: text
                   constraints:
                     nullable: false
         - addUniqueConstraint:
@@ -104,17 +104,17 @@ databaseChangeLog:
             columns:
               - column:
                   name: enum
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: annotation_key_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
               - column:
                   name: cohort_id
-                  type: ${id.type}
+                  type: text
                   constraints:
                     nullable: false
         - addUniqueConstraint:

--- a/service/src/main/resources/db/changesets/20230530_avoid_postgres_specific_features.yaml
+++ b/service/src/main/resources/db/changesets/20230530_avoid_postgres_specific_features.yaml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: avoid_postgres_specific_features
       author: marikomedlock
+      dbms: postgresql
       # TODO: Remove the jsonb and 2 text[] columns in a follow-on changeset, once we're sure this migration was successful.
       # study.properties, criteria.tags, annotation_key.enumVals
       changes:


### PR DESCRIPTION
Reverted the changeset modifications from #412. When I tested this locally, PostGres seemed fine with the updated changeset files, since the rendered version was the same. But it failed in our GKE deployment.

This doesn't change the overall approach to getting Tanagra's DB schema working with MariaDB/MySQL. The end goal is still to have a version of the schema that works with both PostGres and MariaDB/MySQL. Since that will require wiping the DB in our existing deployments that use PostGres, we need to wait until user testing is over to combine the schemas. In the meantime, we will maintain 2 separate schemas, and plan to drop the postgres-only schema files once user testing is over.