### PR TITLE
[DT-647] Fine tune condition domain

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/all.sql
@@ -3,8 +3,8 @@ SELECT
     concept_name,
     vocabulary_id,
     concept_code,
-    (CASE WHEN standard_concept IS NULL THEN 'Source' WHEN standard_concept = 'S' THEN 'Standard' ELSE 'Unknown' END) AS standard_concept
-
+    'Standard' AS standard_concept
 FROM `${omopDataset}.concept`
-
 WHERE domain_id = 'Condition'
+   AND vocabulary_id = 'SNOMED'
+   AND standard_concept = 'S'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/childParent.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/childParent.sql
@@ -4,9 +4,14 @@ SELECT
 FROM `${omopDataset}.concept_relationship` cr
 JOIN `${omopDataset}.concept` c1  ON c1.concept_id = cr.concept_id_1
 JOIN `${omopDataset}.concept` c2  ON c2.concept_id = cr.concept_id_2
+JOIN `${omopDataset}.relationship` r ON cr.relationship_id = r.relationship_id
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.domain_id = c2.domain_id
   AND c2.domain_id = 'Condition'
   AND c1.vocabulary_id = c2.vocabulary_id
   AND c2.vocabulary_id = 'SNOMED'
+  AND c1.standard_concept = c2.standard_concept
+  AND c2.standard_concept = 'S'
+  AND r.is_hierarchical = '1'
+  AND r.defines_ancestry = '1'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/all.sql
@@ -1,0 +1,10 @@
+SELECT DISTINCT
+    concept_id,
+    concept_name,
+    vocabulary_id,
+    concept_code,
+    'Standard' AS standard_concept
+FROM `${omopDataset}.condition_occurrence` co
+JOIN `${omopDataset}.concept` c on co.condition_concept_id = c.concept_id
+    AND c.vocabulary_id != 'SNOMED'
+    AND c.standard_concept = 'S'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/entity.json
@@ -1,5 +1,5 @@
 {
-  "name": "condition",
+  "name": "conditionNonHierarchy",
   "allInstancesSqlFile": "all.sql",
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "concept_id" },
@@ -14,15 +14,5 @@
     "idTextPairsSqlFile": "textSearch.sql",
     "idFieldName": "concept_id",
     "textFieldName": "concept_synonym_name"
-  },
-  "hierarchies": [
-    {
-      "childParentIdPairsSqlFile": "childParent.sql",
-      "childIdFieldName": "child",
-      "parentIdFieldName": "parent",
-      "rootNodeIds": [ 441840 ],
-      "maxDepth": 20,
-      "keepOrphanNodes": false
-    }
-  ]
+  }
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
@@ -14,5 +14,6 @@
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],
-  "idAttribute": "id"
+  "idAttribute": "id",
+  "optimizeGroupByAttributes": [ "condition" ]
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/conditionNonHierarchyPerson/entityGroup.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/conditionNonHierarchyPerson/entityGroup.json
@@ -1,0 +1,20 @@
+{
+  "name": "conditionNonHierarchyPerson",
+  "criteriaEntity": "conditionNonHierarchy",
+  "occurrenceEntities": [
+    {
+      "occurrenceEntity": "conditionOccurrence",
+      "criteriaRelationship": {
+        "foreignKeyAttributeOccurrenceEntity": "condition"
+      },
+      "primaryRelationship": {
+        "foreignKeyAttributeOccurrenceEntity": "person_id"
+      }
+    }
+  ],
+  "primaryCriteriaRelationship": {
+    "idPairsSqlFile": "primaryCriteria.sql",
+    "primaryEntityIdFieldName": "person_id",
+    "criteriaEntityIdFieldName": "condition_concept_id"
+  }
+}

--- a/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/conditionNonHierarchyPerson/primaryCriteria.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/conditionNonHierarchyPerson/primaryCriteria.sql
@@ -1,0 +1,10 @@
+SELECT
+  co.person_id,
+  co.condition_concept_id
+FROM `${omopDataset}.condition_occurrence` AS co
+WHERE co.condition_concept_id
+  IN (SELECT concept_id
+      FROM `${omopDataset}.concept` c
+      WHERE domain_id = 'Condition'
+        AND c.vocabulary_id != 'SNOMED'
+        AND c.standard_concept = 'S')

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -21,8 +21,8 @@
             "entityAttribute": "id",
             "hierarchy": "default",
             "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
+              "attribute": "name",
+              "direction": "ASC"
             }
           },
           {
@@ -30,7 +30,7 @@
             "attribute":"source_criteria_id",
             "entity":"icd9cm",
             "entityAttribute":"id",
-            "hierarchy":"default",
+            "hierarchy": "default",
             "defaultSort":{
               "attribute":"label",
               "direction":"ASC"
@@ -46,6 +46,12 @@
               "attribute": "label",
               "direction": "ASC"
             }
+          },
+          {
+            "id": "condition_non_hierarchy",
+            "attribute": "condition_concept_id",
+            "entity": "conditionNonHierarchy",
+            "entityAttribute": "id"
           }
         ]
       },
@@ -155,7 +161,7 @@
             "attribute":"source_criteria_id",
             "entity":"icd9cm",
             "entityAttribute":"id",
-            "hierarchy": "default",
+            "hierarchy":"default",
             "defaultSort":{
               "attribute":"label",
               "direction":"ASC"
@@ -403,15 +409,16 @@
         { "key": "standard_concept", "width": 120, "title": "Source/standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
+        { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "hierarchyColumns": [
-        { "key": "name", "width": "100%", "title": "Condition" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
+        { "key": "concept_code", "width": "100%", "title": "Code" },
+        { "key": "name", "width": "120", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrences": "condition_occurrence",
-      "classifications": ["condition"],
+      "classifications": ["condition", "condition_non_hierarchy"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/underlay.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/underlay.json
@@ -6,6 +6,7 @@
 
     "aouRT/condition",
     "aouRT/conditionOccurrence",
+    "aouRT/conditionNonHierarchy",
     "aouRT/procedure",
     "aouRT/procedureOccurrence",
 
@@ -52,6 +53,8 @@
   ],
   "criteriaOccurrenceEntityGroups": [
     "aouRT/conditionPerson",
+    "aouRT/conditionNonHierarchyPerson",
+
     "aouRT/procedurePerson",
 
     "aouRT/ingredientPerson",

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -407,9 +407,9 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "hierarchyColumns": [
-        { "key": "concept_code", "width": "100%", "title": "Code" },
-        { "key": "name", "width": "120", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+        { "key": "concept_code", "width": "15%", "title": "Code" },
+        { "key": "name", "width": "60%", "title": "Concept Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
       "occurrences": "condition_occurrence",
       "classifications": ["condition", "condition_non_hierarchy"],

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -21,8 +21,8 @@
             "entityAttribute": "id",
             "hierarchy": "default",
             "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
+              "attribute": "name",
+              "direction": "ASC"
             }
           },
           {
@@ -46,6 +46,12 @@
               "attribute": "label",
               "direction": "ASC"
             }
+          },
+          {
+            "id": "condition_non_hierarchy",
+            "attribute": "condition_concept_id",
+            "entity": "conditionNonHierarchy",
+            "entityAttribute": "id"
           }
         ]
       },
@@ -390,7 +396,7 @@
       "title": "Condition",
       "conceptSet": true,
       "category": "Domains",
-      "tags": ["Standard Codes"], 
+      "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Concept name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
@@ -401,12 +407,12 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "hierarchyColumns": [
-        { "key": "name", "width": "100%", "title": "Condition" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
+        { "key": "concept_code", "width": "100%", "title": "Code" },
+        { "key": "name", "width": "120", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
       "occurrences": "condition_occurrence",
-      "classifications": ["condition"],
+      "classifications": ["condition", "condition_non_hierarchy"],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/underlay.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/underlay.json
@@ -6,6 +6,7 @@
 
     "aouRT/condition",
     "aouRT/conditionOccurrence",
+    "aouRT/conditionNonHierarchy",
     "aouRT/procedure",
     "aouRT/procedureOccurrence",
 
@@ -50,6 +51,8 @@
   ],
   "criteriaOccurrenceEntityGroups": [
     "aouRT/conditionPerson",
+    "aouRT/conditionNonHierarchyPerson",
+
     "aouRT/procedurePerson",
 
     "aouRT/ingredientPerson",


### PR DESCRIPTION
- update for non-hierarchy
- update for clustering when indexing
- update view for 
  - entity table
  - hierarchy-view
 
- contains `item-count` and initial sort on `rollup-count`
![image](https://github.com/DataBiosphere/tanagra/assets/4452480/0e8d606f-2803-4055-a199-992fc6f3f547)

- hierarchy view sorted on `name`
<img width="1064" alt="image" src="https://github.com/DataBiosphere/tanagra/assets/4452480/e1b30b57-d654-47de-a201-f5beef0ce00a">

- added non-hierarchy conditions
![image](https://github.com/DataBiosphere/tanagra/assets/4452480/ea39aea1-102e-4c4f-ae7e-5f91a37eca6e)



**Note** Concepts with _item-count/rollup-count_ that are _zero_ are not yet filtered/removed from indexing build 