### PR TITLE
Pass through null display literals for ValueDisplay attributes.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/instances/EntityInstance.java
+++ b/service/src/main/java/bio/terra/tanagra/service/instances/EntityInstance.java
@@ -54,7 +54,7 @@ public final class EntityInstance {
                         .getMapping(Underlay.MappingType.INDEX)
                         .getDisplayMappingAlias())
                 .getString()
-                .get();
+                .orElse("");
         attributeValues.put(selectedAttribute, new ValueDisplay(valueOpt.get(), display));
       } else {
         throw new SystemException("Unknown attribute type: " + selectedAttribute.getType());

--- a/service/src/main/java/bio/terra/tanagra/service/instances/EntityInstance.java
+++ b/service/src/main/java/bio/terra/tanagra/service/instances/EntityInstance.java
@@ -54,7 +54,7 @@ public final class EntityInstance {
                         .getMapping(Underlay.MappingType.INDEX)
                         .getDisplayMappingAlias())
                 .getString()
-                .orElse("");
+                .orElse(null); // Preserve NULL display values.
         attributeValues.put(selectedAttribute, new ValueDisplay(valueOpt.get(), display));
       } else {
         throw new SystemException("Unknown attribute type: " + selectedAttribute.getType());


### PR DESCRIPTION
The backend was not handling the case where the display part of a `ValueDisplay` object is `null`. This bug came up for the Helix underlay specifically.