### PR TITLE
Add env var option for post message origin

### DIFF
--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -160,7 +160,10 @@ export function useExitAction() {
       if (process.env.REACT_APP_USE_EXIT_URL) {
         navigate(exitURL(params));
       } else {
-        window.parent.postMessage({ message: "CLOSE" }, window.location.origin);
+        window.parent.postMessage(
+          { message: "CLOSE" },
+          process.env.REACT_APP_POST_MESSAGE_ORIGIN || window.location.origin
+        );
       }
     }
   }, [location, params, navigate]);

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -162,7 +162,7 @@ export function useExitAction() {
       } else {
         window.parent.postMessage(
           { message: "CLOSE" },
-          process.env.REACT_APP_POST_MESSAGE_ORIGIN || window.location.origin
+          process.env.REACT_APP_POST_MESSAGE_ORIGIN ?? window.location.origin
         );
       }
     }


### PR DESCRIPTION
Add option to use `REACT_APP_POST_MESSAGE_ORIGIN` environment variable for the target origin when sending a `postMessage` from the Tanagra iframe to the parent window.

This is needed for the AoU test env where the Workbench and Tanagra apps are deployed on different domains. It will also be useful for local dev on the SD Tanagra project since the UIs need to be deployed on different ports.