### PR TITLE
Fix occasional hang when initially searching

### DIFF
--- a/ui/src/util/searchState.tsx
+++ b/ui/src/util/searchState.tsx
@@ -23,8 +23,9 @@ export function useGlobalSearchState(): [
   (update: (state: GlobalSearchState) => void) => void
 ] {
   const [searchData, updateSearchData] = useSearchData();
-  const storedData = JSON.parse(
-    window.localStorage.getItem(STORAGE_ID) ?? "{}"
+  const storedData = useMemo(
+    () => JSON.parse(window.localStorage.getItem(STORAGE_ID) ?? "{}"),
+    []
   );
 
   return [


### PR DESCRIPTION
Sometimes the app would get into a state where it was constantly re-requesting instances because it thought the stored data was continuously changing. Memoize the stored data to prevent this.