### PR TITLE
Store the records count for export and review logs.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ActivityLogApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ActivityLogApiController.java
@@ -78,7 +78,9 @@ public class ActivityLogApiController implements ActivityLogApi {
                 .map(alr -> toApiObject(alr))
                 .collect(Collectors.toList()))
         .additionalInfo(
-            new ApiActivityLogEntryAdditionalInfo().exportModel(activityLog.getExportModel()));
+            new ApiActivityLogEntryAdditionalInfo()
+                .exportModel(activityLog.getExportModel())
+                .recordsCount(activityLog.getRecordsCount()));
   }
 
   private ApiResource toApiObject(ActivityLogResource activityLogResource) {

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -91,7 +91,12 @@ public class ExportApiController implements ExportApi {
             body.getCohorts(),
             request,
             entityQueryRequests,
-            fromApiConversionService.fromApiObject(body.getPrimaryEntityFilter(), underlayName),
+            // TODO: Remove the null handling here once the UI is passing the primary entity filter
+            // to the export endpoint.
+            body.getPrimaryEntityFilter() == null
+                ? null
+                : fromApiConversionService.fromApiObject(
+                    body.getPrimaryEntityFilter(), underlayName),
             SpringAuthentication.getCurrentUser().getEmail());
     return ResponseEntity.ok(toApiObject(result));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -91,6 +91,7 @@ public class ExportApiController implements ExportApi {
             body.getCohorts(),
             request,
             entityQueryRequests,
+            fromApiConversionService.fromApiObject(body.getPrimaryEntityFilter(), underlayName),
             SpringAuthentication.getCurrentUser().getEmail());
     return ResponseEntity.ok(toApiObject(result));
   }

--- a/service/src/main/java/bio/terra/tanagra/db/ActivityLogDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/ActivityLogDao.java
@@ -26,7 +26,7 @@ public class ActivityLogDao {
 
   // SQL query and row mapper for reading an activity log entry.
   private static final String ACTIVITY_LOG_SELECT_SQL =
-      "SELECT id, user_email, logged, version_git_tag, version_git_hash, version_build, activity_type, export_model FROM activity_log";
+      "SELECT id, user_email, logged, version_git_tag, version_git_hash, version_build, activity_type, export_model, records_count FROM activity_log";
   private static final RowMapper<ActivityLog.Builder> ACTIVITY_LOG_ROW_MAPPER =
       (rs, rowNum) ->
           ActivityLog.builder()
@@ -37,7 +37,8 @@ public class ActivityLogDao {
               .versionGitHash(rs.getString("version_git_hash"))
               .versionBuild(rs.getString("version_build"))
               .type(ActivityLog.Type.valueOf(rs.getString("activity_type")))
-              .exportModel(rs.getString("export_model"));
+              .exportModel(rs.getString("export_model"))
+              .recordsCount(rs.getObject("records_count", Long.class));
 
   // SQL query and row mapper for reading an activity log entry resource.
   private static final String ACTIVITY_LOG_RESOURCE_SELECT_SQL =
@@ -72,8 +73,8 @@ public class ActivityLogDao {
   @WriteTransaction
   public void createActivityLog(ActivityLog activityLog) {
     String sql =
-        "INSERT INTO activity_log (id, user_email, version_git_tag, version_git_hash, version_build, activity_type, export_model) "
-            + "VALUES (:id, :user_email, :version_git_tag, :version_git_hash, :version_build, :activity_type, :export_model)";
+        "INSERT INTO activity_log (id, user_email, version_git_tag, version_git_hash, version_build, activity_type, export_model, records_count) "
+            + "VALUES (:id, :user_email, :version_git_tag, :version_git_hash, :version_build, :activity_type, :export_model, :records_count)";
     LOGGER.debug("CREATE activity log: {}", sql);
     MapSqlParameterSource params =
         new MapSqlParameterSource()
@@ -83,7 +84,8 @@ public class ActivityLogDao {
             .addValue("version_git_hash", activityLog.getVersionGitHash())
             .addValue("version_build", activityLog.getVersionBuild())
             .addValue("activity_type", activityLog.getType().name())
-            .addValue("export_model", activityLog.getExportModel());
+            .addValue("export_model", activityLog.getExportModel())
+            .addValue("records_count", activityLog.getRecordsCount());
     int rowsAffected = jdbcTemplate.update(sql, params);
     LOGGER.debug("CREATE activity log rowsAffected = {}", rowsAffected);
 

--- a/service/src/main/java/bio/terra/tanagra/service/ActivityLogService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/ActivityLogService.java
@@ -80,11 +80,16 @@ public class ActivityLogService {
             .reviewId(review.getId())
             .cohortRevisionId(review.getRevision().getId())
             .build();
-    createActivityLog(ActivityLog.builder(), userEmail, type, List.of(resource));
+    createActivityLog(
+        ActivityLog.builder().recordsCount(review.getRevision().getRecordsCount()),
+        userEmail,
+        type,
+        List.of(resource));
   }
 
   public void logExport(
       String exportModel,
+      Long allCohortsCount,
       String userEmail,
       String studyId,
       Map<String, String> cohortToRevisionIdMap) {
@@ -103,7 +108,7 @@ public class ActivityLogService {
                 })
             .collect(Collectors.toList());
     createActivityLog(
-        ActivityLog.builder().exportModel(exportModel),
+        ActivityLog.builder().exportModel(exportModel).recordsCount(allCohortsCount),
         userEmail,
         ActivityLog.Type.EXPORT_COHORT,
         resources);

--- a/service/src/main/java/bio/terra/tanagra/service/FromApiConversionService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FromApiConversionService.java
@@ -44,7 +44,11 @@ public final class FromApiConversionService {
 
   public EntityFilter fromApiObject(ApiFilterV2 apiFilter, String studyId, String cohortId) {
     Cohort cohort = cohortService.getCohort(studyId, cohortId);
-    Underlay underlay = underlaysService.getUnderlay(cohort.getUnderlay());
+    return fromApiObject(apiFilter, cohort.getUnderlay());
+  }
+
+  public EntityFilter fromApiObject(ApiFilterV2 apiFilter, String underlayName) {
+    Underlay underlay = underlaysService.getUnderlay(underlayName);
     return fromApiObject(apiFilter, underlay.getPrimaryEntity(), underlay.getName());
   }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ActivityLog.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ActivityLog.java
@@ -22,6 +22,7 @@ public class ActivityLog {
   private final String versionBuild;
   private final Type type;
   private final String exportModel;
+  private final Long recordsCount;
   private final List<ActivityLogResource> resources;
 
   private ActivityLog(Builder builder) {
@@ -33,6 +34,7 @@ public class ActivityLog {
     this.versionBuild = builder.versionBuild;
     this.type = builder.type;
     this.exportModel = builder.exportModel;
+    this.recordsCount = builder.recordsCount;
     this.resources = builder.resources;
   }
 
@@ -72,6 +74,10 @@ public class ActivityLog {
     return exportModel;
   }
 
+  public Long getRecordsCount() {
+    return recordsCount;
+  }
+
   public List<ActivityLogResource> getResources() {
     return Collections.unmodifiableList(resources);
   }
@@ -85,6 +91,7 @@ public class ActivityLog {
     private String versionBuild;
     private Type type;
     private String exportModel;
+    private Long recordsCount;
     private List<ActivityLogResource> resources;
 
     public Builder id(String id) {
@@ -127,6 +134,11 @@ public class ActivityLog {
       return this;
     }
 
+    public Builder recordsCount(Long recordsCount) {
+      this.recordsCount = recordsCount;
+      return this;
+    }
+
     public Builder resources(List<ActivityLogResource> resources) {
       this.resources = resources;
       return this;
@@ -162,6 +174,8 @@ public class ActivityLog {
         && this.type.equals(activityLog.getType())
         && ((this.exportModel != null && this.exportModel.equals(activityLog.getExportModel()))
             || (this.exportModel == null && activityLog.getExportModel() == null))
+        && ((this.recordsCount != null && this.recordsCount.equals(activityLog.getRecordsCount()))
+            || (this.recordsCount == null && activityLog.getRecordsCount() == null))
         && resources.equals(activityLog.getResources());
   }
 
@@ -182,6 +196,7 @@ public class ActivityLog {
         && versionBuild.equals(that.versionBuild)
         && type == that.type
         && Objects.equals(exportModel, that.exportModel)
+        && Objects.equals(recordsCount, that.recordsCount)
         && Objects.equals(resources, that.resources);
   }
 
@@ -196,6 +211,7 @@ public class ActivityLog {
         versionBuild,
         type,
         exportModel,
+        recordsCount,
         resources);
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/CohortRevision.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/CohortRevision.java
@@ -18,6 +18,7 @@ public class CohortRevision {
   private final String createdBy;
   private final OffsetDateTime lastModified;
   private final String lastModifiedBy;
+  private final Long recordsCount;
 
   private CohortRevision(Builder builder) {
     this.id = builder.id;
@@ -29,6 +30,7 @@ public class CohortRevision {
     this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
     this.lastModifiedBy = builder.lastModifiedBy;
+    this.recordsCount = builder.recordsCount;
   }
 
   public static Builder builder() {
@@ -45,7 +47,8 @@ public class CohortRevision {
         .created(created)
         .createdBy(createdBy)
         .lastModified(lastModified)
-        .lastModifiedBy(lastModifiedBy);
+        .lastModifiedBy(lastModifiedBy)
+        .recordsCount(recordsCount);
   }
 
   public String getId() {
@@ -84,6 +87,10 @@ public class CohortRevision {
     return lastModifiedBy;
   }
 
+  public Long getRecordsCount() {
+    return recordsCount;
+  }
+
   public static class Builder {
     private String id;
     private List<CriteriaGroupSection> sections = new ArrayList<>();
@@ -94,6 +101,7 @@ public class CohortRevision {
     private String createdBy;
     private OffsetDateTime lastModified;
     private String lastModifiedBy;
+    private Long recordsCount;
 
     public Builder id(String id) {
       this.id = id;
@@ -140,6 +148,11 @@ public class CohortRevision {
       return this;
     }
 
+    public Builder recordsCount(Long recordsCount) {
+      this.recordsCount = recordsCount;
+      return this;
+    }
+
     public CohortRevision build() {
       if (id == null) {
         id = RandomStringUtils.randomAlphanumeric(10);
@@ -176,7 +189,8 @@ public class CohortRevision {
         && created.equals(that.created)
         && createdBy.equals(that.createdBy)
         && lastModified.equals(that.lastModified)
-        && lastModifiedBy.equals(that.lastModifiedBy);
+        && lastModifiedBy.equals(that.lastModifiedBy)
+        && recordsCount.equals(that.recordsCount);
   }
 
   @Override
@@ -190,7 +204,8 @@ public class CohortRevision {
         created,
         createdBy,
         lastModified,
-        lastModifiedBy);
+        lastModifiedBy,
+        recordsCount);
   }
 
   public static class CriteriaGroupSection {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2582,9 +2582,10 @@ components:
               description: (EXPORT_COHORT) Name of the export model used
               type: string
               nullable: true
-            primaryEntityCount:
-              description: (EXPORT_COHORT, CREATE_REVIEW) Number of primary entity instances included in the cohort revision
+            recordsCount:
+              description: (EXPORT_COHORT, CREATE_REVIEW) Number of primary entity records involved
               type: integer
+              format: int64
               nullable: true
       required:
         - id

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -19,4 +19,5 @@
     <include file="changesets/20230713_review_instance_stable_index.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230831_artifact_is_deleted_flags.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230901_activity_log.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230908_activity_log_count.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230908_activity_log_count.yaml
+++ b/service/src/main/resources/db/changesets/20230908_activity_log_count.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: cohort_revision_count
+      author: marikomedlock
+      changes:
+        - addColumn:
+            tableName: cohort_revision
+            columns:
+              - column:
+                  name: records_count
+                  type: bigint
+                  constraints:
+                    nullable: true
+        - addColumn:
+            tableName: activity_log
+            columns:
+              - column:
+                  name: records_count
+                  type: bigint
+                  constraints:
+                    nullable: true

--- a/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
@@ -98,7 +98,12 @@ public class AnnotationServiceTest {
             columnHeaderSchema);
     review1 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort1.getId(), Review.builder().size(11), userEmail, queryResult);
+            study1.getId(),
+            cohort1.getId(),
+            Review.builder().size(11),
+            userEmail,
+            queryResult,
+            1_500_000L);
     assertNotNull(review1);
     LOGGER.info("Created review {} at {}", review1.getId(), review1.getCreated());
 
@@ -111,7 +116,12 @@ public class AnnotationServiceTest {
             columnHeaderSchema);
     review2 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort2.getId(), Review.builder().size(14), userEmail, queryResult);
+            study1.getId(),
+            cohort2.getId(),
+            Review.builder().size(14),
+            userEmail,
+            queryResult,
+            4_500_000L);
     assertNotNull(review2);
     LOGGER.info("Created review {} at {}", review2.getId(), review2.getCreated());
     queryResult =
@@ -122,7 +132,12 @@ public class AnnotationServiceTest {
             columnHeaderSchema);
     review3 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort2.getId(), Review.builder().size(3), userEmail, queryResult);
+            study1.getId(),
+            cohort2.getId(),
+            Review.builder().size(3),
+            userEmail,
+            queryResult,
+            4_500_000L);
     assertNotNull(review3);
     LOGGER.info("Created review {} at {}", review3.getId(), review3.getCreated());
     queryResult =
@@ -133,7 +148,12 @@ public class AnnotationServiceTest {
             columnHeaderSchema);
     review4 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort2.getId(), Review.builder().size(4), userEmail, queryResult);
+            study1.getId(),
+            cohort2.getId(),
+            Review.builder().size(4),
+            userEmail,
+            queryResult,
+            4_500_000L);
     assertNotNull(review4);
     LOGGER.info("Created review {} at {}", review4.getId(), review4.getCreated());
   }

--- a/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
@@ -16,6 +16,7 @@ import bio.terra.tanagra.service.export.ExportRequest;
 import bio.terra.tanagra.service.export.ExportResult;
 import bio.terra.tanagra.service.instances.*;
 import bio.terra.tanagra.service.instances.filter.AttributeFilter;
+import bio.terra.tanagra.service.instances.filter.EntityFilter;
 import bio.terra.tanagra.underlay.Entity;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.utils.GoogleCloudStorage;
@@ -208,6 +209,7 @@ public class DataExportServiceTest {
             List.of(cohort1.getId()),
             exportRequest,
             List.of(buildEntityQueryRequest()),
+            buildPrimaryEntityFilter(),
             "abc@123.com");
     assertNotNull(exportResult);
     assertEquals(ExportResult.Status.COMPLETE, exportResult.getStatus());
@@ -255,6 +257,7 @@ public class DataExportServiceTest {
             List.of(cohort1.getId()),
             exportRequest,
             List.of(buildEntityQueryRequest()),
+            buildPrimaryEntityFilter(),
             "abc@123.com");
     assertNotNull(exportResult);
     assertEquals(ExportResult.Status.COMPLETE, exportResult.getStatus());
@@ -315,6 +318,7 @@ public class DataExportServiceTest {
             List.of(cohort1.getId()),
             exportRequest,
             List.of(buildEntityQueryRequest()),
+            buildPrimaryEntityFilter(),
             "abc@123.com");
     assertNotNull(exportResult);
     assertEquals(ExportResult.Status.COMPLETE, exportResult.getStatus());
@@ -342,5 +346,13 @@ public class DataExportServiceTest {
         .selectAttributes(primaryEntity.getAttributes())
         .limit(5)
         .build();
+  }
+
+  private EntityFilter buildPrimaryEntityFilter() {
+    Entity primaryEntity = underlaysService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity();
+    return new AttributeFilter(
+        primaryEntity.getAttribute("year_of_birth"),
+        BinaryFilterVariable.BinaryOperator.EQUALS,
+        new Literal(11L));
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewInstanceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewInstanceTest.java
@@ -96,7 +96,12 @@ public class ReviewInstanceTest {
             columnHeaderSchema);
     review1 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort1.getId(), Review.builder().size(11), userEmail, queryResult);
+            study1.getId(),
+            cohort1.getId(),
+            Review.builder().size(11),
+            userEmail,
+            queryResult,
+            1_500_000L);
     assertNotNull(review1);
     LOGGER.info("Created review1 {} at {}", review1.getId(), review1.getCreated());
 
@@ -108,7 +113,12 @@ public class ReviewInstanceTest {
             columnHeaderSchema);
     review2 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort1.getId(), Review.builder().size(14), userEmail, queryResult);
+            study1.getId(),
+            cohort1.getId(),
+            Review.builder().size(14),
+            userEmail,
+            queryResult,
+            1_500_000L);
     assertNotNull(review2);
     LOGGER.info("Created review2 {} at {}", review2.getId(), review2.getCreated());
 
@@ -120,7 +130,12 @@ public class ReviewInstanceTest {
             columnHeaderSchema);
     review3 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort1.getId(), Review.builder().size(3), userEmail, queryResult);
+            study1.getId(),
+            cohort1.getId(),
+            Review.builder().size(3),
+            userEmail,
+            queryResult,
+            1_500_000L);
     assertNotNull(review3);
     LOGGER.info("Created review3 {} at {}", review3.getId(), review3.getCreated());
 
@@ -132,7 +147,12 @@ public class ReviewInstanceTest {
             columnHeaderSchema);
     review4 =
         reviewService.createReviewHelper(
-            study1.getId(), cohort1.getId(), Review.builder().size(4), userEmail, queryResult);
+            study1.getId(),
+            cohort1.getId(),
+            Review.builder().size(4),
+            userEmail,
+            queryResult,
+            1_500_000L);
     assertNotNull(review4);
     LOGGER.info("Created review4 {} at {}", review4.getId(), review4.getCreated());
 

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
@@ -112,7 +112,8 @@ public class ReviewServiceTest {
             cohort1.getId(),
             Review.builder().displayName(displayName).description(description).size(11),
             createdByEmail,
-            queryResult);
+            queryResult,
+            27);
     assertNotNull(createdReview);
     LOGGER.info("Created review {} at {}", createdReview.getId(), createdReview.getCreated());
     assertEquals(11, createdReview.getSize());
@@ -184,7 +185,8 @@ public class ReviewServiceTest {
             cohort1.getId(),
             Review.builder().displayName("review 1").description("first review").size(11),
             userEmail,
-            queryResult);
+            queryResult,
+            22);
     assertNotNull(review1);
     LOGGER.info("Created review {} at {}", review1.getId(), review1.getCreated());
 
@@ -195,7 +197,8 @@ public class ReviewServiceTest {
             cohort2.getId(),
             Review.builder().displayName("review 2").description("second review").size(3),
             userEmail,
-            queryResult);
+            queryResult,
+            25);
     assertNotNull(review2);
     LOGGER.info("Created review {} at {}", review2.getId(), review2.getCreated());
     Review review3 =
@@ -204,7 +207,8 @@ public class ReviewServiceTest {
             cohort2.getId(),
             Review.builder().displayName("review 3").description("third review").size(5),
             userEmail,
-            queryResult);
+            queryResult,
+            25);
     assertNotNull(review3);
     LOGGER.info("Created review {} at {}", review3.getId(), review3.getCreated());
 
@@ -273,6 +277,7 @@ public class ReviewServiceTest {
                 cohort1.getId(),
                 Review.builder().size(11),
                 "abc@123.com",
-                emptyQueryResult));
+                emptyQueryResult,
+                0));
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
@@ -138,7 +138,8 @@ public class BaseAccessControlTest {
             cohort1.getId(),
             Review.builder().displayName("review 1").description("first review").size(11),
             "abc@123.com",
-            queryResult);
+            queryResult,
+            14);
     assertNotNull(review1);
     LOGGER.info("Created review {} at {}", review1.getId(), review1.getCreated());
     review2 =
@@ -147,7 +148,8 @@ public class BaseAccessControlTest {
             cohort2.getId(),
             Review.builder().displayName("review 2").description("second review").size(3),
             "def@123.com",
-            queryResult);
+            queryResult,
+            15);
     assertNotNull(review2);
     LOGGER.info("Created review {} at {}", review2.getId(), review2.getCreated());
 


### PR DESCRIPTION
- Updated the activity log to compute and store the number of primary entity records involved.
  - `CREATE_REVIEW`: Re-use the entity filter for the random sample query to also do a count of the total cohort size.
  - `EXPORT_COHORT`: Use the recently added `primaryEntityFilter` API parameter to do a count of the total size of all unioned cohorts.
- Added temporary `null` handling for the export endpoint `primaryEntityFilter` parameter. Once the UI is passing this to the backend, it will compute the count. Until then, it will just store a placeholder value. This will allow merging this PR without breaking exports in the meantime.
- At review creation time, I also added a field on the cohort revision itself to store the count. I think this will be helpful in the future e.g. for showing a timeline view of how a cohort was modified.