### PR TITLE
Add dataflow subnetwork name config property.

### DIFF
--- a/docs/INDEXING.md
+++ b/docs/INDEXING.md
@@ -189,7 +189,6 @@ or a particular entity group:
 ```
 
 ### Run dataflow locally
-
 While developing a job, running locally is faster. Also, you can use Intellij debugger.
 - Add to `BigQueryIndexingJob.buildDataflowPipelineOptions()`:
   ```

--- a/underlay/src/main/java/bio/terra/tanagra/serialization/datapointer/UFBigQueryDataset.java
+++ b/underlay/src/main/java/bio/terra/tanagra/serialization/datapointer/UFBigQueryDataset.java
@@ -22,6 +22,7 @@ public class UFBigQueryDataset extends UFDataPointer {
   private final String dataflowRegion;
   private final String dataflowWorkerMachineType;
   private final boolean dataflowUsePublicIps;
+  private final String dataflowSubnetworkName;
 
   public UFBigQueryDataset(BigQueryDataset dataPointer) {
     super(dataPointer);
@@ -33,6 +34,7 @@ public class UFBigQueryDataset extends UFDataPointer {
     this.dataflowRegion = dataPointer.getDataflowRegion();
     this.dataflowWorkerMachineType = dataPointer.getDataflowWorkerMachineType();
     this.dataflowUsePublicIps = dataPointer.isDataflowUsePublicIps();
+    this.dataflowSubnetworkName = dataPointer.getDataflowSubnetworkName();
   }
 
   private UFBigQueryDataset(Builder builder) {
@@ -45,6 +47,7 @@ public class UFBigQueryDataset extends UFDataPointer {
     this.dataflowRegion = builder.dataflowRegion;
     this.dataflowWorkerMachineType = builder.dataflowWorkerMachineType;
     this.dataflowUsePublicIps = builder.dataflowUsePublicIps;
+    this.dataflowSubnetworkName = builder.dataflowSubnetworkName;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -57,6 +60,7 @@ public class UFBigQueryDataset extends UFDataPointer {
     private String dataflowRegion;
     private String dataflowWorkerMachineType;
     private boolean dataflowUsePublicIps = true;
+    private String dataflowSubnetworkName;
 
     public Builder projectId(String projectId) {
       this.projectId = projectId;
@@ -95,6 +99,11 @@ public class UFBigQueryDataset extends UFDataPointer {
 
     public Builder dataflowUsePublicIps(boolean dataflowUsePublicIps) {
       this.dataflowUsePublicIps = dataflowUsePublicIps;
+      return this;
+    }
+
+    public Builder dataflowSubnetworkName(String dataflowSubnetworkName) {
+      this.dataflowSubnetworkName = dataflowSubnetworkName;
       return this;
     }
 
@@ -141,5 +150,9 @@ public class UFBigQueryDataset extends UFDataPointer {
 
   public boolean isDataflowUsePublicIps() {
     return dataflowUsePublicIps;
+  }
+
+  public String getDataflowSubnetworkName() {
+    return dataflowSubnetworkName;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/datapointer/BigQueryDataset.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/datapointer/BigQueryDataset.java
@@ -34,6 +34,7 @@ public final class BigQueryDataset extends DataPointer {
   private final String dataflowRegion;
   private final String dataflowWorkerMachineType;
   private final boolean dataflowUsePublicIps;
+  private final String dataflowSubnetworkName;
 
   private GoogleBigQuery bigQueryService;
   private BigQueryExecutor queryExecutor;
@@ -48,7 +49,8 @@ public final class BigQueryDataset extends DataPointer {
       String dataflowTempLocation,
       String dataflowRegion,
       String dataflowWorkerMachineType,
-      boolean dataflowUsePublicIps) {
+      boolean dataflowUsePublicIps,
+      String dataflowSubnetworkName) {
     super(name);
     this.projectId = projectId;
     this.datasetId = datasetId;
@@ -58,6 +60,7 @@ public final class BigQueryDataset extends DataPointer {
     this.dataflowRegion = dataflowRegion;
     this.dataflowWorkerMachineType = dataflowWorkerMachineType;
     this.dataflowUsePublicIps = dataflowUsePublicIps;
+    this.dataflowSubnetworkName = dataflowSubnetworkName;
   }
 
   public static BigQueryDataset fromSerialized(UFBigQueryDataset serialized) {
@@ -85,7 +88,8 @@ public final class BigQueryDataset extends DataPointer {
         serialized.getDataflowTempLocation(),
         serialized.getDataflowRegion(),
         serialized.getDataflowWorkerMachineType(),
-        serialized.isDataflowUsePublicIps());
+        serialized.isDataflowUsePublicIps(),
+        serialized.getDataflowSubnetworkName());
   }
 
   @Override
@@ -239,5 +243,9 @@ public final class BigQueryDataset extends DataPointer {
 
   public boolean isDataflowUsePublicIps() {
     return dataflowUsePublicIps;
+  }
+
+  public String getDataflowSubnetworkName() {
+    return dataflowSubnetworkName;
   }
 }


### PR DESCRIPTION
This property is required for VPC networks set to "custom subnet mode". It is not required for "auto subnet mode".