### PR TITLE
AoU Workbench access control implementation class with placeholders.

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -100,3 +100,17 @@ tanagra:
         base-path: https://www.verilygroups.com
         oauth-client-id: 12345.apps.googleusercontent.com    <--- Example value only. Get this from the VerilyGroups docs.
 ```
+
+### AouWorkbench Access Control
+Access control is enforced on studies only. For studies and their child artifacts (e.g. cohorts), send a request to
+the AoU Researcher Workbench API to check access on the containing workspace. Expect the Tanagra study id to be the
+same as the workbench workspace id. =For underlays, allow everything. This was written to support the AoU deployment.
+```
+tanagra:
+    access-control:
+        model: AOU_WORKBENCH
+        params: []
+        base-path: https://all-of-us-workbench-test.appspot.com
+        oauth-client-id: 12345.apps.googleusercontent.com    <--- Example value only. Get this from the workbench team.
+```
+

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/AccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/AccessControl.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.service.accesscontrol;
 
+import bio.terra.tanagra.service.accesscontrol.impl.AouWorkbenchAccessControl;
 import bio.terra.tanagra.service.accesscontrol.impl.OpenAccessControl;
 import bio.terra.tanagra.service.accesscontrol.impl.VerilyGroupsAccessControl;
 import bio.terra.tanagra.service.accesscontrol.impl.VumcAdminAccessControl;
@@ -13,7 +14,8 @@ public interface AccessControl {
   enum Model {
     OPEN_ACCESS(() -> new OpenAccessControl()),
     VUMC_ADMIN(() -> new VumcAdminAccessControl()),
-    VERILY_GROUP(() -> new VerilyGroupsAccessControl());
+    VERILY_GROUP(() -> new VerilyGroupsAccessControl()),
+    AOU_WORKBENCH(() -> new AouWorkbenchAccessControl());
 
     private Supplier<AccessControl> createNewInstanceFn;
 

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/AouWorkbenchAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/AouWorkbenchAccessControl.java
@@ -1,0 +1,190 @@
+package bio.terra.tanagra.service.accesscontrol.impl;
+
+import bio.terra.tanagra.service.accesscontrol.*;
+import bio.terra.tanagra.service.auth.UserId;
+import java.util.*;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AoU Researcher Workbench access control plugin implementation that checks permissions on the
+ * workspace that is mapped to each study.
+ */
+public class AouWorkbenchAccessControl implements AccessControl {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AouWorkbenchAccessControl.class);
+  // Workspace owners have all permissions in a study.
+  private static final Map<ResourceType, Set<Action>> WORKSPACE_OWNER_PERMISSIONS =
+      Map.of(
+          ResourceType.STUDY,
+          Set.of(
+              Action.READ,
+              Action.UPDATE,
+              Action.DELETE,
+              Action.CREATE_COHORT,
+              Action.CREATE_CONCEPT_SET),
+          ResourceType.COHORT,
+          ResourceType.COHORT.getActions(), // All cohort actions.
+          ResourceType.CONCEPT_SET,
+          ResourceType.CONCEPT_SET.getActions(), // All concept set actions.
+          ResourceType.REVIEW,
+          ResourceType.REVIEW.getActions(), // All review actions.
+          ResourceType.ANNOTATION_KEY,
+          ResourceType.ANNOTATION_KEY.getActions()); // All annotation key actions.
+
+  // Workspace writers have all permissions in a study, except for deleting the study.
+  private static final Map<ResourceType, Set<Action>> WORKSPACE_WRITER_PERMISSIONS =
+      Map.of(
+          ResourceType.STUDY,
+          Set.of(Action.READ, Action.UPDATE, Action.CREATE_COHORT, Action.CREATE_CONCEPT_SET),
+          ResourceType.COHORT,
+          ResourceType.COHORT.getActions(), // All cohort actions.
+          ResourceType.CONCEPT_SET,
+          ResourceType.CONCEPT_SET.getActions(), // All concept set actions.
+          ResourceType.REVIEW,
+          ResourceType.REVIEW.getActions(), // All review actions.
+          ResourceType.ANNOTATION_KEY,
+          ResourceType.ANNOTATION_KEY.getActions()); // All annotation key actions.
+
+  // Workspace readers cannnot persist any changes to a study, only view the existing state.
+  private static final Map<ResourceType, Set<Action>> WORKSPACE_READER_PERMISSIONS =
+      Map.of(
+          ResourceType.STUDY, Set.of(Action.READ),
+          ResourceType.COHORT, Set.of(Action.READ),
+          ResourceType.CONCEPT_SET, Set.of(Action.READ),
+          ResourceType.REVIEW, Set.of(Action.READ, Action.QUERY_INSTANCES, Action.QUERY_COUNTS),
+          ResourceType.ANNOTATION_KEY, Set.of(Action.READ));
+  private String basePath;
+  private String oauthClientId;
+
+  @Override
+  public String getDescription() {
+    return "Check AoU Researcher Workbench for workspace access";
+  }
+
+  @Override
+  public void initialize(List<String> params, String basePath, String oauthClientId) {
+    // Store the basePath and oauthClientId first, so we can use it when calling the workbench API.
+    if (basePath == null || oauthClientId == null) {
+      throw new IllegalArgumentException(
+          "Base URL and OAuth client id are required for Workbench API calls");
+    }
+    this.basePath = basePath;
+    this.oauthClientId = oauthClientId;
+  }
+
+  @Override
+  public boolean isAuthorized(UserId user, Permissions permissions, @Nullable ResourceId resource) {
+    if (permissions.getType().equals(ResourceType.UNDERLAY)) {
+      // Browsing the cohort builder without saving. Always allow.
+      return true;
+    } else if (Permissions.forActions(ResourceType.STUDY, Action.CREATE).equals(permissions)) {
+      // Workbench creates a Tanagra study as part of workspace creation. Always allow.
+      return true;
+    } else {
+      // Check for some permissions on a particular artifact (e.g. study, cohort).
+      if (resource == null || resource.getStudy() == null) {
+        LOGGER.error(
+            "Study id is required to check authorization of a particular artifact: {}", resource);
+        return false;
+      }
+
+      // Call the workbench to get the user's role on the workspace that contains this study.
+      // Expect the Tanagra study id to match the Workbench workspace id.
+      WorkspaceRole role = apiGetWorkspaceAccess(user, resource.getStudy());
+      if (role == null) {
+        return false;
+      }
+
+      // Map the workspace role to Tanagra permissions.
+      return role.getTanagraPermissions()
+          .get(permissions.getType())
+          .containsAll(permissions.getActions());
+    }
+  }
+
+  @Override
+  public ResourceCollection listAllPermissions(
+      UserId user, ResourceType type, @Nullable ResourceId parentResource, int offset, int limit) {
+    if (ResourceType.UNDERLAY.equals(type)) {
+      // Browsing the cohort builder without saving. Allow for all underlays.
+      return ResourceCollection.allResourcesAllPermissions(ResourceType.UNDERLAY, null);
+    } else if (ResourceType.STUDY.equals(type)) {
+      // Call the workbench to get the list of workspaces the user can see, and their role on each.
+      Map<String, WorkspaceRole> workspaceRoleMap = apiListWorkspacesWithAccess(user);
+
+      // Map the workspace roles to Tanagra permissions.
+      Map<ResourceId, Permissions> studyPermissionsMap = new HashMap<>();
+      workspaceRoleMap.entrySet().stream()
+          .forEach(
+              entry -> {
+                String studyId = entry.getKey();
+                WorkspaceRole role = entry.getValue();
+                studyPermissionsMap.put(
+                    ResourceId.forStudy(studyId),
+                    Permissions.forActions(
+                        ResourceType.STUDY, role.getTanagraPermissions().get(ResourceType.STUDY)));
+              });
+      return studyPermissionsMap.isEmpty()
+          ? ResourceCollection.empty(type, parentResource)
+          : ResourceCollection.resourcesDifferentPermissions(studyPermissionsMap);
+    } else {
+      // Check for some permissions on a child artifact of a study (e.g. cohort).
+      if (parentResource == null || parentResource.getStudy() == null) {
+        LOGGER.error(
+            "Study id is required to list permissions for a child artifact: {}", parentResource);
+        return ResourceCollection.empty(type, parentResource);
+      }
+
+      // Call the workbench to get the user's role on the workspace that contains this study.
+      // Expect the Tanagra study id to match the Workbench workspace id.
+      WorkspaceRole role = apiGetWorkspaceAccess(user, parentResource.getStudy());
+      if (role == null) {
+        return ResourceCollection.empty(type, parentResource);
+      }
+
+      // Map the workspace role to Tanagra permissions.
+      return ResourceCollection.allResourcesSamePermissions(
+          Permissions.forActions(type, role.getTanagraPermissions().get(type)), parentResource);
+    }
+  }
+
+  public enum WorkspaceRole {
+    OWNER(WORKSPACE_OWNER_PERMISSIONS),
+    WRITER(WORKSPACE_WRITER_PERMISSIONS),
+    READER(WORKSPACE_READER_PERMISSIONS);
+    private final Map<ResourceType, Set<Action>> tanagraPermissions;
+
+    WorkspaceRole(Map<ResourceType, Set<Action>> tanagraPermissions) {
+      this.tanagraPermissions = tanagraPermissions;
+    }
+
+    public Map<ResourceType, Set<Action>> getTanagraPermissions() {
+      return Collections.unmodifiableMap(tanagraPermissions);
+    }
+  }
+
+  /**
+   * @return the role that the user has on the workspace, or null if the user has no permissions.
+   */
+  protected @Nullable WorkspaceRole apiGetWorkspaceAccess(UserId userId, String workspaceId) {
+    LOGGER.debug(
+        "Calling workbench API to check access to workspace {} for user {}",
+        workspaceId,
+        userId.getEmail());
+    LOGGER.debug("Workbench API base path: {}, oauth client id: {}", basePath, oauthClientId);
+    // TODO: Call the workbench API to get the role the user has on the given workspace.
+    return WorkspaceRole.OWNER; // Temporarily, everyone is an owner on every workspace.
+  }
+
+  /** @return a map of the workspace id -> role that the user has on each. */
+  protected Map<String, WorkspaceRole> apiListWorkspacesWithAccess(UserId userId) {
+    LOGGER.debug(
+        "Calling workbench API to list workspaces user {} can see, and their role on each.",
+        userId.getEmail());
+    LOGGER.debug("Workbench API base path: {}, oauth client id: {}", basePath, oauthClientId);
+    // TODO: Call the workbench API to list the workspaces the user has access to, and their role on
+    // each.
+    return Map.of(); // Temporarily, no one has access to any worksapces.
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/AouWorkbenchAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/AouWorkbenchAccessControlTest.java
@@ -1,0 +1,264 @@
+package bio.terra.tanagra.service.accesscontrol;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import bio.terra.tanagra.service.accesscontrol.impl.AouWorkbenchAccessControl;
+import bio.terra.tanagra.service.accesscontrol.impl.MockAouWorkbenchAccessControl;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AouWorkbenchAccessControlTest extends BaseAccessControlTest {
+
+  @BeforeEach
+  void createArtifactsAndDefinePermissionsInMock() {
+    createArtifacts();
+
+    // Define user permissions in AouWorkbench mock impl.
+    MockAouWorkbenchAccessControl awImpl = new MockAouWorkbenchAccessControl();
+    // workspaces
+    //   user1: study1 (OWNER), study2 (READER)
+    //   user2: study1 (WRITER)
+    //   user3:
+    //   user4: study2 (READER)
+    awImpl.addPermission(USER_1, study1.getId(), AouWorkbenchAccessControl.WorkspaceRole.OWNER);
+    awImpl.addPermission(USER_1, study2.getId(), AouWorkbenchAccessControl.WorkspaceRole.READER);
+    awImpl.addPermission(USER_2, study1.getId(), AouWorkbenchAccessControl.WorkspaceRole.WRITER);
+    awImpl.addPermission(USER_4, study2.getId(), AouWorkbenchAccessControl.WorkspaceRole.READER);
+
+    impl = awImpl;
+    impl.initialize(List.of(), "FAKE_BASE_PATH", "FAKE_OAUTH_CLIENT_ID");
+  }
+
+  @AfterEach
+  protected void cleanup() {
+    deleteStudies();
+  }
+
+  @Test
+  void underlay() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);
+    ResourceId aouSyntheticId = ResourceId.forUnderlay(AOU_SYNTHETIC);
+    ResourceId sddId = ResourceId.forUnderlay(SDD);
+    assertHasPermissions(USER_1, cmsSynpufId);
+    assertHasPermissions(USER_1, aouSyntheticId);
+    assertHasPermissions(USER_1, sddId);
+    assertHasPermissions(USER_2, cmsSynpufId);
+    assertHasPermissions(USER_2, aouSyntheticId);
+    assertHasPermissions(USER_2, sddId);
+    assertHasPermissions(USER_3, cmsSynpufId);
+    assertHasPermissions(USER_3, aouSyntheticId);
+    assertHasPermissions(USER_3, sddId);
+    assertHasPermissions(USER_4, cmsSynpufId);
+    assertHasPermissions(USER_4, aouSyntheticId);
+    assertHasPermissions(USER_4, sddId);
+
+    // service.list
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+    assertServiceListWithReadPermission(
+        USER_3, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.UNDERLAY, null, true, cmsSynpufId, aouSyntheticId, sddId);
+  }
+
+  @Test
+  void study() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    Action[] studyActionsExceptCreate = {
+      Action.READ, Action.UPDATE, Action.DELETE, Action.CREATE_COHORT, Action.CREATE_CONCEPT_SET,
+    };
+    ResourceId study1Id = ResourceId.forStudy(study1.getId());
+    ResourceId study2Id = ResourceId.forStudy(study2.getId());
+    assertHasPermissions(USER_1, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_1, study2Id, Action.READ);
+    assertDoesNotHavePermissions(
+        USER_1,
+        study2Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_COHORT,
+        Action.CREATE_CONCEPT_SET);
+    assertHasPermissions(
+        USER_2,
+        study1Id,
+        Action.READ,
+        Action.UPDATE,
+        Action.CREATE_COHORT,
+        Action.CREATE_CONCEPT_SET);
+    assertDoesNotHavePermissions(USER_2, study1Id, Action.DELETE);
+    assertDoesNotHavePermissions(USER_2, study2Id, studyActionsExceptCreate);
+    assertDoesNotHavePermissions(USER_3, study1Id, studyActionsExceptCreate);
+    assertDoesNotHavePermissions(USER_3, study2Id, studyActionsExceptCreate);
+    assertDoesNotHavePermissions(USER_4, study1Id, studyActionsExceptCreate);
+    assertHasPermissions(USER_4, study2Id, Action.READ);
+    assertDoesNotHavePermissions(
+        USER_4,
+        study2Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_COHORT,
+        Action.CREATE_CONCEPT_SET);
+
+    // isAuthorized for STUDY.CREATE
+    assertTrue(
+        impl.isAuthorized(USER_1, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_2, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_3, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+    assertTrue(
+        impl.isAuthorized(USER_4, Permissions.forActions(ResourceType.STUDY, Action.CREATE), null));
+
+    // service.list
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.STUDY, null, false, study1Id, study2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.STUDY, null, false, study1Id);
+    assertServiceListWithReadPermission(USER_3, ResourceType.STUDY, null, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.STUDY, null, false, study2Id);
+  }
+
+  @Test
+  void cohort() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId cohort1Id = ResourceId.forCohort(study1.getId(), cohort1.getId());
+    ResourceId cohort2Id = ResourceId.forCohort(study2.getId(), cohort2.getId());
+    assertHasPermissions(USER_1, cohort1Id);
+    assertHasPermissions(USER_1, cohort2Id, Action.READ);
+    assertDoesNotHavePermissions(
+        USER_1,
+        cohort2Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_REVIEW,
+        Action.CREATE_ANNOTATION_KEY);
+    assertHasPermissions(USER_2, cohort1Id);
+    assertDoesNotHavePermissions(USER_2, cohort2Id);
+    assertDoesNotHavePermissions(USER_3, cohort1Id);
+    assertDoesNotHavePermissions(USER_3, cohort2Id);
+    assertDoesNotHavePermissions(USER_4, cohort1Id);
+    assertHasPermissions(USER_4, cohort2Id, Action.READ);
+    assertDoesNotHavePermissions(
+        USER_4,
+        cohort2Id,
+        Action.UPDATE,
+        Action.DELETE,
+        Action.CREATE_REVIEW,
+        Action.CREATE_ANNOTATION_KEY);
+
+    // service.list
+    ResourceId study1Id = cohort1Id.getParent();
+    ResourceId study2Id = cohort2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_1, ResourceType.COHORT, study2Id, true, cohort2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study1Id, true, cohort1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.COHORT, study2Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.COHORT, study2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study1Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.COHORT, study2Id, true, cohort2Id);
+  }
+
+  @Test
+  void conceptSet() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId conceptSet1Id = ResourceId.forConceptSet(study1.getId(), conceptSet1.getId());
+    ResourceId conceptSet2Id = ResourceId.forConceptSet(study2.getId(), conceptSet2.getId());
+    assertHasPermissions(USER_1, conceptSet1Id);
+    assertHasPermissions(USER_1, conceptSet2Id, Action.READ);
+    assertDoesNotHavePermissions(USER_1, conceptSet2Id, Action.UPDATE, Action.DELETE);
+    assertHasPermissions(USER_2, conceptSet1Id);
+    assertDoesNotHavePermissions(USER_2, conceptSet2Id);
+    assertDoesNotHavePermissions(USER_3, conceptSet1Id);
+    assertDoesNotHavePermissions(USER_3, conceptSet2Id);
+    assertDoesNotHavePermissions(USER_4, conceptSet1Id);
+    assertHasPermissions(USER_4, conceptSet2Id, Action.READ);
+    assertDoesNotHavePermissions(USER_4, conceptSet2Id, Action.UPDATE, Action.DELETE);
+
+    // service.list
+    ResourceId study1Id = conceptSet1Id.getParent();
+    ResourceId study2Id = conceptSet2Id.getParent();
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.CONCEPT_SET, study1Id, true, conceptSet1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.CONCEPT_SET, study2Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.CONCEPT_SET, study1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.CONCEPT_SET, study2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.CONCEPT_SET, study1Id, false);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.CONCEPT_SET, study2Id, true, conceptSet2Id);
+  }
+
+  @Test
+  void review() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId review1Id = ResourceId.forReview(study1.getId(), cohort1.getId(), review1.getId());
+    ResourceId review2Id = ResourceId.forReview(study2.getId(), cohort2.getId(), review2.getId());
+    assertHasPermissions(USER_1, review1Id);
+    assertHasPermissions(
+        USER_1, review2Id, Action.READ, Action.QUERY_INSTANCES, Action.QUERY_COUNTS);
+    assertDoesNotHavePermissions(USER_1, review2Id, Action.UPDATE, Action.DELETE);
+    assertHasPermissions(USER_2, review1Id);
+    assertDoesNotHavePermissions(USER_2, review2Id);
+    assertDoesNotHavePermissions(USER_3, review1Id);
+    assertDoesNotHavePermissions(USER_3, review2Id);
+    assertDoesNotHavePermissions(USER_4, review1Id);
+    assertHasPermissions(
+        USER_4, review2Id, Action.READ, Action.QUERY_INSTANCES, Action.QUERY_COUNTS);
+    assertDoesNotHavePermissions(USER_4, review2Id, Action.UPDATE, Action.DELETE);
+
+    // service.list
+    ResourceId cohort1Id = review1Id.getParent();
+    ResourceId cohort2Id = review2Id.getParent();
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_1, ResourceType.REVIEW, cohort2Id, true, review2Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort1Id, true, review1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.REVIEW, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.REVIEW, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.REVIEW, cohort2Id, true, review2Id);
+  }
+
+  @Test
+  void annotationKey() {
+    // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
+    ResourceId annotationKey1Id =
+        ResourceId.forAnnotationKey(study1.getId(), cohort1.getId(), annotationKey1.getId());
+    ResourceId annotationKey2Id =
+        ResourceId.forAnnotationKey(study2.getId(), cohort2.getId(), annotationKey2.getId());
+    assertHasPermissions(USER_1, annotationKey1Id);
+    assertHasPermissions(USER_1, annotationKey1Id, Action.READ);
+    assertDoesNotHavePermissions(USER_1, annotationKey2Id, Action.UPDATE, Action.DELETE);
+    assertHasPermissions(USER_2, annotationKey1Id);
+    assertDoesNotHavePermissions(USER_2, annotationKey2Id);
+    assertDoesNotHavePermissions(USER_3, annotationKey1Id);
+    assertDoesNotHavePermissions(USER_3, annotationKey2Id);
+    assertDoesNotHavePermissions(USER_4, annotationKey1Id);
+    assertHasPermissions(USER_4, annotationKey2Id, Action.READ);
+    assertDoesNotHavePermissions(USER_4, annotationKey2Id, Action.UPDATE, Action.DELETE);
+
+    // service.list
+    ResourceId cohort1Id = annotationKey1Id.getParent();
+    ResourceId cohort2Id = annotationKey2Id.getParent();
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(
+        USER_1, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+    assertServiceListWithReadPermission(
+        USER_2, ResourceType.ANNOTATION_KEY, cohort1Id, true, annotationKey1Id);
+    assertServiceListWithReadPermission(USER_2, ResourceType.ANNOTATION_KEY, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.ANNOTATION_KEY, cohort1Id, false);
+    assertServiceListWithReadPermission(USER_3, ResourceType.ANNOTATION_KEY, cohort2Id, false);
+    assertServiceListWithReadPermission(USER_4, ResourceType.ANNOTATION_KEY, cohort1Id, false);
+    assertServiceListWithReadPermission(
+        USER_4, ResourceType.ANNOTATION_KEY, cohort2Id, true, annotationKey2Id);
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockAouWorkbenchAccessControl.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockAouWorkbenchAccessControl.java
@@ -1,0 +1,34 @@
+package bio.terra.tanagra.service.accesscontrol.impl;
+
+import bio.terra.tanagra.service.auth.UserId;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class MockAouWorkbenchAccessControl extends AouWorkbenchAccessControl {
+  // Map of user email -> map of (workspace id -> role).
+  private final Map<String, Map<String, WorkspaceRole>> permissions = new HashMap<>();
+
+  @Override
+  protected @Nullable WorkspaceRole apiGetWorkspaceAccess(UserId userId, String workspaceId) {
+    return permissions.containsKey(userId.getEmail())
+        ? permissions.get(userId.getEmail()).get(workspaceId)
+        : null;
+  }
+
+  @Override
+  protected Map<String, WorkspaceRole> apiListWorkspacesWithAccess(UserId userId) {
+    return permissions.containsKey(userId.getEmail())
+        ? permissions.get(userId.getEmail())
+        : new HashMap<>();
+  }
+
+  public void addPermission(UserId user, String workspaceId, WorkspaceRole role) {
+    Map<String, WorkspaceRole> permissionsForUser =
+        permissions.containsKey(user.getEmail())
+            ? permissions.get(user.getEmail())
+            : new HashMap<>();
+    permissionsForUser.put(workspaceId, role);
+    permissions.put(user.getEmail(), permissionsForUser);
+  }
+}


### PR DESCRIPTION
- Added an implementation class of the `AccessControl` interface for the AoU Researcher Workbench. The class defines placeholder methods for actually calling the workbench API, this PR just includes logic for processing possible responses.
- Defined a mock implementation that just uses an in-memory map, instead of actually calling the workbench API, and wrote tests against it.