### PR TITLE
API updates for the VUMC audit UI.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesV2ApiController.java
@@ -78,6 +78,7 @@ public class StudiesV2ApiController implements StudiesV2Api {
       String displayName,
       String description,
       String createdBy,
+      Boolean includeDeleted,
       List<String> properties,
       Integer offset,
       Integer limit) {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -210,6 +210,7 @@ paths:
         - $ref: "#/components/parameters/StudyFilterDisplayNameV2"
         - $ref: "#/components/parameters/StudyFilterDescriptionV2"
         - $ref: "#/components/parameters/StudyFilterCreatedByV2"
+        - $ref: "#/components/parameters/StudyFilterIncludeDeleted"
         - $ref: "#/components/parameters/StudyFilterPropertiesV2"
         - $ref: "#/components/parameters/OffsetV2"
         - $ref: "#/components/parameters/LimitV2"
@@ -1011,6 +1012,14 @@ components:
       required: false
       schema:
         type: string
+
+    StudyFilterIncludeDeleted:
+      name: includeDeleted
+      in: query
+      description: True to include studies that have been deleted
+      required: false
+      schema:
+        type: boolean
 
     StudyFilterPropertiesV2:
       name: properties
@@ -2506,6 +2515,9 @@ components:
         studyDisplayName:
           $ref: "#/components/schemas/StudyDisplayNameV2"
           nullable: true
+        studyProperties:
+          $ref: "#/components/schemas/PropertiesV2"
+          nullable: true
         cohortId:
           $ref: "#/components/schemas/CohortIdV2"
           nullable: true
@@ -2559,6 +2571,10 @@ components:
             exportModel:
               description: (EXPORT_COHORT) Name of the export model used
               type: string
+              nullable: true
+            primaryEntityCount:
+              description: (EXPORT_COHORT, CREATE_REVIEW) Number of primary entity instances included in the cohort revision
+              type: integer
               nullable: true
       required:
         - id


### PR DESCRIPTION
- API updates to support the VUMC audit UI. Discussed in Sept 6 meeting w/product and eng.
  - Add an optional `includeDeleted` flag to the `listStudies` endpoint. The audit UI will set this to true to list all studies that may have associated audit logs.
  - Include the study key-value metadata map in the activity log entry. The audit UI will use this to display the associated IRB number.
  - Add a `primaryEntityCount` to the activity log entry. For the `CREATE_REVIEW` and `EXPORT_COHORT` activity types only, this will be populated with the number of persons in the cohort(s). 
- This PR does not include implementation, just the API definitions. I will do the implementation separately in follow-on PRs.