### PR TITLE
updated source/index dataset names for sd-vumc-tanagra-test env

### DIFF
--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sdd_refresh0323.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sdd_refresh0323.json
@@ -3,17 +3,17 @@
   "dataPointers": [
     { "type": "BQ_DATASET",
       "name": "omop_dataset",
-      "projectId": "victr-tanagra-test",
-      "dataflowRegion" : "us-east1",
+      "projectId": "sd-vumc-tanagra-test",
+      "dataflowRegion" : "us-central1",
       "datasetId": "sd_20230328"
     },
     { "type": "BQ_DATASET",
       "name": "index_dataset",
-      "projectId": "victr-tanagra-deploytest",
-      "datasetId": "sd_20230328_indexes",
-      "dataflowServiceAccountEmail": "victr-tanagra-deploytest@appspot.gserviceaccount.com",
-      "dataflowTempLocation":  "gs://dataflow-indexing-victr-tanagra-deploytest/temp/",
-      "dataflowRegion": "us-east1",
+      "projectId": "sd-vumc-tanagra-test",
+      "datasetId": "indexed_sd_20230328",
+      "dataflowServiceAccountEmail": "sd-test-dataflow-index-admin@sd-vumc-tanagra-test.iam.gserviceaccount.com",
+      "dataflowTempLocation":  "gs://dataflow-indexing-sd-test-tanagra/temp/",
+      "dataflowRegion": "us-central1",
       "dataflowWorkerMachineType" : "n1-standard-4",
       "dataflowUsePublicIps": false
     }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/brand_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/brand_all.sql
@@ -1,5 +1,5 @@
 SELECT *
-FROM `victr-tanagra-test.sd_20230328.concept`
+FROM `sd-vumc-tanagra-test.sd_20230328.concept`
 WHERE
   domain_id = 'Drug' AND concept_class_id = 'Brand Name'
   AND vocabulary_id IN ('RxNorm', 'RxNorm Extension')

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/brand_ingredients.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/brand_ingredients.sql
@@ -11,7 +11,7 @@
 */
 SELECT cr.*
 FROM
-    `victr-tanagra-test.sd_20230328.concept_relationship` cr,
-    `victr-tanagra-test.sd_20230328.concept` c2
+    `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr,
+    `sd-vumc-tanagra-test.sd_20230328.concept` c2
 WHERE
     cr.concept_id_2 = c2.concept_id AND c2.concept_class_id = 'Ingredient'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/brand_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/brand_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Drug'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/condition_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/condition_occurrence_all.sql
@@ -5,10 +5,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(co.condition_start_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   co.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.condition_occurrence` AS co
+FROM `sd-vumc-tanagra-test.sd_20230328.condition_occurrence` AS co
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = co.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = co.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/condition_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/condition_parentChild.sql
@@ -1,9 +1,9 @@
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.domain_id = c2.domain_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/condition_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/condition_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Condition'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_all.sql
@@ -5,9 +5,9 @@ SELECT
     pc.type, pc.is_standard, pc.code,
     CASE WHEN pc.code IS NULL THEN pc.name ELSE CONCAT(pc.code, ' ', pc.name) END AS label
 
-FROM `victr-tanagra-test.aou_static_prep.prep_cpt` pc
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` pc
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.concept` c
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = pc.concept_id
 AND c.vocabulary_id = pc.type
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_ingredientOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_ingredientOccurrence.sql
@@ -1,7 +1,7 @@
 SELECT io.drug_exposure_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.drug_exposure` AS io
+FROM `sd-vumc-tanagra-test.sd_20230328.drug_exposure` AS io
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = io.drug_source_concept_id
 
 WHERE pc.type = 'CPT4'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_measurementOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_measurementOccurrence.sql
@@ -1,7 +1,7 @@
 SELECT mo.measurement_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = mo.measurement_source_concept_id
 
 WHERE pc.type = 'CPT4'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_observationOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_observationOccurrence.sql
@@ -1,7 +1,7 @@
 SELECT oo.observation_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.observation` AS oo
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS oo
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = oo.observation_source_concept_id
 
 WHERE pc.type = 'CPT4'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_parentChild.sql
@@ -2,7 +2,7 @@ SELECT
     pc.id AS child,
     pc.parent_id AS parent
 
-FROM `victr-tanagra-test.aou_static_prep.prep_cpt` pc
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` pc
 
 WHERE pc.type = 'CPT4'
 AND pc.parent_id != 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_person.sql
@@ -1,7 +1,7 @@
 SELECT po.person_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = po.procedure_source_concept_id
 
 WHERE pc.type = 'CPT4'
@@ -9,9 +9,9 @@ WHERE pc.type = 'CPT4'
 UNION ALL
 
 SELECT mo.person_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = mo.measurement_source_concept_id
 
 WHERE pc.type = 'CPT4'
@@ -19,9 +19,9 @@ WHERE pc.type = 'CPT4'
 UNION ALL
 
 SELECT oo.person_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.observation` AS oo
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS oo
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = oo.observation_source_concept_id
 
 WHERE pc.type = 'CPT4'
@@ -29,9 +29,9 @@ WHERE pc.type = 'CPT4'
 UNION ALL
 
 SELECT io.person_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.drug_exposure` AS io
+FROM `sd-vumc-tanagra-test.sd_20230328.drug_exposure` AS io
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = io.drug_source_concept_id
 
 WHERE pc.type = 'CPT4'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_procedureOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_procedureOccurrence.sql
@@ -1,7 +1,7 @@
 SELECT po.procedure_occurrence_id, pc.id AS cpt4_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.aou_static_prep.prep_cpt` AS pc
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` AS pc
 ON pc.concept_id = po.procedure_source_concept_id
 
 WHERE pc.type = 'CPT4'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_rootNodesFilter.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/cpt4_rootNodesFilter.sql
@@ -1,5 +1,5 @@
 SELECT pc.id
 
-FROM `victr-tanagra-test.aou_static_prep.prep_cpt` pc
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_cpt` pc
 
 WHERE pc.type = 'CPT4' AND pc.parent_id = 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/device_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/device_occurrence_all.sql
@@ -5,10 +5,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(de.device_exposure_start_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   de.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.device_exposure` AS de
+FROM `sd-vumc-tanagra-test.sd_20230328.device_exposure` AS de
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = de.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/device_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/device_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Device'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotype_result.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotype_result.sql
@@ -3,4 +3,4 @@
  Currently indexing doesn't handle floats properly, so change column to INTEGER.
 */
 SELECT genotype_result_id AS genotype_result_id, person_id, CAST(platform_id as INT64) as platform_id
-FROM `victr-tanagra-test.sd_20230328.x_genotype_result`
+FROM `sd-vumc-tanagra-test.sd_20230328.x_genotype_result`

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_all.sql
@@ -3,7 +3,7 @@
  Currently indexing doesn't handle floats properly, so change column to INTEGER.
 */
 SELECT CAST(platform_id as INT64) AS platform_id, assay_name as assay_name
-FROM `victr-tanagra-test.sd_20230328.platform`
+FROM `sd-vumc-tanagra-test.sd_20230328.platform`
 UNION ALL
 /*
  Add some rows to get hierarchy to work. Parent ids are defined in

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_parentChild.sql
@@ -2,5 +2,5 @@ SELECT
 /* Use parent ids defined in platform.sql */
     parent_seq + 100 AS parent,
     CAST(platform_id as INT64) AS child
-FROM `victr-tanagra-test.sd_20230328.genotype_criteria` g, `victr-tanagra-test.sd_20230328.platform` p
+FROM `sd-vumc-tanagra-test.sd_20230328.genotype_criteria` g, `sd-vumc-tanagra-test.sd_20230328.platform` p
 WHERE g.name = p.assay_name

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10cm_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10cm_all.sql
@@ -1,6 +1,6 @@
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.sd_20230328.concept`
+FROM `sd-vumc-tanagra-test.sd_20230328.concept`
 WHERE
   vocabulary_id = 'ICD10CM'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0
@@ -9,7 +9,7 @@ UNION ALL
 
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.aou_static_prep.prep_concept`
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept`
 WHERE
   vocabulary_id = 'ICD10CM'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10cm_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10cm_parentChild.sql
@@ -4,9 +4,9 @@ Relationships between levels 1 and 2, which includes the AoU/VUMC-defined organi
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.aou_static_prep.prep_concept_relationship` cr
-JOIN `victr-tanagra-test.aou_static_prep.prep_concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.aou_static_prep.prep_concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id
@@ -20,8 +20,8 @@ Relationships between levels 2 and 3, which is the link between the standard ICD
 SELECT
     p.concept_id AS parent,
     c.concept_id AS child
-FROM `victr-tanagra-test.aou_static_prep.prep_concept` p
-LEFT JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept` p
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
     ON c.vocabulary_id = p.vocabulary_id
     AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([a-zA-Z0-9]+)-'))
     AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([a-zA-Z0-9]+)$'))
@@ -36,9 +36,9 @@ Relationships between levels 3+, which includes the standard ICD-10-CM defined c
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10cm_person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10cm_person.sql
@@ -1,7 +1,7 @@
 SELECT co.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.condition_occurrence` AS co
+FROM `sd-vumc-tanagra-test.sd_20230328.condition_occurrence` AS co
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = co.condition_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD10CM'
@@ -9,9 +9,9 @@ WHERE c.vocabulary_id = 'ICD10CM'
 UNION ALL
 
 SELECT mo.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = mo.measurement_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD10CM'
@@ -19,9 +19,9 @@ WHERE c.vocabulary_id = 'ICD10CM'
 UNION ALL
 
 SELECT oo.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.observation` AS oo
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS oo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = oo.observation_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD10CM'
@@ -29,9 +29,9 @@ WHERE c.vocabulary_id = 'ICD10CM'
 UNION ALL
 
 SELECT po.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = po.procedure_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD10CM'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10pcs_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10pcs_all.sql
@@ -1,6 +1,6 @@
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.sd_20230328.concept`
+FROM `sd-vumc-tanagra-test.sd_20230328.concept`
 WHERE
   vocabulary_id = 'ICD10PCS'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0
@@ -9,7 +9,7 @@ UNION ALL
 
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.aou_static_prep.prep_concept`
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept`
 WHERE
   vocabulary_id = 'ICD10PCS'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10pcs_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10pcs_parentChild.sql
@@ -4,14 +4,14 @@ Relationships between levels 1 and 2, which is the link between the standard ICD
 SELECT
     2500000022 AS parent,
     c.concept_id AS child
-FROM `victr-tanagra-test.sd_20230328.concept` AS c
+FROM `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 WHERE
     c.vocabulary_id = 'ICD10PCS'
     AND c.domain_id = 'Procedure'
     AND DATE_DIFF(CAST(c.valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0
     AND NOT EXISTS (
       SELECT cr.concept_id_1
-      FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
+      FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
       WHERE cr.concept_id_2 = c.concept_id
           AND cr.relationship_id = 'Subsumes'
     )
@@ -24,9 +24,9 @@ Relationships between levels 2+, which includes the standard ICD-10-PCS defined 
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10pcs_person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd10pcs_person.sql
@@ -1,7 +1,7 @@
 SELECT po.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = po.procedure_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD10PCS'
@@ -9,9 +9,9 @@ WHERE c.vocabulary_id = 'ICD10PCS'
 UNION ALL
 
 SELECT io.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.drug_exposure` AS io
+FROM `sd-vumc-tanagra-test.sd_20230328.drug_exposure` AS io
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = io.drug_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD10PCS'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_all.sql
@@ -1,6 +1,6 @@
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.sd_20230328.concept`
+FROM `sd-vumc-tanagra-test.sd_20230328.concept`
 WHERE
   vocabulary_id = 'ICD9CM'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0
@@ -9,7 +9,7 @@ UNION ALL
 
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.aou_static_prep.prep_concept`
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept`
 WHERE
   vocabulary_id = 'ICD9CM'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_parentChild.sql
@@ -4,9 +4,9 @@ Relationships between levels 1 and 2, which includes the AoU/VUMC-defined organi
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.aou_static_prep.prep_concept_relationship` cr
-JOIN `victr-tanagra-test.aou_static_prep.prep_concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.aou_static_prep.prep_concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id
@@ -20,8 +20,8 @@ Relationships between levels 2 and 3, which is the link between the standard ICD
 SELECT
     p.concept_id AS parent,
     c.concept_id AS child
-FROM `victr-tanagra-test.aou_static_prep.prep_concept` p
-LEFT JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept` p
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
     ON c.vocabulary_id = p.vocabulary_id
     AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([a-zA-Z0-9\.]+)-'))
     AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([a-zA-Z0-9\.]+)$'))
@@ -36,9 +36,9 @@ Relationships between levels 3+, which includes the standard ICD-9-CM defined co
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9cm_person.sql
@@ -1,7 +1,7 @@
 SELECT co.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.condition_occurrence` AS co
+FROM `sd-vumc-tanagra-test.sd_20230328.condition_occurrence` AS co
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = co.condition_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD9CM'
@@ -9,9 +9,9 @@ WHERE c.vocabulary_id = 'ICD9CM'
 UNION ALL
 
 SELECT mo.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = mo.measurement_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD9CM'
@@ -19,9 +19,9 @@ WHERE c.vocabulary_id = 'ICD9CM'
 UNION ALL
 
 SELECT oo.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.observation` AS oo
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS oo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = oo.observation_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD9CM'
@@ -29,9 +29,9 @@ WHERE c.vocabulary_id = 'ICD9CM'
 UNION ALL
 
 SELECT po.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = po.procedure_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD9CM'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9proc_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9proc_all.sql
@@ -1,6 +1,6 @@
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.sd_20230328.concept`
+FROM `sd-vumc-tanagra-test.sd_20230328.concept`
 WHERE
   vocabulary_id = 'ICD9Proc'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0
@@ -9,7 +9,7 @@ UNION ALL
 
 SELECT concept_id, concept_name, vocabulary_id, standard_concept, concept_code,
 CASE WHEN concept_code IS NULL THEN concept_name ELSE CONCAT(concept_code, ' ', concept_name) END AS label
-FROM `victr-tanagra-test.aou_static_prep.prep_concept`
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept`
 WHERE
   vocabulary_id = 'ICD9Proc'
   AND DATE_DIFF(CAST(valid_end_date AS DATE), CURRENT_DATE(), DAY) > 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9proc_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9proc_parentChild.sql
@@ -4,9 +4,9 @@ Relationships between levels 1 and 2, which includes the AoU/VUMC-defined organi
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.aou_static_prep.prep_concept_relationship` cr
-JOIN `victr-tanagra-test.aou_static_prep.prep_concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.aou_static_prep.prep_concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.aou_static_prep.prep_concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id
@@ -20,8 +20,8 @@ Relationships between levels 2 and 3, which is the link between the standard ICD
 SELECT
     p.concept_id AS parent,
     c.concept_id AS child
-FROM `victr-tanagra-test.aou_static_prep.prep_concept` p
-LEFT JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+FROM `sd-vumc-tanagra-test.aou_static_prep.prep_concept` p
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
     ON c.vocabulary_id = p.vocabulary_id
     AND UPPER(c.concept_code) >= UPPER(REGEXP_EXTRACT(p.concept_code, r'^([0-9\.]+)-'))
     AND UPPER(c.concept_code) <= UPPER(REGEXP_EXTRACT(p.concept_code, r'-([0-9\.]+)$'))
@@ -36,9 +36,9 @@ Relationships between levels 3 and 4, which is the first level in the standard I
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id
@@ -54,8 +54,8 @@ Relationships between levels 4+, which are the remaining levels in the standard 
 SELECT
   p.concept_id AS parent,
   c.concept_id AS child,
-FROM `victr-tanagra-test.sd_20230328.concept` p
-LEFT JOIN `victr-tanagra-test.sd_20230328.concept` c
+FROM `sd-vumc-tanagra-test.sd_20230328.concept` p
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
     ON c.vocabulary_id = p.vocabulary_id
     AND STARTS_WITH(c.concept_code, p.concept_code)
 WHERE

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9proc_person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/icd9proc_person.sql
@@ -1,7 +1,7 @@
 SELECT po.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = po.procedure_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD9Proc'
@@ -9,9 +9,9 @@ WHERE c.vocabulary_id = 'ICD9Proc'
 UNION ALL
 
 SELECT io.person_id, c.concept_id
-FROM `victr-tanagra-test.sd_20230328.drug_exposure` AS io
+FROM `sd-vumc-tanagra-test.sd_20230328.drug_exposure` AS io
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = io.drug_source_concept_id
 
 WHERE c.vocabulary_id = 'ICD9Proc'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_all.sql
@@ -1,6 +1,6 @@
 SELECT
   c.concept_id AS id, c.concept_name AS name, c.vocabulary_id, c.standard_concept, c.concept_code
-FROM `victr-tanagra-test.sd_20230328.concept` c
+FROM `sd-vumc-tanagra-test.sd_20230328.concept` c
 WHERE c.domain_id = 'Drug'
 AND (
     (c.vocabulary_id = 'ATC' AND c.standard_concept = 'C')

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_occurrence_all.sql
@@ -6,10 +6,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(de.drug_exposure_start_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   de.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.drug_exposure` AS de
+FROM `sd-vumc-tanagra-test.sd_20230328.drug_exposure` AS de
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = de.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_parentChild.sql
@@ -1,9 +1,9 @@
 SELECT
     cr.concept_id_1 AS parent,
     cr.concept_id_2 AS child
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1 ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2 ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1 ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2 ON c2.concept_id = cr.concept_id_2
 WHERE
     c1.concept_id != c2.concept_id
     AND c1.domain_id = 'Drug' AND c2.domain_id = 'Drug'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/ingredient_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Drug'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementLoinc_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementLoinc_parentChild.sql
@@ -1,9 +1,9 @@
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementLoinc_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementLoinc_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.vocabulary_id = 'LOINC' AND c.concept_class_id IN ('LOINC Hierarchy', 'LOINC Component', 'Lab Test')

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementSnomed_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementSnomed_parentChild.sql
@@ -1,9 +1,9 @@
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.vocabulary_id = c2.vocabulary_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementSnomed_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurementSnomed_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Measurement' AND c.vocabulary_id = 'SNOMED'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/measurement_occurrence_all.sql
@@ -5,10 +5,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(mo.measurement_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   mo.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = mo.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = mo.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/note_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/note_occurrence_all.sql
@@ -5,10 +5,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(n.note_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   n.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.note` AS n
+FROM `sd-vumc-tanagra-test.sd_20230328.note` AS n
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = n.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = n.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/note_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/note_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.vocabulary_id IN ('Note Type', 'VUMC Note Type', 'VUMC PSS Type')

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/observation_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/observation_occurrence_all.sql
@@ -5,10 +5,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(o.observation_date, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   o.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.observation` AS o
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS o
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = o.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = o.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/observation_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/observation_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Observation'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/person.sql
@@ -5,14 +5,14 @@ SELECT
     /* Add BioVU sample columns. The way x_biovu_sample_status is created, there should be at
        most one row per person. */
     EXISTS
-        (SELECT 1 FROM `victr-tanagra-test.sd_20230328.x_biovu_sample_status` x WHERE p.person_id = x.person_id)
+        (SELECT 1 FROM `sd-vumc-tanagra-test.sd_20230328.x_biovu_sample_status` x WHERE p.person_id = x.person_id)
                                                                                                         AS has_biovu_sample,
     x.dna_yield_ind AS biovu_sample_dna_yield,
     /* As a courtesy, convert string fields to boolean: 0 -> No, 1 -> Yes */
     CASE WHEN x.compromise_ind = '1' THEN true WHEN x.compromise_ind = '0' THEN false ELSE null END AS biovu_sample_is_compromised,
     CASE WHEN x.nonshippable_ind = '1' THEN true WHEN x.nonshippable_ind = '0' THEN false ELSE null END AS biovu_sample_is_nonshippable,
     CASE WHEN x.plasma_ind = '1' THEN true WHEN x.plasma_ind = '0' THEN false ELSE null END AS biovu_sample_has_plasma
-FROM `victr-tanagra-test.sd_20230328.person` p
+FROM `sd-vumc-tanagra-test.sd_20230328.person` p
     LEFT OUTER JOIN
         (
             /* Get rid of duplicate rows in x_biovu_sample_status. For example, person
@@ -21,7 +21,7 @@ FROM `victr-tanagra-test.sd_20230328.person` p
                 SELECT
                 *,
                 ROW_NUMBER() OVER(PARTITION BY person_id) AS rn
-                FROM `victr-tanagra-test.sd_20230328.x_biovu_sample_status`
+                FROM `sd-vumc-tanagra-test.sd_20230328.x_biovu_sample_status`
             )
             SELECT * FROM x_biovu_sample_status WHERE rn = 1
         ) x

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_all.sql
@@ -3,4 +3,4 @@ SELECT
     REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code,
     REGEXP_EXTRACT(label, r'^PHEWAS_[0-9.]+-(.*)') AS display_name,
     REGEXP_EXTRACT(label, r'^PHEWAS_(.*)') AS label,
-FROM `victr-tanagra-test.sd_20230328.phewas_criteria`
+FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria`

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_conditionOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_conditionOccurrence.sql
@@ -1,15 +1,15 @@
 SELECT co.condition_occurrence_id, co.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.condition_occurrence` AS co
+FROM `sd-vumc-tanagra-test.sd_20230328.condition_occurrence` AS co
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = co.condition_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_measurementOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_measurementOccurrence.sql
@@ -1,15 +1,15 @@
 SELECT mo.measurement_id AS measurement_occurrence_id, mo.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = mo.measurement_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_observationOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_observationOccurrence.sql
@@ -1,15 +1,15 @@
 SELECT oo.observation_id AS observation_occurrence_id, oo.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.observation` AS oo
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS oo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = oo.observation_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_parentChild.sql
@@ -1,3 +1,3 @@
 SELECT criteria_meta_seq AS child, parent_seq AS parent
-FROM `victr-tanagra-test.sd_20230328.phewas_criteria`
+FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria`
 WHERE parent_seq != 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_person.sql
@@ -1,15 +1,15 @@
 SELECT co.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.condition_occurrence` AS co
+FROM `sd-vumc-tanagra-test.sd_20230328.condition_occurrence` AS co
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = co.condition_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 
@@ -19,17 +19,17 @@ AND c.vocabulary_id IN ('ICD9CM', 'ICD9Proc')
 UNION ALL
 
 SELECT mo.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.measurement` AS mo
+FROM `sd-vumc-tanagra-test.sd_20230328.measurement` AS mo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = mo.measurement_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 
@@ -39,17 +39,17 @@ AND c.vocabulary_id IN ('ICD9CM', 'ICD9Proc')
 UNION ALL
 
 SELECT oo.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.observation` AS oo
+FROM `sd-vumc-tanagra-test.sd_20230328.observation` AS oo
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = oo.observation_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 
@@ -59,17 +59,17 @@ AND c.vocabulary_id IN ('ICD9CM', 'ICD9Proc')
 UNION ALL
 
 SELECT po.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = po.procedure_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_procedureOccurrence.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/phewas_procedureOccurrence.sql
@@ -1,15 +1,15 @@
 SELECT po.procedure_occurrence_id, po.person_id, phewas.id AS phewas_id
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.concept` AS c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` AS c
 ON c.concept_id = po.procedure_source_concept_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.phewas_criteria_icd` AS pci
 ON pci.icd9_code = c.concept_code
 
 LEFT JOIN (
     SELECT criteria_meta_seq AS id, REGEXP_EXTRACT(label, r'^PHEWAS_([0-9.]+)-') AS code
-    FROM `victr-tanagra-test.sd_20230328.phewas_criteria` AS pc
+    FROM `sd-vumc-tanagra-test.sd_20230328.phewas_criteria` AS pc
 ) phewas
 ON phewas.code = pci.phewas_code
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/procedure_occurrence_all.sql
@@ -4,10 +4,10 @@ SELECT
   CAST(FLOOR(TIMESTAMP_DIFF(po.procedure_date, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
   po.visit_occurrence_id, vo.visit_concept_id
 
-FROM `victr-tanagra-test.sd_20230328.procedure_occurrence` AS po
+FROM `sd-vumc-tanagra-test.sd_20230328.procedure_occurrence` AS po
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = po.person_id
 
-LEFT JOIN `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+LEFT JOIN `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = po.visit_occurrence_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/procedure_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/procedure_parentChild.sql
@@ -1,9 +1,9 @@
 SELECT
   cr.concept_id_1 AS parent,
   cr.concept_id_2 AS child,
-FROM `victr-tanagra-test.sd_20230328.concept_relationship` cr
-JOIN `victr-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
-JOIN `victr-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
+FROM `sd-vumc-tanagra-test.sd_20230328.concept_relationship` cr
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c1  ON c1.concept_id = cr.concept_id_1
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c2  ON c2.concept_id = cr.concept_id_2
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.domain_id = c2.domain_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/procedure_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/procedure_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Procedure'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/snp_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/snp_all.sql
@@ -1,5 +1,5 @@
 SELECT crit_noid.snp_id, ROW_NUMBER() OVER (ORDER BY crit_noid.snp_id) AS row_num
 FROM (
 SELECT DISTINCT snp_id
-FROM `victr-tanagra-test.sd_20230328.x_snp`
+FROM `sd-vumc-tanagra-test.sd_20230328.x_snp`
 ) AS crit_noid

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/snp_occurrence_all.sql-e-e-e
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/snp_occurrence_all.sql-e-e-e
@@ -1,12 +1,12 @@
 SELECT crit.row_num, occ.snp_id, occ.person_id
 
-FROM `sd-vumc-tanagra-test.sd_20230328.x_snp` AS occ
+FROM `victr-tanagra-test.sd_20230328.x_snp` AS occ
 
 JOIN (
   SELECT crit_noid.snp_id, ROW_NUMBER() OVER (ORDER BY crit_noid.snp_id) AS row_num
   FROM (
     SELECT DISTINCT snp_id
-    FROM `sd-vumc-tanagra-test.sd_20230328.x_snp`
+    FROM `victr-tanagra-test.sd_20230328.x_snp`
   ) AS crit_noid
 ) AS crit
 ON crit.snp_id = occ.snp_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/visit_occurrence_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/visit_occurrence_all.sql
@@ -4,7 +4,7 @@ SELECT
   vo.visit_source_value AS source_value, vo.visit_source_concept_id AS source_criteria_id,
   CAST(FLOOR(TIMESTAMP_DIFF(vo.visit_start_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence
 
-FROM `victr-tanagra-test.sd_20230328.visit_occurrence` AS vo
+FROM `sd-vumc-tanagra-test.sd_20230328.visit_occurrence` AS vo
 
-JOIN `victr-tanagra-test.sd_20230328.person` AS p
+JOIN `sd-vumc-tanagra-test.sd_20230328.person` AS p
 ON p.person_id = vo.person_id

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/visit_textSearch.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/visit_textSearch.sql
@@ -2,22 +2,22 @@ SELECT textsearch.id, textsearch.text FROM (
 
     SELECT
       c.concept_id AS id, c.concept_name AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, CAST(c.concept_id AS STRING) AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 
     UNION ALL
 
     SELECT
       c.concept_id AS id, c.concept_code AS text
-    FROM  `victr-tanagra-test.sd_20230328.concept` c
+    FROM  `sd-vumc-tanagra-test.sd_20230328.concept` c
 ) AS textsearch
 
-JOIN `victr-tanagra-test.sd_20230328.concept` c
+JOIN `sd-vumc-tanagra-test.sd_20230328.concept` c
 ON c.concept_id = textsearch.id
 
 WHERE c.domain_id = 'Visit'


### PR DESCRIPTION
I have renamed the references to the source/index datasets and projects from the deprecated <project_id>.<dataset> to our current names.