### PR TITLE
Override numeric range hint for SD occurrence entities.

### DIFF
--- a/underlay/src/main/resources/config/datamapping/sd/entity/bloodPressure/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/bloodPressure/entity.json
@@ -9,7 +9,7 @@
     { "name": "diastolic", "dataType": "INT64", "isComputeDisplayHint": true },
     { "name": "bp", "dataType": "STRING" },
     { "name": "status_code", "dataType": "INT64", "valueFieldName": "status_code", "displayFieldName": "status_code_name", "isComputeDisplayHint": true },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/bmi/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/bmi/entity.json
@@ -9,7 +9,7 @@
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name", "isComputeDisplayHint": true },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/conditionOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/conditionOccurrence/entity.json
@@ -10,7 +10,7 @@
     { "name": "stop_reason", "dataType": "STRING" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "condition_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "condition_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/deviceOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/deviceOccurrence/entity.json
@@ -9,7 +9,7 @@
     { "name": "end_date", "dataType": "TIMESTAMP", "valueFieldName": "device_exposure_end_date" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "device_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "device_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/familyHistory/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/familyHistory/entity.json
@@ -8,7 +8,7 @@
     { "name": "note_text", "dataType": "STRING" },
     { "name": "family_history_src_name", "dataType": "STRING" },
     { "name": "relation_name", "dataType": "STRING" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/height/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/height/entity.json
@@ -9,7 +9,7 @@
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name", "isComputeDisplayHint": true },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/ingredientOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/ingredientOccurrence/entity.json
@@ -12,7 +12,7 @@
     { "name": "days_supply", "dataType": "INT64" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "drug_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "drug_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementOccurrence/entity.json
@@ -11,7 +11,7 @@
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "measurement_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/noteOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/noteOccurrence/entity.json
@@ -9,7 +9,7 @@
     { "name": "title", "dataType": "STRING", "valueFieldName": "note_title" },
     { "name": "note_text", "dataType": "STRING" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "note_source_value" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/observationOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/observationOccurrence/entity.json
@@ -11,7 +11,7 @@
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "observation_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "observation_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/procedureOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/procedureOccurrence/entity.json
@@ -8,7 +8,7 @@
     { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "procedure_date" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "procedure_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/pulse/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/pulse/entity.json
@@ -8,7 +8,7 @@
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name", "isComputeDisplayHint": true },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/respiratoryRate/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/respiratoryRate/entity.json
@@ -8,7 +8,7 @@
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name", "isComputeDisplayHint": true },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],

--- a/underlay/src/main/resources/config/datamapping/sd/entity/visitOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/visitOccurrence/entity.json
@@ -9,7 +9,7 @@
     { "name": "end_date", "dataType": "TIMESTAMP", "valueFieldName": "visit_end_date" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "visit_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "visit_source_concept_id" },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true }
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 }
   ],
   "idAttribute": "id"
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/weight/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/weight/entity.json
@@ -9,7 +9,7 @@
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number", "isComputeDisplayHint": true },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name", "isComputeDisplayHint": true },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name", "isComputeDisplayHint": true },
-    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],


### PR DESCRIPTION
Request from user-testing feedback. "Like the age filter, the Age at Occurrence modifier slider is set based on the data values. It should have a manual override set to 0-89."