### PR TITLE
Check url for token if local env var set

### DIFF
--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -310,6 +310,15 @@ function apiForEnvironment<Real, Fake>(
     const config: tanagra.ConfigurationParameters = {
       basePath: process.env.REACT_APP_BACKEND_HOST || "",
     };
+    // For local dev only, get the bearer token from the iframe url param
+    if (process.env.REACT_APP_GET_LOCAL_AUTH_TOKEN) {
+      const accessToken = new URLSearchParams(
+        window.location.href.split("?")[1]
+      ).get("token");
+      if (accessToken) {
+        config.accessToken = accessToken;
+      }
+    }
     return new real(new tanagra.Configuration(config));
   };
   return React.createContext(fn());


### PR DESCRIPTION
Add check for a new UI env var `REACT_APP_GET_LOCAL_AUTH_TOKEN` which should only be set for local dev environments. If the env var is set, check the url for the `token` query param and set it as the access token. This is needed for enabling and testing authz for local dev.

This is the same temp solution we've used in the AoU test env, but it will be removed there once we get both apps on the same domain. I have not been able to find a local solution for deploying multiple apps on the same domain/port, so we'll need this workaround for local dev. We are also open to other solutions if you know of any.