### PR TITLE
Compute rollup counts for group-items hierarchies.

### DIFF
--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -112,6 +112,21 @@ public final class JobSequencer {
       jobSet.addJob(
           new ComputeRollupCounts(
               groupItems.getGroupEntity(), groupItems.getGroupItemsRelationship(), null));
+
+      // If the criteria entity has hierarchies, then also compute the criteria rollup counts for
+      // each hierarchy.
+      // e.g. To show rollup counts for each genotyping.
+      if (groupItems.getGroupEntity().hasHierarchies()) {
+        groupItems.getGroupEntity().getHierarchies().stream()
+            .forEach(
+                hierarchy -> {
+                  jobSet.addJob(
+                      new ComputeRollupCounts(
+                          groupItems.getGroupEntity(),
+                          groupItems.getGroupItemsRelationship(),
+                          hierarchy));
+                });
+      }
     }
 
     return jobSet;


### PR DESCRIPTION
This means we will compute rollup counts for the `genotyping` entity, which is part of a group-items entity group and also has a hierarchy.

I also partially re-indexed the verily/sdd underlay, just the `genotyping` entity and group.