### PR TITLE
Accommodate letters in ICD9-CM codes.

### DIFF
--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/icd9cm_parentChild.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/icd9cm_parentChild.sql
@@ -23,8 +23,8 @@ SELECT
 FROM `verily-tanagra-dev.aou_static_prep_useast1.prep_concept` p
 LEFT JOIN `victr-tanagra-test.sd_20230328.concept` AS c
     ON c.vocabulary_id = p.vocabulary_id
-    AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([0-9\.]+)-'))
-    AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([0-9\.]+)$'))
+    AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([a-zA-Z0-9\.]+)-'))
+    AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([a-zA-Z0-9\.]+)$'))
     AND NOT CONTAINS_SUBSTR(c.concept_code, '.')
 WHERE p.vocabulary_id='ICD9CM' AND p.concept_id NOT IN (2500000023, 2500000024, 2500000025) AND c.concept_id IS NOT NULL
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_parentChild.sql
@@ -23,8 +23,8 @@ SELECT
 FROM `victr-tanagra-test.aou_static_prep.prep_concept` p
 LEFT JOIN `victr-tanagra-test.sd_20230328.concept` AS c
     ON c.vocabulary_id = p.vocabulary_id
-    AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([0-9\.]+)-'))
-    AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([0-9\.]+)$'))
+    AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([a-zA-Z0-9\.]+)-'))
+    AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([a-zA-Z0-9\.]+)$'))
     AND NOT CONTAINS_SUBSTR(c.concept_code, '.')
 WHERE p.vocabulary_id='ICD9CM' AND p.concept_id NOT IN (2500000023, 2500000024, 2500000025) AND c.concept_id IS NOT NULL
 


### PR DESCRIPTION
- Allowed for letters in the ICD9-CM codes child/parent relationships query. Previously, only numeric codes were allowed.
- Re-indexed just the ICD9-CM entity and group in the existing `verily/sdd` index dataset.
- This fix is in response to a bug report from VUMC while testing out the source hierarchies.