### PR TITLE
Add support for Vitals

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1376,6 +1376,7 @@ components:
     Filter:
       type: object
       description: Union of references to each filter type. Exactly one should be specified based on the filterType.
+      nullable: true
       properties:
         filterType:
           type: string
@@ -2246,7 +2247,7 @@ components:
       properties:
         status:
           type: string
-          enum: [ "RUNNING", "COMPLETE" ]
+          enum: ["RUNNING", "COMPLETE"]
         redirectAwayUrl:
           type: string
           nullable: true
@@ -2288,7 +2289,7 @@ components:
 
     ResourceType:
       type: string
-      enum: [ "STUDY", "COHORT", "REVIEW" ]
+      enum: ["STUDY", "COHORT", "REVIEW"]
 
     Resource:
       type: object
@@ -2326,7 +2327,16 @@ components:
 
     ActivityType:
       type: string
-      enum: [ "CREATE_STUDY", "DELETE_STUDY", "CREATE_COHORT", "DELETE_COHORT", "EXPORT_COHORT", "CREATE_REVIEW", "DELETE_REVIEW" ]
+      enum:
+        [
+          "CREATE_STUDY",
+          "DELETE_STUDY",
+          "CREATE_COHORT",
+          "DELETE_COHORT",
+          "EXPORT_COHORT",
+          "CREATE_REVIEW",
+          "DELETE_REVIEW",
+        ]
 
     ActivityLogEntry:
       type: object

--- a/service/src/main/resources/config/verily/sdd_refresh0323/ui/top_level.json
+++ b/service/src/main/resources/config/verily/sdd_refresh0323/ui/top_level.json
@@ -370,6 +370,42 @@
             }
           }
         ]
+      },
+      {
+        "id": "blood_pressure_occurrence",
+        "displayName": "Blood pressure",
+        "entity": "bloodPressure",
+        "key": "id"
+      },
+      {
+        "id": "bmi_occurrence",
+        "displayName": "BMI",
+        "entity": "bmi",
+        "key": "id"
+      },
+      {
+        "id": "weight_occurrence",
+        "displayName": "Weight",
+        "entity": "weight",
+        "key": "id"
+      },
+      {
+        "id": "height_occurrence",
+        "displayName": "Height",
+        "entity": "height",
+        "key": "id"
+      },
+      {
+        "id": "pulse_occurrence",
+        "displayName": "Pulse",
+        "entity": "pulse",
+        "key": "id"
+      },
+      {
+        "id": "resp_rate_occurrence",
+        "displayName": "Resp rate",
+        "entity": "respiratoryRate",
+        "key": "id"
       }
     ]
   },
@@ -801,6 +837,109 @@
         "age_at_occurrence",
         "visit_type",
         "start_date_group_by_count"
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-bmi",
+      "title": "BMI",
+      "category": "Vitals",
+      "occurrence": "bmi_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Cleanliness",
+          "attribute": "is_clean"
+        },
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "kg/m^2"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-blood-pressure",
+      "title": "Blood pressure",
+      "category": "Vitals",
+      "occurrence": "blood_pressure_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Category",
+          "attribute": "status_code"
+        },
+        {
+          "title": "Systolic",
+          "attribute": "systolic"
+        },
+        {
+          "title": "Diastolic",
+          "attribute": "diastolic"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-height",
+      "title": "Height",
+      "category": "Vitals",
+      "occurrence": "height_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Cleanliness",
+          "attribute": "is_clean"
+        },
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "cm"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-weight",
+      "title": "Weight",
+      "category": "Vitals",
+      "occurrence": "weight_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Cleanliness",
+          "attribute": "is_clean"
+        },
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "kg"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-pulse",
+      "title": "Pulse",
+      "category": "Vitals",
+      "occurrence": "pulse_occurrence",
+      "valueConfigs": [
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "bpm"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-resp-rate",
+      "title": "Resp Rate",
+      "category": "Vitals",
+      "occurrence": "resp_rate_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Resp rate in br/min",
+          "attribute": "value_numeric",
+          "unit": "br/min"
+        }
       ]
     }
   ],

--- a/service/src/main/resources/config/vumc/sdd_refresh0323/ui/top_level.json
+++ b/service/src/main/resources/config/vumc/sdd_refresh0323/ui/top_level.json
@@ -370,6 +370,42 @@
             }
           }
         ]
+      },
+      {
+        "id": "blood_pressure_occurrence",
+        "displayName": "Blood pressure",
+        "entity": "bloodPressure",
+        "key": "id"
+      },
+      {
+        "id": "bmi_occurrence",
+        "displayName": "BMI",
+        "entity": "bmi",
+        "key": "id"
+      },
+      {
+        "id": "weight_occurrence",
+        "displayName": "Weight",
+        "entity": "weight",
+        "key": "id"
+      },
+      {
+        "id": "height_occurrence",
+        "displayName": "Height",
+        "entity": "height",
+        "key": "id"
+      },
+      {
+        "id": "pulse_occurrence",
+        "displayName": "Pulse",
+        "entity": "pulse",
+        "key": "id"
+      },
+      {
+        "id": "resp_rate_occurrence",
+        "displayName": "Resp rate",
+        "entity": "respiratoryRate",
+        "key": "id"
       }
     ]
   },
@@ -801,6 +837,109 @@
         "age_at_occurrence",
         "visit_type",
         "start_date_group_by_count"
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-bmi",
+      "title": "BMI",
+      "category": "Vitals",
+      "occurrence": "bmi_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Cleanliness",
+          "attribute": "is_clean"
+        },
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "kg/m^2"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-blood-pressure",
+      "title": "Blood pressure",
+      "category": "Vitals",
+      "occurrence": "blood_pressure_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Category",
+          "attribute": "status_code"
+        },
+        {
+          "title": "Systolic",
+          "attribute": "systolic"
+        },
+        {
+          "title": "Diastolic",
+          "attribute": "diastolic"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-height",
+      "title": "Height",
+      "category": "Vitals",
+      "occurrence": "height_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Cleanliness",
+          "attribute": "is_clean"
+        },
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "cm"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-weight",
+      "title": "Weight",
+      "category": "Vitals",
+      "occurrence": "weight_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Cleanliness",
+          "attribute": "is_clean"
+        },
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "kg"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-pulse",
+      "title": "Pulse",
+      "category": "Vitals",
+      "occurrence": "pulse_occurrence",
+      "valueConfigs": [
+        {
+          "title": "",
+          "attribute": "value_numeric",
+          "unit": "bpm"
+        }
+      ]
+    },
+    {
+      "type": "multiAttribute",
+      "id": "tanagra-resp-rate",
+      "title": "Resp Rate",
+      "category": "Vitals",
+      "occurrence": "resp_rate_occurrence",
+      "valueConfigs": [
+        {
+          "title": "Resp rate in br/min",
+          "attribute": "value_numeric",
+          "unit": "br/min"
+        }
       ]
     }
   ],

--- a/ui/src/components/rangeSlider.tsx
+++ b/ui/src/components/rangeSlider.tsx
@@ -1,6 +1,7 @@
 import DeleteIcon from "@mui/icons-material/Delete";
 import IconButton from "@mui/material/IconButton";
 import Input from "@mui/material/Input";
+import InputAdornment from "@mui/material/InputAdornment";
 import Slider from "@mui/material/Slider";
 import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
@@ -18,6 +19,7 @@ export type RangeSliderProps = {
   range: DataRange;
   index: number;
   multiRange?: boolean;
+  unit?: string;
 
   onUpdate: (range: DataRange, index: number, min: number, max: number) => void;
   onDelete?: (range: DataRange, index: number) => void;
@@ -79,7 +81,7 @@ export function RangeSlider(props: RangeSliderProps) {
 
   return (
     <GridBox
-      sx={{ width: "30%", minWidth: 400, height: "auto", mt: 0.5 }}
+      sx={{ width: "40%", minWidth: 600, height: "auto", mt: 0.5 }}
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -91,6 +93,11 @@ export function RangeSlider(props: RangeSliderProps) {
           size="medium"
           onChange={handleMinInputChange}
           onBlur={handleMinInputBlur}
+          endAdornment={
+            props.unit ? (
+              <InputAdornment position="end">{props.unit}</InputAdornment>
+            ) : undefined
+          }
           inputProps={{
             min: minBound,
             max: maxBound,
@@ -111,6 +118,11 @@ export function RangeSlider(props: RangeSliderProps) {
           value={maxInputValue}
           onChange={handleMaxInputChange}
           onBlur={handleMaxInputBlur}
+          endAdornment={
+            props.unit ? (
+              <InputAdornment position="end">{props.unit}</InputAdornment>
+            ) : undefined
+          }
           inputProps={{
             min: minBound,
             max: maxBound,

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -25,6 +25,7 @@ type Selection = {
 interface Config extends CriteriaConfig {
   attribute: string;
   multiRange?: boolean;
+  unit?: string;
 }
 
 interface Data {
@@ -131,6 +132,7 @@ type SliderProps = {
   criteriaId?: string;
   index: number;
   multiRange?: boolean;
+  unit?: string;
 };
 
 function AttributeSlider(props: SliderProps) {
@@ -170,6 +172,7 @@ function AttributeSlider(props: SliderProps) {
       range={props.range}
       index={props.index}
       multiRange={props.multiRange}
+      unit={props.unit}
       onUpdate={onUpdate}
       onDelete={onDelete}
     />
@@ -232,6 +235,7 @@ function AttributeInline(props: AttributeInlineProps) {
           minBound={hintDataState.data.integerHint.min}
           maxBound={hintDataState.data.integerHint.max}
           range={emptyRange}
+          unit={props.config.unit}
           data={props.data}
           groupId={props.groupId}
           criteriaId={props.criteriaId}
@@ -248,6 +252,7 @@ function AttributeInline(props: AttributeInlineProps) {
             minBound={hintDataState.data.integerHint.min}
             maxBound={hintDataState.data.integerHint.max}
             range={range}
+            unit={props.config.unit}
             data={props.data}
             groupId={props.groupId}
             criteriaId={props.criteriaId}

--- a/ui/src/criteria/multiAttribute.tsx
+++ b/ui/src/criteria/multiAttribute.tsx
@@ -1,0 +1,214 @@
+import { CriteriaPlugin, registerCriteriaPlugin } from "cohort";
+import {
+  ANY_VALUE_DATA,
+  generateValueDataFilter,
+  ValueConfig,
+  ValueData,
+  ValueDataEdit,
+} from "criteria/valueData";
+import { ROLLUP_COUNT_ATTRIBUTE } from "data/configuration";
+import { Source } from "data/source";
+import { DataEntry } from "data/types";
+import { useUpdateCriteria } from "hooks";
+import produce from "immer";
+import { CriteriaConfig } from "underlaysSlice";
+import { isValid } from "util/valid";
+
+export interface Config extends CriteriaConfig {
+  occurrence: string;
+  singleValue?: boolean;
+  valueConfigs: ValueConfig[];
+}
+
+export interface Data {
+  valueData: ValueData[];
+}
+
+// "multiAttribute" plugins select occurrences based on one or more attributes
+// that can be selected by the user. It supports two modes, one where a single
+// value is switched between multiple attributes and another where multiple
+// attributes can be set simultaneously.
+@registerCriteriaPlugin(
+  "multiAttribute",
+  (source: Source, c: CriteriaConfig, dataEntry?: DataEntry) => {
+    const valueData: ValueData[] = [];
+    if (dataEntry) {
+      valueData.push({
+        ...ANY_VALUE_DATA,
+        attribute: String(dataEntry.t_attribute),
+        numeric: false,
+        selected: [{ name: String(dataEntry.name), value: dataEntry.key }],
+      });
+    }
+
+    return {
+      valueData,
+    };
+  },
+  search
+)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class _ implements CriteriaPlugin<Data> {
+  public data: Data;
+  private config: Config;
+
+  constructor(public id: string, config: CriteriaConfig, data: unknown) {
+    this.config = config as Config;
+    this.data = data as Data;
+  }
+
+  renderInline(groupId: string) {
+    if (!this.config.valueConfigs) {
+      return null;
+    }
+
+    return (
+      <MultiAttributeInline
+        groupId={groupId}
+        criteriaId={this.id}
+        data={this.data}
+        config={this.config}
+      />
+    );
+  }
+
+  displayDetails() {
+    if (this.data.valueData.length === 0) {
+      return {
+        title: "(any)",
+      };
+    }
+
+    const details = this.data.valueData.map((vd) => {
+      if (vd.numeric) {
+        return {
+          title: `${vd.range.min} - ${vd.range.max}`,
+        };
+      }
+
+      if (vd.selected.length === 0) {
+        return {
+          title: "(any)",
+        };
+      }
+
+      if (vd.selected.length === 1) {
+        return {
+          title: vd.selected[0].name,
+        };
+      }
+
+      return {
+        title: `(${vd.selected.length} selected)`,
+        additionalText: vd.selected.map((s) => s.name),
+      };
+    });
+
+    if (this.config.singleValue || this.config.valueConfigs.length === 1) {
+      return details[0];
+    }
+
+    const title = this.data.valueData
+      .map((vd, i) => {
+        const title = this.config.valueConfigs.find(
+          (c) => c.attribute === vd.attribute
+        )?.title;
+        return (title ? title + ": " : "") + details[i].title;
+      })
+      .join(", ");
+    const additionalText = this.data.valueData
+      .map((vd, i) => {
+        const at = details[i].additionalText;
+        if (!at) {
+          return undefined;
+        }
+        const title = this.config.valueConfigs.find(
+          (c) => c.attribute === vd.attribute
+        )?.title;
+        return (title ? title + ": " : "") + at.join(", ");
+      })
+      .filter(isValid);
+
+    return {
+      title,
+      additionalText,
+    };
+  }
+
+  generateFilter() {
+    return generateValueDataFilter(this.data.valueData);
+  }
+
+  filterOccurrenceIds() {
+    return [this.config.occurrence];
+  }
+}
+
+type MultiAttributeInlineProps = {
+  groupId: string;
+  criteriaId: string;
+  data: Data;
+  config: Config;
+};
+
+function MultiAttributeInline(props: MultiAttributeInlineProps) {
+  const updateCriteria = useUpdateCriteria(props.groupId, props.criteriaId);
+
+  if (!props.config.valueConfigs) {
+    return null;
+  }
+
+  return (
+    <ValueDataEdit
+      occurrence={props.config.occurrence}
+      valueConfigs={props.config.valueConfigs}
+      valueData={props.data.valueData}
+      update={(valueData) =>
+        updateCriteria(
+          produce(props.data, (data) => {
+            data.valueData = valueData;
+          })
+        )
+      }
+    />
+  );
+}
+
+async function search(
+  source: Source,
+  c: CriteriaConfig,
+  query: string
+): Promise<DataEntry[]> {
+  const config = c as Config;
+
+  const allHintData = await source.getAllHintData(config.occurrence);
+
+  const re = new RegExp(query, "i");
+  const results: DataEntry[] = [];
+  allHintData.forEach((hintData) => {
+    if (!hintData?.enumHintOptions) {
+      return;
+    }
+
+    hintData.enumHintOptions.forEach((hint) => {
+      const key = hint.value;
+      if (
+        (typeof key === "string" || typeof key === "number") &&
+        hint.name.search(re) >= 0
+      ) {
+        results.push({
+          key: key,
+          t_attribute: hintData.attribute,
+          name: hint.name,
+          [ROLLUP_COUNT_ATTRIBUTE]: hint.count,
+        });
+      }
+    });
+  });
+
+  return results.sort(
+    (a, b) =>
+      (b[ROLLUP_COUNT_ATTRIBUTE] as number) -
+      (a[ROLLUP_COUNT_ATTRIBUTE] as number)
+  );
+}

--- a/ui/src/criteria/valueData.tsx
+++ b/ui/src/criteria/valueData.tsx
@@ -1,0 +1,341 @@
+import FormControl from "@mui/material/FormControl";
+import MenuItem from "@mui/material/MenuItem";
+import OutlinedInput from "@mui/material/OutlinedInput";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import Typography from "@mui/material/Typography";
+import { HintDataSelect } from "components/hintDataSelect";
+import Loading from "components/loading";
+import { DataRange, RangeSlider } from "components/rangeSlider";
+import { FilterType, makeArrayFilter } from "data/filter";
+import { HintData } from "data/source";
+import { useSource } from "data/sourceContext";
+import { DataKey, DataValue } from "data/types";
+import produce from "immer";
+import { GridBox } from "layout/gridBox";
+import GridLayout from "layout/gridLayout";
+import { ReactNode, useMemo } from "react";
+import useSWRImmutable from "swr/immutable";
+import { isValid } from "util/valid";
+
+export type ValueConfig = {
+  attribute: string;
+  title: string;
+  unit?: string;
+};
+
+export type ValueSelection = {
+  value: DataValue;
+  name: string;
+};
+
+export const ANY_VALUE = "t_any";
+
+export type ValueData = {
+  attribute: string;
+  numeric: boolean;
+  selected: ValueSelection[];
+  range: DataRange;
+};
+
+export const ANY_VALUE_DATA = {
+  attribute: ANY_VALUE,
+  numeric: false,
+  selected: [],
+  range: {
+    id: "",
+    min: 0,
+    max: 0,
+  },
+};
+
+export type ValueDataEditProps = {
+  occurrence: string;
+  entity?: string;
+  hintKey?: DataKey;
+
+  singleValue?: boolean;
+  valueConfigs: ValueConfig[];
+  valueData: ValueData[];
+  update: (data: ValueData[]) => void;
+};
+
+export function ValueDataEdit(props: ValueDataEditProps) {
+  const source = useSource();
+
+  const hintDataState = useSWRImmutable(
+    {
+      type: "hintData",
+      occurrence: props.occurrence,
+      entity: props.entity,
+      key: props.hintKey,
+    },
+    async (key) => {
+      const hintData = props.valueConfigs
+        ? await source.getAllHintData(key.occurrence, key.entity, key.key)
+        : undefined;
+      // TODO(tjennison): Remove once index is updated.
+      if (!hintData?.find((hd) => hd.attribute === "is_clean")) {
+        (hintData ?? []).push({
+          attribute: "is_clean",
+          enumHintOptions: [
+            {
+              value: false,
+              name: "Raw",
+              count: 10,
+            },
+            {
+              value: true,
+              name: "Cleaned",
+              count: 20,
+            },
+          ],
+        });
+      }
+      return {
+        hintData,
+      };
+    }
+  );
+
+  const onSelect = (event: SelectChangeEvent<string>) => {
+    const {
+      target: { value: sel },
+    } = event;
+    const attribute =
+      props.valueConfigs.find((c) => c.attribute === sel)?.attribute ??
+      ANY_VALUE;
+    if (props.valueData[0] && attribute === props.valueData[0]?.attribute) {
+      return;
+    }
+
+    const hintData = hintDataState.data?.hintData?.find(
+      (hint) => hint.attribute === attribute
+    );
+
+    if (hintData) {
+      props.update([defaultValueData(hintData)]);
+    } else {
+      props.update([ANY_VALUE_DATA]);
+    }
+  };
+
+  const selectedConfigs = useMemo(() => {
+    return props.valueConfigs
+      .map((valueConfig) => {
+        const hintData = hintDataState.data?.hintData?.find(
+          (hint) => hint.attribute === valueConfig.attribute
+        );
+        if (!hintData) {
+          return null;
+        }
+
+        let valueData = props.valueData.find(
+          (data) => data.attribute === valueConfig.attribute
+        );
+        if (props.singleValue && !valueData) {
+          return null;
+        }
+        if (!valueData) {
+          valueData = defaultValueData(hintData);
+        }
+
+        return {
+          valueConfig,
+          valueData,
+          hintData,
+        };
+      })
+      .filter(isValid);
+  }, [
+    props.singleValue,
+    props.valueConfigs,
+    props.valueData,
+    hintDataState.data,
+  ]);
+
+  const onValueSelect = (sel: ValueSelection[], valueData: ValueData) => {
+    props.update(
+      produce(props.valueData, (data) => {
+        if (!props.singleValue && sel.length === 0) {
+          return data.filter(
+            (vd) =>
+              vd.attribute != valueData.attribute && vd.attribute != ANY_VALUE
+          );
+        }
+
+        const existing = data.find(
+          (vd) =>
+            vd.attribute === valueData.attribute || vd.attribute === ANY_VALUE
+        );
+        if (existing) {
+          existing.attribute = valueData.attribute;
+          existing.selected = sel;
+        } else {
+          valueData.selected = sel;
+          data.push(valueData);
+        }
+      })
+    );
+  };
+
+  const onUpdateRange = (
+    range: DataRange,
+    index: number,
+    min: number,
+    max: number,
+    valueData: ValueData
+  ) => {
+    props.update(
+      produce(props.valueData, (data) => {
+        const hintData = selectedConfigs.find(
+          (c) => c.hintData.attribute === valueData.attribute
+        )?.hintData;
+        if (
+          !props.singleValue &&
+          hintData?.integerHint &&
+          hintData.integerHint.min === min &&
+          hintData.integerHint.max === max
+        ) {
+          return data.filter(
+            (vd) =>
+              vd.attribute != valueData.attribute && vd.attribute != ANY_VALUE
+          );
+        }
+
+        const existing = data.find(
+          (vd) =>
+            vd.attribute === valueData.attribute || vd.attribute === ANY_VALUE
+        );
+        if (existing) {
+          existing.attribute = valueData.attribute;
+          existing.range.min = min;
+          existing.range.max = max;
+        } else {
+          valueData.range.min = min;
+          valueData.range.max = max;
+          data.push(valueData);
+        }
+      })
+    );
+  };
+
+  return (
+    <Loading status={hintDataState}>
+      <GridLayout
+        cols={!!props.singleValue ? true : undefined}
+        rows={!props.singleValue ? true : undefined}
+        spacing={2}
+        height="auto"
+      >
+        {!!props.valueData.length && props.singleValue ? (
+          <FormControl
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <Select
+              value={props.valueData[0].attribute}
+              input={<OutlinedInput />}
+              disabled={!hintDataState.data?.hintData?.length}
+              onChange={onSelect}
+            >
+              <MenuItem key={ANY_VALUE} value={ANY_VALUE}>
+                Any value
+              </MenuItem>
+              {props.valueConfigs?.map((c) =>
+                hintDataState.data?.hintData?.find(
+                  (hint) => hint.attribute === c.attribute
+                ) ? (
+                  <MenuItem key={c.attribute} value={c.attribute}>
+                    {c.title}
+                  </MenuItem>
+                ) : null
+              )}
+            </Select>
+          </FormControl>
+        ) : null}
+        {selectedConfigs.map((c) => {
+          let component: ReactNode = null;
+          if (c.hintData.enumHintOptions) {
+            component = (
+              <HintDataSelect
+                key={c.valueConfig.attribute}
+                hintData={c.hintData}
+                selected={c.valueData.selected}
+                onSelect={(sel) => onValueSelect(sel, c.valueData)}
+              />
+            );
+          }
+          if (c.hintData.integerHint) {
+            component = (
+              <RangeSlider
+                key={c.valueConfig.attribute}
+                index={0}
+                minBound={c.hintData.integerHint.min}
+                maxBound={c.hintData.integerHint.max}
+                range={c.valueData.range}
+                unit={c.valueConfig.unit}
+                onUpdate={(range, index, min, max) =>
+                  onUpdateRange(range, index, min, max, c.valueData)
+                }
+              />
+            );
+          }
+          if (!component || props.singleValue) {
+            return component;
+          }
+
+          return (
+            <GridLayout
+              key={c.valueData.attribute}
+              cols
+              rowAlign="middle"
+              spacing={3}
+              height="auto"
+            >
+              {!!c.valueConfig.title ? (
+                <Typography variant="body1">{c.valueConfig.title}</Typography>
+              ) : null}
+              {component}
+            </GridLayout>
+          );
+        })}
+        <GridBox />
+      </GridLayout>
+    </Loading>
+  );
+}
+
+export function generateValueDataFilter(valueData: ValueData[]) {
+  if (!valueData.length || valueData[0].attribute === ANY_VALUE) {
+    return {
+      type: FilterType.Attribute,
+      attribute: "id",
+      nonNull: true,
+    };
+  }
+
+  return makeArrayFilter(
+    {},
+    valueData.map((vd) => ({
+      type: FilterType.Attribute,
+      attribute: vd.attribute,
+      values: !vd.numeric ? vd.selected.map((s) => s.value) : undefined,
+      ranges: vd.numeric ? [vd.range] : undefined,
+    }))
+  );
+}
+
+function defaultValueData(hintData: HintData): ValueData {
+  return {
+    attribute: hintData.attribute,
+    numeric: !!hintData?.integerHint,
+    selected: [],
+    range: {
+      id: "",
+      min: hintData?.integerHint?.min ?? Number.MIN_SAFE_INTEGER,
+      max: hintData?.integerHint?.max ?? Number.MAX_SAFE_INTEGER,
+    },
+  };
+}

--- a/ui/src/data/filter.ts
+++ b/ui/src/data/filter.ts
@@ -64,6 +64,7 @@ export type AttributeFilter = BaseFilter & {
   attribute: string;
   values?: DataValue[];
   ranges?: { min: number; max: number }[];
+  nonNull?: boolean;
 };
 
 export function isAttributeFilter(filter: Filter): filter is AttributeFilter {

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -1560,9 +1560,6 @@ export function generateFilter(
   if (isRelationshipFilter(filter)) {
     const entity = findEntity(filter.entityId, source.config);
     const subfilter = generateFilter(source, filter.subfilter);
-    if (!subfilter) {
-      return null;
-    }
 
     return {
       filterType: tanagra.FilterFilterTypeEnum.Relationship,
@@ -1636,6 +1633,9 @@ export function generateFilter(
     };
   }
   if (isAttributeFilter(filter)) {
+    if (filter.nonNull) {
+      return null;
+    }
     if (filter.ranges?.length) {
       return makeBooleanLogicFilter(
         tanagra.BooleanLogicFilterOperatorEnum.Or,

--- a/ui/src/plugins.ts
+++ b/ui/src/plugins.ts
@@ -2,6 +2,7 @@
 
 // Core plugins
 import "criteria/attribute";
+import "criteria/multiAttribute";
 import "criteria/classification";
 import "criteria/textSearch";
 import "criteria/unhintedValue";


### PR DESCRIPTION
* Add a new criteria that handles multiple attributes at the same time based on the labs and measurements values code. It supports two modes, one that selects between attributes and one that displays them all simultaneously.
* Add support for units units for attribute sliders.
* Add SDD vitals configuration.
* Make filters nullable to pass a null relationship subfilter.