### PR TITLE
Disable BQ legacy SQL.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/FieldVariable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/FieldVariable.java
@@ -31,8 +31,6 @@ public class FieldVariable implements SQLExpression {
   }
 
   public String renderSqlForOrderOrGroupBy(boolean includedInSelect) {
-    LOGGER.info(
-        "renderSqlForOrderOrGroupBy: includedInSelect {}, alias {}", includedInSelect, alias);
     if (includedInSelect) {
       if (alias == null) {
         String sql = renderSQL(false, true);

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -194,7 +194,8 @@ public final class GoogleBigQuery {
    */
   public TableResult queryBigQuery(
       String query, @Nullable String pageToken, @Nullable Integer pageSize) {
-    QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
+    QueryJobConfiguration queryConfig =
+        QueryJobConfiguration.newBuilder(query).setUseLegacySql(false).build();
     Job job = bigQuery.create(JobInfo.newBuilder(queryConfig).build());
 
     List<BigQuery.QueryResultsOption> queryResultsOptions = new ArrayList<>();

--- a/underlay/src/main/java/bio/terra/tanagra/utils/HttpUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/HttpUtils.java
@@ -144,16 +144,16 @@ public class HttpUtils {
     do {
       numTries++;
       try {
-        LOGGER.debug("Request attempt #{}/{}", numTries - 1, maxCalls);
+        LOGGER.trace("Request attempt #{}/{}", numTries - 1, maxCalls);
 
         T result = makeRequest.makeRequest();
-        LOGGER.debug("Result: {}", result);
+        LOGGER.trace("Result: {}", result);
 
         boolean jobCompleted = isDone.test(result);
         boolean timedOut = numTries > maxCalls;
         if (jobCompleted || timedOut) {
           // polling is either done (i.e. job completed) or timed out: return the last result
-          LOGGER.debug(
+          LOGGER.trace(
               "polling with retries completed. jobCompleted = {}, timedOut = {}",
               jobCompleted,
               timedOut);


### PR DESCRIPTION
- BQ legacy SQL does not support clustering, which is one of the performance improvements I am working on. This PR explicitly disables it.
- Also bumped some log statements from debug -> trace.