### PR TITLE
[DT-468] Updated indexing builds and pointed to inside secure perimeter project ids

### DIFF
--- a/service/src/main/resources/config/aou/test/SC2022Q4R6/SC2022Q4R6.json
+++ b/service/src/main/resources/config/aou/test/SC2022Q4R6/SC2022Q4R6.json
@@ -4,13 +4,13 @@
   "dataPointers": [
     { "type": "BQ_DATASET",
       "name": "omop_dataset",
-      "projectId": "all-of-us-ehr-dev",
+      "projectId": "fc-aou-cdr-synth-test-2",
       "datasetId": "SC2022Q4R6",
-      "queryProjectId": "all-of-us-ehr-dev"
+      "queryProjectId": "fc-aou-cdr-synth-test-2"
     },
     { "type": "BQ_DATASET",
       "name": "index_dataset",
-      "projectId": "all-of-us-ehr-dev",
+      "projectId": "fc-aou-cdr-synth-test-2",
       "datasetId": "SC2022Q4R6",
       "dataflowServiceAccountEmail" : "tanagra-indexing-runner@all-of-us-ehr-dev.iam.gserviceaccount.com",
       "dataflowTempLocation" : "gs://all-of-us-ehr-dev-tanagra-indexing/SC2022Q4R6/tanagra_index_temp",

--- a/service/src/main/resources/config/aou/test/SR2022Q4R6/SR2022Q4R6.json
+++ b/service/src/main/resources/config/aou/test/SR2022Q4R6/SR2022Q4R6.json
@@ -4,13 +4,13 @@
   "dataPointers": [
     { "type": "BQ_DATASET",
       "name": "omop_dataset",
-      "projectId": "all-of-us-ehr-dev",
+      "projectId": "fc-aou-cdr-synth-test",
       "datasetId": "SR2022Q4R6",
-      "queryProjectId": "all-of-us-ehr-dev"
+      "queryProjectId": "fc-aou-cdr-synth-test"
     },
     { "type": "BQ_DATASET",
       "name": "index_dataset",
-      "projectId": "all-of-us-ehr-dev",
+      "projectId": "fc-aou-cdr-synth-test",
       "datasetId": "SR2022Q4R6",
       "dataflowServiceAccountEmail" : "tanagra-indexing-runner@all-of-us-ehr-dev.iam.gserviceaccount.com",
       "dataflowTempLocation" : "gs://all-of-us-ehr-dev-tanagra-indexing/SR2022Q4R6/tanagra_index_temp",


### PR DESCRIPTION
- Ran indexing build for RT and CT test AoU datasets
- Updated projectId and queryProjectId to values for projects inside the secure perimeter for RT and CT
- 