### PR TITLE
[DT-556] Fix modifiers aou tanagra all domains and cpt4

### DIFF
--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_brand.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_brand.json
@@ -10,35 +10,8 @@
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
     "tablePointer": {
-      "table": "concept",
-      "filter": {
-        "type": "BOOLEAN_AND_OR",
-        "operator": "AND",
-        "subfilters": [
-          { "type": "BINARY",
-            "field": { "column": "domain_id" },
-            "operator": "EQUALS",
-            "value": { "stringVal": "Drug" } },
-          { "type": "BINARY",
-            "field": { "column": "concept_class_id" },
-            "operator": "EQUALS",
-            "value": { "stringVal": "Brand Name" } },
-          { "type": "BINARY",
-            "field": { "column": "invalid_reason" },
-            "operator": "IS",
-            "value": { "stringVal": null } },
-          { "type": "BOOLEAN_AND_OR",
-            "operator": "OR",
-            "subfilters": [
-              { "type": "BINARY",
-                "field": { "column": "vocabulary_id" },
-                "operator": "EQUALS",
-                "value": { "stringVal": "RxNorm" } },
-              { "type": "BINARY",
-                "field": { "column": "vocabulary_id" },
-                "operator": "EQUALS",
-                "value": { "stringVal": "RxNorm Extension" } }
-            ] } ] } },
+      "rawSqlFile": "t_brand_all.sql"
+    },
     "attributeMappings": {
       "id": { "value": { "column": "concept_id" } },
       "name": { "value": { "column": "concept_name" } },

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_condition_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_condition_occurrence.json
@@ -8,15 +8,17 @@
     { "type": "SIMPLE", "name": "start_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "end_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "stop_reason", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "condition_occurrence" },
+    "tablePointer": { "rawSqlFile": "t_condition_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "condition_occurrence_id" } },
       "condition": {
         "value": { "column": "condition_concept_id" },
         "display": {
@@ -24,10 +26,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "start_date": { "value": { "column": "condition_start_date" } },
-      "end_date": { "value": { "column": "condition_end_date" } },
-      "source_value": { "value": { "column": "condition_source_value" } },
-      "source_criteria_id": { "value": { "column": "condition_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_device_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_device_occurrence.json
@@ -7,15 +7,17 @@
     { "type": "KEY_AND_DISPLAY", "name": "device", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "start_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "end_date", "dataType": "DATE" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "device_exposure" },
+    "tablePointer": { "rawSqlFile": "t_device_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "device_exposure_id" } },
       "device": {
         "value": { "column": "device_concept_id" },
         "display": {
@@ -23,10 +25,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "start_date": { "value": { "column": "device_exposure_start_date" } },
-      "end_date": { "value": { "column": "device_exposure_end_date" } },
-      "source_value": { "value": { "column": "device_source_value" } },
-      "source_criteria_id": { "value": { "column": "device_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_ingredient_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_ingredient_occurrence.json
@@ -10,15 +10,17 @@
     { "type": "SIMPLE", "name": "stop_reason", "dataType": "STRING" },
     { "type": "SIMPLE", "name": "refills", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "days_supply", "dataType": "INT64" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "drug_exposure" },
+    "tablePointer": { "rawSqlFile": "t_ingredient_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "drug_exposure_id" } },
       "ingredient": {
         "value": { "column": "drug_concept_id" },
         "display": {
@@ -26,10 +28,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "start_date": { "value": { "column": "drug_exposure_start_date" } },
-      "end_date": { "value": { "column": "drug_exposure_end_date" } },
-      "source_value": { "value": { "column": "drug_source_value" } },
-      "source_criteria_id": { "value": { "column": "drug_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_measurement_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_measurement_occurrence.json
@@ -9,15 +9,17 @@
     { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
     { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
     { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "measurement" },
+    "tablePointer": { "rawSqlFile": "t_measurement_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "measurement_id" } },
       "measurement": {
         "value": { "column": "measurement_concept_id" },
         "display": {
@@ -26,7 +28,6 @@
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
       "date": { "value": { "column": "measurement_date" } },
-      "value_numeric": { "value": { "column": "value_as_number" } },
       "value_enum": {
         "value": { "column": "value_as_concept_id" },
         "display": {
@@ -41,8 +42,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "source_value": { "value": { "column": "measurement_source_value" } },
-      "source_criteria_id": { "value": { "column": "measurement_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_observation_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_observation_occurrence.json
@@ -9,15 +9,17 @@
     { "type": "SIMPLE", "name": "value_as_string", "dataType": "STRING" },
     { "type": "KEY_AND_DISPLAY", "name": "value", "dataType": "INT64" },
     { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "observation" },
+    "tablePointer": { "rawSqlFile": "t_observation_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "observation_id" } },
       "observation": {
         "value": { "column": "observation_concept_id" },
         "display": {
@@ -40,8 +42,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "source_value": { "value": { "column": "observation_source_value" } },
-      "source_criteria_id": { "value": { "column": "observation_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_procedure_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_procedure_occurrence.json
@@ -6,15 +6,17 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "procedure", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "date", "dataType": "DATE" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "procedure_occurrence" },
+    "tablePointer": { "rawSqlFile": "t_procedure_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "procedure_occurrence_id" } },
       "procedure": {
         "value": { "column": "procedure_concept_id" },
         "display": {
@@ -23,8 +25,13 @@
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
       "date": { "value": { "column": "procedure_date" } },
-      "source_value": { "value": { "column": "procedure_source_value" } },
-      "source_criteria_id": { "value": { "column": "procedure_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_visit_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/entity/t_visit_occurrence.json
@@ -4,19 +4,21 @@
   "attributes": [
     { "type": "SIMPLE", "name": "id", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "visit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "start_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "end_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
     { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64", "displayHintTypes": ["NONE"] }],
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
     "tablePointer": { "rawSqlFile": "t_visit_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "id" } },
-      "visit": {
+      "id": { "value": { "column": "visit_occurrence_id" } },
+      "visit_type": {
         "value": { "column": "visit_concept_id" },
         "display": {
           "column": "visit_concept_id",

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_condition_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_condition_occurrence_all.sql
@@ -13,8 +13,8 @@ ON p.person_id = co.person_id
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = co.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_condition_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_condition_occurrence_all.sql
@@ -18,4 +18,3 @@ LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_condition_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_condition_occurrence_all.sql
@@ -12,3 +12,10 @@ ON p.person_id = co.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = co.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_device_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_device_occurrence_all.sql
@@ -12,3 +12,10 @@ ON p.person_id = de.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_device_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_device_occurrence_all.sql
@@ -13,8 +13,8 @@ ON p.person_id = de.person_id
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_device_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_device_occurrence_all.sql
@@ -18,4 +18,3 @@ LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_ingredient_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_ingredient_occurrence_all.sql
@@ -13,3 +13,10 @@ ON p.person_id = de.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_ingredient_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_ingredient_occurrence_all.sql
@@ -19,4 +19,3 @@ LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_measurement_occurrence_all.sql
@@ -20,4 +20,3 @@ LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_measurement_occurrence_all.sql
@@ -15,8 +15,8 @@ ON p.person_id = mo.person_id
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = mo.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_measurement_occurrence_all.sql
@@ -1,5 +1,7 @@
 SELECT
-  mo.measurement_id AS id, mo.person_id, mo.measurement_concept_id, mo.measurement_date,
+  mo.measurement_id AS id, mo.person_id,
+  CASE WHEN mo.measurement_concept_id IS NULL THEN 0 ELSE mo.measurement_concept_id END AS measurement_concept_id,
+  mo.measurement_date,
   mo.value_as_number AS value_numeric, mo.value_as_concept_id, mo.unit_concept_id,
   mo.measurement_source_value AS source_value, mo.measurement_source_concept_id AS source_criteria_id,
   CAST(FLOOR(TIMESTAMP_DIFF(mo.measurement_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
@@ -12,3 +14,10 @@ ON p.person_id = mo.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = mo.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_observation_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_observation_occurrence_all.sql
@@ -12,3 +12,10 @@ ON p.person_id = o.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = o.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_observation_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_observation_occurrence_all.sql
@@ -13,8 +13,8 @@ ON p.person_id = o.person_id
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = o.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_observation_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_observation_occurrence_all.sql
@@ -18,4 +18,3 @@ LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_procedure_occurrence_all.sql
@@ -12,8 +12,8 @@ ON p.person_id = po.person_id
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = po.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_procedure_occurrence_all.sql
@@ -11,3 +11,10 @@ ON p.person_id = po.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = po.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_procedure_occurrence_all.sql
@@ -17,4 +17,3 @@ LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_visit_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_visit_occurrence_all.sql
@@ -14,4 +14,3 @@ ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_visit_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/sql/t_visit_occurrence_all.sql
@@ -1,5 +1,5 @@
 SELECT
-  vo.visit_occurrence_id AS id, vo.person_id, vo.visit_concept_id,
+  vo.visit_occurrence_id, vo.person_id, vo.visit_concept_id,
   vo.visit_start_date AS start_date, vo.visit_end_date AS end_date,
   vo.visit_source_value AS source_value, vo.visit_source_concept_id AS source_criteria_id,
   CAST(FLOOR(TIMESTAMP_DIFF(vo.visit_start_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/ui/top_level.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/ui/top_level.json
@@ -393,8 +393,8 @@
         "direction": "ASC"
       },
       "modifiers": [
-      "age_at_occurrence",
-      "start_date_group_by_count"
+        "age_at_occurrence",
+        "start_date_group_by_count"
     ]
     },
     {

--- a/service/src/main/resources/config/aou/test/SC2023Q3R1/ui/top_level.json
+++ b/service/src/main/resources/config/aou/test/SC2023Q3R1/ui/top_level.json
@@ -391,7 +391,11 @@
       "defaultSort": {
         "attribute": "name",
         "direction": "ASC"
-      }
+      },
+      "modifiers": [
+      "age_at_occurrence",
+      "start_date_group_by_count"
+    ]
     },
     {
       "type": "classification",
@@ -409,7 +413,12 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "occurrences": "device_occurrence",
-      "classifications": ["device"]
+      "classifications": ["device"],
+      "modifiers": [
+        "age_at_occurrence",
+        "visit_type",
+        "start_date_group_by_count"
+      ]
     },
     {
       "type": "attribute",

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_brand.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_brand.json
@@ -10,35 +10,8 @@
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
     "tablePointer": {
-      "table": "concept",
-      "filter": {
-        "type": "BOOLEAN_AND_OR",
-        "operator": "AND",
-        "subfilters": [
-          { "type": "BINARY",
-            "field": { "column": "domain_id" },
-            "operator": "EQUALS",
-            "value": { "stringVal": "Drug" } },
-          { "type": "BINARY",
-            "field": { "column": "concept_class_id" },
-            "operator": "EQUALS",
-            "value": { "stringVal": "Brand Name" } },
-          { "type": "BINARY",
-            "field": { "column": "invalid_reason" },
-            "operator": "IS",
-            "value": { "stringVal": null } },
-          { "type": "BOOLEAN_AND_OR",
-            "operator": "OR",
-            "subfilters": [
-              { "type": "BINARY",
-                "field": { "column": "vocabulary_id" },
-                "operator": "EQUALS",
-                "value": { "stringVal": "RxNorm" } },
-              { "type": "BINARY",
-                "field": { "column": "vocabulary_id" },
-                "operator": "EQUALS",
-                "value": { "stringVal": "RxNorm Extension" } }
-            ] } ] } },
+      "rawSqlFile": "t_brand_all.sql"
+    },
     "attributeMappings": {
       "id": { "value": { "column": "concept_id" } },
       "name": { "value": { "column": "concept_name" } },

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_condition_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_condition_occurrence.json
@@ -8,15 +8,17 @@
     { "type": "SIMPLE", "name": "start_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "end_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "stop_reason", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "condition_occurrence" },
+    "tablePointer": { "rawSqlFile": "t_condition_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "condition_occurrence_id" } },
       "condition": {
         "value": { "column": "condition_concept_id" },
         "display": {
@@ -24,10 +26,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "start_date": { "value": { "column": "condition_start_date" } },
-      "end_date": { "value": { "column": "condition_end_date" } },
-      "source_value": { "value": { "column": "condition_source_value" } },
-      "source_criteria_id": { "value": { "column": "condition_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_device_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_device_occurrence.json
@@ -7,15 +7,17 @@
     { "type": "KEY_AND_DISPLAY", "name": "device", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "start_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "end_date", "dataType": "DATE" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "device_exposure" },
+    "tablePointer": { "rawSqlFile": "t_device_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "device_exposure_id" } },
       "device": {
         "value": { "column": "device_concept_id" },
         "display": {
@@ -23,10 +25,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "start_date": { "value": { "column": "device_exposure_start_date" } },
-      "end_date": { "value": { "column": "device_exposure_end_date" } },
-      "source_value": { "value": { "column": "device_source_value" } },
-      "source_criteria_id": { "value": { "column": "device_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_ingredient_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_ingredient_occurrence.json
@@ -10,15 +10,17 @@
     { "type": "SIMPLE", "name": "stop_reason", "dataType": "STRING" },
     { "type": "SIMPLE", "name": "refills", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "days_supply", "dataType": "INT64" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "drug_exposure" },
+    "tablePointer": { "rawSqlFile": "t_ingredient_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "drug_exposure_id" } },
       "ingredient": {
         "value": { "column": "drug_concept_id" },
         "display": {
@@ -26,10 +28,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "start_date": { "value": { "column": "drug_exposure_start_date" } },
-      "end_date": { "value": { "column": "drug_exposure_end_date" } },
-      "source_value": { "value": { "column": "drug_source_value" } },
-      "source_criteria_id": { "value": { "column": "drug_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_measurement_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_measurement_occurrence.json
@@ -9,15 +9,17 @@
     { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
     { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
     { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "measurement" },
+    "tablePointer": { "rawSqlFile": "t_measurement_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "measurement_id" } },
       "measurement": {
         "value": { "column": "measurement_concept_id" },
         "display": {
@@ -26,7 +28,6 @@
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
       "date": { "value": { "column": "measurement_date" } },
-      "value_numeric": { "value": { "column": "value_as_number" } },
       "value_enum": {
         "value": { "column": "value_as_concept_id" },
         "display": {
@@ -41,8 +42,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "source_value": { "value": { "column": "measurement_source_value" } },
-      "source_criteria_id": { "value": { "column": "measurement_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_observation_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_observation_occurrence.json
@@ -9,15 +9,17 @@
     { "type": "SIMPLE", "name": "value_as_string", "dataType": "STRING" },
     { "type": "KEY_AND_DISPLAY", "name": "value", "dataType": "INT64" },
     { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "observation" },
+    "tablePointer": { "rawSqlFile": "t_observation_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "observation_id" } },
       "observation": {
         "value": { "column": "observation_concept_id" },
         "display": {
@@ -40,8 +42,13 @@
           "foreignTable": "concept",
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
-      "source_value": { "value": { "column": "observation_source_value" } },
-      "source_criteria_id": { "value": { "column": "observation_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_procedure_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_procedure_occurrence.json
@@ -6,15 +6,17 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "procedure", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "date", "dataType": "DATE" },
-    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
-    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] } ],
+    { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
-    "tablePointer": { "table": "procedure_occurrence" },
+    "tablePointer": { "rawSqlFile": "t_procedure_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "procedure_occurrence_id" } },
       "procedure": {
         "value": { "column": "procedure_concept_id" },
         "display": {
@@ -23,8 +25,13 @@
           "foreignKey": "concept_id",
           "foreignColumn": "concept_name" } },
       "date": { "value": { "column": "procedure_date" } },
-      "source_value": { "value": { "column": "procedure_source_value" } },
-      "source_criteria_id": { "value": { "column": "procedure_source_concept_id" } }
+      "visit_type": {
+        "value": { "column": "visit_concept_id" },
+        "display": {
+          "column": "visit_concept_id",
+          "foreignTable": "concept",
+          "foreignKey": "concept_id",
+          "foreignColumn": "concept_name" } }
     }
   },
 

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_visit_occurrence.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/entity/t_visit_occurrence.json
@@ -4,19 +4,21 @@
   "attributes": [
     { "type": "SIMPLE", "name": "id", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "visit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "start_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "end_date", "dataType": "DATE" },
     { "type": "SIMPLE", "name": "source_value", "dataType": "STRING" },
     { "type": "SIMPLE", "name": "source_criteria_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64", "displayHintTypes": ["NONE"] }],
+    { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
+    { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }
+  ],
 
   "sourceDataMapping": {
     "dataPointer": "omop_dataset",
     "tablePointer": { "rawSqlFile": "t_visit_occurrence_all.sql" },
     "attributeMappings": {
-      "id": { "value": { "column": "id" } },
-      "visit": {
+      "id": { "value": { "column": "visit_occurrence_id" } },
+      "visit_type": {
         "value": { "column": "visit_concept_id" },
         "display": {
           "column": "visit_concept_id",

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_condition_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_condition_occurrence_all.sql
@@ -12,3 +12,10 @@ ON p.person_id = co.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = co.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_condition_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_condition_occurrence_all.sql
@@ -13,9 +13,8 @@ ON p.person_id = co.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = co.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
           ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_condition_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_condition_occurrence_all.sql
@@ -13,8 +13,8 @@ ON p.person_id = co.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = co.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_device_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_device_occurrence_all.sql
@@ -13,9 +13,8 @@ ON p.person_id = de.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
           ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_device_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_device_occurrence_all.sql
@@ -13,8 +13,8 @@ ON p.person_id = de.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_device_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_device_occurrence_all.sql
@@ -12,3 +12,10 @@ ON p.person_id = de.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_ingredient_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_ingredient_occurrence_all.sql
@@ -13,3 +13,9 @@ ON p.person_id = de.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = de.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_measurement_occurrence_all.sql
@@ -1,5 +1,7 @@
 SELECT
-  mo.measurement_id AS id, mo.person_id, mo.measurement_concept_id, mo.measurement_date,
+  mo.measurement_id AS id, mo.person_id,
+  CASE WHEN mo.measurement_concept_id IS NULL THEN 0 ELSE mo.measurement_concept_id END AS measurement_concept_id,
+  mo.measurement_date,
   mo.value_as_number AS value_numeric, mo.value_as_concept_id, mo.unit_concept_id,
   mo.measurement_source_value AS source_value, mo.measurement_source_concept_id AS source_criteria_id,
   CAST(FLOOR(TIMESTAMP_DIFF(mo.measurement_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence,
@@ -12,3 +14,10 @@ ON p.person_id = mo.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = mo.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_measurement_occurrence_all.sql
@@ -15,9 +15,8 @@ ON p.person_id = mo.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = mo.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
           ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_measurement_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_measurement_occurrence_all.sql
@@ -15,8 +15,8 @@ ON p.person_id = mo.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = mo.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_observation_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_observation_occurrence_all.sql
@@ -12,3 +12,10 @@ ON p.person_id = o.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = o.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_observation_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_observation_occurrence_all.sql
@@ -13,8 +13,8 @@ ON p.person_id = o.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = o.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_observation_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_observation_occurrence_all.sql
@@ -13,9 +13,8 @@ ON p.person_id = o.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = o.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
           ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_procedure_occurrence_all.sql
@@ -11,3 +11,10 @@ ON p.person_id = po.person_id
 
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = po.visit_occurrence_id
+
+LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+          ON vo.visit_concept_id = c.concept_id
+
+WHERE c.domain_id = 'Visit'
+  AND c.standard_concept = 'S'
+  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_procedure_occurrence_all.sql
@@ -12,9 +12,8 @@ ON p.person_id = po.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = po.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SC2023Q3R1.concept` AS c
+LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
           ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_procedure_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_procedure_occurrence_all.sql
@@ -12,8 +12,8 @@ ON p.person_id = po.person_id
 LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.visit_occurrence` AS vo
 ON vo.visit_occurrence_id = po.visit_occurrence_id
 
-LEFT JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
-          ON vo.visit_concept_id = c.concept_id
+JOIN `all-of-us-ehr-dev.SR2023Q3R1.concept` AS c
+ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_visit_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_visit_occurrence_all.sql
@@ -14,4 +14,3 @@ ON vo.visit_concept_id = c.concept_id
 
 WHERE c.domain_id = 'Visit'
   AND c.standard_concept = 'S'
-  AND vo.visit_concept_id > 0

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_visit_occurrence_all.sql
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/sql/t_visit_occurrence_all.sql
@@ -1,5 +1,5 @@
 SELECT
-  vo.visit_occurrence_id AS id, vo.person_id, vo.visit_concept_id,
+  vo.visit_occurrence_id, vo.person_id, vo.visit_concept_id,
   vo.visit_start_date AS start_date, vo.visit_end_date AS end_date,
   vo.visit_source_value AS source_value, vo.visit_source_concept_id AS source_criteria_id,
   CAST(FLOOR(TIMESTAMP_DIFF(vo.visit_start_datetime, p.birth_datetime, DAY) / 365.25) AS INT64) AS age_at_occurrence

--- a/service/src/main/resources/config/aou/test/SR2023Q3R1/ui/top_level.json
+++ b/service/src/main/resources/config/aou/test/SR2023Q3R1/ui/top_level.json
@@ -385,7 +385,11 @@
       "defaultSort": {
         "attribute": "name",
         "direction": "ASC"
-      }
+      },
+      "modifiers": [
+        "age_at_occurrence",
+        "start_date_group_by_count"
+      ]
     },
     {
       "type": "classification",
@@ -403,7 +407,12 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "occurrences": "device_occurrence",
-      "classifications": ["device"]
+      "classifications": ["device"],
+      "modifiers": [
+        "age_at_occurrence",
+        "visit_type",
+        "start_date_group_by_count"
+      ]
     },
     {
       "type": "attribute",


### PR DESCRIPTION
- Updated to add modifiers to all domains
- Restricted visit_type for modifiers: All  **t_domain**_occurrence_all.sql were modified with the following snippet from [AoU build-cb-criteria-visit.sh](https://github.com/all-of-us/workbench/blob/4d572150dc81ffc51f0a00581683e0fe9b8c7f81/api/db-cdr/generate-cdr/build-cb-criteria-visit.sh#L59-L61) 
```
...
LEFT JOIN `all-of-us-ehr-dev.Sx2023Q3R1.visit_occurrence` AS vo
ON vo.visit_occurrence_id = co.visit_occurrence_id

LEFT JOIN `all-of-us-ehr-dev.Sx2023Q3R1.concept` AS c
          ON vo.visit_concept_id = c.concept_id

WHERE c.domain_id = 'Visit'
  AND c.standard_concept = 'S'
```
