### PR TITLE
Support multiple occurence outputs from criteria

### DIFF
--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/ui/top_level.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/ui/top_level.json
@@ -171,7 +171,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classification": "condition",
       "modifiers": [
         "age_at_occurrence",
@@ -198,7 +198,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classification": "procedure",
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -216,7 +216,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classification": "observation",
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -239,7 +239,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classification": "ingredient",
       "modifiers": [
         "age_at_occurrence",
@@ -266,7 +266,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "measurement_occurrence",
+      "occurrences": "measurement_occurrence",
       "classification": "measurement",
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
@@ -425,37 +425,37 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_fitbit_actvity_summary_id",
       "name": "Fitbit Activity Summary",
-      "occurrence": "t_fitbit_activity_summary_id"
+      "occurrences": "t_fitbit_activity_summary_id"
     },
     {
       "id": "_fitbit_steps_intraday_id",
       "name": "Fitbit Steps Intraday",
-      "occurrence": "t_fitbit_steps_intraday_id"
+      "occurrences": "t_fitbit_steps_intraday_id"
     },
     {
       "id": "_fitbit_heart_rate_summary_id",
       "name": "Fitbit Heart Rate Summary",
-      "occurrence": "t_fitbit_heart_rate_summary_id"
+      "occurrences": "t_fitbit_heart_rate_summary_id"
     },
     {
       "id": "_fitbit_heart_rate_level_id",
       "name": "Fitbit Heart Rate Level",
-      "occurrence": "t_fitbit_heart_rate_level_id"
+      "occurrences": "t_fitbit_heart_rate_level_id"
     },
     {
       "id": "_fitbit_sleep_daily_summary_id",
       "name": "Fitbit Sleep Daily Summary",
-      "occurrence": "t_fitbit_sleep_daily_summary_id"
+      "occurrences": "t_fitbit_sleep_daily_summary_id"
     },
     {
       "id": "_fitbit_sleep_level_id",
       "name": "Fitbit Sleep Level",
-      "occurrence": "t_fitbit_sleep_level_id"
+      "occurrences": "t_fitbit_sleep_level_id"
     }
   ],
   "criteriaSearchConfig": {
@@ -512,7 +512,7 @@
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "occurrences": "procedure_occurrence",
           "columns": [
             { "key": "procedure", "width": "100%", "title": "Procedure name" },
             { "key": "date", "width": 200, "title": "Date" }

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/ui/top_level.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/ui/top_level.json
@@ -171,7 +171,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classification": "condition",
       "modifiers": [
         "age_at_occurrence",
@@ -198,7 +198,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classification": "procedure",
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -216,7 +216,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classification": "observation",
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -239,7 +239,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classification": "ingredient",
       "modifiers": [
         "age_at_occurrence",
@@ -266,7 +266,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "measurement_occurrence",
+      "occurrences": "measurement_occurrence",
       "classification": "measurement",
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
@@ -425,37 +425,37 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_fitbit_actvity_summary_id",
       "name": "Fitbit Activity Summary",
-      "occurrence": "t_fitbit_activity_summary_id"
+      "occurrences": "t_fitbit_activity_summary_id"
     },
     {
       "id": "_fitbit_steps_intraday_id",
       "name": "Fitbit Steps Intraday",
-      "occurrence": "t_fitbit_steps_intraday_id"
+      "occurrences": "t_fitbit_steps_intraday_id"
     },
     {
       "id": "_fitbit_heart_rate_summary_id",
       "name": "Fitbit Heart Rate Summary",
-      "occurrence": "t_fitbit_heart_rate_summary_id"
+      "occurrences": "t_fitbit_heart_rate_summary_id"
     },
     {
       "id": "_fitbit_heart_rate_level_id",
       "name": "Fitbit Heart Rate Level",
-      "occurrence": "t_fitbit_heart_rate_level_id"
+      "occurrences": "t_fitbit_heart_rate_level_id"
     },
     {
       "id": "_fitbit_sleep_daily_summary_id",
       "name": "Fitbit Sleep Daily Summary",
-      "occurrence": "t_fitbit_sleep_daily_summary_id"
+      "occurrences": "t_fitbit_sleep_daily_summary_id"
     },
     {
       "id": "_fitbit_sleep_level_id",
       "name": "Fitbit Sleep Level",
-      "occurrence": "t_fitbit_sleep_level_id"
+      "occurrences": "t_fitbit_sleep_level_id"
     }
   ],
   "criteriaSearchConfig": {

--- a/service/src/main/resources/config/broad/aou_synthetic/ui/top_level.json
+++ b/service/src/main/resources/config/broad/aou_synthetic/ui/top_level.json
@@ -114,7 +114,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"]
     },
     {
@@ -136,7 +136,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"]
     },
     {
@@ -153,7 +153,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"]
     },
     {
@@ -175,7 +175,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"]
     },
     {
@@ -253,12 +253,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/service/src/main/resources/config/broad/cms_synpuf/ui/top_level.json
+++ b/service/src/main/resources/config/broad/cms_synpuf/ui/top_level.json
@@ -114,7 +114,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
@@ -140,7 +140,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
@@ -158,7 +158,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
@@ -181,7 +181,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
@@ -284,12 +284,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/service/src/main/resources/config/verily/aou_synthetic/ui/top_level.json
+++ b/service/src/main/resources/config/verily/aou_synthetic/ui/top_level.json
@@ -114,7 +114,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"]
     },
     {
@@ -136,7 +136,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"]
     },
     {
@@ -153,7 +153,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"]
     },
     {
@@ -175,7 +175,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"]
     },
     {
@@ -253,12 +253,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/service/src/main/resources/config/verily/cms_synpuf/ui/top_level.json
+++ b/service/src/main/resources/config/verily/cms_synpuf/ui/top_level.json
@@ -114,7 +114,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
@@ -140,7 +140,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
@@ -158,7 +158,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
@@ -181,7 +181,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
@@ -284,12 +284,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/service/src/main/resources/config/verily/pilot_synthea_2022q3/ui/top_level.json
+++ b/service/src/main/resources/config/verily/pilot_synthea_2022q3/ui/top_level.json
@@ -134,7 +134,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
@@ -161,7 +161,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -179,7 +179,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -202,7 +202,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
@@ -229,7 +229,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "measurement_occurrence",
+      "occurrences": "measurement_occurrence",
       "classifications": ["measurement"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
@@ -339,12 +339,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/service/src/main/resources/config/verily/sdd_refresh0323/ui/top_level.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/ui/top_level.json
@@ -110,9 +110,31 @@
             }
           },
           {
-            "id": "icd9proc",
+            "id": "phewas",
             "attribute": "source_criteria_id",
-            "entity": "icd9proc",
+            "entity": "phewas",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd9cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd10cm",
             "entityAttribute": "id",
             "hierarchy": "standard",
             "defaultSort": {
@@ -148,6 +170,50 @@
               "attribute": "t_rollup_count",
               "direction": "DESC"
             }
+          },
+          {
+            "id": "cpt4",
+            "attribute": "source_criteria_id",
+            "entity": "cpt4",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "phewas",
+            "attribute": "source_criteria_id",
+            "entity": "phewas",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd9cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd10cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
           }
         ]
       },
@@ -178,6 +244,17 @@
                 "attributes": ["name", "id", "standard_concept", "concept_code"]
               }
             ]
+          },
+          {
+            "id": "cpt4",
+            "attribute": "source_criteria_id",
+            "entity": "cpt4",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
           }
         ]
       },
@@ -214,6 +291,72 @@
               "attribute": "t_item_count",
               "direction": "DESC"
             }
+          },
+          {
+            "id": "cpt4",
+            "attribute": "source_criteria_id",
+            "entity": "cpt4",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "phewas",
+            "attribute": "source_criteria_id",
+            "entity": "phewas",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd9cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9proc",
+            "attribute": "source_criteria_id",
+            "entity": "icd9proc",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd10cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10pcs",
+            "attribute": "source_criteria_id",
+            "entity": "icd10pcs",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
           }
         ]
       }
@@ -232,7 +375,7 @@
         { "key": "name", "width": "100%", "title": "Genotyping platform" },
         { "key": "id", "width": 100, "title": "Id" }
       ],
-      "occurrence": "",
+      "occurrences": "",
       "classifications": ["genotyping"]
     },
     {
@@ -269,7 +412,7 @@
       "title": "SNP variant",
       "category": "Demographics",
       "columns": [{ "key": "name", "width": "100%", "title": "SNP variant" }],
-      "occurrence": "",
+      "occurrences": "",
       "classifications": ["snp"]
     },
     {
@@ -297,7 +440,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "measurement_occurrence",
+      "occurrences": "measurement_occurrence",
       "classifications": ["loinc", "snomed"],
       "classificationMergeSort": {
         "attribute": "t_item_count",
@@ -350,7 +493,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
@@ -376,7 +519,12 @@
         { "key": "id", "width": 120, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": [
+        "condition_occurrence",
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence"
+      ],
       "classifications": ["phewas"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -408,7 +556,12 @@
         { "key": "id", "width": 120, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": [
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence",
+        "ingredient_occurrence"
+      ],
       "classifications": ["cpt4"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -440,7 +593,12 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": [
+        "condition_occurrence",
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence"
+      ],
       "classifications": ["icd9cm"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -472,7 +630,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": ["procedure_occurrence"],
       "classifications": ["icd9proc"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -504,7 +662,12 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": [
+        "condition_occurrence",
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence"
+      ],
       "classifications": ["icd10cm"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -536,7 +699,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": ["procedure_occurrence", "ingredient_occurrence"],
       "classifications": ["icd10pcs"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -568,7 +731,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -587,7 +750,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -611,7 +774,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
@@ -687,12 +850,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/ui/top_level.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/ui/top_level.json
@@ -110,9 +110,31 @@
             }
           },
           {
-            "id": "icd9proc",
+            "id": "phewas",
             "attribute": "source_criteria_id",
-            "entity": "icd9proc",
+            "entity": "phewas",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd9cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd10cm",
             "entityAttribute": "id",
             "hierarchy": "standard",
             "defaultSort": {
@@ -148,6 +170,50 @@
               "attribute": "t_rollup_count",
               "direction": "DESC"
             }
+          },
+          {
+            "id": "cpt4",
+            "attribute": "source_criteria_id",
+            "entity": "cpt4",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "phewas",
+            "attribute": "source_criteria_id",
+            "entity": "phewas",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd9cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd10cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
           }
         ]
       },
@@ -178,6 +244,17 @@
                 "attributes": ["name", "id", "standard_concept", "concept_code"]
               }
             ]
+          },
+          {
+            "id": "cpt4",
+            "attribute": "source_criteria_id",
+            "entity": "cpt4",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
           }
         ]
       },
@@ -214,6 +291,72 @@
               "attribute": "t_item_count",
               "direction": "DESC"
             }
+          },
+          {
+            "id": "cpt4",
+            "attribute": "source_criteria_id",
+            "entity": "cpt4",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "phewas",
+            "attribute": "source_criteria_id",
+            "entity": "phewas",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd9cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd9proc",
+            "attribute": "source_criteria_id",
+            "entity": "icd9proc",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10cm",
+            "attribute": "source_criteria_id",
+            "entity": "icd10cm",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
+          },
+          {
+            "id": "icd10pcs",
+            "attribute": "source_criteria_id",
+            "entity": "icd10pcs",
+            "entityAttribute": "id",
+            "hierarchy": "standard",
+            "defaultSort": {
+              "attribute": "label",
+              "direction": "ASC"
+            }
           }
         ]
       }
@@ -232,7 +375,7 @@
         { "key": "name", "width": "100%", "title": "Genotyping platform" },
         { "key": "id", "width": 100, "title": "Id" }
       ],
-      "occurrence": "",
+      "occurrences": "",
       "classifications": ["genotyping"]
     },
     {
@@ -269,7 +412,7 @@
       "title": "SNP variant",
       "category": "Demographics",
       "columns": [{ "key": "name", "width": "100%", "title": "SNP variant" }],
-      "occurrence": "",
+      "occurrences": "",
       "classifications": ["snp"]
     },
     {
@@ -297,7 +440,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "measurement_occurrence",
+      "occurrences": "measurement_occurrence",
       "classifications": ["loinc", "snomed"],
       "classificationMergeSort": {
         "attribute": "t_item_count",
@@ -350,7 +493,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": "condition_occurrence",
       "classifications": ["condition"],
       "modifiers": [
         "age_at_occurrence",
@@ -376,7 +519,12 @@
         { "key": "id", "width": 120, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": [
+        "condition_occurrence",
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence"
+      ],
       "classifications": ["phewas"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -408,7 +556,12 @@
         { "key": "id", "width": 120, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": [
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence",
+        "ingredient_occurrence"
+      ],
       "classifications": ["cpt4"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -440,7 +593,12 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": [
+        "condition_occurrence",
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence"
+      ],
       "classifications": ["icd9cm"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -472,7 +630,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": ["procedure_occurrence"],
       "classifications": ["icd9proc"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -504,7 +662,12 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "condition_occurrence",
+      "occurrences": [
+        "condition_occurrence",
+        "measurement_occurrence",
+        "observation_occurrence",
+        "procedure_occurrence"
+      ],
       "classifications": ["icd10cm"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -536,7 +699,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": ["procedure_occurrence", "ingredient_occurrence"],
       "classifications": ["icd10pcs"],
       "defaultSort": {
         "attribute": "t_rollup_count",
@@ -568,7 +731,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "procedure_occurrence",
+      "occurrences": "procedure_occurrence",
       "classifications": ["procedure"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -587,7 +750,7 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "observation_occurrence",
+      "occurrences": "observation_occurrence",
       "classifications": ["observation"],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
@@ -611,7 +774,7 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "classifications": ["ingredient"],
       "modifiers": [
         "age_at_occurrence",
@@ -687,12 +850,12 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "occurrences": ""
     },
     {
       "id": "_analgesics",
       "name": "Analgesics",
-      "occurrence": "ingredient_occurrence",
+      "occurrences": "ingredient_occurrence",
       "filter": {
         "type": "CLASSIFICATION",
         "occurrenceId": "ingredient_occurrence",

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -52,33 +52,43 @@ function generateSectionFilter(
 
 function generateGroupSectionFilter(group: tanagraUI.UIGroup): Filter | null {
   const plugins = group.criteria.map((c) => getCriteriaPlugin(c));
-  const filter = makeArrayFilter(
-    {},
-    plugins.map((p) => p.generateFilter()).filter(isValid)
-  );
-
-  if (!filter || !group.entity) {
-    return filter;
-  }
-
-  const groupByCountFilters = plugins
-    .map((p) => p.groupByCountFilter?.())
-    .filter(isValid);
-  if (groupByCountFilters.length > 1) {
-    throw new Error(
-      `Criteria groups may not have multiple group by count filters: ${JSON.stringify(
-        groupByCountFilters
-      )}`
+  // TODO(tjennison): Multiple occurrence: Store entities in an array instead of
+  // a string.
+  const entityFilters = group.entity.split(",").map((entity) => {
+    // TODO(tjennison): Multiple occurrence: This should be using the occurrence
+    // that matches the entity of this iteration so we need to store occurrences
+    // instead of entities in groups.
+    const filter = makeArrayFilter(
+      {},
+      plugins
+        .map((p) => p.generateFilter(p.filterOccurrenceIds()[0]))
+        .filter(isValid)
     );
-  }
 
-  return {
-    type: FilterType.Relationship,
-    entityId: group.entity,
-    subfilter: filter,
-    groupByCount:
-      groupByCountFilters.length > 0 ? groupByCountFilters[0] : undefined,
-  };
+    if (!filter || !entity) {
+      return filter;
+    }
+
+    const groupByCountFilters = plugins
+      .map((p) => p.groupByCountFilter?.())
+      .filter(isValid);
+    if (groupByCountFilters.length > 1) {
+      throw new Error(
+        `Criteria groups may not have multiple group by count filters: ${JSON.stringify(
+          groupByCountFilters
+        )}`
+      );
+    }
+
+    return {
+      type: FilterType.Relationship,
+      entityId: entity,
+      subfilter: filter,
+      groupByCount:
+        groupByCountFilters.length > 0 ? groupByCountFilters[0] : undefined,
+    };
+  });
+  return makeArrayFilter({ min: 1 }, entityFilters);
 }
 
 export function sectionName(section: tanagraUI.UIGroupSection, index: number) {
@@ -101,9 +111,13 @@ export function defaultSection(
 export function defaultGroup(
   criteria: tanagraUI.UICriteria
 ): tanagraUI.UIGroup {
+  // TODO(tjennison): Multiple occurrence: This should be using the occurrence
+  // that matches the entity of this iteration so we need to store occurrences
+  // instead of entities in groups. It should also be storing them as an array
+  // instead of a string.
   return {
     id: criteria.id,
-    entity: getCriteriaPlugin(criteria).filterOccurrenceId(),
+    entity: getCriteriaPlugin(criteria).filterOccurrenceIds().join(","),
     criteria: [criteria],
   };
 }
@@ -124,9 +138,9 @@ export interface CriteriaPlugin<DataType> {
   ) => JSX.Element;
   renderInline: (groupId: string) => ReactNode;
   displayDetails: () => DisplayDetails;
-  generateFilter: () => Filter | null;
+  generateFilter: (occurrenceId: string) => Filter | null;
   groupByCountFilter?: () => tanagraUI.UIGroupByCount | null;
-  filterOccurrenceId: () => string;
+  filterOccurrenceIds: () => string[];
   outputOccurrenceIds?: () => string[];
 }
 

--- a/ui/src/cohortReview/cohortReview.tsx
+++ b/ui/src/cohortReview/cohortReview.tsx
@@ -136,7 +136,6 @@ export function CohortReview() {
             id,
             {
               type: FilterType.Attribute,
-              occurrenceId: "",
               attribute: "id",
               values: [instance?.data?.[primaryKey]],
             },

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -117,8 +117,8 @@ class _ implements CriteriaPlugin<Data> {
     };
   }
 
-  filterOccurrenceId() {
-    return "";
+  filterOccurrenceIds() {
+    return [""];
   }
 }
 

--- a/ui/src/criteria/textSearch.tsx
+++ b/ui/src/criteria/textSearch.tsx
@@ -105,8 +105,8 @@ class _ implements CriteriaPlugin<Data> {
     ]);
   }
 
-  filterOccurrenceId() {
-    return this.config.occurrenceId;
+  filterOccurrenceIds() {
+    return [this.config.occurrenceId];
   }
 }
 

--- a/ui/src/criteria/unhintedValue.tsx
+++ b/ui/src/criteria/unhintedValue.tsx
@@ -109,8 +109,8 @@ class _ implements CriteriaPlugin<Data> {
     };
   }
 
-  filterOccurrenceId() {
-    return this.config.attribute ?? "";
+  filterOccurrenceIds() {
+    return [this.config.attribute ?? ""];
   }
 }
 

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -878,7 +878,7 @@ export class BackendSource implements Source {
             underlayName,
             criteria: toAPICriteria(criteria),
             entity: findEntity(
-              getCriteriaPlugin(criteria).filterOccurrenceId(),
+              getCriteriaPlugin(criteria).filterOccurrenceIds()[0],
               this.config
             ).entity,
           },

--- a/ui/src/datasets.tsx
+++ b/ui/src/datasets.tsx
@@ -484,11 +484,10 @@ function useConceptSetOccurrences(
       ?.filter((cs) => selectedConceptSets.has(cs.id))
       ?.forEach((conceptSet) => {
         const plugin = getCriteriaPlugin(conceptSet.criteria);
-        const occurrenceIds = plugin.outputOccurrenceIds?.() ?? [
-          plugin.filterOccurrenceId(),
-        ];
+        const occurrenceIds =
+          plugin.outputOccurrenceIds?.() ?? plugin.filterOccurrenceIds();
         occurrenceIds.forEach((o) => {
-          addFilter(o, plugin.generateFilter());
+          addFilter(o, plugin.generateFilter(o));
         });
       });
 

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -435,7 +435,9 @@ function ParticipantsGroup(props: {
   const modifierPlugins = useMemo(
     () =>
       modifierCriteria.map((c) => {
-        const p = getCriteriaPlugin(c, props.group.entity);
+        // TODO: Multiple occurrence: Store entities in an array instead of a
+        // string.
+        const p = getCriteriaPlugin(c, props.group.entity.split(",")[0]);
         return { title: getCriteriaTitle(c, p), plugin: p };
       }),
     [modifierCriteria, props.group.entity]

--- a/ui/src/plugins/vumc/biovu.tsx
+++ b/ui/src/plugins/vumc/biovu.tsx
@@ -167,8 +167,8 @@ class _ implements CriteriaPlugin<Data> {
     return makeArrayFilter({}, filters);
   }
 
-  filterOccurrenceId() {
-    return "";
+  filterOccurrenceIds() {
+    return [""];
   }
 }
 


### PR DESCRIPTION
* Adds multiple occurrence support for source criteria.
* Fixes incorrect rollup counts for source criteria.
* All possible output tables are shown, even if empty. TBD if there should be different behavior or messaging there.
* Some places in the code use the first occurrence in a list, basically assuming that all can be used interchangeably. This is potentially incorrect, especially when it comes to modifiers. Some discussion will be needed around what exactly our data model should look like in order to resolve these inconcistencies.
* The CriteriaGroup entity field is being used to store all occurrences as a comma separated list. It should maybe be the entity group instead but that's something to discuss and improve as part of the above discussion.