### PR TITLE
Change `is_clean` attribute from boolean to enum.

### DIFF
--- a/underlay/src/main/resources/config/datamapping/sd/entity/bmi/all.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/bmi/all.sql
@@ -1,10 +1,14 @@
 SELECT
   mo.measurement_id,
   mo.person_id,
-  CAST(CASE
+  CASE
     WHEN mo.measurement_source_value = 'BMI_CLEAN' THEN 1
     ELSE 0
-  END AS BOOLEAN) AS is_clean,
+  END AS is_clean,
+  CASE
+    WHEN mo.measurement_source_value = 'BMI_CLEAN' THEN "Clean"
+    ELSE 'Raw'
+  END AS is_clean_name,
   mo.measurement_date,
   mo.value_as_number,
   mo.value_as_concept_id,

--- a/underlay/src/main/resources/config/datamapping/sd/entity/bmi/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/bmi/entity.json
@@ -4,7 +4,7 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "measurement_id" },
     { "name": "person_id", "dataType": "INT64" },
-    { "name": "is_clean", "dataType": "BOOLEAN" },
+    { "name": "is_clean", "dataType": "INT64", "displayFieldName": "is_clean_name", "isComputeDisplayHint": true },
     { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },

--- a/underlay/src/main/resources/config/datamapping/sd/entity/height/all.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/height/all.sql
@@ -1,10 +1,14 @@
 SELECT
   mo.measurement_id,
   mo.person_id,
-  CAST(CASE
+  CASE
     WHEN xvw.x_invalid = 'N' THEN 1
     ELSE 0
-  END AS BOOLEAN) AS is_clean,
+  END AS is_clean,
+  CASE
+    WHEN xvw.x_invalid = 'N' THEN 'Clean'
+    ELSE 'Raw'
+  END AS is_clean_name,
   mo.measurement_date,
   mo.value_as_number,
   mo.value_as_concept_id,

--- a/underlay/src/main/resources/config/datamapping/sd/entity/height/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/height/entity.json
@@ -4,7 +4,7 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "measurement_id" },
     { "name": "person_id", "dataType": "INT64" },
-    { "name": "is_clean", "dataType": "BOOLEAN" },
+    { "name": "is_clean", "dataType": "INT64", "displayFieldName": "is_clean_name", "isComputeDisplayHint": true },
     { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },

--- a/underlay/src/main/resources/config/datamapping/sd/entity/pulse/all.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/pulse/all.sql
@@ -1,10 +1,6 @@
 SELECT
   mo.measurement_id,
   mo.person_id,
-  CAST(CASE
-    WHEN xvw.x_invalid = 'N' THEN 1
-    ELSE 0
-  END AS BOOLEAN) AS is_clean,
   mo.measurement_date,
   mo.value_as_number,
   mo.value_as_concept_id,
@@ -17,9 +13,6 @@ SELECT
   vc.concept_name AS visit_concept_name
 
 FROM `${omopDataset}.measurement` AS mo
-
-LEFT JOIN `${omopDataset}.x_vs_wh` AS xvw
-    ON xvw.measurement_id = mo.measurement_id
 
 JOIN `${omopDataset}.person` AS p
     ON p.person_id = mo.person_id

--- a/underlay/src/main/resources/config/datamapping/sd/entity/pulse/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/pulse/entity.json
@@ -4,7 +4,6 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "measurement_id" },
     { "name": "person_id", "dataType": "INT64" },
-    { "name": "is_clean", "dataType": "BOOLEAN" },
     { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },

--- a/underlay/src/main/resources/config/datamapping/sd/entity/respiratoryRate/all.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/respiratoryRate/all.sql
@@ -1,10 +1,6 @@
 SELECT
   mo.measurement_id,
   mo.person_id,
-  CAST(CASE
-    WHEN xvw.x_invalid = 'N' THEN 1
-    ELSE 0
-  END AS BOOLEAN) AS is_clean,
   mo.measurement_date,
   mo.value_as_number,
   mo.value_as_concept_id,
@@ -17,9 +13,6 @@ SELECT
   vc.concept_name AS visit_concept_name
 
 FROM `${omopDataset}.measurement` AS mo
-
-LEFT JOIN `${omopDataset}.x_vs_wh` AS xvw
-    ON xvw.measurement_id = mo.measurement_id
 
 JOIN `${omopDataset}.person` AS p
     ON p.person_id = mo.person_id

--- a/underlay/src/main/resources/config/datamapping/sd/entity/respiratoryRate/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/respiratoryRate/entity.json
@@ -4,7 +4,6 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "measurement_id" },
     { "name": "person_id", "dataType": "INT64" },
-    { "name": "is_clean", "dataType": "BOOLEAN" },
     { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },

--- a/underlay/src/main/resources/config/datamapping/sd/entity/weight/all.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/weight/all.sql
@@ -1,10 +1,14 @@
 SELECT
   mo.measurement_id,
   mo.person_id,
-  CAST(CASE
+  CASE
     WHEN xvw.x_invalid = 'N' THEN 1
     ELSE 0
-  END AS BOOLEAN) AS is_clean,
+  END AS is_clean,
+  CASE
+    WHEN xvw.x_invalid = 'N' THEN 'Clean'
+    ELSE 'Raw'
+  END AS is_clean_name,
   mo.measurement_date,
   mo.value_as_number,
   mo.value_as_concept_id,

--- a/underlay/src/main/resources/config/datamapping/sd/entity/weight/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/weight/entity.json
@@ -4,7 +4,7 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "measurement_id" },
     { "name": "person_id", "dataType": "INT64" },
-    { "name": "is_clean", "dataType": "BOOLEAN" },
+    { "name": "is_clean", "dataType": "INT64", "displayFieldName": "is_clean_name", "isComputeDisplayHint": true },
     { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },


### PR DESCRIPTION
- Changed `is_clean` attribute of `bmi`, `height`, `weight` entities from a boolean to an enum. Now the UI can query the backend for the enum values, instead of hard-coding clean/raw in the plugin code.
- Removed `is_clean` attribute from `pulse`, `respiratoryRate` entities, because it doesn't apply there.
- As part of this PR, I also partially re-indexed the SD underlay on Verily infrastructure -- only the 5 entities that were modified.