### PR TITLE
[DT-647] Fine tune procedure domain

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/all.sql
@@ -3,8 +3,8 @@ SELECT
     concept_name,
     vocabulary_id,
     concept_code,
-    (CASE WHEN standard_concept IS NULL THEN 'Source' WHEN standard_concept = 'S' THEN 'Standard' ELSE 'Unknown' END) AS standard_concept
-
+    'Standard' AS standard_concept
 FROM `${omopDataset}.concept`
-
 WHERE domain_id = 'Procedure'
+   AND vocabulary_id = 'SNOMED'
+   AND standard_concept = 'S'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/childParent.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/childParent.sql
@@ -4,9 +4,14 @@ SELECT
 FROM `${omopDataset}.concept_relationship` cr
 JOIN `${omopDataset}.concept` c1  ON c1.concept_id = cr.concept_id_1
 JOIN `${omopDataset}.concept` c2  ON c2.concept_id = cr.concept_id_2
+JOIN `${omopDataset}.relationship` r ON cr.relationship_id = r.relationship_id
 WHERE
   cr.relationship_id = 'Subsumes'
   AND c1.domain_id = c2.domain_id
   AND c2.domain_id = 'Procedure'
   AND c1.vocabulary_id = c2.vocabulary_id
   AND c2.vocabulary_id = 'SNOMED'
+  AND c1.standard_concept = c2.standard_concept
+  AND c2.standard_concept = 'S'
+  AND r.is_hierarchical = '1'
+  AND r.defines_ancestry = '1'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/entity.json
@@ -10,7 +10,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureOccurrence/entity.json
@@ -12,5 +12,6 @@
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],
-  "idAttribute": "id"
+  "idAttribute": "id",
+  "optimizeGroupByAttributes": [ "procedure" ]
 }

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -68,8 +68,8 @@
             "entityAttribute": "id",
             "hierarchy": "default",
             "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
+              "attribute": "name",
+              "direction": "ASC"
             }
           },
           {
@@ -425,9 +425,9 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "hierarchyColumns": [
-        { "key": "concept_code", "width": "100%", "title": "Code" },
-        { "key": "name", "width": "120", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+        { "key": "concept_code", "width": "15%", "title": "Code" },
+        { "key": "name", "width": "60%", "title": "Concept Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
       "occurrences": "condition_occurrence",
       "classifications": ["condition", "condition_non_hierarchy"],
@@ -454,9 +454,9 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "hierarchyColumns": [
-        { "key": "name", "width": "100%", "title": "Procedure" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+        { "key": "concept_code", "width": "15%", "title": "Code" },
+        { "key": "name", "width": "60%", "title": "Concept Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
       "occurrences": "procedure_occurrence",
       "classifications": ["procedure", "procedure_non_hierarchy"],

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -68,8 +68,8 @@
             "entityAttribute": "id",
             "hierarchy": "default",
             "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
+              "attribute": "name",
+              "direction": "ASC"
             }
           },
           {
@@ -448,9 +448,9 @@
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
       "hierarchyColumns": [
-        { "key": "name", "width": "100%", "title": "Procedure" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+        { "key": "concept_code", "width": "15%", "title": "Code" },
+        { "key": "name", "width": "60%", "title": "Concept Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
       "occurrences": "procedure_occurrence",
       "classifications": ["procedure", "procedure_non_hierarchy"],


### PR DESCRIPTION
- update for clustering when indexing

- update view for
  - entity table
  - hierarchy-view
- contains `item-count` and initial sort on `rollup-count` - Rollup counts and item counts match for items between AoU and tanagra 
![image](https://github.com/DataBiosphere/tanagra/assets/4452480/80e2ff1a-b1c1-496a-9f9c-8b452e80ac28)

- hierarchy view sorted on `name`
 
![image](https://github.com/DataBiosphere/tanagra/assets/4452480/b17f0092-4010-4007-a882-f1d343e2545e)
