### PR TITLE
Add support for feature sets

### DIFF
--- a/ui/cypress/e2e/featureSet.cy.js
+++ b/ui/cypress/e2e/featureSet.cy.js
@@ -1,0 +1,42 @@
+///<reference types="cypress-iframe" />
+import "cypress-iframe";
+
+function generateCohort() {
+  return `New cohort ${Math.floor(1000000 * Math.random())}`;
+}
+
+describe("Basic tests", () => {
+  it("Export", () => {
+    const featureSet = "featureSet";
+    cy.get("button:Contains(New feature set)").click();
+    cy.wait(2000);
+
+    cy.iframe().find("a:Contains(Add a data feature)").first().click();
+    cy.iframe().find("[data-testid='tanagra-procedures']").click();
+    cy.iframe().find("input").type("Procedure on body system");
+    cy.iframe().find("[data-testid='Procedure on body system']").click();
+
+    cy.iframe().find("button:Contains(Add data feature)").click();
+    cy.iframe().find("[data-testid='tanagra-conditions']").click();
+    cy.iframe().find("input").type("Red color");
+    cy.iframe().find("[data-testid='Red color']").click();
+
+    cy.iframe().find("button:Contains(procedure_occurrence)").click();
+    cy.iframe().find("[name='procedure']").click();
+
+    cy.iframe().find("button:Contains(condition_occurrence)").click();
+    cy.iframe().find("[name='end_date']").click();
+
+    cy.iframe().find("[name='show-included-columns-only']").click();
+    cy.iframe().contains("end_date").should("not.exist");
+
+    cy.iframe().contains("Manage columns").click();
+    cy.iframe().find("[name='end_date']").click();
+    cy.iframe().find('[class*="MuiPopover-root"]').click(0, 0);
+    cy.wait(2000);
+    cy.iframe().find("[name='end_date']").click();
+
+    cy.iframe().find("button:Contains(New cohort)").click();
+    cy.iframe().contains("Untitled cohort");
+  });
+});

--- a/ui/src/addCriteria.tsx
+++ b/ui/src/addCriteria.tsx
@@ -25,11 +25,24 @@ import { createConceptSet, useConceptSetContext } from "conceptSetContext";
 import { MergedItem } from "data/source";
 import { useSource } from "data/sourceContext";
 import { DataEntry, DataKey } from "data/types";
-import { useCohortGroupSectionAndGroup, useUnderlay } from "hooks";
+import {
+  insertFeatureSetCriteria,
+  useFeatureSetContext,
+} from "featureSet/featureSetContext";
+import {
+  useCohortGroupSectionAndGroup,
+  useFeatureSet,
+  useUnderlay,
+} from "hooks";
 import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
 import { useCallback, useMemo } from "react";
-import { cohortURL, newCriteriaURL, useExitAction } from "router";
+import {
+  cohortURL,
+  featureSetURL,
+  newCriteriaURL,
+  useExitAction,
+} from "router";
 import useSWRImmutable from "swr/immutable";
 import * as tanagraUI from "tanagra-ui";
 import { CriteriaConfig } from "underlaysSlice";
@@ -89,6 +102,28 @@ export function AddCohortCriteria() {
   return (
     <AddCriteria
       title={`Adding criteria for group ${name}`}
+      onInsertCriteria={onInsertCriteria}
+    />
+  );
+}
+
+export function AddFeatureSetCriteria() {
+  const navigate = useNavigate();
+  const context = useFeatureSetContext();
+  const featureSet = useFeatureSet();
+
+  const onInsertCriteria = useCallback(
+    (criteria: tanagraUI.UICriteria) => {
+      insertFeatureSetCriteria(context, criteria);
+      navigate("../../" + featureSetURL(featureSet.id));
+    },
+    [context, featureSet.id, navigate]
+  );
+
+  return (
+    <AddCriteria
+      conceptSet
+      title={`Adding criteria for ${featureSet.name}`}
       onInsertCriteria={onInsertCriteria}
     />
   );

--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -4,6 +4,7 @@ import { useUnderlay } from "hooks";
 import produce from "immer";
 import { createContext, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { absoluteCohortURL, BaseParams } from "router";
 import useSWR, { useSWRConfig } from "swr";
 import * as tanagraUI from "tanagra-ui";
 import {
@@ -157,6 +158,32 @@ export function useNewCohortContext(showSnackbar: (message: string) => void) {
         );
       },
     },
+  };
+}
+
+export function cohortUndoRedo(params: BaseParams, context: CohortContextData) {
+  const cohortURL = absoluteCohortURL(params, context.state?.present?.id ?? "");
+  return {
+    undoURL: context.state?.past?.length ? cohortURL : "",
+    redoURL: context.state?.future?.length ? cohortURL : "",
+    undoAction: context.state?.past?.length
+      ? () => {
+          context.updateState((state) => {
+            state.future.push(state.present);
+            state.present = state.past[state.past.length - 1];
+            state.past.pop();
+          });
+        }
+      : undefined,
+    redoAction: context.state?.future?.length
+      ? () => {
+          context.updateState((state) => {
+            state.past.push(state.present);
+            state.present = state.future[state.future.length - 1];
+            state.future.pop();
+          });
+        }
+      : undefined,
   };
 }
 

--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -22,17 +22,21 @@ exports[`Table renders correctly 1`] = `
                 class="MuiBox-root css-j6zvzo"
               >
                 <div
-                  class="MuiBox-root css-semc09"
+                  class="MuiBox-root css-ochz84"
                 >
                   <div
                     class="MuiBox-root css-j6zvzo"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
-                      title="Column 1"
+                    <div
+                      class="css-caf4u6"
                     >
-                      Column 1
-                    </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
+                        title="Column 1"
+                      >
+                        Column 1
+                      </span>
+                    </div>
                   </div>
                   <div
                     class="MuiBox-root css-9qc0eg"
@@ -57,6 +61,13 @@ exports[`Table renders correctly 1`] = `
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
+                  </div>
+                  <div
+                    class="MuiBox-root css-buq1co"
+                  >
+                    <div
+                      class="css-uwwqev"
+                    />
                   </div>
                 </div>
               </div>
@@ -72,17 +83,21 @@ exports[`Table renders correctly 1`] = `
                 class="MuiBox-root css-j6zvzo"
               >
                 <div
-                  class="MuiBox-root css-semc09"
+                  class="MuiBox-root css-ochz84"
                 >
                   <div
                     class="MuiBox-root css-j6zvzo"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
-                      title="Column 2"
+                    <div
+                      class="css-caf4u6"
                     >
-                      Column 2
-                    </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
+                        title="Column 2"
+                      >
+                        Column 2
+                      </span>
+                    </div>
                   </div>
                   <div
                     class="MuiBox-root css-9qc0eg"
@@ -108,6 +123,13 @@ exports[`Table renders correctly 1`] = `
                       />
                     </button>
                   </div>
+                  <div
+                    class="MuiBox-root css-buq1co"
+                  >
+                    <div
+                      class="css-uwwqev"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -122,27 +144,38 @@ exports[`Table renders correctly 1`] = `
                 class="MuiBox-root css-j6zvzo"
               >
                 <div
-                  class="MuiBox-root css-1jjjjm8"
+                  class="MuiBox-root css-22ybcc"
                 >
                   <div
                     class="MuiBox-root css-j6zvzo"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
-                      title="[object Object]"
+                    <div
+                      class="css-caf4u6"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                        data-testid="AccountTreeIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <span
+                        class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
+                        title="[object Object]"
                       >
-                        <path
-                          d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
-                        />
-                      </svg>
-                    </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="AccountTreeIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-9qc0eg"
+                  >
+                    <div
+                      class="css-uwwqev"
+                    />
                   </div>
                 </div>
               </div>
@@ -155,7 +188,7 @@ exports[`Table renders correctly 1`] = `
           style="height: 48px;"
         >
           <td
-            style="max-width: 100%; width: 100%; min-width: 100%;"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-ttlwsw-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -189,7 +222,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            style="max-width: 150px; width: 150px; min-width: 150px;"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-o3sd3r-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -203,7 +236,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            style="max-width: 50px; width: 50px; min-width: 50px;"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1gu6ett-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -219,7 +252,7 @@ exports[`Table renders correctly 1`] = `
           style="display: none; height: 48px;"
         >
           <td
-            style="max-width: 100%; width: 100%; min-width: 100%; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-kv8qlv-MuiStack-root"
@@ -253,7 +286,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            style="max-width: 150px; width: 150px; min-width: 150px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -267,7 +300,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            style="max-width: 50px; width: 50px; min-width: 50px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -285,7 +318,7 @@ exports[`Table renders correctly 1`] = `
           style="height: 48px;"
         >
           <td
-            style="max-width: 100%; width: 100%; min-width: 100%; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -299,7 +332,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            style="max-width: 150px; width: 150px; min-width: 150px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -313,7 +346,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            style="max-width: 50px; width: 50px; min-width: 50px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -365,17 +398,21 @@ exports[`Table renders correctly 2`] = `
                 class="MuiBox-root css-j6zvzo"
               >
                 <div
-                  class="MuiBox-root css-semc09"
+                  class="MuiBox-root css-ochz84"
                 >
                   <div
                     class="MuiBox-root css-j6zvzo"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
-                      title="Column 1"
+                    <div
+                      class="css-caf4u6"
                     >
-                      Column 1
-                    </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
+                        title="Column 1"
+                      >
+                        Column 1
+                      </span>
+                    </div>
                   </div>
                   <div
                     class="MuiBox-root css-9qc0eg"
@@ -410,6 +447,13 @@ exports[`Table renders correctly 2`] = `
                       </span>
                     </button>
                   </div>
+                  <div
+                    class="MuiBox-root css-buq1co"
+                  >
+                    <div
+                      class="css-uwwqev"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -424,17 +468,21 @@ exports[`Table renders correctly 2`] = `
                 class="MuiBox-root css-j6zvzo"
               >
                 <div
-                  class="MuiBox-root css-semc09"
+                  class="MuiBox-root css-ochz84"
                 >
                   <div
                     class="MuiBox-root css-j6zvzo"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
-                      title="Column 2"
+                    <div
+                      class="css-caf4u6"
                     >
-                      Column 2
-                    </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
+                        title="Column 2"
+                      >
+                        Column 2
+                      </span>
+                    </div>
                   </div>
                   <div
                     class="MuiBox-root css-9qc0eg"
@@ -460,6 +508,13 @@ exports[`Table renders correctly 2`] = `
                       />
                     </button>
                   </div>
+                  <div
+                    class="MuiBox-root css-buq1co"
+                  >
+                    <div
+                      class="css-uwwqev"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -474,27 +529,38 @@ exports[`Table renders correctly 2`] = `
                 class="MuiBox-root css-j6zvzo"
               >
                 <div
-                  class="MuiBox-root css-1jjjjm8"
+                  class="MuiBox-root css-22ybcc"
                 >
                   <div
                     class="MuiBox-root css-j6zvzo"
                   >
-                    <span
-                      class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
-                      title="[object Object]"
+                    <div
+                      class="css-caf4u6"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                        data-testid="AccountTreeIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <span
+                        class="MuiTypography-root MuiTypography-overline css-szitil-MuiTypography-root"
+                        title="[object Object]"
                       >
-                        <path
-                          d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
-                        />
-                      </svg>
-                    </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="AccountTreeIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root css-9qc0eg"
+                  >
+                    <div
+                      class="css-uwwqev"
+                    />
                   </div>
                 </div>
               </div>
@@ -507,7 +573,7 @@ exports[`Table renders correctly 2`] = `
           style="height: 48px;"
         >
           <td
-            style="max-width: 100%; width: 100%; min-width: 100%;"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-ttlwsw-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -541,7 +607,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            style="max-width: 150px; width: 150px; min-width: 150px;"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-o3sd3r-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -555,7 +621,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            style="max-width: 50px; width: 50px; min-width: 50px;"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1gu6ett-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -571,7 +637,7 @@ exports[`Table renders correctly 2`] = `
           style="display: none; height: 48px;"
         >
           <td
-            style="max-width: 100%; width: 100%; min-width: 100%; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-kv8qlv-MuiStack-root"
@@ -605,7 +671,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            style="max-width: 150px; width: 150px; min-width: 150px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -619,7 +685,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            style="max-width: 50px; width: 50px; min-width: 50px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -637,7 +703,7 @@ exports[`Table renders correctly 2`] = `
           style="height: 48px;"
         >
           <td
-            style="max-width: 100%; width: 100%; min-width: 100%; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -651,7 +717,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            style="max-width: 150px; width: 150px; min-width: 150px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -665,7 +731,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            style="max-width: 50px; width: 50px; min-width: 50px; box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.12);"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"

--- a/ui/src/components/checkbox.tsx
+++ b/ui/src/components/checkbox.tsx
@@ -1,6 +1,7 @@
 import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
 import IconButton from "@mui/material/IconButton";
+import { cloneElement, ReactElement } from "react";
 
 export type CheckboxProps = {
   checked?: boolean;
@@ -8,7 +9,12 @@ export type CheckboxProps = {
   size?: "small" | "medium" | "large";
   fontSize?: "small" | "medium" | "large" | "inherit";
   name?: string;
+  checkedIcon?: ReactElement;
+  uncheckedIcon?: ReactElement;
 };
+
+const defaultCheckedIcon = <CheckBoxIcon />;
+const defaultUncheckedIcon = <CheckBoxOutlineBlankIcon />;
 
 export default function Checkbox({
   checked,
@@ -16,6 +22,8 @@ export default function Checkbox({
   size,
   fontSize,
   name,
+  checkedIcon = defaultCheckedIcon,
+  uncheckedIcon = defaultUncheckedIcon,
 }: CheckboxProps) {
   return (
     <IconButton
@@ -28,14 +36,19 @@ export default function Checkbox({
         }
       }}
     >
-      {checked ? (
-        <CheckBoxIcon fontSize={fontSize} color="primary" />
-      ) : (
-        <CheckBoxOutlineBlankIcon
-          fontSize={fontSize}
-          sx={{ fill: "inherit" }}
-        />
-      )}
+      {checked
+        ? cloneElement(checkedIcon, {
+            size: size,
+            fontSize: fontSize,
+            color: "primary",
+          })
+        : cloneElement(uncheckedIcon, {
+            size: size,
+            fontSize: fontSize,
+            sx: {
+              fill: "inherit",
+            },
+          })}
     </IconButton>
   );
 }

--- a/ui/src/components/popover.tsx
+++ b/ui/src/components/popover.tsx
@@ -1,0 +1,36 @@
+import {
+  default as BasePopover,
+  PopoverProps as BasePopoverProps,
+} from "@mui/material/Popover";
+import { MouseEvent, ReactElement, useState } from "react";
+
+type PopoverProps = Omit<BasePopoverProps, "anchorEl" | "open" | "onClose">;
+
+export function usePopover({
+  children,
+  ...props
+}: PopoverProps): [
+  ReactElement,
+  (e: MouseEvent<HTMLElement | undefined>) => void
+] {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>();
+  const show = (e: MouseEvent<HTMLElement | undefined>) =>
+    setAnchorEl(e.currentTarget);
+
+  return [
+    // eslint-disable-next-line react/jsx-key
+    <BasePopover
+      {...props}
+      anchorEl={anchorEl}
+      open={!!anchorEl}
+      onClose={() => setAnchorEl(undefined)}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+    >
+      {children}
+    </BasePopover>,
+    show,
+  ];
+}

--- a/ui/src/components/saveStatus.tsx
+++ b/ui/src/components/saveStatus.tsx
@@ -1,0 +1,31 @@
+import CloudDoneIcon from "@mui/icons-material/CloudDone";
+import LoopIcon from "@mui/icons-material/Loop";
+import Typography from "@mui/material/Typography";
+import GridLayout from "layout/gridLayout";
+import { isValid } from "util/valid";
+
+export type SaveStatusProps = {
+  saving?: boolean;
+  lastModified?: Date;
+};
+
+export function SaveStatus(props: SaveStatusProps) {
+  if (!isValid(props.saving) || !isValid(props.lastModified)) {
+    return null;
+  }
+
+  return (
+    <GridLayout cols spacing={0.5} rowAlign="middle">
+      <Typography variant="body1">
+        {props.saving
+          ? "Saving..."
+          : `Last saved: ${props.lastModified.toLocaleString()}`}
+      </Typography>
+      {props.saving ? (
+        <LoopIcon fontSize="small" sx={{ display: "block" }} />
+      ) : (
+        <CloudDoneIcon fontSize="small" sx={{ display: "block" }} />
+      )}
+    </GridLayout>
+  );
+}

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -9,6 +9,7 @@ import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import { SxProps, Theme, useTheme } from "@mui/material/styles";
+import TableCell from "@mui/material/TableCell";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import produce from "immer";
@@ -57,6 +58,7 @@ export type TreeGridColumn = {
   title?: string | JSX.Element;
   sortable?: boolean;
   filterable?: boolean;
+  suffixElements?: ReactNode;
 };
 
 export type ColumnCustomization = {
@@ -64,6 +66,7 @@ export type ColumnCustomization = {
   prefixElements?: ReactNode;
   onClick?: () => void;
   content?: ReactNode;
+  backgroundSx?: SxProps<Theme>;
 };
 
 export enum TreeGridSortDirection {
@@ -281,25 +284,24 @@ export function TreeGrid(props: TreeGridProps) {
                     py: 1,
                   }}
                 >
-                  <GridLayout
-                    cols
-                    spacing={1}
-                    rowAlign="middle"
-                    sx={{
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                    }}
-                  >
-                    <Typography
-                      variant="overline"
-                      title={String(col.title)}
+                  <GridLayout cols spacing={0} rowAlign="middle" sx={{ px: 2 }}>
+                    <GridBox
                       sx={{
-                        display: "inline",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
                       }}
                     >
-                      {col.title}
-                    </Typography>
+                      <Typography
+                        variant="overline"
+                        title={String(col.title)}
+                        sx={{
+                          display: "inline",
+                        }}
+                      >
+                        {col.title}
+                      </Typography>
+                    </GridBox>
                     {col.sortable ? (
                       <SortIconButton
                         col={col}
@@ -307,6 +309,8 @@ export function TreeGrid(props: TreeGridProps) {
                         onClick={() => onSort(col, props.sortOrders)}
                       />
                     ) : null}
+                    {col.suffixElements}
+                    <GridBox />
                   </GridLayout>
                   {col.filterable ? (
                     <GridBox sx={{ px: 1, pb: 1 }}>
@@ -404,12 +408,9 @@ function renderChildren(
     const renderColumn = (
       column: number,
       value: TreeGridValue,
-      title: string
+      title: string,
+      columnCustomization?: ColumnCustomization
     ) => {
-      const columnCustomization = rowCustomization?.find(
-        (c) => c.column === column
-      );
-
       const textSx = {
         width: "100%",
         textAlign: "initial",
@@ -522,19 +523,28 @@ function renderChildren(
             title = value;
           }
 
+          const columnCustomization = rowCustomization?.find(
+            (c) => c.column === i
+          );
+
+          const sx: SxProps<Theme> | undefined =
+            columnCustomization?.backgroundSx;
           return (
-            <td
+            <TableCell
               key={i}
-              style={{
-                ...(col.width && {
-                  maxWidth: col.width,
-                  width: col.width,
-                  minWidth: col.width,
-                }),
-                boxShadow: !first
-                  ? `inset 0 1px 0 ${theme.palette.divider}`
-                  : undefined,
-              }}
+              sx={[
+                {
+                  ...(col.width && {
+                    maxWidth: col.width,
+                    width: col.width,
+                    minWidth: col.width,
+                  }),
+                  boxShadow: !first
+                    ? `inset 0 1px 0 ${theme.palette.divider}`
+                    : undefined,
+                },
+                ...(Array.isArray(sx) ? sx : [sx]),
+              ]}
             >
               <Stack
                 direction="row"
@@ -553,9 +563,9 @@ function renderChildren(
                   }),
                 }}
               >
-                {renderColumn(i, value, title)}
+                {renderColumn(i, value, title, columnCustomization)}
               </Stack>
-            </td>
+            </TableCell>
           );
         })}
       </tr>

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -1,0 +1,531 @@
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import ViewColumnIcon from "@mui/icons-material/ViewColumn";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
+import Step from "@mui/material/Step";
+import StepConnector from "@mui/material/StepConnector";
+import StepLabel from "@mui/material/StepLabel";
+import Switch from "@mui/material/Switch";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import ActionBar from "actionBar";
+import {
+  getCriteriaPlugin,
+  getCriteriaTitle,
+  getOccurrenceList,
+  OccurrenceFilters,
+} from "cohort";
+import Checkbox from "components/checkbox";
+import Empty from "components/empty";
+import Loading from "components/loading";
+import { usePopover } from "components/popover";
+import { SaveStatus } from "components/saveStatus";
+import { Tabs } from "components/tabs";
+import { useTextInputDialog } from "components/textInputDialog";
+import { TreeGrid, TreeGridData } from "components/treegrid";
+import { Filter, FilterType, makeArrayFilter } from "data/filter";
+import { useSource } from "data/sourceContext";
+import {
+  deleteFeatureSetCriteria,
+  setExcludedFeatureSetColumns,
+  toggleFeatureSetColumn,
+  updateFeatureSet,
+  useFeatureSetContext,
+} from "featureSet/featureSetContext";
+import { useFeatureSet, useStudyId, useUnderlay } from "hooks";
+import { GridBox } from "layout/gridBox";
+import GridLayout from "layout/gridLayout";
+import { useMemo, useState } from "react";
+import {
+  absoluteCohortURL,
+  featureSetCriteriaURL,
+  featureSetURL,
+  useBaseParams,
+  useExitAction,
+} from "router";
+import { StudyName } from "studyName";
+import useSWRImmutable from "swr/immutable";
+import * as tanagraUI from "tanagra-ui";
+import UndoRedoToolbar from "undoRedoToolbar";
+import { useGlobalSearchState, useNavigate } from "util/searchState";
+
+export function FeatureSet() {
+  const context = useFeatureSetContext();
+  const featureSet = useFeatureSet();
+  const exit = useExitAction();
+  const underlay = useUnderlay();
+  const source = useSource();
+  const navigate = useNavigate();
+  const params = useBaseParams();
+  const studyId = useStudyId();
+
+  const [renameTitleDialog, showRenameTitleDialog] = useTextInputDialog();
+
+  const newCohort = async () => {
+    const cohort = await source.createCohort(underlay.name, studyId);
+    navigate(absoluteCohortURL(params, cohort.id));
+  };
+
+  return (
+    <GridLayout rows>
+      <ActionBar
+        title={featureSet.name}
+        subtitle={
+          <GridLayout cols spacing={5} rowAlign="middle">
+            <StudyName />
+            <SaveStatus
+              saving={context.state?.saving}
+              lastModified={context.state?.present?.lastModified}
+            />
+          </GridLayout>
+        }
+        titleControls={
+          <IconButton
+            onClick={() =>
+              showRenameTitleDialog({
+                title: "Editing feature set name",
+                initialText: featureSet.name,
+                textLabel: "FeatureSet name",
+                buttonLabel: "Update",
+                onConfirm: (name: string) => {
+                  updateFeatureSet(context, name);
+                },
+              })
+            }
+          >
+            <EditIcon />
+          </IconButton>
+        }
+        rightControls={<UndoRedoToolbar />}
+        backAction={exit}
+      />
+      <GridLayout rows spacing={3} sx={{ px: 5, py: 3 }}>
+        <GridLayout cols="380px auto" spacing={2} rowAlign="middle">
+          <GridLayout cols>
+            <Step index={0} active>
+              <StepLabel>Add data features of interest</StepLabel>
+            </Step>
+            <StepConnector />
+          </GridLayout>
+          <GridLayout cols fillCol={1}>
+            <Step
+              index={1}
+              active={featureSet.criteria.length > 0}
+              disabled={featureSet.criteria.length === 0}
+            >
+              <StepLabel>Preview and manage columns</StepLabel>
+            </Step>
+            <GridBox />
+            <Button
+              startIcon={<AddIcon />}
+              onClick={() => newCohort()}
+              variant="outlined"
+            >
+              New cohort
+            </Button>
+          </GridLayout>
+        </GridLayout>
+        <GridLayout cols="380px auto" spacing={2}>
+          <Paper sx={{ height: "100%" }}>
+            <FeatureList />
+            {renameTitleDialog}
+          </Paper>
+          <Paper sx={{ height: "100%" }}>
+            <Preview />
+          </Paper>
+        </GridLayout>
+      </GridLayout>
+    </GridLayout>
+  );
+}
+
+function FeatureList() {
+  const featureSet = useFeatureSet();
+  const navigate = useNavigate();
+
+  const addURL = `../${featureSetURL(featureSet.id)}/add`;
+
+  const sortedCriteria = useMemo(() => {
+    const criteriaNames: [string, tanagraUI.UICriteria][] =
+      featureSet.criteria.map((c) => [getCriteriaTitle(c), c]);
+    return criteriaNames
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, c]) => c);
+  }, [featureSet.criteria]);
+
+  return (
+    <GridBox sx={{ px: 2, py: 1 }}>
+      <GridLayout rows spacing={2}>
+        {!sortedCriteria.length ? (
+          <GridLayout cols rowAlign="middle">
+            <Empty
+              maxWidth="90%"
+              title="Select the data features of interest to your research"
+              subtitle={
+                <>
+                  <Link
+                    variant="link"
+                    underline="hover"
+                    onClick={() => navigate(addURL)}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    Add a data feature
+                  </Link>{" "}
+                  to get started
+                </>
+              }
+            />
+          </GridLayout>
+        ) : (
+          <GridLayout rows height="auto" sx={{ overflowY: "auto" }}>
+            {sortedCriteria.map((c) => (
+              <GridBox key={c.id} sx={{ pb: 1 }}>
+                <FeatureSetCriteria criteria={c} />
+                <Divider />
+              </GridBox>
+            ))}
+            <Button variant="contained" onClick={() => navigate(addURL)}>
+              Add data feature
+            </Button>
+          </GridLayout>
+        )}
+      </GridLayout>
+    </GridBox>
+  );
+}
+
+type FeatureSetCriteriaProps = {
+  criteria: tanagraUI.UICriteria;
+};
+
+function FeatureSetCriteria(props: FeatureSetCriteriaProps) {
+  const context = useFeatureSetContext();
+  const navigate = useNavigate();
+
+  const plugin = getCriteriaPlugin(props.criteria);
+  const title = getCriteriaTitle(props.criteria, plugin);
+
+  return (
+    <GridLayout cols rowAlign="middle" sx={{ px: 1 }}>
+      <Typography variant="body1" title={title}>
+        {title}
+      </Typography>
+      <IconButton
+        disabled={!plugin?.renderEdit}
+        onClick={() => navigate(featureSetCriteriaURL(props.criteria.id))}
+      >
+        <EditIcon />
+      </IconButton>
+      <IconButton
+        onClick={() => deleteFeatureSetCriteria(context, props.criteria.id)}
+      >
+        <DeleteIcon />
+      </IconButton>
+      <GridBox />
+    </GridLayout>
+  );
+}
+
+type PreviewTabData = {
+  name: string;
+  data: TreeGridData;
+};
+
+function Preview() {
+  const featureSet = useFeatureSet();
+  const underlay = useUnderlay();
+  const source = useSource();
+  const navigate = useNavigate();
+
+  const occurrenceList = useMemo(() => {
+    const selectedCriteria = new Set<string>();
+    underlay.uiConfiguration.prepackagedConceptSets?.forEach((conceptSet) => {
+      if (featureSet.predefinedCriteria.includes(conceptSet.id)) {
+        selectedCriteria.add(conceptSet.id);
+      }
+    });
+
+    featureSet.criteria.forEach((criteria) => {
+      selectedCriteria.add(criteria.id);
+    });
+
+    return getOccurrenceList(
+      source,
+      selectedCriteria,
+      featureSet.criteria,
+      underlay.uiConfiguration.prepackagedConceptSets
+    );
+  }, [featureSet.criteria, featureSet.predefinedCriteria]);
+
+  // TODO(tjennison): Look at supporting a "true" filter instead.
+  const cohortFilter: Filter = {
+    type: FilterType.Attribute,
+    attribute: source.lookupOccurrence("").key,
+    ranges: [{ min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER }],
+  };
+
+  const tabDataState = useSWRImmutable<PreviewTabData[]>(
+    {
+      type: "previewData",
+      cohortFilter,
+      occurrences: occurrenceList,
+    },
+    async () => {
+      return Promise.all(
+        occurrenceList.map(async (params) => {
+          const res = await source.listData(
+            params.attributes,
+            params.id,
+            cohortFilter,
+            makeArrayFilter({ min: 1 }, params.filters)
+          );
+
+          const data: TreeGridData = {
+            root: { data: {}, children: [] },
+          };
+
+          res.data.forEach((entry, i) => {
+            data[i] = { data: entry };
+            data.root?.children?.push(i);
+          });
+
+          return {
+            id: params.id,
+            name: params.name,
+            data: data,
+          };
+        })
+      );
+    }
+  );
+
+  return (
+    <GridLayout rows sx={{ pt: 1 }}>
+      {featureSet.criteria.length > 0 ||
+      featureSet.predefinedCriteria.length > 0 ? (
+        <Loading status={tabDataState}>
+          <Tabs
+            configs={
+              tabDataState.data?.map((data, i) => ({
+                id: data.name,
+                title: data.name,
+                render: () =>
+                  data.data.root?.children?.length ? (
+                    <PreviewTable occurrence={occurrenceList[i]} data={data} />
+                  ) : (
+                    <GridLayout cols rowAlign="middle">
+                      <Empty
+                        maxWidth="90%"
+                        image="/empty.svg"
+                        title="No data matched"
+                        subtitle="No data in this table matched the specified cohorts and data features"
+                      />
+                    </GridLayout>
+                  ),
+              })) ?? []
+            }
+          />
+        </Loading>
+      ) : (
+        <GridLayout cols rowAlign="middle">
+          <Empty
+            maxWidth="90%"
+            image="/empty.svg"
+            title="Set up columns for each data feature here. You’ll see a preview of your table."
+            subtitle={
+              <>
+                <Link
+                  variant="link"
+                  underline="hover"
+                  onClick={() =>
+                    navigate(`../${featureSetURL(featureSet.id)}/add`)
+                  }
+                  sx={{ cursor: "pointer" }}
+                >
+                  Add a data feature
+                </Link>{" "}
+                to start tinkering. Your columns will be saved as part of the
+                data feature set.
+              </>
+            }
+          />
+        </GridLayout>
+      )}
+    </GridLayout>
+  );
+}
+
+type PreviewTableProps = {
+  occurrence: OccurrenceFilters;
+  data: PreviewTabData;
+};
+
+function PreviewTable(props: PreviewTableProps) {
+  const context = useFeatureSetContext();
+  const featureSet = useFeatureSet();
+  const [globalSearchState, updateGlobalSearchState] = useGlobalSearchState();
+
+  const output = featureSet.output.find(
+    (o) => o.occurrence === props.occurrence.id
+  );
+
+  const columns = useMemo(() => {
+    return props.occurrence.attributes
+      .filter(
+        (attribute) =>
+          !globalSearchState.showSelectedColumnsOnly ||
+          !output?.excludedColumns?.includes(attribute)
+      )
+      .map((attribute) => {
+        return {
+          key: attribute,
+          width: 200,
+          title: attribute,
+          suffixElements: (
+            <Checkbox
+              name={attribute}
+              size="small"
+              fontSize="small"
+              checked={!output?.excludedColumns?.includes(attribute)}
+              onChange={() =>
+                toggleFeatureSetColumn(context, props.occurrence.id, attribute)
+              }
+            />
+          ),
+        };
+      });
+  }, [
+    props.occurrence,
+    featureSet.output,
+    globalSearchState.showSelectedColumnsOnly,
+  ]);
+
+  const [columnSearch, setColumnSearch] = useState("");
+
+  const columnSearchRE = useMemo(
+    () => new RegExp(columnSearch, "i"),
+    [columnSearch]
+  );
+
+  const [manageColumns, showManageColumns] = usePopover({
+    children: (
+      <GridBox sx={{ width: "300px", height: "auto" }}>
+        <GridLayout rows>
+          <GridBox sx={{ p: 1 }}>
+            <TextField
+              size="small"
+              fullWidth
+              label="Find column"
+              value={columnSearch}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                setColumnSearch(event.target.value);
+              }}
+            />
+          </GridBox>
+          {props.occurrence.attributes
+            .filter(
+              (attribute) => !columnSearch || attribute.match(columnSearchRE)
+            )
+            .map((attribute) => (
+              <GridLayout key={attribute} cols>
+                <Switch
+                  name={attribute}
+                  size="small"
+                  checked={!output?.excludedColumns?.includes(attribute)}
+                  onChange={() =>
+                    toggleFeatureSetColumn(
+                      context,
+                      props.occurrence.id,
+                      attribute
+                    )
+                  }
+                />
+                <Typography variant="body2">{attribute}</Typography>
+              </GridLayout>
+            ))}
+          <GridLayout cols fillCol={1}>
+            <Button
+              size="medium"
+              onClick={() =>
+                setExcludedFeatureSetColumns(
+                  context,
+                  props.occurrence.id,
+                  props.occurrence.attributes
+                )
+              }
+            >
+              Exclude all
+            </Button>
+            <GridBox />
+            <Button
+              size="medium"
+              onClick={() =>
+                setExcludedFeatureSetColumns(context, props.occurrence.id, [])
+              }
+            >
+              Include all
+            </Button>
+          </GridLayout>
+        </GridLayout>
+      </GridBox>
+    ),
+    PaperProps: {
+      square: true,
+    },
+  });
+
+  return (
+    <GridLayout rows>
+      <GridLayout cols fillCol={1} sx={{ px: 2, py: 1 }}>
+        <Button
+          size="medium"
+          startIcon={<ViewColumnIcon />}
+          onClick={showManageColumns}
+        >
+          Manage columns
+        </Button>
+        <GridBox>{manageColumns}</GridBox>
+        <Switch
+          name="show-included-columns-only"
+          checked={globalSearchState.showSelectedColumnsOnly}
+          onChange={() => {
+            updateGlobalSearchState((state) => {
+              state.showSelectedColumnsOnly = !state.showSelectedColumnsOnly;
+            });
+          }}
+          size="small"
+        />
+        <Typography variant="body1">Show included columns only</Typography>
+      </GridLayout>
+      {output?.excludedColumns?.length !==
+      props.occurrence.attributes.length ? (
+        <TreeGrid
+          data={props.data?.data}
+          columns={columns}
+          rowCustomization={() => {
+            return columns.map((col, i) => ({
+              column: i,
+              backgroundSx: output?.excludedColumns?.includes(col.key)
+                ? {
+                    backgroundColor: (theme) =>
+                      theme.palette.background.default,
+                  }
+                : undefined,
+            }));
+          }}
+        />
+      ) : (
+        <Empty
+          maxWidth="90%"
+          title="No columns are included"
+          subtitle={"Select columns to include using the Manage columns button"}
+        />
+      )}
+    </GridLayout>
+  );
+}

--- a/ui/src/featureSet/featureSetContext.ts
+++ b/ui/src/featureSet/featureSetContext.ts
@@ -1,0 +1,277 @@
+import { getCriteriaTitle, upgradeCriteria } from "cohort";
+import { FeatureSet } from "data/source";
+import { useSource } from "data/sourceContext";
+import { useUnderlay } from "hooks";
+import produce from "immer";
+import { createContext, useContext, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { absoluteFeatureSetURL, BaseParams } from "router";
+import useSWR, { useSWRConfig } from "swr";
+import * as tanagraUI from "tanagra-ui";
+
+type FeatureSetState = {
+  past: FeatureSet[];
+  present: FeatureSet;
+  future: FeatureSet[];
+
+  saving: boolean;
+  showSnackbar: (message: string) => void;
+};
+
+type FeatureSetContextData = {
+  state: FeatureSetState | null;
+  updateState: (update: (state: FeatureSetState) => void) => void;
+  updatePresent: (
+    update: (
+      present: FeatureSet,
+      showSnackbar: (message: string) => void
+    ) => void
+  ) => void;
+};
+
+export const FeatureSetContext = createContext<FeatureSetContextData | null>(
+  null
+);
+
+export function useFeatureSetContext() {
+  const context = useContext(FeatureSetContext);
+  if (!context) {
+    throw new Error("Attempting to use featureSet context when not provided.");
+  }
+  return context;
+}
+
+export function useNewFeatureSetContext(
+  showSnackbar: (message: string) => void
+) {
+  const underlay = useUnderlay();
+  const source = useSource();
+  const { studyId, featureSetId } =
+    useParams<{ studyId: string; featureSetId: string }>();
+
+  if (!studyId || !featureSetId) {
+    throw new Error(
+      "Cannot create featureSet context without study and featureSet IDs."
+    );
+  }
+
+  const [state, setState] = useState<FeatureSetState | null>(null);
+
+  const key = {
+    type: "featureSet",
+    studyId,
+    featureSetId,
+  };
+  const status = useSWR(key, async () => {
+    const featureSet = await source.getFeatureSet(studyId, featureSetId);
+    for (const c of featureSet.criteria) {
+      upgradeCriteria(c, underlay.uiConfiguration.criteriaConfigs);
+    }
+    return featureSet;
+  });
+
+  useEffect(
+    () =>
+      setState(
+        status.data
+          ? {
+              past: state?.past ?? [],
+              present: status.data,
+              future: state?.future ?? [],
+
+              saving: false,
+              showSnackbar,
+            }
+          : null
+      ),
+    [status.data]
+  );
+
+  const updateFeatureSet = async (newState: FeatureSetState | null) => {
+    if (!newState) {
+      throw new Error("Invalid null featureSet update.");
+    }
+    setState(newState);
+    await source.updateFeatureSet(studyId, newState.present);
+
+    setState(
+      produce(newState, (state) => {
+        state.saving = false;
+      })
+    );
+
+    status.mutate();
+  };
+
+  const { mutate } = useSWRConfig();
+
+  return {
+    ...status,
+    isLoading: status.isLoading || !state,
+    context: {
+      state: state,
+      updateState: async (update: (state: FeatureSetState) => void) => {
+        updateFeatureSet(
+          produce(state, (state) => {
+            if (state) {
+              update(state);
+              state.saving = true;
+            }
+          })
+        );
+      },
+      updatePresent: async (
+        update: (
+          present: FeatureSet,
+          showSnackbar: (message: string) => void
+        ) => void
+      ) => {
+        if (!state) {
+          throw new Error("Attempting to update null featureSet.");
+        }
+
+        // Produce twice, otherwise edits to the present featureSet still end up
+        // affecting the pushed featureSet as well.
+        const pushed = produce(state, (state) => {
+          state.past.push(state.present);
+          state.future = [];
+        });
+        const newState = produce(pushed, (state) => {
+          update(state.present, state.showSnackbar);
+          state.saving = true;
+        });
+
+        await updateFeatureSet(newState);
+
+        mutate(
+          (key: { type: string; studyId: string; list: boolean }) =>
+            key.type === "featureSet" &&
+            key.studyId === studyId &&
+            key.list === true,
+          undefined,
+          { revalidate: true }
+        );
+      },
+    },
+  };
+}
+
+export function featureSetUndoRedo(
+  params: BaseParams,
+  context: FeatureSetContextData
+) {
+  const featureSetURL = absoluteFeatureSetURL(
+    params,
+    context.state?.present?.id ?? ""
+  );
+  return {
+    undoURL: context.state?.past?.length ? featureSetURL : "",
+    redoURL: context.state?.future?.length ? featureSetURL : "",
+    undoAction: context.state?.past?.length
+      ? () => {
+          context.updateState((state) => {
+            state.future.push(state.present);
+            state.present = state.past[state.past.length - 1];
+            state.past.pop();
+          });
+        }
+      : undefined,
+    redoAction: context.state?.future?.length
+      ? () => {
+          context.updateState((state) => {
+            state.past.push(state.present);
+            state.present = state.future[state.future.length - 1];
+            state.future.pop();
+          });
+        }
+      : undefined,
+  };
+}
+
+export function insertFeatureSetCriteria(
+  context: FeatureSetContextData,
+  criteria: tanagraUI.UICriteria
+) {
+  context.updatePresent((present, showSnackbar) => {
+    present.criteria.push(criteria);
+    showSnackbar(`"${getCriteriaTitle(criteria)}" added`);
+  });
+}
+
+export function updateFeatureSetCriteria(
+  context: FeatureSetContextData,
+  data: object,
+  criteriaId?: string
+) {
+  context.updatePresent((present) => {
+    const index = present.criteria.findIndex((c) => c.id === criteriaId);
+    if (index >= 0) {
+      present.criteria[index].data = data;
+    }
+  });
+}
+
+export function deleteFeatureSetCriteria(
+  context: FeatureSetContextData,
+  criteriaId: string
+) {
+  context.updatePresent((present) => {
+    const index = present.criteria.findIndex((c) => c.id === criteriaId);
+    if (index < 0) {
+      throw new Error(
+        `Criteria ${criteriaId} does not exist on feature set ${JSON.stringify(
+          present
+        )}.`
+      );
+    }
+
+    present.criteria.splice(index, 1);
+  });
+}
+
+export function updateFeatureSet(context: FeatureSetContextData, name: string) {
+  context.updatePresent((present) => {
+    present.name = name;
+  });
+}
+
+export function setExcludedFeatureSetColumns(
+  context: FeatureSetContextData,
+  occurrence: string,
+  columns: string[]
+) {
+  context.updatePresent((present) => {
+    const output = present.output.find((o) => o.occurrence === occurrence);
+    if (output) {
+      output.excludedColumns = columns;
+    } else {
+      present.output.push({
+        occurrence,
+        excludedColumns: columns,
+      });
+    }
+  });
+}
+
+export function toggleFeatureSetColumn(
+  context: FeatureSetContextData,
+  occurrence: string,
+  column: string
+) {
+  context.updatePresent((present) => {
+    const output = present.output.find((o) => o.occurrence === occurrence);
+    if (output) {
+      const index = output.excludedColumns.findIndex((c) => c === column);
+      if (index >= 0) {
+        output.excludedColumns.splice(index, 1);
+      } else {
+        output.excludedColumns.push(column);
+      }
+    } else {
+      present.output.push({
+        occurrence,
+        excludedColumns: [column],
+      });
+    }
+  });
+}

--- a/ui/src/featureSet/featureSetEdit.tsx
+++ b/ui/src/featureSet/featureSetEdit.tsx
@@ -1,0 +1,15 @@
+import { getCriteriaPlugin, getCriteriaTitle } from "cohort";
+import CriteriaHolder from "criteriaHolder";
+import { useFeatureSetAndCriteria } from "hooks";
+
+export function FeatureSetEdit() {
+  const { criteria } = useFeatureSetAndCriteria();
+  const plugin = getCriteriaPlugin(criteria);
+
+  return (
+    <CriteriaHolder
+      title={`Editing criteria "${getCriteriaTitle(criteria, plugin)}"`}
+      plugin={plugin}
+    />
+  );
+}

--- a/ui/src/featureSet/featureSetRoot.tsx
+++ b/ui/src/featureSet/featureSetRoot.tsx
@@ -1,22 +1,22 @@
 import Snackbar from "@mui/material/Snackbar";
-import {
-  CohortContext,
-  cohortUndoRedo,
-  useNewCohortContext,
-} from "cohortContext";
 import Loading from "components/loading";
+import {
+  FeatureSetContext,
+  featureSetUndoRedo,
+  useNewFeatureSetContext,
+} from "featureSet/featureSetContext";
 import { SyntheticEvent, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { useBaseParams } from "router";
 import { UndoRedoContext } from "undoRedoToolbar";
 
-export default function CohortRoot() {
+export default function FeatureSetRoot() {
   const params = useBaseParams();
 
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
 
-  const status = useNewCohortContext((message: string) => {
+  const status = useNewFeatureSetContext((message: string) => {
     setMessage(message);
     setOpen(true);
   });
@@ -31,9 +31,9 @@ export default function CohortRoot() {
 
   return (
     <Loading status={status}>
-      <CohortContext.Provider value={status.context}>
+      <FeatureSetContext.Provider value={status.context}>
         <UndoRedoContext.Provider
-          value={cohortUndoRedo(params, status.context)}
+          value={featureSetUndoRedo(params, status.context)}
         >
           <Outlet />
           <Snackbar
@@ -43,7 +43,7 @@ export default function CohortRoot() {
             message={message}
           />
         </UndoRedoContext.Provider>
-      </CohortContext.Provider>
+      </FeatureSetContext.Provider>
     </Loading>
   );
 }

--- a/ui/src/featureSet/newFeatureSet.tsx
+++ b/ui/src/featureSet/newFeatureSet.tsx
@@ -1,0 +1,21 @@
+import { getCriteriaPlugin } from "cohort";
+import CriteriaHolder from "criteriaHolder";
+import { useFeatureSet, useNewCriteria } from "hooks";
+import { absoluteFeatureSetURL, useBaseParams } from "router";
+import { useNavigate } from "util/searchState";
+
+export function NewFeatureSet() {
+  const params = useBaseParams();
+  const criteria = useNewCriteria();
+  const navigate = useNavigate();
+  const featureSet = useFeatureSet();
+
+  return (
+    <CriteriaHolder
+      title={`Adding "${criteria.config.title}" criteria to ${featureSet.name}`}
+      plugin={getCriteriaPlugin(criteria)}
+      exitAction={() => navigate(absoluteFeatureSetURL(params, featureSet.id))}
+      backURL=".."
+    />
+  );
+}

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -1,6 +1,5 @@
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
-import LoopIcon from "@mui/icons-material/Loop";
 import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -24,10 +23,10 @@ import {
   updateCohortGroupSection,
   useCohortContext,
 } from "cohortContext";
-import CohortToolbar from "cohortToolbar";
 import Empty from "components/empty";
 import Loading from "components/loading";
 import { useMenu } from "components/menu";
+import { SaveStatus } from "components/saveStatus";
 import { useTextInputDialog } from "components/textInputDialog";
 import { useSource } from "data/sourceContext";
 import { DemographicCharts } from "demographicCharts";
@@ -46,6 +45,7 @@ import {
 import { StudyName } from "studyName";
 import useSWRImmutable from "swr/immutable";
 import * as tanagraUI from "tanagra-ui";
+import UndoRedoToolbar from "undoRedoToolbar";
 import { RouterLink, useNavigate } from "util/searchState";
 import {
   createCriteria,
@@ -68,8 +68,12 @@ export function Overview() {
       <ActionBar
         title={cohort.name}
         subtitle={
-          <GridLayout cols spacing={1} rowAlign="middle">
-            <StudyName />•<SaveStatus />
+          <GridLayout cols spacing={5} rowAlign="middle">
+            <StudyName />
+            <SaveStatus
+              saving={context.state?.saving}
+              lastModified={context.state?.present?.lastModified}
+            />
           </GridLayout>
         }
         titleControls={
@@ -89,7 +93,7 @@ export function Overview() {
             <EditIcon />
           </IconButton>
         }
-        rightControls={<CohortToolbar />}
+        rightControls={<UndoRedoToolbar />}
         backAction={exit}
       />
       <GridLayout
@@ -680,25 +684,5 @@ function ParticipantsGroup(props: {
       </GridBox>
       {menu}
     </GridBox>
-  );
-}
-
-function SaveStatus() {
-  const context = useCohortContext();
-  if (!context?.state) {
-    return null;
-  }
-
-  return (
-    <GridLayout cols rowAlign="middle">
-      {!context.state.saving ? (
-        <LoopIcon fontSize="small" sx={{ display: "block" }} />
-      ) : null}
-      <Typography variant="body1">
-        {context.state.saving
-          ? "Saving..."
-          : `Last saved: ${context.state.present.lastModified.toLocaleString()}`}
-      </Typography>
-    </GridLayout>
   );
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,5 +1,9 @@
 import Button from "@mui/material/Button";
-import { AddCohortCriteria, AddConceptSetCriteria } from "addCriteria";
+import {
+  AddCohortCriteria,
+  AddConceptSetCriteria,
+  AddFeatureSetCriteria,
+} from "addCriteria";
 import { CohortReview } from "cohortReview/cohortReview";
 import { CohortReviewList } from "cohortReview/cohortReviewList";
 import CohortRoot from "cohortRoot";
@@ -8,6 +12,10 @@ import ConceptSetRoot from "conceptSetRoot";
 import { SourceContextRoot } from "data/sourceContext";
 import { Datasets } from "datasets";
 import Edit from "edit";
+import { FeatureSet } from "featureSet/featureSet";
+import { FeatureSetEdit } from "featureSet/featureSetEdit";
+import FeatureSetRoot from "featureSet/featureSetRoot";
+import { NewFeatureSet } from "featureSet/newFeatureSet";
 import NewConceptSet from "newConceptSet";
 import NewCriteria from "newCriteria";
 import { Overview } from "overview";
@@ -100,6 +108,37 @@ export function createAppRouter() {
             {
               path: "edit/:conceptSetId",
               element: <ConceptSetEdit />,
+            },
+          ],
+        },
+        {
+          element: <FeatureSetRoot />,
+          children: [
+            {
+              path: "featureSets/:featureSetId",
+              children: [
+                {
+                  index: true,
+                  element: <FeatureSet />,
+                },
+                {
+                  path: "add",
+                  children: [
+                    {
+                      index: true,
+                      element: <AddFeatureSetCriteria />,
+                    },
+                    {
+                      path: ":configId",
+                      element: <NewFeatureSet />,
+                    },
+                  ],
+                },
+                {
+                  path: "edit/:criteriaId",
+                  element: <FeatureSetEdit />,
+                },
+              ],
             },
           ],
         },
@@ -270,6 +309,17 @@ export function absoluteCohortURL(
   return absolutePrefix(params) + cohortURL(cohortId, groupSectionId, groupId);
 }
 
+export function featureSetURL(featureSetId: string) {
+  return `featureSets/${featureSetId}`;
+}
+
+export function absoluteFeatureSetURL(
+  params: BaseParams,
+  featureSetId: string
+) {
+  return absolutePrefix(params) + featureSetURL(featureSetId);
+}
+
 export function absoluteExportURL(params: BaseParams) {
   return absolutePrefix(params) + "export";
 }
@@ -299,6 +349,10 @@ export function criteriaURL() {
 
 export function newCriteriaURL(configId: string) {
   return `add/${configId}`;
+}
+
+export function featureSetCriteriaURL(criteriaId: string) {
+  return "edit/" + criteriaId;
 }
 
 export function absoluteCohortReviewListURL(

--- a/ui/src/undoRedoToolbar.tsx
+++ b/ui/src/undoRedoToolbar.tsx
@@ -2,35 +2,45 @@ import RedoIcon from "@mui/icons-material/Redo";
 import UndoIcon from "@mui/icons-material/Undo";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
-import { useRedoAction, useUndoAction, useUndoRedoUrls } from "hooks";
+import { createContext, useContext } from "react";
 import { RouterLink } from "util/searchState";
 
-export default function CohortToolbar() {
-  const [undoUrlPath, redoUrlPath] = useUndoRedoUrls();
-  const undo = useUndoAction();
-  const redo = useRedoAction();
+export type UndoRedoData = {
+  undoURL: string;
+  redoURL: string;
+  undoAction?: () => void;
+  redoAction?: () => void;
+};
+
+export const UndoRedoContext = createContext<UndoRedoData | null>(null);
+
+export default function UndoRedoToolbar() {
+  const data = useContext(UndoRedoContext);
+  if (!data) {
+    throw new Error("No UndoRedoData available.");
+  }
 
   return (
     <Stack direction="row" spacing={1}>
       <Button
-        onClick={() => undo?.()}
+        onClick={() => data.undoAction?.()}
         variant="outlined"
         size="large"
         startIcon={<UndoIcon fontSize="small" />}
-        disabled={!undo}
+        disabled={!data.undoAction}
         component={RouterLink}
-        to={undoUrlPath}
+        to={data.undoURL}
       >
         Undo
       </Button>
       <Button
-        onClick={() => redo?.()}
+        onClick={() => data.redoAction?.()}
         variant="outlined"
         size="large"
         startIcon={<RedoIcon fontSize="small" />}
-        disabled={!redo}
+        disabled={!data.redoAction}
         component={RouterLink}
-        to={redoUrlPath}
+        to={data.redoURL}
       >
         Redo
       </Button>

--- a/ui/src/util/searchState.tsx
+++ b/ui/src/util/searchState.tsx
@@ -9,6 +9,9 @@ import {
 export type GlobalSearchState = {
   // addCriteria
   addCriteriaTags?: string[];
+
+  // featureSet
+  showSelectedColumnsOnly?: boolean;
 };
 
 const STORAGE_ID = "t_globalSearchState";


### PR DESCRIPTION
* Add main feature sets UI and link from study overview.
* Fake backend using localstorage until API is ready.
* Add helpers for popovers.
* Refactor functionality from datasets to share with feature sets page.
* Refactor undo/redo toolbar.
* Add arbitrary icon support to checkboxes.
* Add column background styling and header suffixes to treegrid.

TODO:
* Preview using a specified cohort.
* Export page.
* Backend integration.