### PR TITLE
Allow manually specifying a display hint range in the attribute config.

### DIFF
--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -40,6 +40,24 @@ Field or column name in the [all instances SQL file](#szentityallinstancessqlfil
 
 A separate display field is useful for enum-type attributes, which often use a foreign-key to another table to get a readable string from a code (e.g. in OMOP, `person.gender_concept_id` and `concept.concept_name`).
 
+### SZAttribute.displayHintRangeMax
+**optional** double
+
+The maximum value to display when filtering on this attribute. This is useful when the underlying data has outliers that we want to exclude from the display, but not from the available data.
+
+e.g. A person has an invalid date of birth that produces an age range that spans very large numbers. This causes the slider when filtering by age to span very large numbers also. Setting this property sets the right end of the slider. It does not remove the person with the invalid date of birth from the table. So if they have asthma, they would still show up in a cohort filtering on this condition.
+
+The #szattributedisplayhintrangemin may be set as well, but they are not required to be set together. The #szattributeiscomputedisplayhint is also independent of this property. You can still calculate the actual maximum in the data, if you set this property.
+
+### SZAttribute.displayHintRangeMin
+**optional** double
+
+The minimum value to display when filtering on this attribute. This is useful when the underlying data has outliers that we want to exclude from the display, but not from the available data.
+
+e.g. A person has an invalid date of birth that produces an age range that spans negative numbers. This causes the slider when filtering by age to span negative numbers also. Setting this property sets the left end of the slider. It does not remove the person with the invalid date of birth from the table. So if they have asthma, they would still show up in a cohort filtering on this condition.
+
+The #szattributedisplayhintrangemax may be set as well, but they are not required to be set together. The #szattributeiscomputedisplayhint is also independent of this property. You can still calculate the actual minimum in the data, if you set this property.
+
 ### SZAttribute.isComputeDisplayHint
 **optional** boolean
 

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -1,6 +1,8 @@
 export type SZAttribute = {
   dataType: SZDataType;
   displayFieldName?: string;
+  displayHintRangeMax?: double;
+  displayHintRangeMin?: double;
   isComputeDisplayHint?: boolean;
   name: string;
   runtimeDataType?: SZDataType;

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -1,8 +1,8 @@
 export type SZAttribute = {
   dataType: SZDataType;
   displayFieldName?: string;
-  displayHintRangeMax?: double;
-  displayHintRangeMin?: double;
+  displayHintRangeMax?: number;
+  displayHintRangeMin?: number;
   isComputeDisplayHint?: boolean;
   name: string;
   runtimeDataType?: SZDataType;

--- a/underlay/src/main/java/bio/terra/tanagra/annotation/TypescriptWalker.java
+++ b/underlay/src/main/java/bio/terra/tanagra/annotation/TypescriptWalker.java
@@ -91,7 +91,7 @@ public class TypescriptWalker extends AnnotationWalker {
       String[] pieces = typeName.split("\\.");
       String javaTypeName = pieces[pieces.length - 1].toLowerCase();
 
-      final List<String> javaTypesThatMapToNumber = List.of("int", "long");
+      final List<String> javaTypesThatMapToNumber = List.of("int", "long", "double");
       return javaTypesThatMapToNumber.contains(javaTypeName) ? "number" : javaTypeName;
     }
   }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
@@ -156,6 +156,38 @@ public class SZEntity {
         optional = true,
         defaultValue = "false")
     public boolean isComputeDisplayHint;
+
+    @AnnotatedField(
+        name = "SZAttribute.displayHintRangeMin",
+        markdown =
+            "The minimum value to display when filtering on this attribute. This is useful when the underlying "
+                + "data has outliers that we want to exclude from the display, but not from the available data.\n\n"
+                + "e.g. A person has an invalid date of birth that produces an age range that spans negative "
+                + "numbers. This causes the slider when filtering by age to span negative numbers also. Setting this "
+                + "property sets the left end of the slider. It does not remove the person with the invalid date of "
+                + "birth from the table. So if they have asthma, they would still show up in a cohort filtering on "
+                + "this condition.\n\n"
+                + "The ${SZAttribute.displayHintRangeMax} may be set as well, but they are not required to be set "
+                + "together. The ${SZAttribute.isComputeDisplayHint} is also independent of this property. You can "
+                + "still calculate the actual minimum in the data, if you set this property.",
+        optional = true)
+    public double displayHintRangeMin;
+
+    @AnnotatedField(
+        name = "SZAttribute.displayHintRangeMax",
+        markdown =
+            "The maximum value to display when filtering on this attribute. This is useful when the underlying "
+                + "data has outliers that we want to exclude from the display, but not from the available data.\n\n"
+                + "e.g. A person has an invalid date of birth that produces an age range that spans very large "
+                + "numbers. This causes the slider when filtering by age to span very large numbers also. Setting this "
+                + "property sets the right end of the slider. It does not remove the person with the invalid date of "
+                + "birth from the table. So if they have asthma, they would still show up in a cohort filtering on "
+                + "this condition.\n\n"
+                + "The ${SZAttribute.displayHintRangeMin} may be set as well, but they are not required to be set "
+                + "together. The ${SZAttribute.isComputeDisplayHint} is also independent of this property. You can "
+                + "still calculate the actual maximum in the data, if you set this property.",
+        optional = true)
+    public double displayHintRangeMax;
   }
 
   @AnnotatedClass(name = "SZHierarchy", markdown = "Hierarchy for an entity.")

--- a/underlay/src/main/resources/config/datamapping/sd/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/person/entity.json
@@ -4,7 +4,9 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "person_id" },
     { "name": "year_of_birth", "dataType": "INT64", "isComputeDisplayHint": true },
-    { "name": "age", "dataType": "TIMESTAMP", "valueFieldName": "birth_datetime", "runtimeSqlFunctionWrapper": "CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)", "runtimeDataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age", "dataType": "TIMESTAMP", "valueFieldName": "birth_datetime",
+      "runtimeSqlFunctionWrapper": "CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)",
+      "runtimeDataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "person_source_value", "dataType": "STRING" },
     { "name": "gender", "dataType": "INT64", "valueFieldName": "gender_concept_id", "displayFieldName": "gender_concept_name", "isComputeDisplayHint": true },
     { "name": "race", "dataType": "INT64", "valueFieldName": "race_concept_id", "displayFieldName": "race_concept_name", "isComputeDisplayHint": true },


### PR DESCRIPTION
- Added `displayHintRangeMax/Min` properties to the attribute config `SZAttribute`.
- Regenerated the documentation and Typescript file.
- Defined these properties for the `person.age` attribute [0-89] in the SD underlay.