### PR TITLE
Add export model to download ipynb file.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -77,8 +77,6 @@ public class ExportApiController implements ExportApi {
             .model(body.getExportModel())
             .inputs(body.getInputs())
             .redirectBackUrl(body.getRedirectBackUrl())
-            .study(studyId)
-            .cohorts(body.getCohorts())
             .includeAnnotations(body.isIncludeAnnotations());
     List<EntityQueryRequest> entityQueryRequests =
         body.getInstanceQuerys().stream()
@@ -87,7 +85,8 @@ public class ExportApiController implements ExportApi {
                     fromApiConversionService.fromApiObject(
                         apiQuery.getQuery(), underlayName, apiQuery.getEntity()))
             .collect(Collectors.toList());
-    ExportResult result = dataExportService.run(request, entityQueryRequests);
+    ExportResult result =
+        dataExportService.run(studyId, body.getCohorts(), request, entityQueryRequests);
     return ResponseEntity.ok(toApiObject(result));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
@@ -16,6 +16,7 @@ import bio.terra.tanagra.service.accesscontrol.Permissions;
 import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
 import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.artifact.Study;
+import bio.terra.tanagra.service.utils.ToApiConversionUtils;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +48,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
             .description(body.getDescription())
             .properties(fromApiObject(body.getProperties()));
     return ResponseEntity.ok(
-        toApiObject(
+        ToApiConversionUtils.toApiObject(
             studyService.createStudy(
                 studyToCreate, SpringAuthentication.getCurrentUser().getEmail())));
   }
@@ -68,7 +69,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
         SpringAuthentication.getCurrentUser(),
         Permissions.forActions(STUDY, READ),
         ResourceId.forStudy(studyId));
-    return ResponseEntity.ok(toApiObject(studyService.getStudy(studyId)));
+    return ResponseEntity.ok(ToApiConversionUtils.toApiObject(studyService.getStudy(studyId)));
   }
 
   @Override
@@ -88,7 +89,8 @@ public class StudiesV2ApiController implements StudiesV2Api {
         studyService.listStudies(
             authorizedStudyIds, offset, limit, fromApiObject(displayName, description, properties));
     ApiStudyListV2 apiStudies = new ApiStudyListV2();
-    authorizedStudies.stream().forEach(study -> apiStudies.add(toApiObject(study)));
+    authorizedStudies.stream()
+        .forEach(study -> apiStudies.add(ToApiConversionUtils.toApiObject(study)));
     return ResponseEntity.ok(apiStudies);
   }
 
@@ -104,7 +106,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
             SpringAuthentication.getCurrentUser().getEmail(),
             body.getDisplayName(),
             body.getDescription());
-    return ResponseEntity.ok(toApiObject(updatedStudy));
+    return ResponseEntity.ok(ToApiConversionUtils.toApiObject(updatedStudy));
   }
 
   @Override
@@ -128,22 +130,6 @@ public class StudiesV2ApiController implements StudiesV2Api {
     studyService.deleteStudyProperties(
         studyId, SpringAuthentication.getCurrentUser().getEmail(), body);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-  }
-
-  private static ApiStudyV2 toApiObject(Study study) {
-    ApiPropertiesV2 apiProperties = new ApiPropertiesV2();
-    study
-        .getProperties()
-        .forEach(
-            (key, value) -> apiProperties.add(new ApiPropertyKeyValueV2().key(key).value(value)));
-    return new ApiStudyV2()
-        .id(study.getId())
-        .displayName(study.getDisplayName())
-        .description(study.getDescription())
-        .properties(apiProperties)
-        .created(study.getCreated())
-        .createdBy(study.getCreatedBy())
-        .lastModified(study.getLastModified());
   }
 
   private static ImmutableMap<String, String> fromApiObject(

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysV2ApiController.java
@@ -12,6 +12,7 @@ import bio.terra.tanagra.service.UnderlaysService;
 import bio.terra.tanagra.service.accesscontrol.Permissions;
 import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
 import bio.terra.tanagra.service.accesscontrol.ResourceId;
+import bio.terra.tanagra.service.utils.ToApiConversionUtils;
 import bio.terra.tanagra.underlay.Underlay;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,8 @@ public class UnderlaysV2ApiController implements UnderlaysV2Api {
     List<Underlay> authorizedUnderlays = underlaysService.listUnderlays(authorizedUnderlayNames);
     ApiUnderlayListV2 apiUnderlays = new ApiUnderlayListV2();
     authorizedUnderlays.stream()
-        .forEach(underlay -> apiUnderlays.addUnderlaysItem(toApiObject(underlay)));
+        .forEach(
+            underlay -> apiUnderlays.addUnderlaysItem(ToApiConversionUtils.toApiObject(underlay)));
     return ResponseEntity.ok(apiUnderlays);
   }
 
@@ -48,15 +50,7 @@ public class UnderlaysV2ApiController implements UnderlaysV2Api {
         SpringAuthentication.getCurrentUser(),
         Permissions.forActions(UNDERLAY, READ),
         ResourceId.forUnderlay(underlayName));
-    return ResponseEntity.ok(toApiObject(underlaysService.getUnderlay(underlayName)));
-  }
-
-  private ApiUnderlayV2 toApiObject(Underlay underlay) {
-    return new ApiUnderlayV2()
-        .name(underlay.getName())
-        // TODO: Add display name to underlay config files.
-        .displayName(underlay.getName())
-        .primaryEntity(underlay.getPrimaryEntity().getName())
-        .uiConfiguration(underlay.getUIConfig());
+    return ResponseEntity.ok(
+        ToApiConversionUtils.toApiObject(underlaysService.getUnderlay(underlayName)));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExport.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExport.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.service.export;
 
 import bio.terra.tanagra.service.export.impl.IndividualFileDownload;
+import bio.terra.tanagra.service.export.impl.IpynbFileDownload;
 import bio.terra.tanagra.service.export.impl.VwbFileImport;
 import java.util.Collections;
 import java.util.Map;
@@ -9,7 +10,8 @@ import java.util.function.Supplier;
 public interface DataExport {
   enum Type {
     INDIVIDUAL_FILE_DOWNLOAD(() -> new IndividualFileDownload()),
-    VWB_FILE_IMPORT(() -> new VwbFileImport());
+    VWB_FILE_IMPORT(() -> new VwbFileImport()),
+    IPYNB_FILE_DOWNLOAD(() -> new IpynbFileDownload());
 
     private Supplier<DataExport> createNewInstanceFn;
 

--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportRequest.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportRequest.java
@@ -1,5 +1,8 @@
 package bio.terra.tanagra.service.export;
 
+import bio.terra.tanagra.generated.model.ApiCohortV2;
+import bio.terra.tanagra.generated.model.ApiStudyV2;
+import bio.terra.tanagra.generated.model.ApiUnderlayV2;
 import bio.terra.tanagra.utils.GoogleCloudStorage;
 import java.util.*;
 import java.util.function.Function;
@@ -9,23 +12,23 @@ public class ExportRequest {
   private final String model;
   private final Map<String, String> inputs;
   private final String redirectBackUrl;
-  private final String study;
-  private final List<String> cohorts;
   private final boolean includeAnnotations;
-
+  private final ApiUnderlayV2 underlay;
+  private final ApiStudyV2 study;
+  private final List<ApiCohortV2> cohorts;
   private final Supplier<Map<String, String>> generateSqlQueriesFn;
   private final Function<String, Map<String, String>> writeEntityDataToGcsFn;
   private final Function<String, Map<String, String>> writeAnnotationDataToGcsFn;
-
   private final Supplier<GoogleCloudStorage> getGoogleCloudStorageFn;
 
   private ExportRequest(Builder builder) {
     this.model = builder.model;
     this.inputs = builder.inputs;
     this.redirectBackUrl = builder.redirectBackUrl;
+    this.includeAnnotations = builder.includeAnnotations;
+    this.underlay = builder.underlay;
     this.study = builder.study;
     this.cohorts = builder.cohorts;
-    this.includeAnnotations = builder.includeAnnotations;
     this.generateSqlQueriesFn = builder.generateSqlQueriesFn;
     this.writeEntityDataToGcsFn = builder.writeEntityDataToGcsFn;
     this.writeAnnotationDataToGcsFn = builder.writeAnnotationDataToGcsFn;
@@ -48,16 +51,20 @@ public class ExportRequest {
     return redirectBackUrl;
   }
 
-  public String getStudy() {
+  public boolean includeAnnotations() {
+    return includeAnnotations;
+  }
+
+  public ApiUnderlayV2 getUnderlay() {
+    return underlay;
+  }
+
+  public ApiStudyV2 getStudy() {
     return study;
   }
 
-  public List<String> getCohorts() {
+  public List<ApiCohortV2> getCohorts() {
     return Collections.unmodifiableList(cohorts);
-  }
-
-  public boolean includeAnnotations() {
-    return includeAnnotations;
   }
 
   public Map<String, String> generateSqlQueries() {
@@ -84,9 +91,10 @@ public class ExportRequest {
     private String model;
     private Map<String, String> inputs;
     private String redirectBackUrl;
-    private String study;
-    private List<String> cohorts;
     private boolean includeAnnotations;
+    private ApiUnderlayV2 underlay;
+    private ApiStudyV2 study;
+    private List<ApiCohortV2> cohorts;
     private Supplier<Map<String, String>> generateSqlQueriesFn;
     private Function<String, Map<String, String>> writeEntityDataToGcsFn;
     private Function<String, Map<String, String>> writeAnnotationDataToGcsFn;
@@ -108,18 +116,23 @@ public class ExportRequest {
       return this;
     }
 
-    public Builder study(String study) {
+    public Builder includeAnnotations(boolean includeAnnotations) {
+      this.includeAnnotations = includeAnnotations;
+      return this;
+    }
+
+    public Builder underlay(ApiUnderlayV2 underlay) {
+      this.underlay = underlay;
+      return this;
+    }
+
+    public Builder study(ApiStudyV2 study) {
       this.study = study;
       return this;
     }
 
-    public Builder cohorts(List<String> cohorts) {
+    public Builder cohorts(List<ApiCohortV2> cohorts) {
       this.cohorts = cohorts;
-      return this;
-    }
-
-    public Builder includeAnnotations(boolean includeAnnotations) {
-      this.includeAnnotations = includeAnnotations;
       return this;
     }
 
@@ -159,11 +172,11 @@ public class ExportRequest {
       return model;
     }
 
-    public String getStudy() {
+    public ApiStudyV2 getStudy() {
       return study;
     }
 
-    public List<String> getCohorts() {
+    public List<ApiCohortV2> getCohorts() {
       return Collections.unmodifiableList(cohorts);
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
@@ -1,0 +1,88 @@
+package bio.terra.tanagra.service.export.impl;
+
+import bio.terra.tanagra.service.export.DataExport;
+import bio.terra.tanagra.service.export.DeploymentConfig;
+import bio.terra.tanagra.service.export.ExportRequest;
+import bio.terra.tanagra.service.export.ExportResult;
+import bio.terra.tanagra.utils.FileUtils;
+import bio.terra.tanagra.utils.NameUtils;
+import bio.terra.tanagra.utils.SqlFormatter;
+import com.google.cloud.storage.BlobId;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.*;
+import org.apache.commons.text.StringSubstitutor;
+
+public class IpynbFileDownload implements DataExport {
+  private static final String IPYNB_TEMPLATE_RESOURCE_FILE = "export/notebook_template.ipynb";
+  public static final String IPYNB_FILE_KEY = "ipynbFile";
+  private List<String> gcsBucketNames;
+
+  @Override
+  public Type getType() {
+    return Type.IPYNB_FILE_DOWNLOAD;
+  }
+
+  @Override
+  public String getDefaultDisplayName() {
+    return "Download ipynb file with embedded SQL";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Signed URL to an ipynb notebook file that includes SQL to get the list of primary entity instances.";
+  }
+
+  @Override
+  public Map<String, String> describeOutputs() {
+    return Map.of(IPYNB_FILE_KEY, "URL to ipynb file");
+  }
+
+  @Override
+  public void initialize(DeploymentConfig deploymentConfig) {
+    gcsBucketNames = deploymentConfig.getShared().getGcsBucketNames();
+  }
+
+  @Override
+  public ExportResult run(ExportRequest request) {
+    // Read in the ipynb template file.
+    String ipynbTemplate =
+        FileUtils.readStringFromFile(
+            FileUtils.getResourceFileStream(Path.of(IPYNB_TEMPLATE_RESOURCE_FILE)));
+
+    // Generate the SQL for the primary entity.
+    Map<String, String> entityToSql = request.generateSqlQueries();
+    String primaryEntitySql =
+        SqlFormatter.format(entityToSql.get(request.getUnderlay().getPrimaryEntity()));
+
+    // Make substitutions in the template file contents.
+    String studyIdAndName =
+        NameUtils.simplifyStringForName(
+            new StringBuilder(
+                    request.getStudy().getDisplayName() + "_" + request.getStudy().getId())
+                .toString());
+    Map<String, String> params =
+        ImmutableMap.<String, String>builder()
+            .put("underlayName", request.getUnderlay().getDisplayName())
+            .put("studyName", studyIdAndName)
+            .put("timestamp", Instant.now().toString())
+            .put("entityName", request.getUnderlay().getPrimaryEntity())
+            .put("formattedSql", primaryEntitySql)
+            .build();
+    String fileContents = StringSubstitutor.replace(ipynbTemplate, params);
+
+    // Write the ipynb file to GCS. Just pick the first bucket name.
+    BlobId blobId =
+        request
+            .getGoogleCloudStorage()
+            .writeFile(
+                gcsBucketNames.get(0), "tanagra_export_" + Instant.now() + ".ipynb", fileContents);
+
+    // Generate a signed URL for the ipynb file.
+    String ipynbSignedUrl = request.getGoogleCloudStorage().createSignedUrl(blobId.toGsUtilUri());
+
+    return ExportResult.forOutputParams(
+        Map.of(IPYNB_FILE_KEY, ipynbSignedUrl), ExportResult.Status.COMPLETE);
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/utils/ToApiConversionUtils.java
@@ -3,12 +3,10 @@ package bio.terra.tanagra.service.utils;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.model.*;
 import bio.terra.tanagra.query.Literal;
-import bio.terra.tanagra.service.artifact.AnnotationValue;
-import bio.terra.tanagra.service.artifact.Cohort;
-import bio.terra.tanagra.service.artifact.CohortRevision;
-import bio.terra.tanagra.service.artifact.Criteria;
+import bio.terra.tanagra.service.artifact.*;
 import bio.terra.tanagra.service.instances.EntityInstanceCount;
 import bio.terra.tanagra.underlay.Attribute;
+import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.ValueDisplay;
 import java.util.HashMap;
 import java.util.Map;
@@ -132,5 +130,30 @@ public final class ToApiConversionUtils {
         .value(toApiObject(annotationValue.getLiteral()))
         .isMostRecent(annotationValue.isMostRecent())
         .isPartOfSelectedReview(annotationValue.isPartOfSelectedReview());
+  }
+
+  public static ApiStudyV2 toApiObject(Study study) {
+    ApiPropertiesV2 apiProperties = new ApiPropertiesV2();
+    study
+        .getProperties()
+        .forEach(
+            (key, value) -> apiProperties.add(new ApiPropertyKeyValueV2().key(key).value(value)));
+    return new ApiStudyV2()
+        .id(study.getId())
+        .displayName(study.getDisplayName())
+        .description(study.getDescription())
+        .properties(apiProperties)
+        .created(study.getCreated())
+        .createdBy(study.getCreatedBy())
+        .lastModified(study.getLastModified());
+  }
+
+  public static ApiUnderlayV2 toApiObject(Underlay underlay) {
+    return new ApiUnderlayV2()
+        .name(underlay.getName())
+        // TODO: Add display name to underlay config files.
+        .displayName(underlay.getName())
+        .primaryEntity(underlay.getPrimaryEntity().getName())
+        .uiConfiguration(underlay.getUIConfig());
   }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -32,6 +32,8 @@ tanagra:
       -
         type: INDIVIDUAL_FILE_DOWNLOAD
       -
+        type: IPYNB_FILE_DOWNLOAD
+      -
         type: VWB_FILE_IMPORT
         redirect-away-url: https://terra-devel-ui-terra.api.verily.com/import?urlList=${tsvFileUrl}&returnUrl=${redirectBackUrl}&returnApp=Tanagra
 

--- a/service/src/main/resources/export/notebook_template.ipynb
+++ b/service/src/main/resources/export/notebook_template.ipynb
@@ -1,0 +1,15 @@
+import pandas
+import os
+
+# This query was generated for dataset ${underlayName} in study ${studyName} at ${timestamp}.
+${entityName}_sql = """
+${formattedSql}
+"""
+
+${entityName}_df = pandas.read_gbq(
+    dataset_${entityName}_sql,
+    dialect="standard",
+    use_bqstorage_api=("BIGQUERY_STORAGE_API_ENABLED" in os.environ),
+    progress_bar_type="tqdm_notebook")
+
+${entityName}_df.head(5)

--- a/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
@@ -731,7 +731,7 @@ public class AnnotationServiceTest {
     LOGGER.info("Created annotation value");
 
     // Generate a TSV string with the annotation values data.
-    String tsv = reviewService.buildTsvStringForAnnotationValues(study1.getId(), cohort2.getId());
+    String tsv = reviewService.buildTsvStringForAnnotationValues(study1, cohort2);
     assertEquals("person_id\tkey1\tkey2\n24\tval 1\t\n25\t\tval 2\n", tsv);
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.service;
 
 import static bio.terra.tanagra.service.CriteriaGroupSectionValues.*;
+import static bio.terra.tanagra.service.export.impl.IpynbFileDownload.IPYNB_FILE_KEY;
 import static org.junit.jupiter.api.Assertions.*;
 
 import bio.terra.tanagra.app.Main;
@@ -146,7 +147,7 @@ public class DataExportServiceTest {
   @Test
   void listEntityModels() {
     Map<String, Pair<String, DataExport>> models = dataExportService.getModels(UNDERLAY_NAME);
-    assertEquals(2, models.size());
+    assertEquals(3, models.size());
 
     // Check the INDIVIDUAL_FILE_DOWNLOAD export option.
     Optional<Map.Entry<String, Pair<String, DataExport>>> individualFileDownload =
@@ -162,6 +163,22 @@ public class DataExportServiceTest {
     DataExport impl = individualFileDownload.get().getValue().getValue();
     assertEquals(
         DataExport.Type.INDIVIDUAL_FILE_DOWNLOAD.name(),
+        modelName); // Default model name is type enum value.
+    assertEquals(impl.getDefaultDisplayName(), displayName);
+    assertNotNull(impl);
+
+    // Check the IPYNB_FILE_DOWNLOAD export option.
+    Optional<Map.Entry<String, Pair<String, DataExport>>> ipynbFileDownload =
+        models.entrySet().stream()
+            .filter(
+                m -> DataExport.Type.IPYNB_FILE_DOWNLOAD.equals(m.getValue().getValue().getType()))
+            .findFirst();
+    assertTrue(ipynbFileDownload.isPresent());
+    modelName = ipynbFileDownload.get().getKey();
+    displayName = ipynbFileDownload.get().getValue().getKey();
+    impl = ipynbFileDownload.get().getValue().getValue();
+    assertEquals(
+        DataExport.Type.IPYNB_FILE_DOWNLOAD.name(),
         modelName); // Default model name is type enum value.
     assertEquals(impl.getDefaultDisplayName(), displayName);
     assertNotNull(impl);
@@ -183,22 +200,25 @@ public class DataExportServiceTest {
   @Test
   void individualFileDownload() throws IOException {
     ExportRequest.Builder exportRequest =
-        ExportRequest.builder()
-            .model("INDIVIDUAL_FILE_DOWNLOAD")
-            .study(study1.getId())
-            .cohorts(List.of(cohort1.getId()))
-            .includeAnnotations(true);
-    Entity primaryEntity = underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity();
-    EntityQueryRequest entityQueryRequest = buildEntityQueryRequest();
-
-    ExportResult exportResult = dataExportService.run(exportRequest, List.of(entityQueryRequest));
+        ExportRequest.builder().model("INDIVIDUAL_FILE_DOWNLOAD").includeAnnotations(true);
+    ExportResult exportResult =
+        dataExportService.run(
+            study1.getId(),
+            List.of(cohort1.getId()),
+            exportRequest,
+            List.of(buildEntityQueryRequest()));
     assertNotNull(exportResult);
     assertEquals(ExportResult.Status.COMPLETE, exportResult.getStatus());
     assertNull(exportResult.getRedirectAwayUrl());
     assertEquals(2, exportResult.getOutputs().size());
 
     // Validate the entity instances file.
-    String signedUrl = exportResult.getOutputs().get("entity:" + primaryEntity.getName());
+    String signedUrl =
+        exportResult
+            .getOutputs()
+            .get(
+                "entity:"
+                    + underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity().getName());
     assertNotNull(signedUrl);
     LOGGER.info("Entity instances signed URL: {}", signedUrl);
     String fileContents = GoogleCloudStorage.readFileContentsFromUrl(signedUrl);
@@ -227,19 +247,13 @@ public class DataExportServiceTest {
         ExportRequest.builder()
             .model("VWB_FILE_IMPORT_DEVEL")
             .redirectBackUrl(redirectBackUrl)
-            .study(study1.getId())
-            .cohorts(List.of(cohort1.getId()))
             .includeAnnotations(true);
-    Entity primaryEntity = underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity();
-    EntityQueryRequest entityQueryRequest =
-        new EntityQueryRequest.Builder()
-            .entity(primaryEntity)
-            .mappingType(Underlay.MappingType.INDEX)
-            .selectAttributes(primaryEntity.getAttributes())
-            .limit(5)
-            .build();
-
-    ExportResult exportResult = dataExportService.run(exportRequest, List.of(entityQueryRequest));
+    ExportResult exportResult =
+        dataExportService.run(
+            study1.getId(),
+            List.of(cohort1.getId()),
+            exportRequest,
+            List.of(buildEntityQueryRequest()));
     assertNotNull(exportResult);
     assertEquals(ExportResult.Status.COMPLETE, exportResult.getStatus());
     assertTrue(exportResult.getOutputs().isEmpty());
@@ -288,6 +302,31 @@ public class DataExportServiceTest {
         entityInstancesFileContents.startsWith(
             "ethnicity,gender,id,race,t_display_ethnicity,t_display_gender,t_display_race,year_of_birth"));
     assertEquals(6, entityInstancesFileContents.split("\n").length); // 5 instances + header row
+  }
+
+  @Test
+  void ipynbFileDownload() throws IOException {
+    ExportRequest.Builder exportRequest = ExportRequest.builder().model("IPYNB_FILE_DOWNLOAD");
+    ExportResult exportResult =
+        dataExportService.run(
+            study1.getId(),
+            List.of(cohort1.getId()),
+            exportRequest,
+            List.of(buildEntityQueryRequest()));
+    assertNotNull(exportResult);
+    assertEquals(ExportResult.Status.COMPLETE, exportResult.getStatus());
+    assertNull(exportResult.getRedirectAwayUrl());
+    assertEquals(1, exportResult.getOutputs().size());
+
+    // Validate the ipynb file.
+    String signedUrl = exportResult.getOutputs().get(IPYNB_FILE_KEY);
+    assertNotNull(signedUrl);
+    LOGGER.info("ipynb file signed URL: {}", signedUrl);
+    String fileContents = GoogleCloudStorage.readFileContentsFromUrl(signedUrl);
+    assertFalse(fileContents.isEmpty());
+    LOGGER.info("ipynb fileContents: {}", fileContents);
+    assertTrue(fileContents.contains("# This query was generated for"));
+    assertTrue(fileContents.split("\n").length >= 16); // length of notebook template file
   }
 
   private EntityQueryRequest buildEntityQueryRequest() {

--- a/service/src/test/resources/application-test.yaml
+++ b/service/src/test/resources/application-test.yaml
@@ -27,6 +27,8 @@ tanagra:
       -
         type: INDIVIDUAL_FILE_DOWNLOAD
       -
+        type: IPYNB_FILE_DOWNLOAD
+      -
         name: VWB_FILE_IMPORT_DEVEL
         displayName: Import to VWB (devel)
         type: VWB_FILE_IMPORT

--- a/underlay/src/main/java/bio/terra/tanagra/query/TablePointer.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/TablePointer.java
@@ -44,7 +44,8 @@ public final class TablePointer implements SQLExpression {
               .resolve(SQL_DIRECTORY_NAME)
               .resolve(Path.of(serialized.getRawSqlFile()));
       String rawSqlString =
-          FileUtils.readStringFromFile(FileIO.getGetFileInputStreamFunction().apply(rawSqlFile));
+          FileUtils.readStringFromFileNoLineBreaks(
+              FileIO.getGetFileInputStreamFunction().apply(rawSqlFile));
       return TablePointer.fromRawSql(rawSqlString, dataPointer);
     }
     // Table is defined by a table name and optional filter.

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -105,7 +105,7 @@ public final class Underlay {
               .resolve(UI_CONFIG_DIRECTORY_NAME)
               .resolve(serialized.getUiConfigFile());
       uiConfig =
-          FileUtils.readStringFromFile(
+          FileUtils.readStringFromFileNoLineBreaks(
               FileIO.getGetFileInputStreamFunction().apply(uiConfigFilePath));
     }
     Map<String, String> metadata =

--- a/underlay/src/main/java/bio/terra/tanagra/utils/FileUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/FileUtils.java
@@ -77,10 +77,24 @@ public final class FileUtils {
    * @param inputStream the stream to the file contents
    * @return a Java String representing the file contents
    */
-  public static String readStringFromFile(InputStream inputStream) {
+  public static String readStringFromFileNoLineBreaks(InputStream inputStream) {
     try {
       return CharStreams.toString(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
           .replace(System.lineSeparator(), " ");
+    } catch (IOException ioEx) {
+      throw new SystemException("Error reading file contents", ioEx);
+    }
+  }
+
+  /**
+   * Read a file into a string.
+   *
+   * @param inputStream the stream to the file contents
+   * @return a Java String representing the file contents
+   */
+  public static String readStringFromFile(InputStream inputStream) {
+    try {
+      return CharStreams.toString(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
     } catch (IOException ioEx) {
       throw new SystemException("Error reading file contents", ioEx);
     }

--- a/underlay/src/main/java/bio/terra/tanagra/utils/NameUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/NameUtils.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
  * <p>Some names traverse Tanagra from HTTP requests to SQL generation. For these names, it's
  * important that they are relatively friendly and simple.
  */
-final class NameUtils {
+public final class NameUtils {
   private NameUtils() {}
 
   // Start with simple lower case letters, numbers, and underscores of less than 32 characters.
@@ -22,6 +22,8 @@ final class NameUtils {
   // attributes (e.g. the t_path_xx attribute that is added for an entity with a hierarchy on
   // attribute xx).
   private static final String TANAGRA_RESERVED_PREFIX = "t_";
+
+  private static final String SIMPLIFY_TO_NAME_REGEX = "[^a-zA-Z0-9_]";
 
   /**
    * Check that the {@code name} matches the {@link #NAME_REGEX}, or else throws an
@@ -47,5 +49,9 @@ final class NameUtils {
         fieldName,
         TANAGRA_RESERVED_PREFIX,
         name);
+  }
+
+  public static String simplifyStringForName(String str) {
+    return str.replaceAll(SIMPLIFY_TO_NAME_REGEX, "");
   }
 }


### PR DESCRIPTION
- Added a new export model to download an ipynb file with an embedded SQL query that returns a list of primary entity ids.
- Changed the `ExportRequest` fields to contain API objects (e.g. `ApiCohort`) instead of just the ids. This allows the export implementation classes to access properties of the artifacts, not just their id. e.g. An implementation class could use the study display name as part of an output file name.
- I copied the ipynb file template from the notebook file preview popup in the AoU test instance.