### PR TITLE
List reviews ordered by created desc.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/db/AnnotationDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/AnnotationDao.java
@@ -209,8 +209,9 @@ public class AnnotationDao {
               annotationKeysMap.get(annotationKeyId).addEnumVal(enumVal);
             });
 
-    return annotationKeysMap.values().stream()
-        .map(AnnotationKey.Builder::build)
+    // Preserve the order returned by the original query.
+    return annotationKeys.stream()
+        .map(a -> annotationKeysMap.get(a.getId()).build())
         .collect(Collectors.toList());
   }
 

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -335,7 +335,10 @@ public class CohortDao {
               cohortsMap.get(cohortId).addRevision(cohortRevision);
             });
 
-    return cohortsMap.values().stream().map(Cohort.Builder::build).collect(Collectors.toList());
+    // Preserve the order returned by the original query.
+    return cohorts.stream()
+        .map(c -> cohortsMap.get(c.getId()).build())
+        .collect(Collectors.toList());
   }
 
   @WriteTransaction

--- a/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ConceptSetDao.java
@@ -238,8 +238,9 @@ public class ConceptSetDao {
               conceptSetsMap.get(conceptSetId).addCriteria(criteria);
             });
 
-    return conceptSetsMap.values().stream()
-        .map(ConceptSet.Builder::build)
+    // Preserve the order returned by the original query.
+    return conceptSets.stream()
+        .map(c -> conceptSetsMap.get(c.getId()).build())
         .collect(Collectors.toList());
   }
 

--- a/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ReviewDao.java
@@ -83,7 +83,7 @@ public class ReviewDao {
   public List<Review> getAllReviews(String cohortId, int offset, int limit) {
     String sql =
         REVIEW_SELECT_SQL
-            + " WHERE cohort_id = :cohort_id ORDER BY display_name LIMIT :limit OFFSET :offset";
+            + " WHERE cohort_id = :cohort_id ORDER BY created DESC LIMIT :limit OFFSET :offset";
     LOGGER.debug("GET ALL reviews: {}", sql);
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -98,7 +98,7 @@ public class ReviewDao {
   @ReadTransaction
   public List<Review> getReviewsMatchingList(Set<String> ids, int offset, int limit) {
     String sql =
-        REVIEW_SELECT_SQL + " WHERE id IN (:ids) ORDER BY display_name LIMIT :limit OFFSET :offset";
+        REVIEW_SELECT_SQL + " WHERE id IN (:ids) ORDER BY created DESC LIMIT :limit OFFSET :offset";
     LOGGER.debug("GET MATCHING reviews: {}", sql);
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -242,6 +242,9 @@ public class ReviewDao {
               reviewsMap.get(reviewId).revision(cohortRevision);
             });
 
-    return reviewsMap.values().stream().map(Review.Builder::build).collect(Collectors.toList());
+    // Preserve the order returned by the original query.
+    return reviews.stream()
+        .map(r -> reviewsMap.get(r.getId()).build())
+        .collect(Collectors.toList());
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/StudyDao.java
@@ -302,7 +302,10 @@ public class StudyDao {
               studiesMap.get(studyId).addProperty(property.getKey(), property.getValue());
             });
 
-    return studiesMap.values().stream().map(Study.Builder::build).collect(Collectors.toList());
+    // Preserve the order returned by the original query.
+    return studies.stream()
+        .map(s -> studiesMap.get(s.getId()).build())
+        .collect(Collectors.toList());
   }
 
   private void updatePropertiesHelper(String studyId, Map<String, String> properties) {

--- a/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
@@ -15,6 +15,7 @@ import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.accesscontrol.ResourceType;
 import bio.terra.tanagra.service.artifact.*;
 import java.sql.Date;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -240,6 +241,11 @@ public class AnnotationServiceTest {
         "Annotation keys found: {}, {}",
         allAnnotationKeys.get(0).getId(),
         allAnnotationKeys.get(1).getId());
+    List<AnnotationKey> allAnnotationKeyssSortedByDisplayNameAsc =
+        allAnnotationKeys.stream()
+            .sorted(Comparator.comparing(AnnotationKey::getDisplayName))
+            .collect(Collectors.toList());
+    assertEquals(allAnnotationKeys, allAnnotationKeyssSortedByDisplayNameAsc);
 
     // List selected annotation key for cohort2.
     List<AnnotationKey> selectedAnnotationKeys =

--- a/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
@@ -12,9 +12,11 @@ import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.accesscontrol.ResourceType;
 import bio.terra.tanagra.service.artifact.Cohort;
 import bio.terra.tanagra.service.artifact.Study;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -167,6 +169,11 @@ public class CohortServiceTest {
             10);
     assertEquals(2, allCohorts.size());
     LOGGER.info("cohorts found: {}, {}", allCohorts.get(0).getId(), allCohorts.get(1).getId());
+    List<Cohort> allCohortsSortedByDisplayNameAsc =
+        allCohorts.stream()
+            .sorted(Comparator.comparing(Cohort::getDisplayName))
+            .collect(Collectors.toList());
+    assertEquals(allCohorts, allCohortsSortedByDisplayNameAsc);
 
     // List selected cohort in study2.
     List<Cohort> selectedCohorts =

--- a/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
@@ -11,9 +11,11 @@ import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.accesscontrol.ResourceType;
 import bio.terra.tanagra.service.artifact.ConceptSet;
 import bio.terra.tanagra.service.artifact.Study;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -186,6 +188,11 @@ public class ConceptSetServiceTest {
     assertEquals(2, allConceptSets.size());
     LOGGER.info(
         "concept sets found: {}, {}", allConceptSets.get(0).getId(), allConceptSets.get(1).getId());
+    List<ConceptSet> allConceptSetsSortedByDisplayNameAsc =
+        allConceptSets.stream()
+            .sorted(Comparator.comparing(ConceptSet::getDisplayName))
+            .collect(Collectors.toList());
+    assertEquals(allConceptSets, allConceptSetsSortedByDisplayNameAsc);
 
     // List selected concept set in study2.
     List<ConceptSet> selectedConceptSets =

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
@@ -14,6 +14,7 @@ import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.accesscontrol.ResourceType;
 import bio.terra.tanagra.service.artifact.*;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -205,6 +206,11 @@ public class ReviewServiceTest {
             10);
     assertEquals(2, allReviews.size());
     LOGGER.info("reviews found: {}, {}", allReviews.get(0).getId(), allReviews.get(1).getId());
+    List<Review> allReviewsSortedByCreatedDesc =
+        allReviews.stream()
+            .sorted(Comparator.comparing(Review::getCreated).reversed())
+            .collect(Collectors.toList());
+    assertEquals(allReviews, allReviewsSortedByCreatedDesc);
 
     // List selected review for cohort2.
     List<Review> selectedReviews =

--- a/service/src/test/java/bio/terra/tanagra/service/StudyServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/StudyServiceTest.java
@@ -9,10 +9,12 @@ import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
 import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.accesscontrol.ResourceType;
 import bio.terra.tanagra.service.artifact.Study;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -114,6 +116,11 @@ public class StudyServiceTest {
         studyService.listStudies(
             ResourceCollection.allResourcesAllPermissions(ResourceType.STUDY, null), 0, 10);
     assertEquals(2, allStudies.size());
+    List<Study> allStudiesSortedByDisplayNameAsc =
+        allStudies.stream()
+            .sorted(Comparator.comparing(Study::getDisplayName))
+            .collect(Collectors.toList());
+    assertEquals(allStudies, allStudiesSortedByDisplayNameAsc);
 
     // List selected.
     List<Study> selectedStudies =


### PR DESCRIPTION
- When listing reviews, order by the created timestamp descending, instead of the display name ascending.
- Updated all the DAO classes to preserve the order of the original query.
- Added to each artifact's `list` test a check on the order.