### PR TITLE
Allow null subfilter in RelationshipFilter.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -71,7 +71,9 @@ public final class FromApiUtils {
         Entity relatedEntity = entity.getUnderlay().getEntity(apiRelationshipFilter.getEntity());
         Relationship relationship = getRelationship(entityGroups, entity, relatedEntity);
         EntityFilter subFilter =
-            fromApiObject(apiRelationshipFilter.getSubfilter(), relatedEntity, underlayName);
+            apiRelationshipFilter.getSubfilter() == null
+                ? null
+                : fromApiObject(apiRelationshipFilter.getSubfilter(), relatedEntity, underlayName);
 
         Attribute groupByCountAttribute = null;
         BinaryFilterVariable.BinaryOperator groupByCountOperator = null;

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/filter/RelationshipFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/filter/RelationshipFilter.java
@@ -18,7 +18,7 @@ public class RelationshipFilter extends EntityFilter {
   private final Entity selectEntity;
   private final Entity filterEntity;
   private final Relationship relationship;
-  private final EntityFilter subFilter;
+  private final @Nullable EntityFilter subFilter;
   private final @Nullable Attribute groupByCountAttribute;
   private final @Nullable BinaryFilterVariable.BinaryOperator groupByCountOperator;
   private final @Nullable Integer groupByCountValue;
@@ -26,7 +26,7 @@ public class RelationshipFilter extends EntityFilter {
   public RelationshipFilter(
       Entity selectEntity,
       Relationship relationship,
-      EntityFilter subFilter,
+      @Nullable EntityFilter subFilter,
       @Nullable Attribute groupByCountAttribute,
       @Nullable BinaryFilterVariable.BinaryOperator groupByCountOperator,
       @Nullable Integer groupByCountValue) {
@@ -53,7 +53,9 @@ public class RelationshipFilter extends EntityFilter {
             filterEntity.getMapping(Underlay.MappingType.INDEX).getTablePointer());
     List<TableVariable> filterEntityTableVars = Lists.newArrayList(filterEntityTableVar);
     FilterVariable filterEntitySubFilterVar =
-        subFilter.getFilterVariable(filterEntityTableVar, filterEntityTableVars);
+        subFilter == null
+            ? null
+            : subFilter.getFilterVariable(filterEntityTableVar, filterEntityTableVars);
 
     TablePointer idPairsTable = indexMapping.getIdPairsTable();
     boolean fkOnSelectTable =


### PR DESCRIPTION
Allow queries like "persons with any blood pressure rows". Further optimization of the generated query to come in a follow-up PR.