### PR TITLE
Fix disappearing tree rows

### DIFF
--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -215,8 +215,8 @@ exports[`Table renders correctly 1`] = `
       <tr
         style={
           Object {
+            "display": "none",
             "height": "48px",
-            "visibility": "collapse",
           }
         }
       >

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -291,7 +291,7 @@ function renderChildren(
       <tr
         key={childKey}
         style={{
-          ...(collapse ? { visibility: "collapse" } : undefined),
+          ...(collapse ? { display: "none" } : undefined),
           height: spacing(theme, props.rowHeight ?? 6),
         }}
       >


### PR DESCRIPTION
* visibility: "collapse" doesn't work the same way in Safari as it does in Chrome. The elements were hidden but still took up space so they were actually just way off the screen. Switching to display: "none" instead which seems like it will work well enough for our use case.