### PR TITLE
Compute entity-level display hints for SDD vitals.

### DIFF
--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -76,7 +76,7 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
                 return;
               }
               DisplayHint hint =
-                  attribute.getMapping(Underlay.MappingType.SOURCE).computeDisplayHint();
+                  attribute.getMapping(Underlay.MappingType.SOURCE).computeDisplayHint(getEntity().getIdAttribute().getMapping(Underlay.MappingType.SOURCE).getValue());
               if (hint == null) {
                 return;
               }

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -124,6 +124,11 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
               }
             });
 
+    if (rowsOfLiterals.isEmpty()) {
+        LOGGER.info("No display hints to insert.");
+        return;
+    }
+
     // Poll for table existence before we try to insert the hint rows. Maximum 18 x 10 sec = 3 min.
     pollForTableExistenceOrThrow(getAuxiliaryTable(), 18, Duration.ofSeconds(10));
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -18,7 +18,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +67,6 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
 
     // Calculate a display hint for each attribute. Build a list of all the hints as JSON records.
     List<List<Literal>> rowsOfLiterals = new ArrayList<>();
-    List<JSONObject> hintRecords = new ArrayList<>();
     getEntity().getAttributes().stream()
         .forEach(
             attribute -> {
@@ -76,7 +74,13 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
                 return;
               }
               DisplayHint hint =
-                  attribute.getMapping(Underlay.MappingType.SOURCE).computeDisplayHint(getEntity().getIdAttribute().getMapping(Underlay.MappingType.SOURCE).getValue());
+                  attribute
+                      .getMapping(Underlay.MappingType.SOURCE)
+                      .computeDisplayHint(
+                          getEntity()
+                              .getIdAttribute()
+                              .getMapping(Underlay.MappingType.SOURCE)
+                              .getValue());
               if (hint == null) {
                 return;
               }

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -50,16 +50,16 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
     List<Field> fieldList =
         BigQuerySchemaUtils.getBigQueryFieldList(EntityLevelDisplayHints.getColumns());
 
-//    bigQuery.createTableFromSchema(
-//        destinationTable,
-//        Schema.of(fieldList),
-//        Clustering.newBuilder()
-//            .setFields(
-//                List.of(
-//                    EntityLevelDisplayHints.Columns.ATTRIBUTE_NAME.getSchema().getColumnName(),
-//                    EntityLevelDisplayHints.Columns.ENUM_VALUE.getSchema().getColumnName()))
-//            .build(),
-//        isDryRun);
+    bigQuery.createTableFromSchema(
+        destinationTable,
+        Schema.of(fieldList),
+        Clustering.newBuilder()
+            .setFields(
+                List.of(
+                    EntityLevelDisplayHints.Columns.ATTRIBUTE_NAME.getSchema().getColumnName(),
+                    EntityLevelDisplayHints.Columns.ENUM_VALUE.getSchema().getColumnName()))
+            .build(),
+        isDryRun);
 
     // TODO: Validate queries for computing display hints when the dry run flag is set.
     if (isDryRun) {

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -125,8 +125,8 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
             });
 
     if (rowsOfLiterals.isEmpty()) {
-        LOGGER.info("No display hints to insert.");
-        return;
+      LOGGER.info("No display hints to insert.");
+      return;
     }
 
     // Poll for table existence before we try to insert the hint rows. Maximum 18 x 10 sec = 3 min.

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/ComputeEntityLevelDisplayHints.java
@@ -50,16 +50,16 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
     List<Field> fieldList =
         BigQuerySchemaUtils.getBigQueryFieldList(EntityLevelDisplayHints.getColumns());
 
-    bigQuery.createTableFromSchema(
-        destinationTable,
-        Schema.of(fieldList),
-        Clustering.newBuilder()
-            .setFields(
-                List.of(
-                    EntityLevelDisplayHints.Columns.ATTRIBUTE_NAME.getSchema().getColumnName(),
-                    EntityLevelDisplayHints.Columns.ENUM_VALUE.getSchema().getColumnName()))
-            .build(),
-        isDryRun);
+//    bigQuery.createTableFromSchema(
+//        destinationTable,
+//        Schema.of(fieldList),
+//        Clustering.newBuilder()
+//            .setFields(
+//                List.of(
+//                    EntityLevelDisplayHints.Columns.ATTRIBUTE_NAME.getSchema().getColumnName(),
+//                    EntityLevelDisplayHints.Columns.ENUM_VALUE.getSchema().getColumnName()))
+//            .build(),
+//        isDryRun);
 
     // TODO: Validate queries for computing display hints when the dry run flag is set.
     if (isDryRun) {
@@ -177,7 +177,7 @@ public class ComputeEntityLevelDisplayHints extends BigQueryIndexingJob {
     // Check if the table already exists.
     // We can't include a check for a single row here (e.g. checkOneRowExists(getAuxiliaryTable())),
     // because there are some cases where an entity has no display hints.
-    return checkTableExists(getAuxiliaryTable()) ? JobStatus.COMPLETE : JobStatus.NOT_STARTED;
+    return JobStatus.NOT_STARTED; //checkTableExists(getAuxiliaryTable()) ? JobStatus.COMPLETE : JobStatus.NOT_STARTED;
   }
 
   public TablePointer getAuxiliaryTable() {

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/bmi.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/bmi.json
@@ -6,9 +6,9 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/height.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/height.json
@@ -7,8 +7,8 @@
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/height.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/height.json
@@ -6,7 +6,7 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
     { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
     { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/pulse.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/pulse.json
@@ -5,9 +5,9 @@
     { "type": "SIMPLE", "name": "id", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/respiratoryRate.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/respiratoryRate.json
@@ -5,9 +5,9 @@
     { "type": "SIMPLE", "name": "id", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/verily/sdd_refresh0323/entity/weight.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/entity/weight.json
@@ -6,9 +6,9 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/bmi.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/bmi.json
@@ -6,9 +6,9 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/height.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/height.json
@@ -6,9 +6,9 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/pulse.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/pulse.json
@@ -5,9 +5,9 @@
     { "type": "SIMPLE", "name": "id", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/respiratoryRate.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/respiratoryRate.json
@@ -5,9 +5,9 @@
     { "type": "SIMPLE", "name": "id", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/entity/weight.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/entity/weight.json
@@ -6,9 +6,9 @@
     { "type": "SIMPLE", "name": "person_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "is_clean", "dataType": "BOOLEAN", "displayHintTypes": ["NONE"] },
     { "type": "SIMPLE", "name": "date", "dataType": "TIMESTAMP", "displayHintTypes": ["NONE"] },
-    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64", "displayHintTypes": ["NONE"] },
-    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64", "displayHintTypes": ["NONE"] },
+    { "type": "SIMPLE", "name": "value_numeric", "dataType": "DOUBLE" },
+    { "type": "KEY_AND_DISPLAY", "name": "value_enum", "dataType": "INT64" },
+    { "type": "KEY_AND_DISPLAY", "name": "unit", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "age_at_occurrence", "dataType": "INT64" },
     { "type": "SIMPLE", "name": "visit_occurrence_id", "dataType": "INT64", "displayHintTypes": ["NONE"] },
     { "type": "KEY_AND_DISPLAY", "name": "visit_type", "dataType": "INT64" }

--- a/underlay/src/main/java/bio/terra/tanagra/query/InsertLiterals.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/InsertLiterals.java
@@ -1,0 +1,42 @@
+package bio.terra.tanagra.query;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.text.StringSubstitutor;
+
+public class InsertLiterals implements SQLExpression {
+    private final TableVariable insertTable;
+    private final List<FieldVariable> valueFields;
+    private final List<List<Literal>> rowsOfLiterals;
+
+    public InsertLiterals(
+            TableVariable insertTable, List<FieldVariable> valueFields, List<List<Literal>> rowsOfLiterals) {
+        this.insertTable = insertTable;
+        this.valueFields = valueFields;
+        this.rowsOfLiterals = rowsOfLiterals;
+    }
+
+    @Override
+    public String renderSQL() {
+        String insertFieldsSQL =
+                valueFields.stream()
+                        .map(valueField -> valueField.getAliasOrColumnName())
+                        .collect(Collectors.joining(", "));
+
+        String rowsOfLiteralsSQL = rowsOfLiterals.stream()
+                .map(row -> "(" + row.stream().map(rowField -> rowField.renderSQL()).collect(Collectors.joining(",")) + ")")
+                .collect(Collectors.joining(", "));
+
+        String template = "INSERT INTO ${insertTableSQL} (${insertFieldsSQL}) VALUES ${rowsOfLiterals}";
+        Map<String, String> params =
+                ImmutableMap.<String, String>builder()
+                        .put("insertTableSQL", insertTable.renderSQL())
+                        .put("insertFieldsSQL", insertFieldsSQL)
+                        .put("rowsOfLiterals", rowsOfLiteralsSQL)
+                        .build();
+        return StringSubstitutor.replace(template, params);
+    }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/query/InsertLiterals.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/InsertLiterals.java
@@ -1,42 +1,50 @@
 package bio.terra.tanagra.query;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
 public class InsertLiterals implements SQLExpression {
-    private final TableVariable insertTable;
-    private final List<FieldVariable> valueFields;
-    private final List<List<Literal>> rowsOfLiterals;
+  private final TableVariable insertTable;
+  private final List<FieldVariable> valueFields;
+  private final List<List<Literal>> rowsOfLiterals;
 
-    public InsertLiterals(
-            TableVariable insertTable, List<FieldVariable> valueFields, List<List<Literal>> rowsOfLiterals) {
-        this.insertTable = insertTable;
-        this.valueFields = valueFields;
-        this.rowsOfLiterals = rowsOfLiterals;
-    }
+  public InsertLiterals(
+      TableVariable insertTable,
+      List<FieldVariable> valueFields,
+      List<List<Literal>> rowsOfLiterals) {
+    this.insertTable = insertTable;
+    this.valueFields = valueFields;
+    this.rowsOfLiterals = rowsOfLiterals;
+  }
 
-    @Override
-    public String renderSQL() {
-        String insertFieldsSQL =
-                valueFields.stream()
-                        .map(valueField -> valueField.getAliasOrColumnName())
-                        .collect(Collectors.joining(", "));
+  @Override
+  public String renderSQL() {
+    String insertFieldsSQL =
+        valueFields.stream()
+            .map(valueField -> valueField.getAliasOrColumnName())
+            .collect(Collectors.joining(", "));
 
-        String rowsOfLiteralsSQL = rowsOfLiterals.stream()
-                .map(row -> "(" + row.stream().map(rowField -> rowField.renderSQL()).collect(Collectors.joining(",")) + ")")
-                .collect(Collectors.joining(", "));
+    String rowsOfLiteralsSQL =
+        rowsOfLiterals.stream()
+            .map(
+                row ->
+                    "("
+                        + row.stream()
+                            .map(rowField -> rowField.renderSQL())
+                            .collect(Collectors.joining(","))
+                        + ")")
+            .collect(Collectors.joining(", "));
 
-        String template = "INSERT INTO ${insertTableSQL} (${insertFieldsSQL}) VALUES ${rowsOfLiterals}";
-        Map<String, String> params =
-                ImmutableMap.<String, String>builder()
-                        .put("insertTableSQL", insertTable.renderSQL())
-                        .put("insertFieldsSQL", insertFieldsSQL)
-                        .put("rowsOfLiterals", rowsOfLiteralsSQL)
-                        .build();
-        return StringSubstitutor.replace(template, params);
-    }
+    String template = "INSERT INTO ${insertTableSQL} (${insertFieldsSQL}) VALUES ${rowsOfLiterals}";
+    Map<String, String> params =
+        ImmutableMap.<String, String>builder()
+            .put("insertTableSQL", insertTable.renderSQL())
+            .put("insertFieldsSQL", insertFieldsSQL)
+            .put("rowsOfLiterals", rowsOfLiteralsSQL)
+            .build();
+    return StringSubstitutor.replace(template, params);
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
@@ -121,7 +121,7 @@ public class Literal implements SQLExpression {
     // TODO: use named parameters for literals to protect against SQL injection
     switch (dataType) {
       case STRING:
-        return stringVal == null ? "NULL" : "'" + stringVal + "'";
+        return stringVal == null ? "NULL" : "'" + stringVal.replace("'", "\'") + "'";
       case INT64:
         return String.valueOf(int64Val);
       case BOOLEAN:

--- a/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/Literal.java
@@ -129,7 +129,7 @@ public class Literal implements SQLExpression {
       case DATE:
         return "DATE('" + dateVal.toString() + "')";
       case DOUBLE:
-        return "FLOAT('" + doubleVal + "')";
+        return String.valueOf(doubleVal);
       case TIMESTAMP:
         return "TIMESTAMP('" + timestampVal.toString() + "')";
       default:

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
@@ -181,9 +181,9 @@ public final class AttributeMapping {
     return dataPointer.lookupDatatype(value);
   }
 
-  public DisplayHint computeDisplayHint() {
+  public DisplayHint computeDisplayHint(FieldPointer countedIdField) {
     if (attribute.getType().equals(Attribute.Type.KEY_AND_DISPLAY)) {
-      return EnumVals.computeForField(attribute.getDataType(), value, display);
+      return EnumVals.computeForField(countedIdField, attribute.getDataType(), value, display);
     }
 
     switch (attribute.getDataType()) {
@@ -193,7 +193,7 @@ public final class AttributeMapping {
       case INT64:
         return NumericRange.computeForField(value,attribute.getDataType());
       case STRING:
-        return EnumVals.computeForField(attribute.getDataType(), value);
+        return EnumVals.computeForField(countedIdField, attribute.getDataType(), value);
       case DATE:
       case TIMESTAMP:
         // TODO: Compute display hints for other data types.

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
@@ -189,12 +189,12 @@ public final class AttributeMapping {
     switch (attribute.getDataType()) {
       case BOOLEAN:
         return null; // boolean values are enum by default
+      case DOUBLE:
       case INT64:
-        return NumericRange.computeForField(value);
+        return NumericRange.computeForField(value,attribute.getDataType());
       case STRING:
         return EnumVals.computeForField(attribute.getDataType(), value);
       case DATE:
-      case DOUBLE:
       case TIMESTAMP:
         // TODO: Compute display hints for other data types.
         return null;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
@@ -182,7 +182,7 @@ public final class AttributeMapping {
   }
 
   public DisplayHint computeDisplayHint(FieldPointer countedIdField) {
-    if (attribute.getType().equals(Attribute.Type.KEY_AND_DISPLAY)) {
+    if (attribute.getType().equals(Attribute.Type.KEY_AND_DISPLAY) && Literal.DataType.INT64.equals(attribute.getDataType())) {
       return EnumVals.computeForField(countedIdField, attribute.getDataType(), value, display);
     }
 
@@ -193,7 +193,6 @@ public final class AttributeMapping {
       case INT64:
         return NumericRange.computeForField(value, attribute.getDataType());
       case STRING:
-        return EnumVals.computeForField(countedIdField, attribute.getDataType(), value);
       case DATE:
       case TIMESTAMP:
         // TODO: Compute display hints for other data types.

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
@@ -191,7 +191,7 @@ public final class AttributeMapping {
         return null; // boolean values are enum by default
       case DOUBLE:
       case INT64:
-        return NumericRange.computeForField(value,attribute.getDataType());
+        return NumericRange.computeForField(value, attribute.getDataType());
       case STRING:
         return EnumVals.computeForField(countedIdField, attribute.getDataType(), value);
       case DATE:

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/AttributeMapping.java
@@ -182,7 +182,8 @@ public final class AttributeMapping {
   }
 
   public DisplayHint computeDisplayHint(FieldPointer countedIdField) {
-    if (attribute.getType().equals(Attribute.Type.KEY_AND_DISPLAY) && Literal.DataType.INT64.equals(attribute.getDataType())) {
+    if (attribute.getType().equals(Attribute.Type.KEY_AND_DISPLAY)
+        && Literal.DataType.INT64.equals(attribute.getDataType())) {
       return EnumVals.computeForField(countedIdField, attribute.getDataType(), value, display);
     }
 

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/displayhint/EnumVals.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/displayhint/EnumVals.java
@@ -90,7 +90,8 @@ public final class EnumVals extends DisplayHint {
    *
    * <p>LIMIT 101
    */
-  public static EnumVals computeForField(FieldPointer countedIdField, Literal.DataType dataType, FieldPointer value) {
+  public static EnumVals computeForField(
+      FieldPointer countedIdField, Literal.DataType dataType, FieldPointer value) {
     return new EnumVals(queryPossibleEnumVals(countedIdField, dataType, value, null));
   }
 
@@ -114,7 +115,10 @@ public final class EnumVals extends DisplayHint {
    * <p>LIMIT 101
    */
   public static EnumVals computeForField(
-          FieldPointer countedIdField, Literal.DataType dataType, FieldPointer value, FieldPointer display) {
+      FieldPointer countedIdField,
+      Literal.DataType dataType,
+      FieldPointer value,
+      FieldPointer display) {
     List<EnumVal> enumVals = queryPossibleEnumVals(countedIdField, dataType, value, display);
 
     // Check that there is exactly one display per value.
@@ -136,8 +140,11 @@ public final class EnumVals extends DisplayHint {
     return new EnumVals(enumVals);
   }
 
-  private static List<EnumVal> queryPossibleEnumVals(FieldPointer countedIdField,
-                                                     Literal.DataType dataType, FieldPointer value, @Nullable FieldPointer display) {
+  private static List<EnumVal> queryPossibleEnumVals(
+      FieldPointer countedIdField,
+      Literal.DataType dataType,
+      FieldPointer value,
+      @Nullable FieldPointer display) {
     List<TableVariable> nestedQueryTables = new ArrayList<>();
     TableVariable nestedPrimaryTable = TableVariable.forPrimary(value.getTablePointer());
     nestedQueryTables.add(nestedPrimaryTable);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/displayhint/EnumVals.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/displayhint/EnumVals.java
@@ -90,8 +90,8 @@ public final class EnumVals extends DisplayHint {
    *
    * <p>LIMIT 101
    */
-  public static EnumVals computeForField(Literal.DataType dataType, FieldPointer value) {
-    return new EnumVals(queryPossibleEnumVals(dataType, value, null));
+  public static EnumVals computeForField(FieldPointer countedIdField, Literal.DataType dataType, FieldPointer value) {
+    return new EnumVals(queryPossibleEnumVals(countedIdField, dataType, value, null));
   }
 
   /**
@@ -114,8 +114,8 @@ public final class EnumVals extends DisplayHint {
    * <p>LIMIT 101
    */
   public static EnumVals computeForField(
-      Literal.DataType dataType, FieldPointer value, FieldPointer display) {
-    List<EnumVal> enumVals = queryPossibleEnumVals(dataType, value, display);
+          FieldPointer countedIdField, Literal.DataType dataType, FieldPointer value, FieldPointer display) {
+    List<EnumVal> enumVals = queryPossibleEnumVals(countedIdField, dataType, value, display);
 
     // Check that there is exactly one display per value.
     Map<Literal, String> valDisplay = new HashMap<>();
@@ -136,8 +136,8 @@ public final class EnumVals extends DisplayHint {
     return new EnumVals(enumVals);
   }
 
-  private static List<EnumVal> queryPossibleEnumVals(
-      Literal.DataType dataType, FieldPointer value, @Nullable FieldPointer display) {
+  private static List<EnumVal> queryPossibleEnumVals(FieldPointer countedIdField,
+                                                     Literal.DataType dataType, FieldPointer value, @Nullable FieldPointer display) {
     List<TableVariable> nestedQueryTables = new ArrayList<>();
     TableVariable nestedPrimaryTable = TableVariable.forPrimary(value.getTablePointer());
     nestedQueryTables.add(nestedPrimaryTable);
@@ -153,7 +153,7 @@ public final class EnumVals extends DisplayHint {
       nestedDisplayFieldVar =
           display.buildVariable(nestedPrimaryTable, nestedQueryTables, ENUM_DISPLAY_COLUMN_ALIAS);
     }
-    FieldPointer countFieldPointer = value.toBuilder().sqlFunctionWrapper("COUNT").build();
+    FieldPointer countFieldPointer = countedIdField.toBuilder().sqlFunctionWrapper("COUNT").build();
     FieldVariable nestedCountFieldVar =
         countFieldPointer.buildVariable(
             nestedPrimaryTable, nestedQueryTables, ENUM_COUNT_COLUMN_ALIAS);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/displayhint/NumericRange.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/displayhint/NumericRange.java
@@ -1,17 +1,7 @@
 package bio.terra.tanagra.underlay.displayhint;
 
 import bio.terra.tanagra.exception.InvalidConfigException;
-import bio.terra.tanagra.query.CellValue;
-import bio.terra.tanagra.query.ColumnHeaderSchema;
-import bio.terra.tanagra.query.ColumnSchema;
-import bio.terra.tanagra.query.FieldPointer;
-import bio.terra.tanagra.query.FieldVariable;
-import bio.terra.tanagra.query.Query;
-import bio.terra.tanagra.query.QueryRequest;
-import bio.terra.tanagra.query.QueryResult;
-import bio.terra.tanagra.query.RowResult;
-import bio.terra.tanagra.query.TablePointer;
-import bio.terra.tanagra.query.TableVariable;
+import bio.terra.tanagra.query.*;
 import bio.terra.tanagra.serialization.UFDisplayHint;
 import bio.terra.tanagra.serialization.displayhint.UFNumericRange;
 import bio.terra.tanagra.underlay.DataPointer;
@@ -57,7 +47,7 @@ public final class NumericRange extends DisplayHint {
     return maxVal;
   }
 
-  public static NumericRange computeForField(FieldPointer value) {
+  public static NumericRange computeForField(FieldPointer value, Literal.DataType dataType) {
     // build the nested query for the possible values
     List<TableVariable> nestedQueryTables = new ArrayList<>();
     TableVariable nestedPrimaryTable = TableVariable.forPrimary(value.getTablePointer());
@@ -100,8 +90,8 @@ public final class NumericRange extends DisplayHint {
 
     List<ColumnSchema> columnSchemas =
         List.of(
-            new ColumnSchema(minValAlias, CellValue.SQLDataType.INT64),
-            new ColumnSchema(maxValAlias, CellValue.SQLDataType.INT64));
+            new ColumnSchema(minValAlias, CellValue.SQLDataType.fromUnderlayDataType(dataType)),
+            new ColumnSchema(maxValAlias, CellValue.SQLDataType.fromUnderlayDataType(dataType)));
 
     QueryRequest queryRequest =
         new QueryRequest(query.renderSQL(), new ColumnHeaderSchema(columnSchemas));


### PR DESCRIPTION
- Updated SDD config for vitals entities to compute display hints for `value_numeric`, `value_enum` and `unit` attributes.
- Change the entity-level display hints indexing jobs to do a direct SQL insert instead of using the storage write streaming API. I'm hoping this will address the sporadic "requested entity not found" errors we see from BigQuery.
- Allowed computing numeric range hints for `float` fields. Previously we only allowed it for `int` fields.
- As part of this PR, I also partially re-indexed the verily/sdd underlay. I regenerated all the `eldh_` index tables.