### PR TITLE
Keep orphan nodes in PheWAS hierarchy.

### DIFF
--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/BuildNumChildrenAndPaths.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/BuildNumChildrenAndPaths.java
@@ -173,10 +173,14 @@ public class BuildNumChildrenAndPaths extends BigQueryIndexingJob {
     PCollection<KV<Long, Long>> nodeNumChildrenKVsPC =
         PathUtils.countChildren(allNodesPC, childParentRelationshipsPC);
 
-    // prune orphan nodes from the hierarchy (i.e. set path=null for nodes with no parents or
-    // children)
-    PCollection<KV<Long, String>> nodePrunedPathKVsPC =
-        PathUtils.pruneOrphanPaths(nodePathKVsPC, nodeNumChildrenKVsPC);
+    PCollection<KV<Long, String>> nodePrunedPathKVsPC;
+    if (sourceHierarchyMapping.isKeepOrphanNodes()) {
+      nodePrunedPathKVsPC = nodePathKVsPC;
+    } else {
+      // prune orphan nodes from the hierarchy (i.e. set path=null for nodes with no parents or
+      // children)
+      nodePrunedPathKVsPC = PathUtils.pruneOrphanPaths(nodePathKVsPC, nodeNumChildrenKVsPC);
+    }
 
     // filter the root nodes
     PCollection<KV<Long, String>> outputNodePathKVsPC =

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/phewas.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/phewas.json
@@ -21,7 +21,8 @@
         "childParent": {
           "tablePointer": { "rawSqlFile": "phewas_parentChild.sql" }
         },
-        "maxHierarchyDepth": 5
+        "maxHierarchyDepth": 5,
+        "keepOrphanNodes": true
       }
     }
   },

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/phewas.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/phewas.json
@@ -21,7 +21,8 @@
         "childParent": {
           "tablePointer": { "rawSqlFile": "phewas_parentChild.sql" }
         },
-        "maxHierarchyDepth": 5
+        "maxHierarchyDepth": 5,
+        "keepOrphanNodes": true
       }
     }
   },

--- a/underlay/src/main/java/bio/terra/tanagra/serialization/UFHierarchyMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/serialization/UFHierarchyMapping.java
@@ -18,6 +18,7 @@ public class UFHierarchyMapping {
   private final UFAuxiliaryDataMapping ancestorDescendant;
   private final UFAuxiliaryDataMapping pathNumChildren;
   private final int maxHierarchyDepth;
+  private final boolean keepOrphanNodes;
 
   public UFHierarchyMapping(HierarchyMapping hierarchyMapping) {
     this.childParent = new UFAuxiliaryDataMapping(hierarchyMapping.getChildParent());
@@ -34,6 +35,7 @@ public class UFHierarchyMapping {
             ? new UFAuxiliaryDataMapping(hierarchyMapping.getPathNumChildren())
             : null;
     this.maxHierarchyDepth = hierarchyMapping.getMaxHierarchyDepth();
+    this.keepOrphanNodes = hierarchyMapping.isKeepOrphanNodes();
   }
 
   private UFHierarchyMapping(Builder builder) {
@@ -42,6 +44,7 @@ public class UFHierarchyMapping {
     this.ancestorDescendant = builder.ancestorDescendant;
     this.pathNumChildren = builder.pathNumChildren;
     this.maxHierarchyDepth = builder.maxHierarchyDepth;
+    this.keepOrphanNodes = builder.keepOrphanNodes;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -51,6 +54,7 @@ public class UFHierarchyMapping {
     private UFAuxiliaryDataMapping ancestorDescendant;
     private UFAuxiliaryDataMapping pathNumChildren;
     private int maxHierarchyDepth;
+    private boolean keepOrphanNodes;
 
     public Builder childParent(UFAuxiliaryDataMapping childParent) {
       this.childParent = childParent;
@@ -74,6 +78,11 @@ public class UFHierarchyMapping {
 
     public Builder maxHierarchyDepth(int maxHierarchyDepth) {
       this.maxHierarchyDepth = maxHierarchyDepth;
+      return this;
+    }
+
+    public Builder keepOrphanNodes(boolean keepOrphanNodes) {
+      this.keepOrphanNodes = keepOrphanNodes;
       return this;
     }
 
@@ -101,5 +110,9 @@ public class UFHierarchyMapping {
 
   public int getMaxHierarchyDepth() {
     return maxHierarchyDepth;
+  }
+
+  public boolean isKeepOrphanNodes() {
+    return keepOrphanNodes;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Entity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Entity.java
@@ -221,7 +221,8 @@ public final class Entity {
                             serialized.getName(),
                             sourceHierarchyMappingSerialized.getKey(),
                             idAttribute.getValue(),
-                            sourceHierarchyMappingSerialized.getValue().getMaxHierarchyDepth())
+                            sourceHierarchyMappingSerialized.getValue().getMaxHierarchyDepth(),
+                            sourceHierarchyMappingSerialized.getValue().isKeepOrphanNodes())
                         : HierarchyMapping.fromSerialized(
                             indexHierarchyMappingsSerialized.get(
                                 sourceHierarchyMappingSerialized.getKey()),

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/HierarchyMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/HierarchyMapping.java
@@ -42,6 +42,7 @@ public final class HierarchyMapping {
   private final AuxiliaryDataMapping ancestorDescendant;
   private final AuxiliaryDataMapping pathNumChildren;
   private final int maxHierarchyDepth;
+  private final boolean keepOrphanNodes;
   private final Underlay.MappingType mappingType;
   private Hierarchy hierarchy;
 
@@ -51,12 +52,14 @@ public final class HierarchyMapping {
       AuxiliaryDataMapping ancestorDescendant,
       AuxiliaryDataMapping pathNumChildren,
       int maxHierarchyDepth,
+      boolean keepOrphanNodes,
       Underlay.MappingType mappingType) {
     this.childParent = childParent;
     this.rootNodesFilter = rootNodesFilter;
     this.ancestorDescendant = ancestorDescendant;
     this.pathNumChildren = pathNumChildren;
     this.maxHierarchyDepth = maxHierarchyDepth;
+    this.keepOrphanNodes = keepOrphanNodes;
     this.mappingType = mappingType;
   }
 
@@ -95,11 +98,16 @@ public final class HierarchyMapping {
         ancestorDescendant,
         pathNumChildren,
         serialized.getMaxHierarchyDepth(),
+        serialized.isKeepOrphanNodes(),
         mappingType);
   }
 
   public static HierarchyMapping defaultIndexMapping(
-      String entityName, String hierarchyName, FieldPointer entityIdField, int maxHierarchyDepth) {
+      String entityName,
+      String hierarchyName,
+      FieldPointer entityIdField,
+      int maxHierarchyDepth,
+      boolean keepOrphanNodes) {
     TablePointer entityTable = entityIdField.getTablePointer();
     DataPointer dataPointer = entityTable.getDataPointer();
     String tablePrefix = entityName + "_" + hierarchyName + "_";
@@ -141,6 +149,7 @@ public final class HierarchyMapping {
         ancestorDescendant,
         pathNumChildren,
         maxHierarchyDepth,
+        keepOrphanNodes,
         Underlay.MappingType.INDEX);
   }
 
@@ -285,5 +294,9 @@ public final class HierarchyMapping {
 
   public int getMaxHierarchyDepth() {
     return maxHierarchyDepth <= 0 ? DEFAULT_MAX_HIERARCHY_DEPTH : maxHierarchyDepth;
+  }
+
+  public boolean isKeepOrphanNodes() {
+    return keepOrphanNodes;
   }
 }


### PR DESCRIPTION
- Added an optional flag to the hierarchy config to keep orphan nodes (i.e. nodes with no parents or children).
- Default is false, and we prune the orphan nodes as we do for most hierarchies.
- Set flag to true for PheWAS hierarchy, where we were missing some root nodes (e.g. 010-Tuberculosis) in the hierarchy view.

I also partially re-indexed the verily/sdd underlay (just the phewas entity and group) to fix the hierarchy view in the test env.