### PR TITLE
Add isDeleted flag to artifacts.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Cohort.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Cohort.java
@@ -16,6 +16,7 @@ public class Cohort {
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final List<CohortRevision> revisions;
+  private final boolean isDeleted;
 
   private Cohort(Builder builder) {
     this.id = builder.id;
@@ -27,6 +28,7 @@ public class Cohort {
     this.displayName = builder.displayName;
     this.description = builder.description;
     this.revisions = builder.revisions;
+    this.isDeleted = builder.isDeleted;
   }
 
   public static Builder builder() {
@@ -78,6 +80,10 @@ public class Cohort {
     return mostRecentRevision.get();
   }
 
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
   public static class Builder {
     private String id;
     private String underlay;
@@ -88,6 +94,7 @@ public class Cohort {
     private @Nullable String displayName;
     private @Nullable String description;
     private List<CohortRevision> revisions;
+    private boolean isDeleted;
 
     public Builder id(String id) {
       this.id = id;
@@ -131,6 +138,11 @@ public class Cohort {
 
     public Builder revisions(List<CohortRevision> revisions) {
       this.revisions = revisions;
+      return this;
+    }
+
+    public Builder isDeleted(boolean isDeleted) {
+      this.isDeleted = isDeleted;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSet.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSet.java
@@ -18,6 +18,7 @@ public class ConceptSet {
   private final String createdBy;
   private final OffsetDateTime lastModified;
   private final String lastModifiedBy;
+  private final boolean isDeleted;
 
   private ConceptSet(Builder builder) {
     this.id = builder.id;
@@ -30,6 +31,7 @@ public class ConceptSet {
     this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.lastModifiedBy = builder.lastModifiedBy;
+    this.isDeleted = builder.isDeleted;
   }
 
   public static Builder builder() {
@@ -78,6 +80,10 @@ public class ConceptSet {
     return description;
   }
 
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
   public static class Builder {
     private String id;
     private String underlay;
@@ -89,6 +95,7 @@ public class ConceptSet {
     private String createdBy;
     private OffsetDateTime lastModified;
     private String lastModifiedBy;
+    private boolean isDeleted;
 
     public Builder id(String id) {
       this.id = id;
@@ -137,6 +144,11 @@ public class ConceptSet {
 
     public Builder lastModifiedBy(String lastModifiedBy) {
       this.lastModifiedBy = lastModifiedBy;
+      return this;
+    }
+
+    public Builder isDeleted(boolean isDeleted) {
+      this.isDeleted = isDeleted;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Review.java
@@ -14,6 +14,7 @@ public class Review {
   private final String createdBy;
   private final OffsetDateTime lastModified;
   private final String lastModifiedBy;
+  private final boolean isDeleted;
 
   private Review(Builder builder) {
     this.id = builder.id;
@@ -25,6 +26,7 @@ public class Review {
     this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.lastModifiedBy = builder.lastModifiedBy;
+    this.isDeleted = builder.isDeleted;
   }
 
   public static Builder builder() {
@@ -67,6 +69,10 @@ public class Review {
     return lastModifiedBy;
   }
 
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
   public static class Builder {
     private String id;
     private String displayName;
@@ -77,6 +83,7 @@ public class Review {
     private String createdBy;
     private OffsetDateTime lastModified;
     private String lastModifiedBy;
+    private boolean isDeleted;
 
     public Builder id(String id) {
       this.id = id;
@@ -120,6 +127,11 @@ public class Review {
 
     public Builder lastModifiedBy(String lastModifiedBy) {
       this.lastModifiedBy = lastModifiedBy;
+      return this;
+    }
+
+    public Builder isDeleted(boolean isDeleted) {
+      this.isDeleted = isDeleted;
       return this;
     }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/Study.java
@@ -27,6 +27,7 @@ public class Study {
   private final String createdBy;
   private final OffsetDateTime lastModified;
   private final String lastModifiedBy;
+  private final boolean isDeleted;
 
   public Study(Builder builder) {
     this.id = builder.id;
@@ -37,6 +38,7 @@ public class Study {
     this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.lastModifiedBy = builder.lastModifiedBy;
+    this.isDeleted = builder.isDeleted;
   }
 
   /** The globally unique identifier of this study. */
@@ -75,6 +77,10 @@ public class Study {
     return lastModifiedBy;
   }
 
+  public boolean isDeleted() {
+    return isDeleted;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -96,6 +102,7 @@ public class Study {
         .append(createdBy, study.createdBy)
         .append(lastModified, study.lastModified)
         .append(lastModifiedBy, study.lastModifiedBy)
+        .append(isDeleted, study.isDeleted)
         .isEquals();
   }
 
@@ -110,6 +117,7 @@ public class Study {
         .append(createdBy)
         .append(lastModified)
         .append(lastModifiedBy)
+        .append(isDeleted)
         .toHashCode();
   }
 
@@ -127,6 +135,7 @@ public class Study {
     private String createdBy;
     private OffsetDateTime lastModified;
     private String lastModifiedBy;
+    private boolean isDeleted;
 
     public Builder id(String id) {
       this.id = id;
@@ -172,6 +181,11 @@ public class Study {
 
     public Builder lastModifiedBy(String lastModifiedBy) {
       this.lastModifiedBy = lastModifiedBy;
+      return this;
+    }
+
+    public Builder isDeleted(boolean isDeleted) {
+      this.isDeleted = isDeleted;
       return this;
     }
 

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -17,4 +17,5 @@
     <include file="changesets/20230606_postgres_rename_columns_and_constraints.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230608_schema_common_reset.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230713_review_instance_stable_index.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230831_artifact_is_deleted_flags.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230831_artifact_is_deleted_flags.yaml
+++ b/service/src/main/resources/db/changesets/20230831_artifact_is_deleted_flags.yaml
@@ -10,8 +10,6 @@ databaseChangeLog:
                   name: is_deleted
                   type: boolean
                   value: false # Backfill existing rows with false.
-                  constraints:
-                    nullable: false
         - addColumn:
             tableName: cohort
             columns:
@@ -19,8 +17,6 @@ databaseChangeLog:
                   name: is_deleted
                   type: boolean
                   value: false # Backfill existing rows with false.
-                  constraints:
-                    nullable: false
         - addColumn:
             tableName: review
             columns:
@@ -28,8 +24,6 @@ databaseChangeLog:
                   name: is_deleted
                   type: boolean
                   value: false # Backfill existing rows with false.
-                  constraints:
-                    nullable: false
         - addColumn:
             tableName: concept_set
             columns:
@@ -37,5 +31,3 @@ databaseChangeLog:
                   name: is_deleted
                   type: boolean
                   value: false # Backfill existing rows with false.
-                  constraints:
-                    nullable: false

--- a/service/src/main/resources/db/changesets/20230831_artifact_is_deleted_flags.yaml
+++ b/service/src/main/resources/db/changesets/20230831_artifact_is_deleted_flags.yaml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+  - changeSet:
+      id: artifact_is_deleted_flags
+      author: marikomedlock
+      changes:
+        - addColumn:
+            tableName: study
+            columns:
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  value: false # Backfill existing rows with false.
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: cohort
+            columns:
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  value: false # Backfill existing rows with false.
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: review
+            columns:
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  value: false # Backfill existing rows with false.
+                  constraints:
+                    nullable: false
+        - addColumn:
+            tableName: concept_set
+            columns:
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  value: false # Backfill existing rows with false.
+                  constraints:
+                    nullable: false

--- a/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
@@ -117,9 +117,19 @@ public class CohortServiceTest {
 
     // Delete.
     cohortService.deleteCohort(study1.getId(), createdCohort.getId());
-    assertThrows(
-        NotFoundException.class,
-        () -> cohortService.getCohort(study1.getId(), createdCohort.getId()));
+    List<Cohort> cohorts =
+        cohortService.listCohorts(
+            ResourceCollection.allResourcesAllPermissions(
+                ResourceType.COHORT, ResourceId.forStudy(study1.getId())),
+            0,
+            10);
+    assertFalse(
+        cohorts.stream()
+            .map(Cohort::getId)
+            .collect(Collectors.toList())
+            .contains(createdCohort.getId()));
+    Cohort cohort = cohortService.getCohort(study1.getId(), createdCohort.getId());
+    assertTrue(cohort.isDeleted());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
@@ -129,9 +129,20 @@ public class ConceptSetServiceTest {
 
     // Delete.
     conceptSetService.deleteConceptSet(study1.getId(), createdConceptSet.getId());
-    assertThrows(
-        NotFoundException.class,
-        () -> conceptSetService.getConceptSet(study1.getId(), createdConceptSet.getId()));
+    List<ConceptSet> conceptSets =
+        conceptSetService.listConceptSets(
+            ResourceCollection.allResourcesAllPermissions(
+                ResourceType.CONCEPT_SET, ResourceId.forStudy(study1.getId())),
+            0,
+            10);
+    assertFalse(
+        conceptSets.stream()
+            .map(ConceptSet::getId)
+            .collect(Collectors.toList())
+            .contains(createdConceptSet.getId()));
+    ConceptSet conceptSet =
+        conceptSetService.getConceptSet(study1.getId(), createdConceptSet.getId());
+    assertTrue(conceptSet.isDeleted());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
@@ -149,9 +149,19 @@ public class ReviewServiceTest {
 
     // Delete.
     reviewService.deleteReview(study1.getId(), cohort1.getId(), createdReview.getId());
-    assertThrows(
-        NotFoundException.class,
-        () -> reviewService.getReview(study1.getId(), cohort1.getId(), createdReview.getId()));
+    List<Review> reviews =
+        reviewService.listReviews(
+            ResourceCollection.allResourcesAllPermissions(
+                ResourceType.REVIEW, ResourceId.forCohort(study1.getId(), cohort1.getId())),
+            0,
+            10);
+    assertFalse(
+        reviews.stream()
+            .map(Review::getId)
+            .collect(Collectors.toList())
+            .contains(createdReview.getId()));
+    Review review = reviewService.getReview(study1.getId(), cohort1.getId(), createdReview.getId());
+    assertTrue(review.isDeleted());
   }
 
   @Test

--- a/service/src/test/java/bio/terra/tanagra/service/StudyServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/StudyServiceTest.java
@@ -82,7 +82,16 @@ public class StudyServiceTest {
 
     // Delete.
     studyService.deleteStudy(createdStudy.getId());
-    assertThrows(NotFoundException.class, () -> studyService.getStudy(createdStudy.getId()));
+    List<Study> studies =
+        studyService.listStudies(
+            ResourceCollection.allResourcesAllPermissions(ResourceType.STUDY, null), 0, 10);
+    assertFalse(
+        studies.stream()
+            .map(Study::getId)
+            .collect(Collectors.toList())
+            .contains(createdStudy.getId()));
+    Study study = studyService.getStudy(createdStudy.getId());
+    assertTrue(study.isDeleted());
 
     // Create with id.
     String id = "aou-rw-26297573";


### PR DESCRIPTION
- Added an `isDeleted` flag to each artifact: cohort, concept set, study, review.
- Listing artifacts will not return deleted ones.
- Updating a deleted artifact will throw an exception.
- Fetching a specific deleted artifact will succeed.

These changes are to support audit requirements for SDD prod. The audit log entries must persist after deletion, so we need to preserve the records in our application DB.