### PR TITLE
[DT-619] Update text search for all domains

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/brand/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/brand/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/brand/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/brand/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/brand/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/brand/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/condition/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionNonHierarchy/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/cpt4/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/cpt4/entity.json
@@ -12,7 +12,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "code" ]
+    "attributes": [ "id", "name", "code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/cpt4/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/cpt4/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/cpt4/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/cpt4/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/device/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/device/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/device/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/device/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/device/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/device/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10cm/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10cm/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10cm/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10cm/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10cm/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10cm/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10pcs/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10pcs/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10pcs/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10pcs/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10pcs/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd10pcs/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9cm/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9cm/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9cm/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9cm/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9proc/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9proc/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9proc/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9proc/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9proc/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/icd9proc/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredient/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredient/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientNonHierarchy/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementLoinc/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementLoinc/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementNonHierarchy/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementSnomed/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementSnomed/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/observation/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/observation/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedure/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureNonHierarchy/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/visit/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/visit/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/visit/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/visit/textSearch.sql
@@ -1,0 +1,2 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/visit/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/visit/textSearch.sql
@@ -1,2 +1,3 @@
 SELECT concept_id, concept_synonym_name
 FROM `${omopDataset}.concept_synonym`
+WHERE NOT REGEXP_CONTAINS(concept_synonym_name, r'\p{Han}') --remove items with Chinese characters

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -21,8 +21,8 @@
             "entityAttribute": "id",
             "hierarchy": "default",
             "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
+              "attribute": "name",
+              "direction": "ASC"
             }
           },
           {

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -21,8 +21,8 @@
             "entityAttribute": "id",
             "hierarchy": "default",
             "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
+              "attribute": "name",
+              "direction": "ASC"
             }
           },
           {


### PR DESCRIPTION
- AoU [full_text/Synonyms](https://github.com/all-of-us/workbench/blob/115ab67d623ce9650ad73a43eea930bbbf2f8aa1/api/db-cdr/generate-cdr/build-cb-criteria-full-text-synonym.sh#L48-L74) has full text search for all concept_ids in cb_criteria. In Tanagra full_text / synonyms are only present on some entities.  Added the text search to the following entities:
  - brand - added textSearch - removed items with Chinese characters
  - condition - already present - removed items with Chinese characters
  - conditionNonHierarchy - already present - removed items with Chinese characters
  - cpt4 - added textSearch  - removed items with Chinese characters
  - device - added textSearch  - removed items with Chinese characters
  - icd9cm - added textSearch  - removed items with Chinese characters
  - icd9proc - added textSearch  - removed items with Chinese characters
  - icd10cm - added textSearch  - removed items with Chinese characters
  - icd10pcs - added textSearch  - removed items with Chinese characters
  - ingredient - already present - removed items with Chinese characters
  - ingredientNonHierarchy - already present - removed items with Chinese characters
  - measurementLoinc - already present - removed items with Chinese characters
  - measurementNonHierarchy - already present - removed items with Chinese characters
  - measurementSnomed - already present - removed items with Chinese characters
  - observation - already present - removed items with Chinese characters
  - procedure - already present - removed items with Chinese characters
  - procedureNonHierarchy - already present - removed items with Chinese characters
  - visit - added textSearch - removed items with Chinese characters
- Fixed missed default sort for hierarchy
