### PR TITLE
Bump Google OAuth2 library version.

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation group: "com.google.cloud", name: "google-cloud-bigquery"
     implementation group: "com.google.cloud", name: "google-cloud-storage"
     implementation group: "com.google.guava", name: "guava"
-    implementation group: "com.google.apis", name: "google-api-services-oauth2", version: "v2-rev20200213-1.32.1"
+    implementation group: "com.google.apis", name: "google-api-services-oauth2", version: "v2-rev20200213-2.0.0"
 
     // OpenApi/Swagger
     implementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.11.2"


### PR DESCRIPTION
Fix dependency conflict that was causing problems decoding bearer token.