### PR TITLE
Delete the entity-level display hints table on clean.

### DIFF
--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -132,8 +132,9 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
 
   @Override
   public void clean(boolean isDryRun) {
-    LOGGER.info(
-        "Nothing to clean. CreateEntityLevelDisplayHintsTable will delete the output table, which includes all the rows inserted by this job.");
+    if (checkTableExists(getAuxiliaryTable())) {
+      deleteTable(getAuxiliaryTable(), isDryRun);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixed the indexing job that computes entity-level display hints and writes them to a new table, to also handle cleanup. Previously, the `CLEAN_ENTITY` indexing command was not deleting this generated table.