### PR TITLE
adding conditional mysql/mariadb dep in service/build.gradle

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -62,7 +62,10 @@ dependencies {
 
     implementation group: "bio.terra", name: "terra-common-lib", version: "0.0.69-SNAPSHOT"
     implementation group: "org.apache.commons", name: "commons-text", version: "1.9"
-    implementation group: "org.mariadb.jdbc", name: "mariadb-java-client"
+    if (project.hasProperty("isMySQL")) {
+        implementation group: "org.mariadb.jdbc", name: "mariadb-java-client"
+        implementation "mysql:mysql-connector-java:8.0.30"
+    }
 
     // GCP libraries. Most versions are controlled by the BOM specified in buildSrc.
     implementation group: "com.google.cloud", name: "google-cloud-bigquery"

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -62,10 +62,8 @@ dependencies {
 
     implementation group: "bio.terra", name: "terra-common-lib", version: "0.0.69-SNAPSHOT"
     implementation group: "org.apache.commons", name: "commons-text", version: "1.9"
-    if (project.hasProperty("isMySQL")) {
-        implementation group: "org.mariadb.jdbc", name: "mariadb-java-client"
-        implementation "mysql:mysql-connector-java:8.0.30"
-    }
+    implementation group: "org.mariadb.jdbc", name: "mariadb-java-client"
+    implementation "mysql:mysql-connector-java:8.0.30"
 
     // GCP libraries. Most versions are controlled by the BOM specified in buildSrc.
     implementation group: "com.google.cloud", name: "google-cloud-bigquery"


### PR DESCRIPTION
Background: In the AoU workbench project we use MySQL in GCP. In order to get the proper drivers to connect to the database we need the following dependencies: 
- mysql-connector-java

I've add them to /service/build.gradle