### PR TITLE
Data feature set backend implementation.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsApiController.java
@@ -15,6 +15,7 @@ import bio.terra.tanagra.generated.model.ApiConceptSet;
 import bio.terra.tanagra.generated.model.ApiConceptSetCreateInfo;
 import bio.terra.tanagra.generated.model.ApiConceptSetList;
 import bio.terra.tanagra.generated.model.ApiConceptSetUpdateInfo;
+import bio.terra.tanagra.generated.model.ApiEntityOutput;
 import bio.terra.tanagra.service.accesscontrol.AccessControlService;
 import bio.terra.tanagra.service.accesscontrol.Permissions;
 import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
@@ -23,6 +24,8 @@ import bio.terra.tanagra.service.artifact.ConceptSetService;
 import bio.terra.tanagra.service.artifact.model.ConceptSet;
 import bio.terra.tanagra.service.artifact.model.Criteria;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,17 +50,13 @@ public class ConceptSetsApiController implements ConceptSetsApi {
         SpringAuthentication.getCurrentUser(),
         Permissions.forActions(STUDY, CREATE_CONCEPT_SET),
         ResourceId.forStudy(studyId));
-    Criteria singleCriteria =
-        body.getCriteria() == null ? null : FromApiUtils.fromApiObject(body.getCriteria());
     ConceptSet createdConceptSet =
         conceptSetService.createConceptSet(
             studyId,
             ConceptSet.builder()
                 .displayName(body.getDisplayName())
                 .description(body.getDescription())
-                .underlay(body.getUnderlayName())
-                .entity(body.getEntity())
-                .criteria(List.of(singleCriteria)),
+                .underlay(body.getUnderlayName()),
             SpringAuthentication.getCurrentUser().getEmail());
     return ResponseEntity.ok(ConceptSetsApiController.toApiObject(createdConceptSet));
   }
@@ -104,8 +103,17 @@ public class ConceptSetsApiController implements ConceptSetsApi {
         SpringAuthentication.getCurrentUser(),
         Permissions.forActions(CONCEPT_SET, UPDATE),
         ResourceId.forConceptSet(studyId, conceptSetId));
-    Criteria singleCriteria =
-        body.getCriteria() == null ? null : FromApiUtils.fromApiObject(body.getCriteria());
+    List<Criteria> criteria =
+        body.getCriteria() == null
+            ? null
+            : body.getCriteria().stream()
+                .map(FromApiUtils::fromApiObject)
+                .collect(Collectors.toList());
+    Map<String, List<String>> outputAttributesPerEntity =
+        body.getEntityOutputs() == null
+            ? null
+            : body.getEntityOutputs().stream()
+                .collect(Collectors.toMap(eo -> eo.getEntity(), eo -> eo.getAttributes()));
     ConceptSet updatedConceptSet =
         conceptSetService.updateConceptSet(
             studyId,
@@ -113,8 +121,8 @@ public class ConceptSetsApiController implements ConceptSetsApi {
             SpringAuthentication.getCurrentUser().getEmail(),
             body.getDisplayName(),
             body.getDescription(),
-            body.getEntity(),
-            List.of(singleCriteria));
+            criteria,
+            outputAttributesPerEntity);
     return ResponseEntity.ok(toApiObject(updatedConceptSet));
   }
 
@@ -122,7 +130,6 @@ public class ConceptSetsApiController implements ConceptSetsApi {
     return new ApiConceptSet()
         .id(conceptSet.getId())
         .underlayName(conceptSet.getUnderlay())
-        .entity(conceptSet.getEntity())
         .displayName(conceptSet.getDisplayName())
         .description(conceptSet.getDescription())
         .created(conceptSet.getCreated())
@@ -131,6 +138,18 @@ public class ConceptSetsApiController implements ConceptSetsApi {
         .criteria(
             conceptSet.getCriteria() == null
                 ? null
-                : ToApiUtils.toApiObject(conceptSet.getCriteria().get(0)));
+                : conceptSet.getCriteria().stream()
+                    .map(ToApiUtils::toApiObject)
+                    .collect(Collectors.toList()))
+        .entityOutputs(
+            conceptSet.getOutputColumnsPerEntity() == null
+                ? null
+                : conceptSet.getOutputColumnsPerEntity().entrySet().stream()
+                    .map(
+                        entry ->
+                            new ApiEntityOutput()
+                                .entity(entry.getKey())
+                                .attributes(entry.getValue()))
+                    .collect(Collectors.toList()));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ConceptSetsApiController.java
@@ -113,7 +113,7 @@ public class ConceptSetsApiController implements ConceptSetsApi {
         body.getEntityOutputs() == null
             ? null
             : body.getEntityOutputs().stream()
-                .collect(Collectors.toMap(eo -> eo.getEntity(), eo -> eo.getAttributes()));
+                .collect(Collectors.toMap(eo -> eo.getEntity(), eo -> eo.getExcludeAttributes()));
     ConceptSet updatedConceptSet =
         conceptSetService.updateConceptSet(
             studyId,
@@ -142,14 +142,14 @@ public class ConceptSetsApiController implements ConceptSetsApi {
                     .map(ToApiUtils::toApiObject)
                     .collect(Collectors.toList()))
         .entityOutputs(
-            conceptSet.getOutputColumnsPerEntity() == null
+            conceptSet.getExcludeOutputAttributesPerEntity() == null
                 ? null
-                : conceptSet.getOutputColumnsPerEntity().entrySet().stream()
+                : conceptSet.getExcludeOutputAttributesPerEntity().entrySet().stream()
                     .map(
                         entry ->
                             new ApiEntityOutput()
                                 .entity(entry.getKey())
-                                .attributes(entry.getValue()))
+                                .excludeAttributes(entry.getValue()))
                     .collect(Collectors.toList()));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -359,6 +359,7 @@ public final class FromApiUtils {
         .displayName(apiObj.getDisplayName())
         .pluginName(apiObj.getPluginName())
         .pluginVersion(apiObj.getPluginVersion() == null ? 0 : apiObj.getPluginVersion())
+        .predefinedId(apiObj.getPredefinedId())
         .uiConfig(apiObj.getUiConfig())
         .selectionData(apiObj.getSelectionData())
         .tags(apiObj.getTags())

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -129,6 +129,7 @@ public final class ToApiUtils {
         .displayName(criteria.getDisplayName())
         .pluginName(criteria.getPluginName())
         .pluginVersion(criteria.getPluginVersion())
+        .predefinedId(criteria.getPredefinedId())
         .selectionData(criteria.getSelectionData())
         .uiConfig(criteria.getUiConfig())
         .tags(criteria.getTags());

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSetService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ConceptSetService.java
@@ -43,8 +43,8 @@ public class ConceptSetService {
     // Make sure underlay, study id, and any entity-attribute pairs are valid.
     studyService.getStudy(studyId);
     Underlay underlay = underlayService.getUnderlay(conceptSetBuilder.getUnderlay());
-    if (conceptSetBuilder.getOutputAttributesPerEntity() != null) {
-      conceptSetBuilder.getOutputAttributesPerEntity().entrySet().stream()
+    if (conceptSetBuilder.getExcludeOutputAttributesPerEntity() != null) {
+      conceptSetBuilder.getExcludeOutputAttributesPerEntity().entrySet().stream()
           .forEach(
               entry -> {
                 Entity entity = underlay.getEntity(entry.getKey());

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/ConceptSet.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/ConceptSet.java
@@ -14,7 +14,7 @@ public class ConceptSet {
   private final String id;
   private final String underlay;
   private final List<Criteria> criteria;
-  private final Map<String, List<String>> outputColumnsPerEntity;
+  private final Map<String, List<String>> excludeOutputAttributesPerEntity;
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final OffsetDateTime created;
@@ -27,7 +27,7 @@ public class ConceptSet {
     this.id = builder.id;
     this.underlay = builder.underlay;
     this.criteria = builder.criteria;
-    this.outputColumnsPerEntity = builder.outputAttributesPerEntity;
+    this.excludeOutputAttributesPerEntity = builder.excludeOutputAttributesPerEntity;
     this.displayName = builder.displayName;
     this.description = builder.description;
     this.created = builder.created;
@@ -53,8 +53,8 @@ public class ConceptSet {
     return criteria;
   }
 
-  public Map<String, List<String>> getOutputColumnsPerEntity() {
-    return outputColumnsPerEntity;
+  public Map<String, List<String>> getExcludeOutputAttributesPerEntity() {
+    return excludeOutputAttributesPerEntity;
   }
 
   public OffsetDateTime getCreated() {
@@ -91,7 +91,7 @@ public class ConceptSet {
     private String id;
     private String underlay;
     private List<Criteria> criteria = new ArrayList<>();
-    private Map<String, List<String>> outputAttributesPerEntity = new HashMap<>();
+    private Map<String, List<String>> excludeOutputAttributesPerEntity = new HashMap<>();
     private String displayName;
     private String description;
     private OffsetDateTime created;
@@ -115,8 +115,9 @@ public class ConceptSet {
       return this;
     }
 
-    public Builder outputAttributesPerEntity(Map<String, List<String>> outputAttributesPerEntity) {
-      this.outputAttributesPerEntity = outputAttributesPerEntity;
+    public Builder excludeOutputAttributesPerEntity(
+        Map<String, List<String>> excludeOutputAttributesPerEntity) {
+      this.excludeOutputAttributesPerEntity = excludeOutputAttributesPerEntity;
       return this;
     }
 
@@ -161,8 +162,8 @@ public class ConceptSet {
       }
       criteria = new ArrayList<>(criteria);
       criteria.sort(Comparator.comparing(Criteria::getId));
-      outputAttributesPerEntity =
-          outputAttributesPerEntity.entrySet().stream()
+      excludeOutputAttributesPerEntity =
+          excludeOutputAttributesPerEntity.entrySet().stream()
               .collect(
                   Collectors.toMap(
                       entry -> entry.getKey(),
@@ -178,21 +179,21 @@ public class ConceptSet {
       return underlay;
     }
 
-    public Map<String, List<String>> getOutputAttributesPerEntity() {
-      return outputAttributesPerEntity;
+    public Map<String, List<String>> getExcludeOutputAttributesPerEntity() {
+      return excludeOutputAttributesPerEntity;
     }
 
     public void addCriteria(Criteria newCriteria) {
       criteria.add(newCriteria);
     }
 
-    public void addOutputAttribute(String entity, String attribute) {
+    public void addExcludeOutputAttribute(String entity, String attribute) {
       List<String> outputAttributes =
-          outputAttributesPerEntity.containsKey(entity)
-              ? outputAttributesPerEntity.get(entity)
+          excludeOutputAttributesPerEntity.containsKey(entity)
+              ? excludeOutputAttributesPerEntity.get(entity)
               : new ArrayList<>();
       outputAttributes.add(attribute);
-      outputAttributesPerEntity.put(entity, outputAttributes);
+      excludeOutputAttributesPerEntity.put(entity, outputAttributes);
     }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/ConceptSet.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/ConceptSet.java
@@ -3,15 +3,18 @@ package bio.terra.tanagra.service.artifact.model;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.RandomStringUtils;
 
 public class ConceptSet {
   private final String id;
   private final String underlay;
-  private final String entity;
   private final List<Criteria> criteria;
+  private final Map<String, List<String>> outputColumnsPerEntity;
   private final @Nullable String displayName;
   private final @Nullable String description;
   private final OffsetDateTime created;
@@ -23,8 +26,8 @@ public class ConceptSet {
   private ConceptSet(Builder builder) {
     this.id = builder.id;
     this.underlay = builder.underlay;
-    this.entity = builder.entity;
     this.criteria = builder.criteria;
+    this.outputColumnsPerEntity = builder.outputAttributesPerEntity;
     this.displayName = builder.displayName;
     this.description = builder.description;
     this.created = builder.created;
@@ -46,12 +49,12 @@ public class ConceptSet {
     return underlay;
   }
 
-  public String getEntity() {
-    return entity;
-  }
-
   public List<Criteria> getCriteria() {
     return criteria;
+  }
+
+  public Map<String, List<String>> getOutputColumnsPerEntity() {
+    return outputColumnsPerEntity;
   }
 
   public OffsetDateTime getCreated() {
@@ -87,8 +90,8 @@ public class ConceptSet {
   public static class Builder {
     private String id;
     private String underlay;
-    private String entity;
     private List<Criteria> criteria = new ArrayList<>();
+    private Map<String, List<String>> outputAttributesPerEntity = new HashMap<>();
     private String displayName;
     private String description;
     private OffsetDateTime created;
@@ -107,13 +110,13 @@ public class ConceptSet {
       return this;
     }
 
-    public Builder entity(String entity) {
-      this.entity = entity;
+    public Builder criteria(List<Criteria> criteria) {
+      this.criteria = criteria;
       return this;
     }
 
-    public Builder criteria(List<Criteria> criteria) {
-      this.criteria = criteria;
+    public Builder outputAttributesPerEntity(Map<String, List<String>> outputAttributesPerEntity) {
+      this.outputAttributesPerEntity = outputAttributesPerEntity;
       return this;
     }
 
@@ -158,6 +161,12 @@ public class ConceptSet {
       }
       criteria = new ArrayList<>(criteria);
       criteria.sort(Comparator.comparing(Criteria::getId));
+      outputAttributesPerEntity =
+          outputAttributesPerEntity.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      entry -> entry.getKey(),
+                      entry -> entry.getValue().stream().sorted().collect(Collectors.toList())));
       return new ConceptSet(this);
     }
 
@@ -169,12 +178,21 @@ public class ConceptSet {
       return underlay;
     }
 
-    public String getEntity() {
-      return entity;
+    public Map<String, List<String>> getOutputAttributesPerEntity() {
+      return outputAttributesPerEntity;
     }
 
     public void addCriteria(Criteria newCriteria) {
       criteria.add(newCriteria);
+    }
+
+    public void addOutputAttribute(String entity, String attribute) {
+      List<String> outputAttributes =
+          outputAttributesPerEntity.containsKey(entity)
+              ? outputAttributesPerEntity.get(entity)
+              : new ArrayList<>();
+      outputAttributes.add(attribute);
+      outputAttributesPerEntity.put(entity, outputAttributes);
     }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/Criteria.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/Criteria.java
@@ -10,15 +10,18 @@ public class Criteria {
   private final String displayName;
   private final String pluginName;
   private final int pluginVersion;
+  private final String predefinedId;
   private final String selectionData;
   private final String uiConfig;
   private final Map<String, String> tags;
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   private Criteria(
       String id,
       String displayName,
       String pluginName,
       int pluginVersion,
+      String predefinedId,
       String selectionData,
       String uiConfig,
       Map<String, String> tags) {
@@ -26,6 +29,7 @@ public class Criteria {
     this.displayName = displayName;
     this.pluginName = pluginName;
     this.pluginVersion = pluginVersion;
+    this.predefinedId = predefinedId;
     this.selectionData = selectionData;
     this.uiConfig = uiConfig;
     this.tags = tags;
@@ -51,6 +55,10 @@ public class Criteria {
     return pluginVersion;
   }
 
+  public String getPredefinedId() {
+    return predefinedId;
+  }
+
   public String getSelectionData() {
     return selectionData;
   }
@@ -68,6 +76,7 @@ public class Criteria {
     private String displayName;
     private String pluginName;
     private int pluginVersion;
+    private String predefinedId;
     private String selectionData;
     private String uiConfig;
     private Map<String, String> tags = new HashMap<>();
@@ -92,6 +101,11 @@ public class Criteria {
       return this;
     }
 
+    public Builder predefinedId(String predefinedId) {
+      this.predefinedId = predefinedId;
+      return this;
+    }
+
     public Builder selectionData(String selectionData) {
       this.selectionData = selectionData;
       return this;
@@ -112,7 +126,7 @@ public class Criteria {
         id = RandomStringUtils.randomAlphanumeric(10);
       }
       return new Criteria(
-          id, displayName, pluginName, pluginVersion, selectionData, uiConfig, tags);
+          id, displayName, pluginName, pluginVersion, predefinedId, selectionData, uiConfig, tags);
     }
 
     public String getId() {
@@ -140,6 +154,7 @@ public class Criteria {
         && displayName.equals(criteria.displayName)
         && pluginName.equals(criteria.pluginName)
         && pluginVersion == criteria.pluginVersion
+        && Objects.equals(predefinedId, criteria.predefinedId)
         && selectionData.equals(criteria.selectionData)
         && uiConfig.equals(criteria.uiConfig)
         && tags.equals(criteria.tags);
@@ -147,6 +162,7 @@ public class Criteria {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, displayName, pluginName, pluginVersion, selectionData, uiConfig, tags);
+    return Objects.hash(
+        id, displayName, pluginName, pluginVersion, predefinedId, selectionData, uiConfig, tags);
   }
 }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1810,14 +1810,20 @@ components:
           $ref: "#/components/schemas/ConceptSetId"
         underlayName:
           $ref: "#/components/schemas/UnderlayName"
-        entity:
-          $ref: "#/components/schemas/EntityName"
         displayName:
           $ref: "#/components/schemas/ConceptSetDisplayName"
         description:
           $ref: "#/components/schemas/ConceptSetDescription"
         criteria:
-          $ref: "#/components/schemas/Criteria"
+          type: array
+          description: Criteria that define the entity filter
+          items:
+            $ref: "#/components/schemas/Criteria"
+        entityOutputs:
+          type: array
+          description: Outputs per entity
+          items:
+            $ref: "#/components/schemas/EntityOutput"
         created:
           description: Timestamp of when the concept set was created
           type: string
@@ -1832,12 +1838,26 @@ components:
       required:
         - id
         - underlayName
-        - entity
         - displayName
         - criteria
+        - entityOutputs
         - created
         - createdBy
         - lastModified
+
+    EntityOutput:
+      type: object
+      properties:
+        entity:
+          description: Entity name
+          type: string
+        attributes:
+          type: array
+          description: Names of attributes to output
+          items:
+            type: string
+        required:
+          - entity
 
     ConceptSetList:
       type: array
@@ -1853,30 +1873,28 @@ components:
       properties:
         underlayName:
           $ref: "#/components/schemas/UnderlayName"
-        entity:
-          $ref: "#/components/schemas/EntityName"
         displayName:
           $ref: "#/components/schemas/ConceptSetDisplayName"
         description:
           $ref: "#/components/schemas/ConceptSetDescription"
-        criteria:
-          $ref: "#/components/schemas/Criteria"
 
     ConceptSetUpdateInfo:
       type: object
       properties:
-        entity:
-          $ref: "#/components/schemas/EntityName"
         displayName:
           $ref: "#/components/schemas/ConceptSetDisplayName"
         description:
           $ref: "#/components/schemas/ConceptSetDescription"
         criteria:
-          $ref: "#/components/schemas/Criteria"
-
-    EntityName:
-      type: string
-      description: Name of the entity (e.g. condition_occurrence)
+          type: array
+          description: Criteria that define the entity filter
+          items:
+            $ref: "#/components/schemas/Criteria"
+        entityOutputs:
+          type: array
+          description: Outputs per entity
+          items:
+            $ref: "#/components/schemas/EntityOutput"
 
     ConceptSetDisplayName:
       type: string

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1851,9 +1851,9 @@ components:
         entity:
           description: Entity name
           type: string
-        attributes:
+        excludeAttributes:
           type: array
-          description: Names of attributes to output
+          description: Names of attributes to exclude from output
           items:
             type: string
         required:
@@ -1984,6 +1984,9 @@ components:
         pluginVersion:
           type: integer
           description: Version of the plugin that generated this criteria
+        predefinedId:
+          type: string
+          description: Id of the predefined criteria in the config
         selectionData:
           type: string # JSON formatted
           description: Serialized plugin-specific representation of the user's selection

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -23,4 +23,5 @@
 
     <!-- Changesets -->
     <include file="changesets/20230922_initial_schema.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20231116_output_attribute.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20231116_output_attribute.yaml
+++ b/service/src/main/resources/db/changesets/20231116_output_attribute.yaml
@@ -1,0 +1,36 @@
+databaseChangeLog:
+  - changeSet:
+      id: output_attribute
+      author: marikomedlock
+      dbms: postgresql,mariadb,mysql
+      changes:
+        - createTable:
+            tableName: output_attribute
+            columns:
+              - column:
+                  name: concept_set_id
+                  type: ${id.type}
+                  constraints:
+                    references: concept_set(id)
+                    foreignKeyName: fk_oa_cs
+                    nullable: true
+                    deleteCascade: true
+                  remarks: Deleting a concept set will cascade to delete the output attributes contained in it
+              - column:
+                  name: entity
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attribute
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            constraintName: pk_oa
+            tableName: output_attribute
+            columnNames: concept_set_id, entity, attribute
+
+        -  dropNotNullConstraint:
+            tableName:  concept_set
+            columnName:  entity

--- a/service/src/main/resources/db/changesets/20231116_output_attribute.yaml
+++ b/service/src/main/resources/db/changesets/20231116_output_attribute.yaml
@@ -22,15 +22,24 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
-                  name: attribute
+                  name: exclude_attribute
                   type: ${text.type}
                   constraints:
                     nullable: false
         - addUniqueConstraint:
             constraintName: pk_oa
             tableName: output_attribute
-            columnNames: concept_set_id, entity, attribute
+            columnNames: concept_set_id, entity, exclude_attribute
 
-        -  dropNotNullConstraint:
-            tableName:  concept_set
-            columnName:  entity
+        -  dropColumn:
+             tableName: concept_set
+             columnName: entity
+
+        - addColumn:
+            tableName: criteria
+            columns:
+              - column:
+                  name: predefined_id
+                  type: ${id.type}
+                  constraints:
+                    nullable: true

--- a/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
@@ -22,6 +22,7 @@ import bio.terra.tanagra.service.artifact.model.ConceptSet;
 import bio.terra.tanagra.service.artifact.model.Study;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -44,6 +45,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class ConceptSetServiceTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConceptSetServiceTest.class);
   private static final String UNDERLAY_NAME = "cmssynpuf";
+
+  private static final List<String> PERSON_ATTRIBUTES = List.of("gender", "age");
 
   @Autowired private StudyService studyService;
   @Autowired private ConceptSetService conceptSetService;
@@ -92,8 +95,8 @@ public class ConceptSetServiceTest {
                 .underlay(UNDERLAY_NAME)
                 .displayName(displayName)
                 .description(description)
-                .entity(GENDER_EQ_WOMAN.getKey())
-                .criteria(List.of(GENDER_EQ_WOMAN.getValue())),
+                .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
+                .outputAttributesPerEntity(Map.of(GENDER_EQ_WOMAN.getKey(), PERSON_ATTRIBUTES)),
             createdByEmail);
     assertNotNull(createdConceptSet);
     LOGGER.info(
@@ -104,15 +107,22 @@ public class ConceptSetServiceTest {
     assertEquals(createdByEmail, createdConceptSet.getCreatedBy());
     assertEquals(createdByEmail, createdConceptSet.getLastModifiedBy());
     assertEquals(createdConceptSet.getCreated(), createdConceptSet.getLastModified());
-    assertEquals(GENDER_EQ_WOMAN.getKey(), createdConceptSet.getEntity());
     assertEquals(1, createdConceptSet.getCriteria().size());
     assertTrue(createdConceptSet.getCriteria().contains(GENDER_EQ_WOMAN.getValue()));
+    assertEquals(1, createdConceptSet.getOutputColumnsPerEntity().keySet().size());
+    assertEquals(
+        PERSON_ATTRIBUTES.stream().sorted().collect(Collectors.toList()),
+        createdConceptSet.getOutputColumnsPerEntity().get(GENDER_EQ_WOMAN.getKey()).stream()
+            .sorted()
+            .collect(Collectors.toList()));
 
     // Update.
     TimeUnit.SECONDS.sleep(1); // Wait briefly, so the last modified and created timestamps differ.
     String displayName2 = "concept set 1 updated";
     String description2 = "first concept set updated";
     String updatedByEmail = "efg@123.com";
+    String outputEntity = "conditionOccurrence";
+    List<String> outputAttributes = List.of("condition", "person_id");
     ConceptSet updatedConceptSet =
         conceptSetService.updateConceptSet(
             study1.getId(),
@@ -120,8 +130,8 @@ public class ConceptSetServiceTest {
             updatedByEmail,
             displayName2,
             description2,
-            CONDITION_EQ_DIABETES.getKey(),
-            List.of(CONDITION_EQ_DIABETES.getValue()));
+            List.of(CONDITION_EQ_DIABETES.getValue()),
+            Map.of(outputEntity, outputAttributes));
     assertNotNull(updatedConceptSet);
     LOGGER.info(
         "Updated concept set {} at {}",
@@ -132,9 +142,14 @@ public class ConceptSetServiceTest {
     assertEquals(createdByEmail, updatedConceptSet.getCreatedBy());
     assertEquals(updatedByEmail, updatedConceptSet.getLastModifiedBy());
     assertTrue(updatedConceptSet.getLastModified().isAfter(updatedConceptSet.getCreated()));
-    assertEquals(CONDITION_EQ_DIABETES.getKey(), updatedConceptSet.getEntity());
     assertEquals(1, updatedConceptSet.getCriteria().size());
     assertTrue(updatedConceptSet.getCriteria().contains(CONDITION_EQ_DIABETES.getValue()));
+    assertEquals(1, updatedConceptSet.getOutputColumnsPerEntity().keySet().size());
+    assertEquals(
+        outputAttributes.stream().sorted().collect(Collectors.toList()),
+        updatedConceptSet.getOutputColumnsPerEntity().get(outputEntity).stream()
+            .sorted()
+            .collect(Collectors.toList()));
 
     // Delete.
     conceptSetService.deleteConceptSet(study1.getId(), createdConceptSet.getId());
@@ -166,8 +181,9 @@ public class ConceptSetServiceTest {
                 .underlay(UNDERLAY_NAME)
                 .displayName("concept set 1")
                 .description("first concept set")
-                .entity(ETHNICITY_EQ_JAPANESE.getKey())
-                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue())),
+                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue()))
+                .outputAttributesPerEntity(
+                    Map.of(ETHNICITY_EQ_JAPANESE.getKey(), PERSON_ATTRIBUTES)),
             userEmail);
     assertNotNull(conceptSet1);
     LOGGER.info("Created concept set {} at {}", conceptSet1.getId(), conceptSet1.getCreated());
@@ -180,8 +196,9 @@ public class ConceptSetServiceTest {
                 .underlay(UNDERLAY_NAME)
                 .displayName("concept set 2")
                 .description("second concept set")
-                .entity(PROCEDURE_EQ_AMPUTATION.getKey())
-                .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue())),
+                .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
+                .outputAttributesPerEntity(
+                    Map.of("procedureOccurrence", List.of("procedure", "person_id"))),
             userEmail);
     assertNotNull(conceptSet2);
     LOGGER.info("Created concept set {} at {}", conceptSet2.getId(), conceptSet2.getCreated());
@@ -192,8 +209,8 @@ public class ConceptSetServiceTest {
                 .underlay(UNDERLAY_NAME)
                 .displayName("concept set 3")
                 .description("third concept set")
-                .entity(GENDER_EQ_WOMAN.getKey())
-                .criteria(List.of(GENDER_EQ_WOMAN.getValue())),
+                .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
+                .outputAttributesPerEntity(Map.of(GENDER_EQ_WOMAN.getKey(), PERSON_ATTRIBUTES)),
             userEmail);
     assertNotNull(conceptSet3);
     LOGGER.info("Created concept set {} at {}", conceptSet3.getId(), conceptSet3.getCreated());
@@ -256,8 +273,18 @@ public class ConceptSetServiceTest {
         NotFoundException.class,
         () ->
             conceptSetService.createConceptSet(
+                study1.getId(), ConceptSet.builder().underlay("invalid_underlay"), "abc@123.com"));
+
+    // Specify invalid attribute.
+    assertThrows(
+        NotFoundException.class,
+        () ->
+            conceptSetService.createConceptSet(
                 study1.getId(),
-                ConceptSet.builder().underlay("invalid_underlay").entity(GENDER_EQ_WOMAN.getKey()),
+                ConceptSet.builder()
+                    .underlay("invalid_underlay")
+                    .outputAttributesPerEntity(
+                        Map.of(GENDER_EQ_WOMAN.getKey(), List.of("invalid_attribute"))),
                 "abc@123.com"));
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
@@ -96,7 +96,8 @@ public class ConceptSetServiceTest {
                 .displayName(displayName)
                 .description(description)
                 .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
-                .outputAttributesPerEntity(Map.of(GENDER_EQ_WOMAN.getKey(), PERSON_ATTRIBUTES)),
+                .excludeOutputAttributesPerEntity(
+                    Map.of(GENDER_EQ_WOMAN.getKey(), PERSON_ATTRIBUTES)),
             createdByEmail);
     assertNotNull(createdConceptSet);
     LOGGER.info(
@@ -109,10 +110,11 @@ public class ConceptSetServiceTest {
     assertEquals(createdConceptSet.getCreated(), createdConceptSet.getLastModified());
     assertEquals(1, createdConceptSet.getCriteria().size());
     assertTrue(createdConceptSet.getCriteria().contains(GENDER_EQ_WOMAN.getValue()));
-    assertEquals(1, createdConceptSet.getOutputColumnsPerEntity().keySet().size());
+    assertEquals(1, createdConceptSet.getExcludeOutputAttributesPerEntity().keySet().size());
     assertEquals(
         PERSON_ATTRIBUTES.stream().sorted().collect(Collectors.toList()),
-        createdConceptSet.getOutputColumnsPerEntity().get(GENDER_EQ_WOMAN.getKey()).stream()
+        createdConceptSet.getExcludeOutputAttributesPerEntity().get(GENDER_EQ_WOMAN.getKey())
+            .stream()
             .sorted()
             .collect(Collectors.toList()));
 
@@ -144,10 +146,10 @@ public class ConceptSetServiceTest {
     assertTrue(updatedConceptSet.getLastModified().isAfter(updatedConceptSet.getCreated()));
     assertEquals(1, updatedConceptSet.getCriteria().size());
     assertTrue(updatedConceptSet.getCriteria().contains(CONDITION_EQ_DIABETES.getValue()));
-    assertEquals(1, updatedConceptSet.getOutputColumnsPerEntity().keySet().size());
+    assertEquals(1, updatedConceptSet.getExcludeOutputAttributesPerEntity().keySet().size());
     assertEquals(
         outputAttributes.stream().sorted().collect(Collectors.toList()),
-        updatedConceptSet.getOutputColumnsPerEntity().get(outputEntity).stream()
+        updatedConceptSet.getExcludeOutputAttributesPerEntity().get(outputEntity).stream()
             .sorted()
             .collect(Collectors.toList()));
 
@@ -182,7 +184,7 @@ public class ConceptSetServiceTest {
                 .displayName("concept set 1")
                 .description("first concept set")
                 .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue()))
-                .outputAttributesPerEntity(
+                .excludeOutputAttributesPerEntity(
                     Map.of(ETHNICITY_EQ_JAPANESE.getKey(), PERSON_ATTRIBUTES)),
             userEmail);
     assertNotNull(conceptSet1);
@@ -197,7 +199,7 @@ public class ConceptSetServiceTest {
                 .displayName("concept set 2")
                 .description("second concept set")
                 .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
-                .outputAttributesPerEntity(
+                .excludeOutputAttributesPerEntity(
                     Map.of("procedureOccurrence", List.of("procedure", "person_id"))),
             userEmail);
     assertNotNull(conceptSet2);
@@ -210,7 +212,8 @@ public class ConceptSetServiceTest {
                 .displayName("concept set 3")
                 .description("third concept set")
                 .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
-                .outputAttributesPerEntity(Map.of(GENDER_EQ_WOMAN.getKey(), PERSON_ATTRIBUTES)),
+                .excludeOutputAttributesPerEntity(
+                    Map.of(GENDER_EQ_WOMAN.getKey(), PERSON_ATTRIBUTES)),
             userEmail);
     assertNotNull(conceptSet3);
     LOGGER.info("Created concept set {} at {}", conceptSet3.getId(), conceptSet3.getCreated());
@@ -283,7 +286,7 @@ public class ConceptSetServiceTest {
                 study1.getId(),
                 ConceptSet.builder()
                     .underlay("invalid_underlay")
-                    .outputAttributesPerEntity(
+                    .excludeOutputAttributesPerEntity(
                         Map.of(GENDER_EQ_WOMAN.getKey(), List.of("invalid_attribute"))),
                 "abc@123.com"));
   }

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
@@ -122,7 +122,7 @@ public class BaseAccessControlTest {
                 .displayName("concept set 1")
                 .description("first concept set")
                 .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue()))
-                .outputAttributesPerEntity(
+                .excludeOutputAttributesPerEntity(
                     Map.of(ETHNICITY_EQ_JAPANESE.getKey(), List.of("gender"))),
             "abc@123.com");
     assertNotNull(conceptSet1);
@@ -136,7 +136,7 @@ public class BaseAccessControlTest {
                 .displayName("concept set 2")
                 .description("second concept set")
                 .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
-                .outputAttributesPerEntity(
+                .excludeOutputAttributesPerEntity(
                     Map.of("procedureOccurrence", List.of("procedure", "person_id"))),
             "def@123.com");
     assertNotNull(conceptSet2);

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
@@ -31,6 +31,7 @@ import bio.terra.tanagra.service.authentication.UserId;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,8 +121,9 @@ public class BaseAccessControlTest {
                 .underlay(CMS_SYNPUF)
                 .displayName("concept set 1")
                 .description("first concept set")
-                .entity(ETHNICITY_EQ_JAPANESE.getKey())
-                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue())),
+                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue()))
+                .outputAttributesPerEntity(
+                    Map.of(ETHNICITY_EQ_JAPANESE.getKey(), List.of("gender"))),
             "abc@123.com");
     assertNotNull(conceptSet1);
     LOGGER.info("Created concept set {} at {}", conceptSet1.getId(), conceptSet1.getCreated());
@@ -133,8 +135,9 @@ public class BaseAccessControlTest {
                 .underlay(CMS_SYNPUF)
                 .displayName("concept set 2")
                 .description("second concept set")
-                .entity(PROCEDURE_EQ_AMPUTATION.getKey())
-                .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue())),
+                .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
+                .outputAttributesPerEntity(
+                    Map.of("procedureOccurrence", List.of("procedure", "person_id"))),
             "def@123.com");
     assertNotNull(conceptSet2);
     LOGGER.info("Created concept set {} at {}", conceptSet2.getId(), conceptSet2.getCreated());


### PR DESCRIPTION
- Updated the OpenAPI schema:
  - Removed the `entity` from concept set definition.
  - Replaced the single `criteria` with an array of `criteria` in the concept set definition.
  - Added array of `entityOutputs` to the concept set definition.
  - Added an optional `predefinedId` to the criteria definition.
- Updated the application DB schema and concept set DAO class:
  - Removed the `entity` column from the concept set table.
  - Added a new `output_attribute` table that foreign keys to the concept set table.
  - Added a nullable `predefined_id` column to the criteria table.
