### PR TITLE
Fix document data feature UI and cohort/concept set loading

### DIFF
--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -1,7 +1,7 @@
 import { defaultGroup, defaultSection } from "cohort";
 import { useSource } from "data/sourceContext";
 import produce from "immer";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import useSWR, { useSWRConfig } from "swr";
 import * as tanagra from "tanagra-api";
@@ -56,17 +56,25 @@ export function useNewCohortContext(showSnackbar: (message: string) => void) {
     cohortId,
   };
   const status = useSWR(key, async () => {
-    const cohort = await source.getCohort(studyId, cohortId);
-    setState((state) => ({
-      past: state?.past ?? [],
-      present: cohort,
-      future: state?.future ?? [],
-
-      saving: false,
-      showSnackbar,
-    }));
-    return cohort;
+    return await source.getCohort(studyId, cohortId);
   });
+
+  useEffect(
+    () =>
+      setState(
+        status.data
+          ? {
+              past: state?.past ?? [],
+              present: status.data,
+              future: state?.future ?? [],
+
+              saving: false,
+              showSnackbar,
+            }
+          : null
+      ),
+    [status.data]
+  );
 
   const updateCohort = async (newState: CohortState | null) => {
     if (!newState) {

--- a/ui/src/criteriaHolder.tsx
+++ b/ui/src/criteriaHolder.tsx
@@ -1,5 +1,6 @@
 import ActionBar from "actionBar";
 import { CriteriaPlugin } from "cohort";
+import Empty from "components/empty";
 import GridLayout from "layout/gridLayout";
 import { useState } from "react";
 
@@ -20,7 +21,16 @@ export default function CriteriaHolder(props: CriteriaHolderProps) {
         title={props.title}
         backURL={backURL ?? props.defaultBackURL}
       />
-      {props.plugin.renderEdit?.(props.doneURL ?? "..", setBackURL)}
+      {props.plugin.renderEdit ? (
+        props.plugin.renderEdit(props.doneURL ?? "..", setBackURL)
+      ) : (
+        <Empty
+          maxWidth="60%"
+          minHeight="400px"
+          image="/empty.svg"
+          subtitle="There are no editable properties for this criteria."
+        />
+      )}
     </GridLayout>
   );
 }


### PR DESCRIPTION
* Editing a document data feature show an empty message instead of an oversized action bar. It would be better disallow editing of data features with no UI but there's no way for the outer app to check that. Future data feature designs chould take into account, or alternatively we could add an editable flag to the API.
* Exiting and returning to a cohort or concept set from the export page could result in an error or endless spinner if no other action was taken that invalidated the SWR cache (e.g. switching apps). Instead of setting state as a side effect of fetching use a useEffect hook so state is always updated at least once, even if nothing is fetched.