### PR TITLE
Join genotype_criteria to x_platform on assay_name case insensitively.

### DIFF
--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_all.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_all.sql
@@ -3,7 +3,7 @@ SELECT CAST(xp.platform_id AS INT64) platform_id, xp.assay_name
 FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
 
 JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
-    ON gc.name = xp.assay_name AND gc.type = 'DNA'
+    ON UPPER(gc.name) = UPPER(xp.assay_name) AND gc.type = 'DNA'
 
 UNION ALL
 

--- a/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_parentChild.sql
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/sql/genotyping_parentChild.sql
@@ -3,4 +3,4 @@ SELECT (100 + gc.parent_seq) AS parent, CAST(xp.platform_id AS INT64) AS child
 FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
 
 JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
-  ON gc.name = xp.assay_name AND gc.type = 'DNA'
+  ON UPPER(gc.name) = UPPER(xp.assay_name) AND gc.type = 'DNA'

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_all.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_all.sql
@@ -3,7 +3,7 @@ SELECT CAST(xp.platform_id AS INT64) platform_id, xp.assay_name
 FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
 
 JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
-    ON gc.name = xp.assay_name AND gc.type = 'DNA'
+    ON UPPER(gc.name) = UPPER(xp.assay_name) AND gc.type = 'DNA'
 
 UNION ALL
 

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_parentChild.sql
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/sql/genotyping_parentChild.sql
@@ -3,4 +3,4 @@ SELECT (100 + gc.parent_seq) AS parent, CAST(xp.platform_id AS INT64) AS child
 FROM `sd-vumc-tanagra-test.sd_20230331`.x_platform AS xp
 
 JOIN `sd-vumc-tanagra-test.sd_20230331`.genotype_criteria AS gc
-  ON gc.name = xp.assay_name AND gc.type = 'DNA'
+  ON UPPER(gc.name) = UPPER(xp.assay_name) AND gc.type = 'DNA'


### PR DESCRIPTION
This fixes the missing `platform_id` for 'Illumina MEGA-ex Array'.

I also partially re-indexed the verily/sdd underlay to reflect this change.