### PR TITLE
Access control tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-![Underlay Build](https://github.com/DataBiosphere/tanagra/actions/workflows/underlay-test.yaml/badge.svg?branch=main)
-![Service Build](https://github.com/DataBiosphere/tanagra/actions/workflows/service-test.yaml/badge.svg?branch=main)
-![Indexer Build](https://github.com/DataBiosphere/tanagra/actions/workflows/indexer-test.yaml/badge.svg?branch=main)
 # Tanagra
 
 Tanagra is a project to build a configurable data explorer. It provides tools for indexing a dataset, a backend
@@ -14,3 +11,15 @@ More information about this codebase can be found in the links below.
 * [Data Export](./docs/DATA_EXPORT.md)
 * [VUMC Admin Service](./docs/VUMC_ADMIN_SERVICE.md)
 * [Contribute Code](./docs/CONTRIBUTING.md)
+
+![Underlay Tests](https://github.com/DataBiosphere/tanagra/actions/workflows/underlay-test.yaml/badge.svg?branch=main)
+
+![Indexer Tests](https://github.com/DataBiosphere/tanagra/actions/workflows/indexer-test.yaml/badge.svg?branch=main)
+
+![Service (PostGres) Tests](https://github.com/DataBiosphere/tanagra/actions/workflows/service-test-postgres.yaml/badge.svg?branch=main)
+
+![Service (MariaDB) Tests](https://github.com/DataBiosphere/tanagra/actions/workflows/service-test-mariadb.yaml/badge.svg?branch=main)
+
+![UI Tests](https://github.com/DataBiosphere/tanagra/actions/workflows/ui-test.yaml/badge.svg?branch=main)
+
+![UI Integration Tests](https://github.com/DataBiosphere/tanagra/actions/workflows/ui-integration-test.yaml/badge.svg?branch=main)

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
@@ -141,7 +141,7 @@ public class VumcAdminAccessControl implements AccessControl {
       case CREATE_CONCEPT_SET:
         return Set.of(ResourceAction.UPDATE);
       default:
-        LOGGER.debug("Unknown mapping for underlay action {}", action);
+        LOGGER.debug("Unknown mapping for study action {}", action);
         return Set.of();
     }
   }
@@ -182,7 +182,7 @@ public class VumcAdminAccessControl implements AccessControl {
       Map<ResourceId, Set<ResourceAction>> studyApiActionsMap =
           listAllPermissions(user, ResourceType.STUDY);
 
-      // User does not have access to the parent study.
+      // Check that the user has access to the parent study.
       ResourceId studyAncestorResource = ResourceId.forStudy(parentResource.getStudy());
       if (!studyApiActionsMap.containsKey(studyAncestorResource)) {
         return ResourceCollection.empty(type, parentResource);
@@ -215,7 +215,7 @@ public class VumcAdminAccessControl implements AccessControl {
               // Ignore any API resources returned that don't match the expected resource type.
               if (!org.vumc.vda.tanagra.admin.model.ResourceType.ALL.equals(apiResource.getType())
                   && !apiResource.getType().name().equals(type.name())) {
-                LOGGER.debug(
+                LOGGER.warn(
                     "API resource list includes unexpected resource type: requested {}, returned {}",
                     type,
                     apiResource.getType());
@@ -254,7 +254,7 @@ public class VumcAdminAccessControl implements AccessControl {
       case CREATE:
       case DELETE:
       default:
-        LOGGER.debug("Unknown mapping for underlay API resource action {}", apiAction);
+        LOGGER.warn("Unknown mapping for underlay API resource action {}", apiAction);
         return Set.of();
     }
   }
@@ -273,7 +273,7 @@ public class VumcAdminAccessControl implements AccessControl {
       case DELETE:
         return Set.of(DELETE);
       default:
-        LOGGER.debug("Unknown mapping for study API resource action {}", apiAction);
+        LOGGER.warn("Unknown mapping for study API resource action {}", apiAction);
         return Set.of();
     }
   }
@@ -297,7 +297,7 @@ public class VumcAdminAccessControl implements AccessControl {
       case CREATE:
       case DELETE:
       default:
-        LOGGER.debug(
+        LOGGER.warn(
             "Unknown mapping for study API resource action {} for descendant resource type {}",
             apiAction,
             descendantType);

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
@@ -1,0 +1,316 @@
+package bio.terra.tanagra.service.accesscontrol;
+
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static bio.terra.tanagra.service.CriteriaValues.ETHNICITY_EQ_JAPANESE;
+import static bio.terra.tanagra.service.CriteriaValues.PROCEDURE_EQ_AMPUTATION;
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.tanagra.app.Main;
+import bio.terra.tanagra.query.*;
+import bio.terra.tanagra.query.inmemory.InMemoryRowResult;
+import bio.terra.tanagra.service.*;
+import bio.terra.tanagra.service.artifact.*;
+import bio.terra.tanagra.service.auth.UserId;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Main.class)
+@SpringBootTest
+@ActiveProfiles("test")
+@SuppressWarnings("PMD.TooManyFields")
+public class BaseAccessControlTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseAccessControlTest.class);
+  @Autowired protected UnderlaysService underlaysService;
+  @Autowired protected StudyService studyService;
+  @Autowired protected CohortService cohortService;
+  @Autowired protected ConceptSetService conceptSetService;
+  @Autowired protected ReviewService reviewService;
+  @Autowired protected AnnotationService annotationService;
+
+  protected AccessControl impl;
+  protected static final String CMS_SYNPUF = "cms_synpuf";
+  protected static final String AOU_SYNTHETIC = "aou_synthetic";
+  protected static final String SDD = "sdd";
+
+  protected static final UserId USER_1 = UserId.fromToken("subject1", "user1@gmail.com", "token1");
+  protected static final UserId USER_2 = UserId.fromToken("subject2", "user2@gmail.com", "token2");
+  protected static final UserId USER_3 = UserId.fromToken("subject3", "user3@gmail.com", "token3");
+  protected static final UserId USER_4 = UserId.fromToken("subject4", "user4@gmail.com", "token4");
+
+  protected Study study1;
+  protected Study study2;
+  protected Cohort cohort1;
+  protected Cohort cohort2;
+  protected ConceptSet conceptSet1;
+  protected ConceptSet conceptSet2;
+  protected Review review1;
+  protected Review review2;
+  protected AnnotationKey annotationKey1;
+  protected AnnotationKey annotationKey2;
+
+  protected void createArtifacts() {
+    // Create 2 studies.
+    study1 = studyService.createStudy(Study.builder().displayName("study 1"), "abc@123.com");
+    assertNotNull(study1);
+    LOGGER.info("Created study1 {} at {}", study1.getId(), study1.getCreated());
+
+    study2 = studyService.createStudy(Study.builder().displayName("study 2"), "def@123.com");
+    assertNotNull(study2);
+    LOGGER.info("Created study2 {} at {}", study2.getId(), study2.getCreated());
+
+    // Create 2 cohorts.
+    cohort1 =
+        cohortService.createCohort(
+            study1.getId(),
+            Cohort.builder()
+                .underlay(CMS_SYNPUF)
+                .displayName("cohort 2")
+                .description("first cohort"),
+            "abc@123.com",
+            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+    assertNotNull(cohort1);
+    LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
+
+    cohort2 =
+        cohortService.createCohort(
+            study2.getId(),
+            Cohort.builder()
+                .underlay(CMS_SYNPUF)
+                .displayName("cohort 2")
+                .description("second cohort"),
+            "def@123.com",
+            List.of(CRITERIA_GROUP_SECTION_2));
+    assertNotNull(cohort2);
+    LOGGER.info("Created cohort {} at {}", cohort2.getId(), cohort2.getCreated());
+
+    // Create 2 concept sets.
+    conceptSet1 =
+        conceptSetService.createConceptSet(
+            study1.getId(),
+            ConceptSet.builder()
+                .underlay(CMS_SYNPUF)
+                .displayName("concept set 1")
+                .description("first concept set")
+                .entity(ETHNICITY_EQ_JAPANESE.getKey())
+                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue())),
+            "abc@123.com");
+    assertNotNull(conceptSet1);
+    LOGGER.info("Created concept set {} at {}", conceptSet1.getId(), conceptSet1.getCreated());
+
+    conceptSet2 =
+        conceptSetService.createConceptSet(
+            study2.getId(),
+            ConceptSet.builder()
+                .underlay(CMS_SYNPUF)
+                .displayName("concept set 2")
+                .description("second concept set")
+                .entity(PROCEDURE_EQ_AMPUTATION.getKey())
+                .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue())),
+            "def@123.com");
+    assertNotNull(conceptSet2);
+    LOGGER.info("Created concept set {} at {}", conceptSet2.getId(), conceptSet2.getCreated());
+
+    // Create 2 reviews.
+    ColumnHeaderSchema columnHeaderSchema =
+        new ColumnHeaderSchema(List.of(new ColumnSchema("id", CellValue.SQLDataType.INT64)));
+    QueryResult queryResult =
+        new QueryResult(
+            List.of(123L, 456L, 789L).stream()
+                .map(id -> new InMemoryRowResult(List.of(id), columnHeaderSchema))
+                .collect(Collectors.toList()),
+            columnHeaderSchema);
+    review1 =
+        reviewService.createReviewHelper(
+            study1.getId(),
+            cohort1.getId(),
+            Review.builder().displayName("review 1").description("first review").size(11),
+            "abc@123.com",
+            queryResult);
+    assertNotNull(review1);
+    LOGGER.info("Created review {} at {}", review1.getId(), review1.getCreated());
+    review2 =
+        reviewService.createReviewHelper(
+            study2.getId(),
+            cohort2.getId(),
+            Review.builder().displayName("review 2").description("second review").size(3),
+            "def@123.com",
+            queryResult);
+    assertNotNull(review2);
+    LOGGER.info("Created review {} at {}", review2.getId(), review2.getCreated());
+
+    // Create 2 annotation keys.
+    annotationKey1 =
+        annotationService.createAnnotationKey(
+            study1.getId(),
+            cohort1.getId(),
+            AnnotationKey.builder()
+                .displayName("annotation key 1")
+                .description("first annotation key")
+                .dataType(Literal.DataType.BOOLEAN));
+    assertNotNull(annotationKey1);
+    LOGGER.info("Created annotation key {}", annotationKey1.getId());
+    annotationKey2 =
+        annotationService.createAnnotationKey(
+            study2.getId(),
+            cohort2.getId(),
+            AnnotationKey.builder()
+                .displayName("annotation key 2")
+                .description("second annotation key")
+                .dataType(Literal.DataType.INT64));
+    assertNotNull(annotationKey2);
+    LOGGER.info("Created annotation key {}", annotationKey2.getId());
+  }
+
+  protected void deleteStudies() {
+    try {
+      studyService.deleteStudy(study1.getId());
+      LOGGER.info("Deleted study1 {}", study1.getId());
+    } catch (Exception ex) {
+      LOGGER.error("Error deleting study1", ex);
+    }
+
+    try {
+      studyService.deleteStudy(study2.getId());
+      LOGGER.info("Deleted study2 {}", study2.getId());
+    } catch (Exception ex) {
+      LOGGER.error("Error deleting study2", ex);
+    }
+  }
+
+  protected void assertHasPermissions(UserId user, ResourceId resource, Action... actions) {
+    Action[] actionsArr =
+        actions.length > 0 ? actions : resource.getType().getActions().toArray(new Action[0]);
+    assertTrue(
+        impl.isAuthorized(user, Permissions.forActions(resource.getType(), actionsArr), resource));
+    assertTrue(
+        impl.getPermissions(user, resource)
+            .contains(Permissions.forActions(resource.getType(), actionsArr)));
+
+    ResourceCollection resources =
+        impl.listAllPermissions(
+            user, resource.getType(), resource.getParent(), 0, Integer.MAX_VALUE);
+    assertTrue(
+        resources
+            .getPermissions(resource)
+            .contains(Permissions.forActions(resource.getType(), actionsArr)));
+
+    if (new HashSet<>(Arrays.asList(actionsArr)).equals(resource.getType().getActions())) {
+      assertTrue(impl.getPermissions(user, resource).isAllActions());
+      assertTrue(resources.getPermissions(resource).isAllActions());
+    }
+
+    resources =
+        impl.listAuthorizedResources(
+            user,
+            Permissions.forActions(resource.getType(), actionsArr),
+            resource.getParent(),
+            0,
+            Integer.MAX_VALUE);
+    assertTrue(resources.contains(resource));
+  }
+
+  protected void assertDoesNotHavePermissions(UserId user, ResourceId resource, Action... actions) {
+    Action[] actionsArr =
+        actions.length > 0 ? actions : resource.getType().getActions().toArray(new Action[0]);
+    assertFalse(
+        impl.isAuthorized(user, Permissions.forActions(resource.getType(), actionsArr), resource));
+    assertFalse(
+        impl.getPermissions(user, resource)
+            .contains(Permissions.forActions(resource.getType(), actionsArr)));
+
+    ResourceCollection resources =
+        impl.listAllPermissions(
+            user, resource.getType(), resource.getParent(), 0, Integer.MAX_VALUE);
+    assertFalse(
+        resources
+            .getPermissions(resource)
+            .contains(Permissions.forActions(resource.getType(), actionsArr)));
+
+    if (new HashSet<>(Arrays.asList(actionsArr)).equals(resource.getType().getActions())) {
+      assertTrue(impl.getPermissions(user, resource).isEmpty());
+      assertTrue(resources.getPermissions(resource).isEmpty());
+    }
+
+    resources =
+        impl.listAuthorizedResources(
+            user,
+            Permissions.forActions(resource.getType(), actionsArr),
+            resource.getParent(),
+            0,
+            Integer.MAX_VALUE);
+    assertFalse(resources.contains(resource));
+  }
+
+  protected void assertServiceListWithReadPermission(
+      UserId user,
+      ResourceType type,
+      ResourceId parent,
+      boolean isAllResources,
+      ResourceId... expectedResources) {
+    ResourceCollection resources =
+        impl.listAuthorizedResources(
+            user, Permissions.forActions(type, Action.READ), parent, 0, Integer.MAX_VALUE);
+    assertEquals(isAllResources, resources.isAllResources());
+
+    Set<ResourceId> actual;
+    switch (type) {
+      case UNDERLAY:
+        actual =
+            underlaysService.listUnderlays(resources).stream()
+                .map(u -> ResourceId.forUnderlay(u.getName()))
+                .collect(Collectors.toSet());
+        break;
+      case STUDY:
+        actual =
+            studyService.listStudies(resources, 0, Integer.MAX_VALUE).stream()
+                .map(s -> ResourceId.forStudy(s.getId()))
+                .collect(Collectors.toSet());
+        break;
+      case COHORT:
+        actual =
+            cohortService.listCohorts(resources, 0, Integer.MAX_VALUE).stream()
+                .map(c -> ResourceId.forCohort(parent.getStudy(), c.getId()))
+                .collect(Collectors.toSet());
+        break;
+      case CONCEPT_SET:
+        actual =
+            conceptSetService.listConceptSets(resources, 0, Integer.MAX_VALUE).stream()
+                .map(c -> ResourceId.forConceptSet(parent.getStudy(), c.getId()))
+                .collect(Collectors.toSet());
+        break;
+      case REVIEW:
+        actual =
+            reviewService.listReviews(resources, 0, Integer.MAX_VALUE).stream()
+                .map(r -> ResourceId.forReview(parent.getStudy(), parent.getCohort(), r.getId()))
+                .collect(Collectors.toSet());
+        break;
+      case ANNOTATION_KEY:
+        actual =
+            annotationService.listAnnotationKeys(resources, 0, Integer.MAX_VALUE).stream()
+                .map(
+                    a ->
+                        ResourceId.forAnnotationKey(
+                            parent.getStudy(), parent.getCohort(), a.getId()))
+                .collect(Collectors.toSet());
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown resource type: " + type);
+    }
+    List<ResourceId> expected = Arrays.asList(expectedResources);
+    assertEquals(expected.size(), actual.size());
+    actual.stream().forEach(r -> assertTrue(expected.contains(r)));
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/OpenAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/OpenAccessControlTest.java
@@ -1,0 +1,215 @@
+package bio.terra.tanagra.service.accesscontrol;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.tanagra.service.accesscontrol.impl.OpenAccessControl;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenAccessControlTest extends BaseAccessControlTest {
+  @BeforeEach
+  void createArtifactsAndDefinePermissionsInMock() {
+    createArtifacts();
+
+    // No need to use a mock here because there are no external service calls.
+    impl = new OpenAccessControl();
+    impl.initialize(List.of(), null, null);
+  }
+
+  @AfterEach
+  protected void cleanup() {
+    deleteStudies();
+  }
+
+  @Test
+  void underlay() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);
+    ResourceId aouSyntheticId = ResourceId.forUnderlay(AOU_SYNTHETIC);
+    ResourceId sddId = ResourceId.forUnderlay(SDD);
+    assertHasPermissions(USER_1, cmsSynpufId);
+    assertHasPermissions(USER_1, aouSyntheticId);
+    assertHasPermissions(USER_1, sddId);
+    assertHasPermissions(USER_2, cmsSynpufId);
+    assertHasPermissions(USER_2, aouSyntheticId);
+    assertHasPermissions(USER_2, sddId);
+    assertHasPermissions(USER_3, cmsSynpufId);
+    assertHasPermissions(USER_3, aouSyntheticId);
+    assertHasPermissions(USER_3, sddId);
+    assertHasPermissions(USER_4, cmsSynpufId);
+    assertHasPermissions(USER_4, aouSyntheticId);
+    assertHasPermissions(USER_4, sddId);
+
+    // service.list
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+  }
+
+  @Test
+  void study() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    Action[] studyActionsExceptCreate = {
+      Action.READ, Action.UPDATE, Action.DELETE, Action.CREATE_COHORT, Action.CREATE_CONCEPT_SET,
+    };
+    ResourceId study1Id = ResourceId.forStudy(study1.getId());
+    ResourceId study2Id = ResourceId.forStudy(study2.getId());
+    assertHasPermissions(USER_1, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_1, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_2, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_2, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_3, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_3, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_4, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_4, study2Id, studyActionsExceptCreate);
+
+    // isAuthorized for STUDY.CREATE
+    assertTrue(
+        impl.isAuthorized(USER_1, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_2, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_3, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_4, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+
+    // service.list
+    assertServiceListWithReadPermission(USER_1, ResourceType.STUDY, null, true, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.STUDY, null, true, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.STUDY, null, true, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.STUDY, null, true, study1Id, study2Id);
+  }
+
+  @Test
+  void cohort() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cohort1Id = ResourceId.forCohort(study1.getId(), cohort1.getId());
+    ResourceId cohort2Id = ResourceId.forCohort(study2.getId(), cohort2.getId());
+    assertHasPermissions(USER_1, cohort1Id);
+    assertHasPermissions(USER_1, cohort2Id);
+    assertHasPermissions(USER_2, cohort1Id);
+    assertHasPermissions(USER_2, cohort2Id);
+    assertHasPermissions(USER_3, cohort1Id);
+    assertHasPermissions(USER_3, cohort2Id);
+    assertHasPermissions(USER_4, cohort1Id);
+    assertHasPermissions(USER_4, cohort2Id);
+
+    // service.list
+    ResourceId study1Id = cohort1Id.getParent();
+    ResourceId study2Id = cohort2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study2Id, true, cohort2Id);
+  }
+
+  @Test
+  void conceptSet() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId conceptSet1Id = ResourceId.forConceptSet(study1.getId(), conceptSet1.getId());
+    ResourceId conceptSet2Id = ResourceId.forConceptSet(study2.getId(), conceptSet2.getId());
+    assertHasPermissions(USER_1, conceptSet1Id);
+    assertHasPermissions(USER_1, conceptSet2Id);
+    assertHasPermissions(USER_2, conceptSet1Id);
+    assertHasPermissions(USER_2, conceptSet2Id);
+    assertHasPermissions(USER_3, conceptSet1Id);
+    assertHasPermissions(USER_3, conceptSet2Id);
+    assertHasPermissions(USER_4, conceptSet1Id);
+    assertHasPermissions(USER_4, conceptSet2Id);
+
+    // service.list
+    ResourceId study1Id = conceptSet1Id.getParent();
+    ResourceId study2Id = conceptSet2Id.getParent();
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+  }
+
+  @Test
+  void review() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId review1Id = ResourceId.forReview(study1.getId(), cohort1.getId(), review1.getId());
+    ResourceId review2Id = ResourceId.forReview(study2.getId(), cohort2.getId(), review2.getId());
+    assertHasPermissions(USER_1, review1Id);
+    assertHasPermissions(USER_1, review2Id);
+    assertHasPermissions(USER_2, review1Id);
+    assertHasPermissions(USER_2, review2Id);
+    assertHasPermissions(USER_3, review1Id);
+    assertHasPermissions(USER_3, review2Id);
+    assertHasPermissions(USER_4, review1Id);
+    assertHasPermissions(USER_4, review2Id);
+
+    // service.list
+    ResourceId cohort1Id = review1Id.getParent();
+    ResourceId cohort2Id = review2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort2Id, true, review2Id);
+  }
+
+  @Test
+  void annotationKey() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId annotationKey1Id =
+        ResourceId.forAnnotationKey(study1.getId(), cohort1.getId(), annotationKey1.getId());
+    ResourceId annotationKey2Id =
+        ResourceId.forAnnotationKey(study2.getId(), cohort2.getId(), annotationKey2.getId());
+    assertHasPermissions(USER_1, annotationKey1Id);
+    assertHasPermissions(USER_1, annotationKey2Id);
+    assertHasPermissions(USER_2, annotationKey1Id);
+    assertHasPermissions(USER_2, annotationKey2Id);
+    assertHasPermissions(USER_3, annotationKey1Id);
+    assertHasPermissions(USER_3, annotationKey2Id);
+    assertHasPermissions(USER_4, annotationKey1Id);
+    assertHasPermissions(USER_4, annotationKey2Id);
+
+    // service.list
+    ResourceId cohort1Id = annotationKey1Id.getParent();
+    ResourceId cohort2Id = annotationKey2Id.getParent();
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VerilyGroupsAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VerilyGroupsAccessControlTest.java
@@ -1,0 +1,234 @@
+package bio.terra.tanagra.service.accesscontrol;
+
+import static bio.terra.tanagra.service.accesscontrol.impl.VerilyGroupsAccessControl.ALL_ACCESS;
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.tanagra.service.accesscontrol.impl.MockVerilyGroupsAccessControl;
+import bio.terra.tanagra.service.accesscontrol.impl.VerilyGroupsAccessControl;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class VerilyGroupsAccessControlTest extends BaseAccessControlTest {
+  @BeforeEach
+  void createArtifactsAndDefinePermissionsInMock() {
+    createArtifacts();
+
+    // Define user permissions in VerilyGroups mock impl.
+    MockVerilyGroupsAccessControl vgImpl = new MockVerilyGroupsAccessControl();
+    // underlays
+    //   user1: cmssynpuf
+    //   user2: cmssynpuf, aousynthetic
+    //   user3:
+    //   user4: all
+    vgImpl.addGroup(
+        new VerilyGroupsAccessControl.VerilyGroup("id1", "cmssynpuf", "name1@verilygroups.com"),
+        List.of(USER_1.getEmail(), USER_2.getEmail()));
+    vgImpl.addGroup(
+        new VerilyGroupsAccessControl.VerilyGroup("id2", "aousynthetic", "name2@verilygroups.com"),
+        List.of(USER_2.getEmail()));
+    vgImpl.addGroup(
+        new VerilyGroupsAccessControl.VerilyGroup("id3", "all", "name3@verilygroups.com"),
+        List.of(USER_4.getEmail()));
+
+    impl = vgImpl;
+    impl.initialize(
+        List.of(CMS_SYNPUF, "cmssynpuf", AOU_SYNTHETIC, "aousynthetic", ALL_ACCESS, "all"),
+        "FAKE_BASE_PATH",
+        "FAKE_OAUTH_CLIENT_ID");
+  }
+
+  @AfterEach
+  protected void cleanup() {
+    deleteStudies();
+  }
+
+  @Test
+  void underlay() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);
+    ResourceId aouSyntheticId = ResourceId.forUnderlay(AOU_SYNTHETIC);
+    ResourceId sddId = ResourceId.forUnderlay(SDD);
+    assertHasPermissions(USER_1, cmsSynpufId);
+    assertDoesNotHavePermissions(USER_1, aouSyntheticId);
+    assertDoesNotHavePermissions(USER_1, sddId);
+    assertHasPermissions(USER_2, cmsSynpufId);
+    assertHasPermissions(USER_2, aouSyntheticId);
+    assertDoesNotHavePermissions(USER_2, sddId);
+    assertDoesNotHavePermissions(USER_3, cmsSynpufId);
+    assertDoesNotHavePermissions(USER_3, aouSyntheticId);
+    assertDoesNotHavePermissions(USER_3, sddId);
+    assertHasPermissions(USER_4, cmsSynpufId);
+    assertHasPermissions(USER_4, aouSyntheticId);
+    assertHasPermissions(USER_4, sddId);
+
+    // service.list
+    assertServiceListWithReadPermission(USER_1, ResourceType.UNDERLAY, null, false, cmsSynpufId);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.UNDERLAY, null, false, cmsSynpufId, aouSyntheticId);
+    assertServiceListWithReadPermission(USER_3, ResourceType.UNDERLAY, null, false);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+  }
+
+  @Test
+  void study() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    Action[] studyActionsExceptCreate = {
+      Action.READ, Action.UPDATE, Action.DELETE, Action.CREATE_COHORT, Action.CREATE_CONCEPT_SET,
+    };
+    ResourceId study1Id = ResourceId.forStudy(study1.getId());
+    ResourceId study2Id = ResourceId.forStudy(study2.getId());
+    assertHasPermissions(USER_1, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_1, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_2, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_2, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_3, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_3, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_4, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_4, study2Id, studyActionsExceptCreate);
+
+    // isAuthorized for STUDY.CREATE
+    assertTrue(
+        impl.isAuthorized(USER_1, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_2, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_3, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_4, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+
+    // service.list
+    assertServiceListWithReadPermission(USER_1, ResourceType.STUDY, null, true, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.STUDY, null, true, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.STUDY, null, true, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.STUDY, null, true, study1Id, study2Id);
+  }
+
+  @Test
+  void cohort() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cohort1Id = ResourceId.forCohort(study1.getId(), cohort1.getId());
+    ResourceId cohort2Id = ResourceId.forCohort(study2.getId(), cohort2.getId());
+    assertHasPermissions(USER_1, cohort1Id);
+    assertHasPermissions(USER_1, cohort2Id);
+    assertHasPermissions(USER_2, cohort1Id);
+    assertHasPermissions(USER_2, cohort2Id);
+    assertHasPermissions(USER_3, cohort1Id);
+    assertHasPermissions(USER_3, cohort2Id);
+    assertHasPermissions(USER_4, cohort1Id);
+    assertHasPermissions(USER_4, cohort2Id);
+
+    // service.list
+    ResourceId study1Id = cohort1Id.getParent();
+    ResourceId study2Id = cohort2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study2Id, true, cohort2Id);
+  }
+
+  @Test
+  void conceptSet() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId conceptSet1Id = ResourceId.forConceptSet(study1.getId(), conceptSet1.getId());
+    ResourceId conceptSet2Id = ResourceId.forConceptSet(study2.getId(), conceptSet2.getId());
+    assertHasPermissions(USER_1, conceptSet1Id);
+    assertHasPermissions(USER_1, conceptSet2Id);
+    assertHasPermissions(USER_2, conceptSet1Id);
+    assertHasPermissions(USER_2, conceptSet2Id);
+    assertHasPermissions(USER_3, conceptSet1Id);
+    assertHasPermissions(USER_3, conceptSet2Id);
+    assertHasPermissions(USER_4, conceptSet1Id);
+    assertHasPermissions(USER_4, conceptSet2Id);
+
+    // service.list
+    ResourceId study1Id = conceptSet1Id.getParent();
+    ResourceId study2Id = conceptSet2Id.getParent();
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+  }
+
+  @Test
+  void review() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId review1Id = ResourceId.forReview(study1.getId(), cohort1.getId(), review1.getId());
+    ResourceId review2Id = ResourceId.forReview(study2.getId(), cohort2.getId(), review2.getId());
+    assertHasPermissions(USER_1, review1Id);
+    assertHasPermissions(USER_1, review2Id);
+    assertHasPermissions(USER_2, review1Id);
+    assertHasPermissions(USER_2, review2Id);
+    assertHasPermissions(USER_3, review1Id);
+    assertHasPermissions(USER_3, review2Id);
+    assertHasPermissions(USER_4, review1Id);
+    assertHasPermissions(USER_4, review2Id);
+
+    // service.list
+    ResourceId cohort1Id = review1Id.getParent();
+    ResourceId cohort2Id = review2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort2Id, true, review2Id);
+  }
+
+  @Test
+  void annotationKey() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId annotationKey1Id =
+        ResourceId.forAnnotationKey(study1.getId(), cohort1.getId(), annotationKey1.getId());
+    ResourceId annotationKey2Id =
+        ResourceId.forAnnotationKey(study2.getId(), cohort2.getId(), annotationKey2.getId());
+    assertHasPermissions(USER_1, annotationKey1Id);
+    assertHasPermissions(USER_1, annotationKey2Id);
+    assertHasPermissions(USER_2, annotationKey1Id);
+    assertHasPermissions(USER_2, annotationKey2Id);
+    assertHasPermissions(USER_3, annotationKey1Id);
+    assertHasPermissions(USER_3, annotationKey2Id);
+    assertHasPermissions(USER_4, annotationKey1Id);
+    assertHasPermissions(USER_4, annotationKey2Id);
+
+    // service.list
+    ResourceId cohort1Id = annotationKey1Id.getParent();
+    ResourceId cohort2Id = annotationKey2Id.getParent();
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VumcAdminAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VumcAdminAccessControlTest.java
@@ -1,0 +1,314 @@
+package bio.terra.tanagra.service.accesscontrol;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.tanagra.service.accesscontrol.impl.MockVumcAdminAccessControl;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.vumc.vda.tanagra.admin.model.ResourceAction;
+
+public class VumcAdminAccessControlTest extends BaseAccessControlTest {
+
+  @BeforeEach
+  void createArtifactsAndDefinePermissionsInMock() {
+    createArtifacts();
+
+    // Define user permissions in VumcAdmin mock impl.
+    MockVumcAdminAccessControl vaImpl = new MockVumcAdminAccessControl();
+    // underlays
+    //   user1: cmssynpuf (ALL)
+    //   user2: cmssynpuf (READ), aousynthetic (ALL)
+    //   user3:
+    //   user4: cmssynpuf (READ), aousynthetic (READ), sdd (ALL)
+    vaImpl.addPermission(
+        USER_1,
+        ResourceAction.ALL,
+        org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY,
+        CMS_SYNPUF);
+    vaImpl.addPermission(
+        USER_2,
+        ResourceAction.READ,
+        org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY,
+        CMS_SYNPUF);
+    vaImpl.addPermission(
+        USER_2,
+        ResourceAction.ALL,
+        org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY,
+        AOU_SYNTHETIC);
+    vaImpl.addPermission(
+        USER_4,
+        ResourceAction.READ,
+        org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY,
+        CMS_SYNPUF);
+    vaImpl.addPermission(
+        USER_4,
+        ResourceAction.READ,
+        org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY,
+        AOU_SYNTHETIC);
+    vaImpl.addPermission(
+        USER_4, ResourceAction.READ, org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY, SDD);
+    // studies
+    //   user1: CREATE, study1 (UPDATE, DELETE)
+    //   user2: CREATE, study1 (ALL), study2 (READ, UPDATE, DELETE)
+    //   user3:
+    //   user4: study2 (READ)
+    vaImpl.addPermission(
+        USER_1, ResourceAction.CREATE, org.vumc.vda.tanagra.admin.model.ResourceType.STUDY, null);
+    vaImpl.addPermission(
+        USER_1,
+        ResourceAction.UPDATE,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study1.getId());
+    vaImpl.addPermission(
+        USER_1,
+        ResourceAction.DELETE,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study1.getId());
+    vaImpl.addPermission(
+        USER_2,
+        ResourceAction.ALL,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study1.getId());
+    vaImpl.addPermission(
+        USER_2,
+        ResourceAction.READ,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study2.getId());
+    vaImpl.addPermission(
+        USER_2, ResourceAction.CREATE, org.vumc.vda.tanagra.admin.model.ResourceType.STUDY, null);
+    vaImpl.addPermission(
+        USER_2,
+        ResourceAction.UPDATE,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study2.getId());
+    vaImpl.addPermission(
+        USER_2,
+        ResourceAction.DELETE,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study2.getId());
+    vaImpl.addPermission(
+        USER_4,
+        ResourceAction.READ,
+        org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
+        study2.getId());
+
+    impl = vaImpl;
+    impl.initialize(List.of(), "FAKE_BASE_PATH", "FAKE_OAUTH_CLIENT_ID");
+  }
+
+  @AfterEach
+  protected void cleanup() {
+    deleteStudies();
+  }
+
+  @Test
+  void underlay() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);
+    ResourceId aouSyntheticId = ResourceId.forUnderlay(AOU_SYNTHETIC);
+    ResourceId sddId = ResourceId.forUnderlay(SDD);
+    assertHasPermissions(USER_1, cmsSynpufId);
+    assertDoesNotHavePermissions(USER_1, aouSyntheticId);
+    assertDoesNotHavePermissions(USER_1, sddId);
+    assertHasPermissions(USER_2, cmsSynpufId);
+    assertHasPermissions(USER_2, aouSyntheticId);
+    assertDoesNotHavePermissions(USER_2, sddId);
+    assertDoesNotHavePermissions(USER_3, cmsSynpufId);
+    assertDoesNotHavePermissions(USER_3, aouSyntheticId);
+    assertDoesNotHavePermissions(USER_3, sddId);
+    assertHasPermissions(USER_4, cmsSynpufId);
+    assertHasPermissions(USER_4, aouSyntheticId);
+    assertHasPermissions(USER_4, sddId);
+
+    // service.list
+    assertServiceListWithReadPermission(USER_1, ResourceType.UNDERLAY, null, false, cmsSynpufId);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.UNDERLAY, null, false, cmsSynpufId, aouSyntheticId);
+    assertServiceListWithReadPermission(USER_3, ResourceType.UNDERLAY, null, false);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.UNDERLAY, null, false, cmsSynpufId, aouSyntheticId, sddId);
+  }
+
+  @Test
+  void study() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    Action[] studyActionsExceptCreate = {
+      Action.READ, Action.UPDATE, Action.DELETE, Action.CREATE_COHORT, Action.CREATE_CONCEPT_SET,
+    };
+    ResourceId study1Id = ResourceId.forStudy(study1.getId());
+    ResourceId study2Id = ResourceId.forStudy(study2.getId());
+    assertHasPermissions(USER_1, study1Id, Action.UPDATE, Action.DELETE);
+    assertDoesNotHavePermissions(USER_1, study1Id, Action.READ);
+    assertDoesNotHavePermissions(USER_1, study2Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_2, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_2, study2Id, studyActionsExceptCreate);
+    assertDoesNotHavePermissions(USER_3, study1Id, studyActionsExceptCreate);
+    assertDoesNotHavePermissions(USER_3, study2Id, studyActionsExceptCreate);
+    assertDoesNotHavePermissions(USER_4, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_4, study2Id, Action.READ);
+    assertDoesNotHavePermissions(
+        USER_4,
+        study2Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_COHORT,
+        Action.CREATE_CONCEPT_SET);
+
+    // isAuthorized for STUDY.CREATE
+    assertTrue(
+        impl.isAuthorized(USER_1, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_2, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertFalse(
+        impl.isAuthorized(USER_3, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertFalse(
+        impl.isAuthorized(USER_4, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+
+    // service.list
+    assertServiceListWithReadPermission(USER_1, ResourceType.STUDY, null, false);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.STUDY, null, false, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.STUDY, null, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.STUDY, null, false, study2Id);
+  }
+
+  @Test
+  void cohort() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cohort1Id = ResourceId.forCohort(study1.getId(), cohort1.getId());
+    ResourceId cohort2Id = ResourceId.forCohort(study2.getId(), cohort2.getId());
+    assertHasPermissions(
+        USER_1,
+        cohort1Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_REVIEW,
+        Action.CREATE_ANNOTATION_KEY);
+    assertDoesNotHavePermissions(USER_1, cohort1Id, Action.READ);
+    assertDoesNotHavePermissions(USER_1, cohort2Id);
+    assertHasPermissions(USER_2, cohort1Id);
+    assertHasPermissions(USER_2, cohort2Id);
+    assertDoesNotHavePermissions(USER_3, cohort1Id);
+    assertDoesNotHavePermissions(USER_3, cohort2Id);
+    assertDoesNotHavePermissions(USER_4, cohort1Id);
+    assertHasPermissions(USER_4, cohort2Id, Action.READ);
+    assertDoesNotHavePermissions(
+        USER_4,
+        cohort2Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_REVIEW,
+        Action.CREATE_ANNOTATION_KEY);
+
+    // service.list
+    ResourceId study1Id = cohort1Id.getParent();
+    ResourceId study2Id = cohort2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study1Id, false);
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study2Id, false);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study1Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study2Id, true, cohort2Id);
+  }
+
+  @Test
+  void conceptSet() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId conceptSet1Id = ResourceId.forConceptSet(study1.getId(), conceptSet1.getId());
+    ResourceId conceptSet2Id = ResourceId.forConceptSet(study2.getId(), conceptSet2.getId());
+    assertHasPermissions(USER_1, conceptSet1Id, Action.UPDATE, Action.DELETE);
+    assertDoesNotHavePermissions(USER_1, conceptSet1Id, Action.READ);
+    assertDoesNotHavePermissions(USER_1, conceptSet2Id);
+    assertHasPermissions(USER_2, conceptSet1Id);
+    assertHasPermissions(USER_2, conceptSet2Id);
+    assertDoesNotHavePermissions(USER_3, conceptSet1Id);
+    assertDoesNotHavePermissions(USER_3, conceptSet2Id);
+    assertDoesNotHavePermissions(USER_4, conceptSet1Id);
+    assertHasPermissions(USER_4, conceptSet2Id, Action.READ);
+    assertDoesNotHavePermissions(USER_4, conceptSet2Id, Action.UPDATE, Action.DELETE);
+
+    // service.list
+    ResourceId study1Id = conceptSet1Id.getParent();
+    ResourceId study2Id = conceptSet2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.CONCEPT_SET, study1Id, false);
+    assertServiceListWithReadPermission(USER_1, ResourceType.CONCEPT_SET, study2Id, false);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.CONCEPT_SET, study1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.CONCEPT_SET, study2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.CONCEPT_SET, study1Id, false);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+  }
+
+  @Test
+  void review() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId review1Id = ResourceId.forReview(study1.getId(), cohort1.getId(), review1.getId());
+    ResourceId review2Id = ResourceId.forReview(study2.getId(), cohort2.getId(), review2.getId());
+    assertHasPermissions(USER_1, review1Id, Action.UPDATE, Action.DELETE);
+    assertDoesNotHavePermissions(
+        USER_1, review1Id, Action.READ, Action.QUERY_INSTANCES, Action.QUERY_COUNTS);
+    assertDoesNotHavePermissions(USER_1, review2Id);
+    assertHasPermissions(USER_2, review1Id);
+    assertHasPermissions(USER_2, review2Id);
+    assertDoesNotHavePermissions(USER_3, review1Id);
+    assertDoesNotHavePermissions(USER_3, review2Id);
+    assertDoesNotHavePermissions(USER_4, review1Id);
+    assertHasPermissions(
+        USER_4, review2Id, Action.READ, Action.QUERY_INSTANCES, Action.QUERY_COUNTS);
+    assertDoesNotHavePermissions(USER_4, review2Id, Action.UPDATE, Action.DELETE);
+
+    // service.list
+    ResourceId cohort1Id = review1Id.getParent();
+    ResourceId cohort2Id = review2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort2Id, true, review2Id);
+  }
+
+  @Test
+  void annotationKey() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId annotationKey1Id =
+        ResourceId.forAnnotationKey(study1.getId(), cohort1.getId(), annotationKey1.getId());
+    ResourceId annotationKey2Id =
+        ResourceId.forAnnotationKey(study2.getId(), cohort2.getId(), annotationKey2.getId());
+    assertHasPermissions(USER_1, annotationKey1Id, Action.UPDATE, Action.DELETE);
+    assertDoesNotHavePermissions(USER_1, annotationKey1Id, Action.READ);
+    assertDoesNotHavePermissions(USER_1, annotationKey2Id);
+    assertHasPermissions(USER_2, annotationKey1Id);
+    assertHasPermissions(USER_2, annotationKey2Id);
+    assertDoesNotHavePermissions(USER_3, annotationKey1Id);
+    assertDoesNotHavePermissions(USER_3, annotationKey2Id);
+    assertDoesNotHavePermissions(USER_4, annotationKey1Id);
+    assertHasPermissions(USER_4, annotationKey2Id, Action.READ);
+    assertDoesNotHavePermissions(USER_4, annotationKey2Id, Action.UPDATE, Action.DELETE);
+
+    // service.list
+    ResourceId cohort1Id = annotationKey1Id.getParent();
+    ResourceId cohort2Id = annotationKey2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.ANNOTATION_KEY, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_1, ResourceType.ANNOTATION_KEY, cohort2Id, false);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.ANNOTATION_KEY, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.ANNOTATION_KEY, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.ANNOTATION_KEY, cohort1Id, false);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockVerilyGroupsAccessControl.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockVerilyGroupsAccessControl.java
@@ -1,0 +1,36 @@
+package bio.terra.tanagra.service.accesscontrol.impl;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class MockVerilyGroupsAccessControl extends VerilyGroupsAccessControl {
+  private final Map<String, VerilyGroup> groups = new HashMap<>(); // group id -> group object
+  private final Map<String, List<String>> members = new HashMap<>(); // group id -> list of members
+
+  /**
+   * Call the VerilyGroups API to list all the groups the application default credentials have
+   * access to.
+   */
+  @Override
+  protected List<VerilyGroup> apiListGroups() {
+    return groups.values().stream()
+        .sorted(Comparator.comparing(VerilyGroup::getId))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Call the VerilyGroups API to list all the members in a group. Administrator access to a group
+   * is required to list its members.
+   *
+   * @return List of member emails.
+   */
+  @Override
+  protected List<String> apiListMembers(String groupId) {
+    return members.get(groupId);
+  }
+
+  public void addGroup(VerilyGroup newGroup, List<String> newMembers) {
+    groups.put(newGroup.getId(), newGroup);
+    members.put(newGroup.getId(), newMembers);
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockVumcAdminAccessControl.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockVumcAdminAccessControl.java
@@ -1,0 +1,51 @@
+package bio.terra.tanagra.service.accesscontrol.impl;
+
+import bio.terra.tanagra.service.auth.UserId;
+import java.util.*;
+import org.vumc.vda.tanagra.admin.model.Resource;
+import org.vumc.vda.tanagra.admin.model.ResourceAction;
+import org.vumc.vda.tanagra.admin.model.ResourceList;
+import org.vumc.vda.tanagra.admin.model.ResourceType;
+
+public class MockVumcAdminAccessControl extends VumcAdminAccessControl {
+  private final Map<String, Set<Resource>> permissions =
+      new HashMap<>(); // user email -> set of permissions
+
+  @Override
+  @SuppressWarnings("PMD.UseObjectForClearerAPI")
+  protected boolean apiIsAuthorized(
+      String userEmail,
+      ResourceAction resourceAction,
+      ResourceType resourceType,
+      String resourceId) {
+    return permissions.containsKey(userEmail)
+        && (permissions
+                .get(userEmail)
+                .contains(new Resource().action(resourceAction).type(resourceType).id(resourceId))
+            || permissions
+                .get(userEmail)
+                .contains(
+                    new Resource().action(ResourceAction.ALL).type(resourceType).id(resourceId)));
+  }
+
+  @Override
+  protected ResourceList apiListAuthorizedResources(String userEmail, ResourceType resourceType) {
+    ResourceList resourceList = new ResourceList();
+    if (permissions.containsKey(userEmail)) {
+      permissions.get(userEmail).stream()
+          .filter(r -> r.getType().equals(resourceType))
+          .forEach(r -> resourceList.add(r));
+    }
+    return resourceList;
+  }
+
+  public void addPermission(
+      UserId user, ResourceAction action, ResourceType type, String resourceId) {
+    Set<Resource> permissionsForUser =
+        permissions.containsKey(user.getEmail())
+            ? permissions.get(user.getEmail())
+            : new HashSet<>();
+    permissionsForUser.add(new Resource().action(action).type(type).id(resourceId));
+    permissions.put(user.getEmail(), permissionsForUser);
+  }
+}


### PR DESCRIPTION
Added tests for all current access control implementations:
  - VumcAdminAccessControl test uses a mock for the calls to the VUMC admin service.
  - VerilyGroupsAccessControl test uses a mock for the calls to the VerilyGroups API.
  - OpenAccessControl test doesn't use a mock.

Tests cover all artifacts: underlay, study, cohort, concept set, review, annotation key.

The VUMC admin service test includes partial permissions e.g. A user has UPDATE,DELETE permissions on a study but not READ. This scenario in the SDD deployment is what prompted the change to support fine-grained access control. In the future, we can modify this mock to test changes since not all developers have credentials to call the VUMC admin service deployment.

Also fixed a broken link in the README.