### PR TITLE
Call new isAuthorizedUser endpoint in VUMC admin service plugin.

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     // [Access control]: VUMC admin service
     // The Jersey libraries are required to use the VUMC admin service client library.
     // Since the client library doesn't correctly expose these dependencies, we include them explicitly here.
-    implementation group: "org.vumc.vda.tanagra", name: "admin-client", version: "0.0.58-SNAPSHOT"
+    implementation group: "org.vumc.vda.tanagra", name: "admin-client", version: "0.0.79-SNAPSHOT"
     implementation group: "org.glassfish.jersey.core", name: "jersey-client", version: "2.32"
     implementation group: "org.glassfish.jersey.inject", name: "jersey-hk2", version: "2.32"
     implementation group: "org.glassfish.jersey.media", name: "jersey-media-multipart", version: "2.32"

--- a/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
+++ b/service/src/main/java/bio/terra/tanagra/service/accesscontrol/impl/VumcAdminAccessControl.java
@@ -65,12 +65,14 @@ public class VumcAdminAccessControl implements AccessControl {
           ResourceType.UNDERLAY,
           resource == null ? null : resource.getUnderlay());
     } else if (ResourceType.STUDY.equals(permissions.getType())) {
-      // For studies, check authorization with the study id.
-      return isAuthorized(
-          user,
-          permissions.getActions(),
-          ResourceType.STUDY,
-          resource == null ? null : resource.getStudy());
+      if (resource == null) {
+        // If the resource id is null, then check if the user is an admin.
+        return apiIsAuthorizedUser(user.getEmail());
+      } else {
+        // Otherwise, check authorization with the study id.
+        return isAuthorized(
+            user, permissions.getActions(), ResourceType.STUDY, resource.getStudy());
+      }
     } else {
       // For artifacts that are children of a study (e.g. cohort):
       //   - Map the action type to the action on the study (e.g. create cohort -> update study).
@@ -312,6 +314,20 @@ public class VumcAdminAccessControl implements AccessControl {
             apiAction,
             descendantType);
         return Set.of();
+    }
+  }
+
+  protected boolean apiIsAuthorizedUser(String userEmail) {
+    AuthorizationApi authorizationApi = new AuthorizationApi(getApiClientAuthenticated());
+    try {
+      authorizationApi.isAuthorizedUser(userEmail);
+      return true;
+    } catch (ApiException apiEx) {
+      if (apiEx.getCode() == HttpStatus.SC_UNAUTHORIZED) {
+        return false;
+      }
+      throw new SystemException(
+          "Error calling VUMC admin service isAuthorizedUser endpoint", apiEx);
     }
   }
 

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VumcAdminAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/VumcAdminAccessControlTest.java
@@ -65,12 +65,11 @@ public class VumcAdminAccessControlTest extends BaseAccessControlTest {
     vaImpl.addPermission(
         USER_4, ResourceAction.READ, org.vumc.vda.tanagra.admin.model.ResourceType.UNDERLAY, SDD);
     // studies
-    //   user1: CREATE, study1 (UPDATE, DELETE)
-    //   user2: CREATE, study1 (ALL), study2 (READ, UPDATE, DELETE)
+    //   user1: CREATE (=isAdmin), study1 (UPDATE, DELETE)
+    //   user2: CREATE (=isAdmin), study1 (ALL), study2 (READ, UPDATE, DELETE)
     //   user3:
     //   user4: study2 (READ)
-    vaImpl.addPermission(
-        USER_1, ResourceAction.CREATE, org.vumc.vda.tanagra.admin.model.ResourceType.STUDY, null);
+    vaImpl.addAdminUser(USER_1);
     vaImpl.addPermission(
         USER_1,
         ResourceAction.UPDATE,
@@ -81,6 +80,7 @@ public class VumcAdminAccessControlTest extends BaseAccessControlTest {
         ResourceAction.DELETE,
         org.vumc.vda.tanagra.admin.model.ResourceType.STUDY,
         study1.getId());
+    vaImpl.addAdminUser(USER_2);
     vaImpl.addPermission(
         USER_2,
         ResourceAction.ALL,

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockVumcAdminAccessControl.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/impl/MockVumcAdminAccessControl.java
@@ -8,8 +8,14 @@ import org.vumc.vda.tanagra.admin.model.ResourceList;
 import org.vumc.vda.tanagra.admin.model.ResourceType;
 
 public class MockVumcAdminAccessControl extends VumcAdminAccessControl {
+  private final List<String> admins = new ArrayList<>(); // user emails
   private final Map<String, Set<Resource>> permissions =
       new HashMap<>(); // user email -> set of permissions
+
+  @Override
+  protected boolean apiIsAuthorizedUser(String userEmail) {
+    return admins.contains(userEmail);
+  }
 
   @Override
   @SuppressWarnings("PMD.UseObjectForClearerAPI")
@@ -37,6 +43,10 @@ public class MockVumcAdminAccessControl extends VumcAdminAccessControl {
           .forEach(r -> resourceList.add(r));
     }
     return resourceList;
+  }
+
+  public void addAdminUser(UserId user) {
+    admins.add(user.getEmail());
   }
 
   public void addPermission(


### PR DESCRIPTION
For the VUMC access control plugin, call the new `isAuthorizedUser` admin service endpoint to check if a user has permission to create a study. All other access control checks remain unchanged.