### PR TITLE
Fix missing root node in genotyping hierarchy.

### DIFF
--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/genotyping.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/genotyping.json
@@ -19,9 +19,6 @@
         "childParent": {
           "tablePointer": { "rawSqlFile": "genotyping_parentChild.sql" }
         },
-        "rootNodesFilter": {
-          "tablePointer": { "rawSqlFile": "genotyping_rootNodesFilter.sql" }
-        },
         "maxHierarchyDepth": 1
       }
     }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entitygroup/genotyping_person.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entitygroup/genotyping_person.json
@@ -7,7 +7,7 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "groupToItems": {
-        "idPairsTable": { "table": "x_genotype_result" },
+        "idPairsTable": { "rawSqlFile": "genotype_result.sql" },
         "idPairsIdA": { "column": "platform_id" },
         "idPairsIdB":  { "column": "person_id" }
       }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entitygroup/genotyping_person.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entitygroup/genotyping_person.json
@@ -7,7 +7,7 @@
     "dataPointer": "omop_dataset",
     "relationshipMappings": {
       "groupToItems": {
-        "idPairsTable": { "rawSqlFile": "genotype_result.sql" },
+        "idPairsTable": { "table": "x_genotype_result" },
         "idPairsIdA": { "column": "platform_id" },
         "idPairsIdB":  { "column": "person_id" }
       }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotype_result.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotype_result.sql
@@ -1,6 +1,2 @@
-/*
- platform_id column has type NUMERIC. This causes index column to be FLOAT.
- Currently indexing doesn't handle floats properly, so change column to INTEGER.
-*/
-SELECT genotype_result_id AS genotype_result_id, person_id, CAST(platform_id as INT64) as platform_id
-FROM `sd-vumc-tanagra-test.sd_20230331.x_genotype_result`
+SELECT CAST(genotype_result_id AS INT64) AS genotype_result_id, person_id, CAST(platform_id AS INT64) AS platform_id
+FROM `sd-vumc-tanagra-test.sd_20230331`.x_genotype_result

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_all.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_all.sql
@@ -1,16 +1,13 @@
-/*
- platform_id column has type NUMERIC. This causes index column to be FLOAT.
- Currently indexing doesn't handle floats properly, so change column to INTEGER.
-*/
-SELECT CAST(platform_id as INT64) AS platform_id, assay_name as assay_name
-FROM `sd-vumc-tanagra-test.sd_20230331.x_platform`
+/* Hierarchy leaf nodes all live in genotype_criteria and x_platform. */
+SELECT xp.platform_id, xp.assay_name
+FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
+
+JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
+    ON gc.name = xp.assay_name AND gc.type = 'DNA'
+
 UNION ALL
-/*
- Add some rows to get hierarchy to work. Parent ids are defined in
- genotype_criteria, criteria_meta_seq column. criteria_meta_seq is not in the
- same "ID space" as platform_id. Tanagra requres parent id to be in same "ID
- space" as platform_id. So create artificial platform_ids for parents.
- */
-(SELECT 101 AS platform_id, 'GWAS Platforms' AS assay_name UNION ALL
- SELECT 102, 'Non-GWAS and Targeted Genotyping Platforms' UNION ALL
- SELECT 103, 'Sequencing Platforms')
+
+/* Hierarchy root nodes only live in genotype_criteria. */
+SELECT (100 + gc.criteria_meta_seq) AS platform_id, gc.name AS assay_name
+FROM `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
+WHERE gc.type = 'DNA' AND gc.parent_seq = 0

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_all.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_all.sql
@@ -1,5 +1,5 @@
 /* Hierarchy leaf nodes all live in genotype_criteria and x_platform. */
-SELECT xp.platform_id, xp.assay_name
+SELECT CAST(xp.platform_id AS INT64) platform_id, xp.assay_name
 FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
 
 JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_parentChild.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_parentChild.sql
@@ -1,6 +1,6 @@
-SELECT
-/* Use parent ids defined in platform.sql */
-    parent_seq + 100 AS parent,
-    CAST(platform_id as INT64) AS child
-FROM `sd-vumc-tanagra-test.sd_20230331.genotype_criteria` g, `sd-vumc-tanagra-test.sd_20230331.x_platform` p
-WHERE g.name = p.assay_name
+SELECT (100 + gc.parent_seq) AS parent, xp.platform_id AS child
+
+FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
+
+JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
+  ON gc.name = xp.assay_name AND gc.type = 'DNA'

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_parentChild.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_parentChild.sql
@@ -1,4 +1,4 @@
-SELECT (100 + gc.parent_seq) AS parent, xp.platform_id AS child
+SELECT (100 + gc.parent_seq) AS parent, CAST(xp.platform_id AS INT64) AS child
 
 FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
 

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_rootNodesFilter.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_rootNodesFilter.sql
@@ -1,4 +1,0 @@
-/* Match the platform ids in platform.sql */
-SELECT 101 AS id UNION ALL
-SELECT 102 UNION ALL
-SELECT 103

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/genotyping.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/genotyping.json
@@ -19,9 +19,6 @@
         "childParent": {
           "tablePointer": { "rawSqlFile": "genotyping_parentChild.sql" }
         },
-        "rootNodesFilter": {
-          "tablePointer": { "rawSqlFile": "genotyping_rootNodesFilter.sql" }
-        },
         "maxHierarchyDepth": 1
       }
     }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotype_result.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotype_result.sql
@@ -1,6 +1,2 @@
-/*
- platform_id column has type NUMERIC. This causes index column to be FLOAT.
- Currently indexing doesn't handle floats properly, so change column to INTEGER.
-*/
-SELECT genotype_result_id AS genotype_result_id, person_id, CAST(platform_id as INT64) as platform_id
-FROM `sd-vumc-tanagra-test.sd_20230331.x_genotype_result`
+SELECT CAST(genotype_result_id AS INT64) AS genotype_result_id, person_id, CAST(platform_id AS INT64) AS platform_id
+FROM `sd-vumc-tanagra-test.sd_20230331`.x_genotype_result

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_all.sql
@@ -1,16 +1,13 @@
-/*
- platform_id column has type NUMERIC. This causes index column to be FLOAT.
- Currently indexing doesn't handle floats properly, so change column to INTEGER.
-*/
-SELECT CAST(platform_id as INT64) AS platform_id, assay_name as assay_name
-FROM `sd-vumc-tanagra-test.sd_20230331.x_platform`
+/* Hierarchy leaf nodes all live in genotype_criteria and x_platform. */
+SELECT CAST(xp.platform_id AS INT64) platform_id, xp.assay_name
+FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
+
+JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
+    ON gc.name = xp.assay_name AND gc.type = 'DNA'
+
 UNION ALL
-/*
- Add some rows to get hierarchy to work. Parent ids are defined in
- genotype_criteria, criteria_meta_seq column. criteria_meta_seq is not in the
- same "ID space" as platform_id. Tanagra requres parent id to be in same "ID
- space" as platform_id. So create artificial platform_ids for parents.
- */
-(SELECT 101 AS platform_id, 'GWAS Platforms' AS assay_name UNION ALL
- SELECT 102, 'Non-GWAS and Targeted Genotyping Platforms' UNION ALL
- SELECT 103, 'Sequencing Platforms')
+
+/* Hierarchy root nodes only live in genotype_criteria. */
+SELECT (100 + gc.criteria_meta_seq) AS platform_id, gc.name AS assay_name
+FROM `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
+WHERE gc.type = 'DNA' AND gc.parent_seq = 0

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_parentChild.sql
@@ -1,6 +1,6 @@
-SELECT
-/* Use parent ids defined in platform.sql */
-    parent_seq + 100 AS parent,
-    CAST(platform_id as INT64) AS child
-FROM `sd-vumc-tanagra-test.sd_20230331.genotype_criteria` g, `sd-vumc-tanagra-test.sd_20230331.x_platform` p
-WHERE g.name = p.assay_name
+SELECT (100 + gc.parent_seq) AS parent, CAST(xp.platform_id AS INT64) AS child
+
+FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
+
+JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
+  ON gc.name = xp.assay_name AND gc.type = 'DNA'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_rootNodesFilter.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_rootNodesFilter.sql
@@ -1,4 +1,0 @@
-/* Match the platform ids in platform.sql */
-SELECT 101 AS id UNION ALL
-SELECT 102 UNION ALL
-SELECT 103


### PR DESCRIPTION
Fixed the missing root node "Non-Genome-Wide Sequencing Platforms" and the incorrect root node names in the `genotyping` entity hierarchy.

- All nodes and the parent-child relationships live in `x_genotype_criteria`.
- The foreign key field that maps a genotyping assay to a row in `x_genotype_result` lives in the `x_platform` table.
- Join `x_genotype_criteria` to `x_platform` on the `name`/`assay_name` fields respectively.

I partially re-indexed the BQ dataset in test to reflect these changes.