### PR TITLE
Activity log access control.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ActivityLogApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ActivityLogApiController.java
@@ -1,9 +1,15 @@
 package bio.terra.tanagra.app.controller;
 
+import static bio.terra.tanagra.service.accesscontrol.Action.READ;
+import static bio.terra.tanagra.service.accesscontrol.ResourceType.ACTIVITY_LOG;
+
+import bio.terra.tanagra.app.auth.SpringAuthentication;
 import bio.terra.tanagra.app.configuration.VersionConfiguration;
 import bio.terra.tanagra.generated.controller.ActivityLogApi;
 import bio.terra.tanagra.generated.model.*;
+import bio.terra.tanagra.service.AccessControlService;
 import bio.terra.tanagra.service.ActivityLogService;
+import bio.terra.tanagra.service.accesscontrol.Permissions;
 import bio.terra.tanagra.service.artifact.ActivityLog;
 import bio.terra.tanagra.service.artifact.ActivityLogResource;
 import java.util.stream.Collectors;
@@ -13,10 +19,13 @@ import org.springframework.http.ResponseEntity;
 public class ActivityLogApiController implements ActivityLogApi {
 
   private final ActivityLogService activityLogService;
+  private final AccessControlService accessControlService;
 
   @Autowired
-  public ActivityLogApiController(ActivityLogService activityLogService) {
+  public ActivityLogApiController(
+      ActivityLogService activityLogService, AccessControlService accessControlService) {
     this.activityLogService = activityLogService;
+    this.accessControlService = accessControlService;
   }
 
   @Override
@@ -27,7 +36,8 @@ public class ActivityLogApiController implements ActivityLogApi {
       ApiActivityType activityType,
       Integer offset,
       Integer limit) {
-    // TODO: Add access control call here.
+    accessControlService.throwIfUnauthorized(
+        SpringAuthentication.getCurrentUser(), Permissions.forActions(ACTIVITY_LOG, READ));
     ApiActivityLogEntryList apiActivityLogs = new ApiActivityLogEntryList();
     activityLogService
         .listActivityLogs(
@@ -44,7 +54,8 @@ public class ActivityLogApiController implements ActivityLogApi {
 
   @Override
   public ResponseEntity<ApiActivityLogEntry> getActivityLogEntry(String activityLogEntryId) {
-    // TODO: Add access control call here.
+    accessControlService.throwIfUnauthorized(
+        SpringAuthentication.getCurrentUser(), Permissions.forActions(ACTIVITY_LOG, READ));
     return ResponseEntity.ok(toApiObject(activityLogService.getActivityLog(activityLogEntryId)));
   }
 

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceType.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/ResourceType.java
@@ -27,7 +27,8 @@ public enum ResourceType {
       Set.of(
           Action.READ, Action.UPDATE, Action.DELETE, Action.QUERY_INSTANCES, Action.QUERY_COUNTS),
       COHORT),
-  ANNOTATION_KEY(Set.of(Action.READ, Action.UPDATE, Action.DELETE), COHORT);
+  ANNOTATION_KEY(Set.of(Action.READ, Action.UPDATE, Action.DELETE), COHORT),
+  ACTIVITY_LOG(Set.of(Action.READ));
 
   private final Set<Action> actions;
   private final ResourceType parentResourceType;

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/AouWorkbenchAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/AouWorkbenchAccessControl.java
@@ -75,7 +75,10 @@ public class AouWorkbenchAccessControl implements AccessControl {
 
   @Override
   public boolean isAuthorized(UserId user, Permissions permissions, @Nullable ResourceId resource) {
-    if (permissions.getType().equals(ResourceType.UNDERLAY)) {
+    if (permissions.getType().equals(ResourceType.ACTIVITY_LOG)) {
+      LOGGER.warn("AoU-RW will not use the activity log, so we should never get here.");
+      return false;
+    } else if (permissions.getType().equals(ResourceType.UNDERLAY)) {
       // Browsing the cohort builder without saving. Always allow.
       return true;
     } else if (Permissions.forActions(ResourceType.STUDY, Action.CREATE).equals(permissions)) {
@@ -106,7 +109,10 @@ public class AouWorkbenchAccessControl implements AccessControl {
   @Override
   public ResourceCollection listAllPermissions(
       UserId user, ResourceType type, @Nullable ResourceId parentResource, int offset, int limit) {
-    if (ResourceType.UNDERLAY.equals(type)) {
+    if (ResourceType.ACTIVITY_LOG.equals(type)) {
+      LOGGER.warn("AoU-RW will not use the activity log, so we should never get here.");
+      return ResourceCollection.empty(ResourceType.ACTIVITY_LOG, null);
+    } else if (ResourceType.UNDERLAY.equals(type)) {
       // Browsing the cohort builder without saving. Allow for all underlays.
       return ResourceCollection.allResourcesAllPermissions(ResourceType.UNDERLAY, null);
     } else if (ResourceType.STUDY.equals(type)) {

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
@@ -54,7 +54,10 @@ public class VumcAdminAccessControl implements AccessControl {
 
   @Override
   public boolean isAuthorized(UserId user, Permissions permissions, @Nullable ResourceId resource) {
-    if (ResourceType.UNDERLAY.equals(permissions.getType())) {
+    if (ResourceType.ACTIVITY_LOG.equals(permissions.getType())) {
+      // TODO: Call VUMC admin service.
+      return true; // Temporarily, all users can see the activity log.
+    } else if (ResourceType.UNDERLAY.equals(permissions.getType())) {
       // For underlays, check authorization with the underlay id.
       return isAuthorized(
           user,
@@ -149,7 +152,12 @@ public class VumcAdminAccessControl implements AccessControl {
   @Override
   public ResourceCollection listAllPermissions(
       UserId user, ResourceType type, @Nullable ResourceId parentResource, int offset, int limit) {
-    if (ResourceType.UNDERLAY.equals(type) || ResourceType.STUDY.equals(type)) {
+    if (ResourceType.ACTIVITY_LOG.equals(type)) {
+      // Users either have all permissions on activity logs, or none.
+      return isAuthorized(user, Permissions.forActions(ResourceType.ACTIVITY_LOG, READ), null)
+          ? ResourceCollection.allResourcesAllPermissions(ResourceType.ACTIVITY_LOG, null)
+          : ResourceCollection.empty(ResourceType.ACTIVITY_LOG, null);
+    } else if (ResourceType.UNDERLAY.equals(type) || ResourceType.STUDY.equals(type)) {
       // Admin service stores permissions for underlays and studies.
       Map<ResourceId, Set<ResourceAction>> resourceApiActionsMap = listAllPermissions(user, type);
 

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/AouWorkbenchAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/AouWorkbenchAccessControlTest.java
@@ -37,6 +37,15 @@ public class AouWorkbenchAccessControlTest extends BaseAccessControlTest {
   }
 
   @Test
+  void activityLog() {
+    // isAuthorized
+    assertFalse(impl.isAuthorized(USER_1, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertFalse(impl.isAuthorized(USER_2, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertFalse(impl.isAuthorized(USER_3, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertFalse(impl.isAuthorized(USER_4, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+  }
+
+  @Test
   void underlay() {
     // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
     ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/OpenAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/OpenAccessControlTest.java
@@ -24,6 +24,15 @@ public class OpenAccessControlTest extends BaseAccessControlTest {
   }
 
   @Test
+  void activityLog() {
+    // isAuthorized
+    assertTrue(impl.isAuthorized(USER_1, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_2, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_3, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_4, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+  }
+
+  @Test
   void underlay() {
     // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
     ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VerilyGroupsAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VerilyGroupsAccessControlTest.java
@@ -45,6 +45,15 @@ public class VerilyGroupsAccessControlTest extends BaseAccessControlTest {
   }
 
   @Test
+  void activityLog() {
+    // isAuthorized
+    assertTrue(impl.isAuthorized(USER_1, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_2, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_3, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_4, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+  }
+
+  @Test
   void underlay() {
     // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
     ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VumcAdminAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VumcAdminAccessControlTest.java
@@ -104,6 +104,15 @@ public class VumcAdminAccessControlTest extends BaseAccessControlTest {
   }
 
   @Test
+  void activityLog() {
+    // isAuthorized
+    assertTrue(impl.isAuthorized(USER_1, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_2, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_3, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+    assertTrue(impl.isAuthorized(USER_4, Permissions.allActions(ResourceType.ACTIVITY_LOG), null));
+  }
+
+  @Test
   void underlay() {
     // isAuthorized, getPermissions, listAllPermissions, listAuthorizedResources
     ResourceId cmsSynpufId = ResourceId.forUnderlay(CMS_SYNPUF);


### PR DESCRIPTION
- Added a new resource type `ACTIVITY_LOG` with a single associated action `READ` to the access control interface.
- Added authorization checks to each of the activity log endpoints.
- Updated the access control implementation classes to handle activity logs:
  - `OPEN_ACCES` allows all users to see activity logs.
  - `VERILY_GROUP` allows all users to see activity logs.
  - `AOU_WORKBENCH` disallows all users from activity logs. We don't currently expect AoU to use the activity logs feature.
  - `VUMC_ADMIN` has a todo to call the VUMC admin service to check activity log access, once we've hashed out what the call should be with VUMC. Temporarily, it allows all users to see activity logs.