### PR TITLE
Multiple entities per classification, list sorting

### DIFF
--- a/service/src/main/resources/config/broad/aou_synthetic/ui/top_level.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/ui/top_level.json
@@ -115,7 +115,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition"
+      "classifications": ["condition"]
     },
     {
       "type": "classification",
@@ -137,7 +137,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure"
+      "classifications": ["procedure"]
     },
     {
       "type": "classification",
@@ -154,7 +154,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation"
+      "classifications": ["observation"]
     },
     {
       "type": "classification",
@@ -176,7 +176,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient"
+      "classifications": ["ingredient"]
     },
     {
       "type": "attribute",

--- a/service/src/main/resources/config/broad/cms_synpuf/ui/top_level.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/ui/top_level.json
@@ -115,7 +115,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition",
+      "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
         "start_date_group_by_count"
@@ -141,7 +141,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure",
+      "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
     {
@@ -159,7 +159,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation",
+      "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
     {
@@ -182,7 +182,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient",
+      "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
         "start_date_group_by_count"

--- a/service/src/main/resources/config/verily/aou_synthetic/ui/top_level.json
+++ b/service/src/main/resources/config/verily/aou_synthetic/ui/top_level.json
@@ -115,7 +115,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition"
+      "classifications": ["condition"]
     },
     {
       "type": "classification",
@@ -137,7 +137,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure"
+      "classifications": ["procedure"]
     },
     {
       "type": "classification",
@@ -154,7 +154,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation"
+      "classifications": ["observation"]
     },
     {
       "type": "classification",
@@ -176,7 +176,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient"
+      "classifications": ["ingredient"]
     },
     {
       "type": "attribute",

--- a/service/src/main/resources/config/verily/cms_synpuf/ui/top_level.json
+++ b/service/src/main/resources/config/verily/cms_synpuf/ui/top_level.json
@@ -115,7 +115,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition",
+      "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
         "start_date_group_by_count"
@@ -141,7 +141,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure",
+      "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
     {
@@ -159,7 +159,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation",
+      "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
     {
@@ -182,7 +182,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient",
+      "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
         "start_date_group_by_count"

--- a/service/src/main/resources/config/verily/pilot_synthea_2022q3/ui/top_level.json
+++ b/service/src/main/resources/config/verily/pilot_synthea_2022q3/ui/top_level.json
@@ -135,7 +135,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition",
+      "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -162,7 +162,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure",
+      "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -180,7 +180,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation",
+      "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -203,7 +203,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient",
+      "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -230,7 +230,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "measurement_occurrence",
-      "classification": "measurement",
+      "classifications": ["measurement"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {

--- a/service/src/main/resources/config/verily/sdd_refresh0323/ui/top_level.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/ui/top_level.json
@@ -194,9 +194,20 @@
         "key": "id",
         "classifications": [
           {
-            "id": "measurement",
+            "id": "loinc",
             "attribute": "measurement",
             "entity": "measurementLoinc",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "t_item_count",
+              "direction": "DESC"
+            }
+          },
+          {
+            "id": "snomed",
+            "attribute": "measurement",
+            "entity": "measurementSnomed",
             "entityAttribute": "id",
             "hierarchy": "standard",
             "defaultSort": {
@@ -222,7 +233,7 @@
         { "key": "id", "width": 100, "title": "Id" }
       ],
       "occurrence": "",
-      "classification": "genotyping"
+      "classifications": ["genotyping"]
     },
     {
       "type": "attribute",
@@ -259,7 +270,7 @@
       "category": "Demographics",
       "columns": [{ "key": "name", "width": "100%", "title": "SNP variant" }],
       "occurrence": "",
-      "classification": "snp"
+      "classifications": ["snp"]
     },
     {
       "type": "biovu",
@@ -287,7 +298,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "measurement_occurrence",
-      "classification": "measurement",
+      "classifications": ["loinc", "snomed"],
+      "classificationMergeSort": {
+        "attribute": "t_item_count",
+        "direction": "DESC"
+      },
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {
@@ -336,7 +351,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition",
+      "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -353,7 +368,6 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Concept name" },
         { "key": "code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "id", "width": 100, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
@@ -363,7 +377,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "phewas",
+      "classifications": ["phewas"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -383,7 +401,6 @@
         { "key": "is_standard", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -392,7 +409,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "cpt4",
+      "classifications": ["cpt4"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -412,7 +433,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -421,7 +441,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "icd9cm",
+      "classifications": ["icd9cm"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -441,7 +465,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -450,7 +473,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "icd9proc",
+      "classifications": ["icd9proc"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -470,7 +497,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -479,7 +505,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "icd10cm",
+      "classifications": ["icd10cm"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -499,7 +529,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -508,7 +537,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "icd10pcs",
+      "classifications": ["icd10pcs"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -536,7 +569,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure",
+      "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -555,7 +588,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation",
+      "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -579,7 +612,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient",
+      "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/ui/top_level.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/ui/top_level.json
@@ -194,9 +194,20 @@
         "key": "id",
         "classifications": [
           {
-            "id": "measurement",
+            "id": "loinc",
             "attribute": "measurement",
             "entity": "measurementLoinc",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "t_item_count",
+              "direction": "DESC"
+            }
+          },
+          {
+            "id": "snomed",
+            "attribute": "measurement",
+            "entity": "measurementSnomed",
             "entityAttribute": "id",
             "hierarchy": "standard",
             "defaultSort": {
@@ -222,7 +233,7 @@
         { "key": "id", "width": 100, "title": "Id" }
       ],
       "occurrence": "",
-      "classification": "genotyping"
+      "classifications": ["genotyping"]
     },
     {
       "type": "attribute",
@@ -259,7 +270,7 @@
       "category": "Demographics",
       "columns": [{ "key": "name", "width": "100%", "title": "SNP variant" }],
       "occurrence": "",
-      "classification": "snp"
+      "classifications": ["snp"]
     },
     {
       "type": "biovu",
@@ -287,7 +298,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "measurement_occurrence",
-      "classification": "measurement",
+      "classifications": ["loinc", "snomed"],
+      "classificationMergeSort": {
+        "attribute": "t_item_count",
+        "direction": "DESC"
+      },
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {
@@ -336,7 +351,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "condition",
+      "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -353,7 +368,6 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Concept name" },
         { "key": "code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "id", "width": 100, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
@@ -363,7 +377,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "phewas",
+      "classifications": ["phewas"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -383,7 +401,6 @@
         { "key": "is_standard", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -392,7 +409,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "cpt4",
+      "classifications": ["cpt4"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -412,7 +433,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -421,7 +441,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "icd9cm",
+      "classifications": ["icd9cm"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -441,7 +465,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -450,7 +473,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "icd9proc",
+      "classifications": ["icd9proc"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -470,7 +497,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -479,7 +505,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "condition_occurrence",
-      "classification": "icd10cm",
+      "classifications": ["icd10cm"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -499,7 +529,6 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "label", "width": 120, "title": "Label" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "hierarchyColumns": [
@@ -508,7 +537,11 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "icd10pcs",
+      "classifications": ["icd10pcs"],
+      "defaultSort": {
+        "attribute": "t_rollup_count",
+        "direction": "DESC"
+      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -536,7 +569,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "procedure_occurrence",
-      "classification": "procedure",
+      "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -555,7 +588,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "observation_occurrence",
-      "classification": "observation",
+      "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -579,7 +612,7 @@
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrence": "ingredient_occurrence",
-      "classification": "ingredient",
+      "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -22,7 +22,7 @@ import {
   TreeGridRowData,
 } from "components/treegrid";
 import { createConceptSet, useConceptSetContext } from "conceptSetContext";
-import { MergedDataEntry } from "data/source";
+import { MergedItem } from "data/source";
 import { useSource } from "data/sourceContext";
 import { DataEntry, DataKey } from "data/types";
 import { useCohortGroupSectionAndGroup, useUnderlay } from "hooks";
@@ -408,5 +408,5 @@ function AddCriteria(props: AddCriteriaProps) {
 }
 
 type CriteriaItem = TreeGridItem & {
-  entry: MergedDataEntry;
+  entry: MergedItem<DataEntry>;
 };

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -1,10 +1,11 @@
+import { ROLLUP_COUNT_ATTRIBUTE } from "data/configuration";
 import {
   Filter,
   FilterType,
   makeArrayFilter,
   UnaryFilterOperator,
 } from "data/filter";
-import { MergedDataEntry, Source } from "data/source";
+import { MergedItem, Source } from "data/source";
 import { DataEntry } from "data/types";
 import { generate } from "randomstring";
 import { ReactNode } from "react";
@@ -176,7 +177,11 @@ export function searchCriteria(
     .filter(isValid);
 
   return Promise.all(promises).then((responses) => ({
-    data: source.mergeDataEntryLists(responses, 100),
+    data: source.mergeLists(
+      responses,
+      100,
+      (value: DataEntry) => value[ROLLUP_COUNT_ATTRIBUTE]
+    ),
   }));
 }
 
@@ -222,7 +227,7 @@ type SearchFn = (
 ) => Promise<DataEntry[]>;
 
 export type SearchResponse = {
-  data: MergedDataEntry[];
+  data: MergedItem<DataEntry>[];
 };
 
 export function createCriteria(


### PR DESCRIPTION
* Add support for combining multiple entities within a single classification criteria. This is initially used to combine the LOINC and SNOMED criteria for standard measurements.
* Make data enry merging code more generic. It could likely be moved out of source.tsx in the future.
* Add configuration for the list view in classification criteria separately from the hierarchy views.
* Move IS_MEMBER filter to after the query to allow for better optimization on the back end.