### PR TITLE
Fix boolean backfill value changelog.

### DIFF
--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -18,6 +18,7 @@
     <include file="changesets/20230608_schema_common_reset.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230713_review_instance_stable_index.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230831_artifact_is_deleted_flags.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230831_artifact_is_deleted_flags_mariadb.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230901_activity_log.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20230908_activity_log_count.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20230831_artifact_is_deleted_flags_mariadb.yaml
+++ b/service/src/main/resources/db/changesets/20230831_artifact_is_deleted_flags_mariadb.yaml
@@ -2,7 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: artifact_is_deleted_flags
       author: marikomedlock
-      dbms: postgresql
+      dbms: mariadb,mysql
       changes:
         - addColumn:
             tableName: study
@@ -10,25 +10,25 @@ databaseChangeLog:
               - column:
                   name: is_deleted
                   type: boolean
-                  value: false # Backfill existing rows with false.
+                  valueBoolean: false # Backfill existing rows with false.
         - addColumn:
             tableName: cohort
             columns:
               - column:
                   name: is_deleted
                   type: boolean
-                  value: false # Backfill existing rows with false.
+                  valueBoolean: false # Backfill existing rows with false.
         - addColumn:
             tableName: review
             columns:
               - column:
                   name: is_deleted
                   type: boolean
-                  value: false # Backfill existing rows with false.
+                  valueBoolean: false # Backfill existing rows with false.
         - addColumn:
             tableName: concept_set
             columns:
               - column:
                   name: is_deleted
                   type: boolean
-                  value: false # Backfill existing rows with false.
+                  valueBoolean: false # Backfill existing rows with false.


### PR DESCRIPTION
- Added a new changelog that uses the `valueBoolean` tag instead of `value`. This tells Liquibase to use the dbms-specific boolean literal.
- Kept the previous changelog, since it has already been deployed in the Verily test env. Tagged it as only applying to postgres, so that AoU deployments won't try to apply it.
- Created a new changelog specifically for MariaDB/MySQL that uses the correct tag. Tested locally that this works with MariaDB when there are existing rows in the `study` table (db upgrades are not handled by our tests - they always start with a clean db).
- Since the AoU deployment had a bad changelog, we'll need to do a partial manual rollback: `alter table study drop column is_deleted;`. Then this new changelog will be applied correctly.
- FYI: We are planning a DB wipe before SDD prod launch, at which time I plan to consolidate all these changelogs.