### PR TITLE
Any BioVU DNA means dna_yield_ind > 0.

### DIFF
--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/person.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/person.sql
@@ -5,7 +5,7 @@ SELECT
     /* Add BioVU sample columns. The way x_biovu_sample_status is created, there should be at
        most one row per person. */
     EXISTS
-        (SELECT 1 FROM `sd-vumc-tanagra-test.sd_20230331.x_biovu_sample_status` x WHERE p.person_id = x.person_id)
+        (SELECT 1 FROM `sd-vumc-tanagra-test.sd_20230331.x_biovu_sample_status` x WHERE p.person_id = x.person_id AND x.dna_yield_ind > 0)
                                                                                                         AS has_biovu_sample,
     x.dna_yield_ind AS biovu_sample_dna_yield,
     /* As a courtesy, convert string fields to boolean: 0 -> No, 1 -> Yes */

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/person.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/person.sql
@@ -5,7 +5,7 @@ SELECT
     /* Add BioVU sample columns. The way x_biovu_sample_status is created, there should be at
        most one row per person. */
     EXISTS
-        (SELECT 1 FROM `sd-vumc-tanagra-test.sd_20230331.x_biovu_sample_status` x WHERE p.person_id = x.person_id)
+        (SELECT 1 FROM `sd-vumc-tanagra-test.sd_20230331.x_biovu_sample_status` x WHERE p.person_id = x.person_id AND x.dna_yield_ind > 0)
                                                                                                         AS has_biovu_sample,
     x.dna_yield_ind AS biovu_sample_dna_yield,
     /* As a courtesy, convert string fields to boolean: 0 -> No, 1 -> Yes */


### PR DESCRIPTION
In the BioVU criteria, the "Any BioVU DNA (no minimum amount or concentration)" option was previously checking for any rows in the `x_biovu_sample_status` table for a given `person_id`. Changed it to check for any rows that have `dna_yield_ind > 0`. Now the counts in Tanagra match those in SDD.

Also partially re-indexed the verily/sdd underlay, just the `person` entity.