### PR TITLE
Handle null value/display hints.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/QuerysService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/QuerysService.java
@@ -91,12 +91,14 @@ public class QuerysService {
       } else {
         // This is part of an enum values hint, which is spread across multiple rows -- one per enum
         // value.
-        Literal val = rowResult.get(MODIFIER_AUX_DATA_ENUM_VAL_COL).getLiteral().orElseThrow();
-        Optional<String> display = rowResult.get(MODIFIER_AUX_DATA_ENUM_DISPLAY_COL).getString();
+        // TODO: Make a static NULL Literal instance, instead of overloading the String value.
+        Literal val =
+            rowResult.get(MODIFIER_AUX_DATA_ENUM_VAL_COL).getLiteral().orElse(new Literal(null));
+        String display = rowResult.get(MODIFIER_AUX_DATA_ENUM_DISPLAY_COL).getString().orElse(null);
         OptionalLong count = rowResult.get(MODIFIER_AUX_DATA_ENUM_COUNT_COL).getLong();
         List<EnumVal> runningEnumVals =
             runningEnumValsMap.containsKey(attr) ? runningEnumValsMap.get(attr) : new ArrayList<>();
-        runningEnumVals.add(new EnumVal(new ValueDisplay(val, display.get()), count.getAsLong()));
+        runningEnumVals.add(new EnumVal(new ValueDisplay(val, display), count.getAsLong()));
         runningEnumValsMap.put(attr, runningEnumVals);
       }
     }

--- a/service/src/test/java/bio/terra/tanagra/underlayspecific/broad/CmsSynpufHintsTest.java
+++ b/service/src/test/java/bio/terra/tanagra/underlayspecific/broad/CmsSynpufHintsTest.java
@@ -50,4 +50,15 @@ public class CmsSynpufHintsTest extends BaseHintsTest {
             "year_of_birth", new NumericRange(1909.0, 1983.0));
     assertEntityLevelHintsMatch("person", expectedHints);
   }
+
+  @Test
+  void conditionOccurrenceEntityLevel() {
+    Map<String, DisplayHint> expectedHints =
+        Map.of(
+            "age_at_occurrence",
+            new NumericRange(24.0, 101.0),
+            "stop_reason",
+            buildEnumVals(List.of(new EnumVal(new ValueDisplay(new Literal(null), null), 0))));
+    assertEntityLevelHintsMatch("condition_occurrence", expectedHints);
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
@@ -203,6 +203,9 @@ public class Literal implements SQLExpression {
     }
     switch (dataType) {
       case STRING:
+        if (stringVal == null) {
+          return value.getStringVal() == null ? 0 : -1;
+        }
         return stringVal.compareTo(value.getStringVal());
       case INT64:
         return Long.compare(int64Val, value.getInt64Val());


### PR DESCRIPTION
- Handle null value/display hints.
- Added a test for fetching the entity-level hints for the `condition_occurrence` entity in the `cms_synpuf` underlay. This entity has a null hint for the `stop_reason` attribute.
- In the future, we can consider changing the indexing job to not store any null hints. But for now, I'm going to leave this as is because it's not affecting the display of anything for the `sdd_refresh0323` underlay (other than this bug in calling the API endpoint).