### PR TITLE
Add check for auth token in parent window local storage

### DIFF
--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -319,25 +319,14 @@ class FakeExportAPI {}
 
 class FakeUsersAPI {}
 
-const getAccessToken = () => {
-  let accessToken = "";
-  if (process.env.REACT_APP_GET_LOCAL_AUTH_TOKEN) {
-    // For local dev only, get the bearer token from the iframe url param
-    accessToken =
-      new URLSearchParams(window.location.href.split("?")[1]).get("token") ??
-      "";
-  } else {
-    // Check parent window's localStorage for auth token
-    // Use try/catch block to prevent UI from breaking in case of CORS error
-    try {
-      accessToken =
-        window.parent.localStorage.getItem("tanagraAccessToken") ?? "";
-    } catch (e) {
-      console.error(e);
-    }
-  }
-  return accessToken;
-};
+function getAccessToken() {
+  // For local dev, get the bearer token from the iframe url param. For all other envs, check parent window's localStorage for auth token
+  return (
+    (process.env.REACT_APP_GET_LOCAL_AUTH_TOKEN
+      ? new URLSearchParams(window.location.href.split("?")[1]).get("token")
+      : window.parent.localStorage.getItem("tanagraAccessToken")) ?? ""
+  );
+}
 
 function apiForEnvironment<Real, Fake>(
   real: { new (c: tanagra.Configuration): Real },

--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -339,6 +339,18 @@ function apiForEnvironment<Real, Fake>(
       if (accessToken) {
         config.accessToken = accessToken;
       }
+    } else {
+      // Check parent window's localStorage for auth token
+      // Use try/catch block to prevent UI from breaking in case of CORS error
+      try {
+        const accessToken =
+          window.parent.localStorage.getItem("tanagraAccessToken");
+        if (accessToken) {
+          config.accessToken = accessToken;
+        }
+      } catch (e) {
+        console.error(e);
+      }
     }
     return new real(new tanagra.Configuration(config));
   };

--- a/underlay/src/main/resources/config/underlay/sd020230331/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd020230331/ui.json
@@ -461,18 +461,6 @@
       "attribute": "age"
     },
     {
-      "type": "classification",
-      "id": "tanagra-snp",
-      "title": "SNP variant",
-      "category": "Demographics",
-      "columns": [
-        { "key": "name", "width": "100%", "title": "SNP variant" },
-        { "key": "t_item_count", "width": 120, "title": "Count" }
-      ],
-      "occurrences": "",
-      "classifications": ["snp"]
-    },
-    {
       "type": "biovu",
       "id": "biovu",
       "title": "BioVU Samples",

--- a/underlay/src/main/resources/config/underlay/sd020230331/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd020230331/ui.json
@@ -461,6 +461,18 @@
       "attribute": "age"
     },
     {
+      "type": "classification",
+      "id": "tanagra-snp",
+      "title": "SNP variant",
+      "category": "Demographics",
+      "columns": [
+        { "key": "name", "width": "100%", "title": "SNP variant" },
+        { "key": "t_item_count", "width": 120, "title": "Count" }
+      ],
+      "occurrences": "",
+      "classifications": ["snp"]
+    },
+    {
       "type": "biovu",
       "id": "biovu",
       "title": "BioVU Samples",


### PR DESCRIPTION
Now that we have the Workbench and Tanagra UIs on the same domain in the AoU test env, we can pass the bearer token through `localStorage`. We will still need to keep the less secure workaround of passing in the iframe url for deploying and testing locally.