### PR TITLE
[DT-683-684] Use death table for is deceased attribute and group dempgraphic

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouCT/entity/person/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouCT/entity/person/all.sql
@@ -33,7 +33,10 @@ SELECT p.person_id,
        CASE
            WHEN svd.sample_name IS NULL THEN 0 ELSE 1 END has_structural_variant_data,
        CASE
-           WHEN ehr.person_id IS NULL THEN 0 ELSE 1 END has_ehr_data
+           WHEN ehr.person_id IS NULL THEN 0 ELSE 1 END has_ehr_data,
+       CASE
+           WHEN d.death_date is null THEN 0 ELSE 1 is_deceased
+
 FROM `${omopDataset}.person` p
 
 LEFT JOIN `${omopDataset}.concept` gc
@@ -113,4 +116,8 @@ LEFT JOIN `${omopDataset}.concept` sc
         FROM`${omopDataset}.visit_occurrence` as a
         LEFT JOIN`${omopDataset}.visit_occurrence_ext` as b on a.visit_occurrence_id = b.visit_occurrence_id
         WHERE lower(b.src_id) like 'ehr site%'
-      ) ehr ON (p.person_id = ehr.person_id)
+      ) ehr ON (p.person_id = ehr.person_id),
+         LEFT JOIN
+      (SELECT DISTINCT person_id
+      FROM `${omopDataset}.death`) d ON (p.person_id = d.person_id)
+

--- a/underlay/src/main/resources/config/datamapping/aouCT/entity/person/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouCT/entity/person/all.sql
@@ -35,89 +35,49 @@ SELECT p.person_id,
        CASE
            WHEN ehr.person_id IS NULL THEN 0 ELSE 1 END has_ehr_data,
        CASE
-           WHEN d.death_date is null THEN 0 ELSE 1 is_deceased
-
+           WHEN d.death_date is null THEN 0 ELSE 1 END is_deceased
 FROM `${omopDataset}.person` p
-
-LEFT JOIN `${omopDataset}.concept` gc
-    ON gc.concept_id = p.gender_concept_id
-
-LEFT JOIN `${omopDataset}.concept` rc
-    ON rc.concept_id = p.race_concept_id
-
-LEFT JOIN `${omopDataset}.concept` ec
-    ON ec.concept_id = p.ethnicity_concept_id
-
-LEFT JOIN `${omopDataset}.concept` sc
-    ON sc.concept_id = p.sex_at_birth_concept_id
-
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.activity_summary`) asum ON (p.person_id = asum.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.heart_rate_minute_level`) hrml ON (p.person_id = hrml.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.heart_rate_summary`) hrs ON (p.person_id = hrs.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.steps_intraday`) si ON (p.person_id = si.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.sleep_daily_summary`) sds ON (p.person_id = sds.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.sleep_level`) sl ON (p.person_id = sl.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT sample_name
-      FROM `${omopDataset}.prep_wgs_metadata`) wgv ON (CAST(p.person_id AS STRING) = wgv.sample_name)
-         LEFT JOIN
-     (SELECT DISTINCT sample_name
-      FROM `${omopDataset}.prep_microarray_metadata`) mad ON (CAST(p.person_id AS STRING) = mad.sample_name)
-         LEFT JOIN
-     (SELECT DISTINCT sample_name
-      FROM `${omopDataset}.prep_longreads_metadata`) lrwgv ON (CAST(p.person_id AS STRING) = lrwgv.sample_name)
-         LEFT JOIN
-     (SELECT DISTINCT sample_name
-      FROM `${omopDataset}.prep_structural_variants_metadata`) svd ON (CAST(p.person_id AS STRING) = svd.sample_name)
-         LEFT JOIN
-      (SELECT DISTINCT person_id
-        FROM`${omopDataset}.measurement` as a
-        LEFT JOIN`${omopDataset}.measurement_ext` as b on a.measurement_id = b.measurement_id
-        WHERE lower(b.src_id) like 'ehr site%'
-        UNION DISTINCT
-        SELECT DISTINCT person_id
-        FROM`${omopDataset}.condition_occurrence` as a
-        LEFT JOIN`${omopDataset}.condition_occurrence_ext` as b on a.condition_occurrence_id = b.condition_occurrence_id
-        WHERE lower(b.src_id) like 'ehr site%'
-        UNION DISTINCT
-        SELECT DISTINCT person_id
-        FROM`${omopDataset}.device_exposure` as a
-        LEFT JOIN`${omopDataset}.device_exposure_ext` as b on a.device_exposure_id = b.device_exposure_id
-        WHERE lower(b.src_id) like 'ehr site%'
-        UNION DISTINCT
-        SELECT DISTINCT person_id
-        FROM`${omopDataset}.drug_exposure` as a
-        LEFT JOIN`${omopDataset}.drug_exposure_ext` as b on a.drug_exposure_id = b.drug_exposure_id
-        WHERE lower(b.src_id) like 'ehr site%'
-        UNION DISTINCT
-        SELECT DISTINCT person_id
-        FROM`${omopDataset}.observation` as a
-        LEFT JOIN`${omopDataset}.observation_ext` as b on a.observation_id = b.observation_id
-        WHERE lower(b.src_id) like 'ehr site%'
-        UNION DISTINCT
-        SELECT DISTINCT person_id
-        FROM`${omopDataset}.procedure_occurrence` as a
-        LEFT JOIN`${omopDataset}.procedure_occurrence_ext` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
-        WHERE lower(b.src_id) like 'ehr site%'
-        UNION DISTINCT
-        SELECT DISTINCT person_id
-        FROM`${omopDataset}.visit_occurrence` as a
-        LEFT JOIN`${omopDataset}.visit_occurrence_ext` as b on a.visit_occurrence_id = b.visit_occurrence_id
-        WHERE lower(b.src_id) like 'ehr site%'
-      ) ehr ON (p.person_id = ehr.person_id),
-         LEFT JOIN
-      (SELECT DISTINCT person_id
-      FROM `${omopDataset}.death`) d ON (p.person_id = d.person_id)
-
+LEFT JOIN `${omopDataset}.concept` gc ON gc.concept_id = p.gender_concept_id
+LEFT JOIN `${omopDataset}.concept` rc ON rc.concept_id = p.race_concept_id
+LEFT JOIN `${omopDataset}.concept` ec ON ec.concept_id = p.ethnicity_concept_id
+LEFT JOIN `${omopDataset}.concept` sc ON sc.concept_id = p.sex_at_birth_concept_id
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.activity_summary`) asum ON (p.person_id = asum.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.heart_rate_minute_level`) hrml ON (p.person_id = hrml.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.heart_rate_summary`) hrs ON (p.person_id = hrs.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.steps_intraday`) si ON (p.person_id = si.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.sleep_daily_summary`) sds ON (p.person_id = sds.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.sleep_level`) sl ON (p.person_id = sl.person_id)
+LEFT JOIN (SELECT DISTINCT sample_name FROM `${omopDataset}.prep_wgs_metadata`) wgv ON (CAST(p.person_id AS STRING) = wgv.sample_name)
+LEFT JOIN (SELECT DISTINCT sample_name FROM `${omopDataset}.prep_microarray_metadata`) mad ON (CAST(p.person_id AS STRING) = mad.sample_name)
+LEFT JOIN (SELECT DISTINCT sample_name FROM `${omopDataset}.prep_longreads_metadata`) lrwgv ON (CAST(p.person_id AS STRING) = lrwgv.sample_name)
+LEFT JOIN (SELECT DISTINCT sample_name FROM `${omopDataset}.prep_structural_variants_metadata`) svd ON (CAST(p.person_id AS STRING) = svd.sample_name)
+LEFT JOIN (SELECT DISTINCT person_id FROM`${omopDataset}.measurement` as a
+            LEFT JOIN`${omopDataset}.measurement_ext` as b on a.measurement_id = b.measurement_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.condition_occurrence` as a
+            LEFT JOIN`${omopDataset}.condition_occurrence_ext` as b on a.condition_occurrence_id = b.condition_occurrence_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.device_exposure` as a
+            LEFT JOIN`${omopDataset}.device_exposure_ext` as b on a.device_exposure_id = b.device_exposure_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.drug_exposure` as a
+            LEFT JOIN`${omopDataset}.drug_exposure_ext` as b on a.drug_exposure_id = b.drug_exposure_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.observation` as a
+            LEFT JOIN`${omopDataset}.observation_ext` as b on a.observation_id = b.observation_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.procedure_occurrence` as a
+            LEFT JOIN`${omopDataset}.procedure_occurrence_ext` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.visit_occurrence` as a
+            LEFT JOIN`${omopDataset}.visit_occurrence_ext` as b on a.visit_occurrence_id = b.visit_occurrence_id
+            WHERE lower(b.src_id) like 'ehr site%'
+           ) ehr ON (p.person_id = ehr.person_id)
+LEFT JOIN (SELECT person_id, max(death_date) as death_date FROM `${omopDataset}.death` GROUP BY person_id) d
+            ON (p.person_id = d.person_id)

--- a/underlay/src/main/resources/config/datamapping/aouCT/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT/entity/person/entity.json
@@ -20,8 +20,9 @@
     { "name": "has_whole_genome_variant", "dataType": "INT64", "isComputeDisplayHint": true },
     { "name": "has_lr_whole_genome_variant", "dataType": "INT64", "isComputeDisplayHint": true },
     { "name": "has_structural_variant_data", "dataType": "INT64", "isComputeDisplayHint": true },
-    { "name": "has_ehr_data", "dataType": "INT64", "isComputeDisplayHint": true }
+    { "name": "has_ehr_data", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "is_deceased", "dataType": "INT64", "isComputeDisplayHint": true }
   ],
   "idAttribute": "id",
-  "optimizeGroupByAttributes": [ "gender", "race", "age" ]
+  "optimizeGroupByAttributes": [ "gender", "race", "age", "ethnicity" ]
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/person/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/person/all.sql
@@ -25,7 +25,10 @@ SELECT p.person_id,
            WHEN asum.person_id IS NULL AND hrml.person_id IS NULL AND hrs.person_id IS NULL
             AND si.person_id IS NULL AND sds.person_id IS NULL AND sl.person_id IS NULL THEN 0 ELSE 1 END has_fitbit,
        CASE
-           WHEN ehr.person_id IS NULL THEN 0 ELSE 1 END has_ehr_data
+           WHEN ehr.person_id IS NULL THEN 0 ELSE 1 END has_ehr_data,
+       CASE
+           WHEN d.death_date is null THEN 0 ELSE 1 is_deceased
+
 FROM `${omopDataset}.person` p
 
 LEFT JOIN `${omopDataset}.concept` gc
@@ -94,3 +97,6 @@ LEFT JOIN `${omopDataset}.concept` sc
           LEFT JOIN`${omopDataset}.visit_occurrence_ext` as b on a.visit_occurrence_id = b.visit_occurrence_id
       WHERE lower(b.src_id) like 'ehr site%'
      ) ehr ON (p.person_id = ehr.person_id)
+         LEFT JOIN
+     (SELECT DISTINCT person_id
+      FROM `${omopDataset}.death`) d ON (p.person_id = d.person_id)

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/person/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/person/all.sql
@@ -27,76 +27,45 @@ SELECT p.person_id,
        CASE
            WHEN ehr.person_id IS NULL THEN 0 ELSE 1 END has_ehr_data,
        CASE
-           WHEN d.death_date is null THEN 0 ELSE 1 is_deceased
-
+           WHEN d.death_date is null THEN 0 ELSE 1 END is_deceased
 FROM `${omopDataset}.person` p
-
-LEFT JOIN `${omopDataset}.concept` gc
-    ON gc.concept_id = p.gender_concept_id
-
-LEFT JOIN `${omopDataset}.concept` rc
-    ON rc.concept_id = p.race_concept_id
-
-LEFT JOIN `${omopDataset}.concept` ec
-    ON ec.concept_id = p.ethnicity_concept_id
-
-LEFT JOIN `${omopDataset}.concept` sc
-    ON sc.concept_id = p.sex_at_birth_concept_id
-
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.activity_summary`) asum ON (p.person_id = asum.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.heart_rate_minute_level`) hrml ON (p.person_id = hrml.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.heart_rate_summary`) hrs ON (p.person_id = hrs.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.steps_intraday`) si ON (p.person_id = si.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.sleep_daily_summary`) sds ON (p.person_id = sds.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.sleep_level`) sl ON (p.person_id = sl.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM`${omopDataset}.measurement` as a
-              LEFT JOIN`${omopDataset}.measurement_ext` as b on a.measurement_id = b.measurement_id
-      WHERE lower(b.src_id) like 'ehr site%'
-      UNION DISTINCT
-      SELECT DISTINCT person_id
-      FROM`${omopDataset}.condition_occurrence` as a
-          LEFT JOIN`${omopDataset}.condition_occurrence_ext` as b on a.condition_occurrence_id = b.condition_occurrence_id
-      WHERE lower(b.src_id) like 'ehr site%'
-      UNION DISTINCT
-      SELECT DISTINCT person_id
-      FROM`${omopDataset}.device_exposure` as a
-          LEFT JOIN`${omopDataset}.device_exposure_ext` as b on a.device_exposure_id = b.device_exposure_id
-      WHERE lower(b.src_id) like 'ehr site%'
-      UNION DISTINCT
-      SELECT DISTINCT person_id
-      FROM`${omopDataset}.drug_exposure` as a
-          LEFT JOIN`${omopDataset}.drug_exposure_ext` as b on a.drug_exposure_id = b.drug_exposure_id
-      WHERE lower(b.src_id) like 'ehr site%'
-      UNION DISTINCT
-      SELECT DISTINCT person_id
-      FROM`${omopDataset}.observation` as a
-          LEFT JOIN`${omopDataset}.observation_ext` as b on a.observation_id = b.observation_id
-      WHERE lower(b.src_id) like 'ehr site%'
-      UNION DISTINCT
-      SELECT DISTINCT person_id
-      FROM`${omopDataset}.procedure_occurrence` as a
-          LEFT JOIN`${omopDataset}.procedure_occurrence_ext` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
-      WHERE lower(b.src_id) like 'ehr site%'
-      UNION DISTINCT
-      SELECT DISTINCT person_id
-      FROM`${omopDataset}.visit_occurrence` as a
-          LEFT JOIN`${omopDataset}.visit_occurrence_ext` as b on a.visit_occurrence_id = b.visit_occurrence_id
-      WHERE lower(b.src_id) like 'ehr site%'
-     ) ehr ON (p.person_id = ehr.person_id)
-         LEFT JOIN
-     (SELECT DISTINCT person_id
-      FROM `${omopDataset}.death`) d ON (p.person_id = d.person_id)
+LEFT JOIN `${omopDataset}.concept` gc ON gc.concept_id = p.gender_concept_id
+LEFT JOIN `${omopDataset}.concept` rc ON rc.concept_id = p.race_concept_id
+LEFT JOIN `${omopDataset}.concept` ec ON ec.concept_id = p.ethnicity_concept_id
+LEFT JOIN `${omopDataset}.concept` sc ON sc.concept_id = p.sex_at_birth_concept_id
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.activity_summary`) asum ON (p.person_id = asum.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.heart_rate_minute_level`) hrml ON (p.person_id = hrml.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.heart_rate_summary`) hrs ON (p.person_id = hrs.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.steps_intraday`) si ON (p.person_id = si.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.sleep_daily_summary`) sds ON (p.person_id = sds.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM `${omopDataset}.sleep_level`) sl ON (p.person_id = sl.person_id)
+LEFT JOIN (SELECT DISTINCT person_id FROM`${omopDataset}.measurement` as a
+            LEFT JOIN`${omopDataset}.measurement_ext` as b on a.measurement_id = b.measurement_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.condition_occurrence` as a
+            LEFT JOIN`${omopDataset}.condition_occurrence_ext` as b on a.condition_occurrence_id = b.condition_occurrence_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.device_exposure` as a
+            LEFT JOIN`${omopDataset}.device_exposure_ext` as b on a.device_exposure_id = b.device_exposure_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.drug_exposure` as a
+            LEFT JOIN`${omopDataset}.drug_exposure_ext` as b on a.drug_exposure_id = b.drug_exposure_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.observation` as a
+            LEFT JOIN`${omopDataset}.observation_ext` as b on a.observation_id = b.observation_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.procedure_occurrence` as a
+            LEFT JOIN`${omopDataset}.procedure_occurrence_ext` as b on a.procedure_occurrence_id = b.procedure_occurrence_id
+            WHERE lower(b.src_id) like 'ehr site%'
+            UNION DISTINCT
+            SELECT DISTINCT person_id FROM`${omopDataset}.visit_occurrence` as a
+            LEFT JOIN`${omopDataset}.visit_occurrence_ext` as b on a.visit_occurrence_id = b.visit_occurrence_id
+            WHERE lower(b.src_id) like 'ehr site%'
+          ) ehr ON (p.person_id = ehr.person_id)
+LEFT JOIN (SELECT person_id, max(death_date) as death_date FROM `${omopDataset}.death` GROUP BY person_id) d
+            ON (p.person_id = d.person_id)

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/person/entity.json
@@ -16,8 +16,9 @@
     { "name": "has_fitbit_sleep_daily_summary", "dataType": "INT64", "isComputeDisplayHint": true },
     { "name": "has_fitbit_sleep_level", "dataType": "INT64", "isComputeDisplayHint": true },
     { "name": "has_fitbit", "dataType": "INT64", "isComputeDisplayHint": true },
-    { "name": "has_ehr_data", "dataType": "INT64", "isComputeDisplayHint": true }
+    { "name": "has_ehr_data", "dataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "is_deceased", "dataType": "INT64", "isComputeDisplayHint": true }
   ],
   "idAttribute": "id",
-  "optimizeGroupByAttributes": [ "gender", "race", "age" ]
+  "optimizeGroupByAttributes": [ "gender", "race", "age", "ethnicity" ]
 }

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -602,6 +602,13 @@
       ]
     },
     {
+      "type": "attribute",
+      "id": "tanagra-has-ehr-data",
+      "title": "Has EHR Data",
+      "category": "Domains",
+      "attribute": "has_ehr_data"
+    },
+    {
       "type": "classification",
       "id": "tanagra-cpt4",
       "title": "CPT-4",
@@ -785,45 +792,46 @@
     },
     {
       "type": "attribute",
-      "id": "tanagra-has-ehr-data",
-      "title": "Has EHR Data",
-      "category": "Program data",
-      "attribute": "has_ehr_data"
+      "id": "tanagra-age",
+      "title": "Age",
+      "category": "Demographics",
+      "attribute": "age"
     },
     {
       "type": "attribute",
+      "id": "tanagra-is-deceased",
+      "title": "Deceased",
+      "category": "Demographics",
+      "attribute": "is_deceased"
+    },
+    {
+
+      "type": "attribute",
       "id": "tanagra-ethnicity",
       "title": "Ethnicity",
-      "category": "Program data",
+      "category": "Demographics",
       "attribute": "ethnicity"
     },
     {
       "type": "attribute",
       "id": "tanagra-gender",
       "title": "Gender identity",
-      "category": "Program data",
+      "category": "Demographics",
       "attribute": "gender"
-    },
-    {
-      "type": "attribute",
-      "id": "tanagra-sex-at-birth",
-      "title": "Sex At Birth",
-      "category": "Program data",
-      "attribute": "sex_at_birth"
     },
     {
       "type": "attribute",
       "id": "tanagra-race",
       "title": "Race",
-      "category": "Program data",
+      "category": "Demographics",
       "attribute": "race"
     },
     {
       "type": "attribute",
-      "id": "tanagra-age",
-      "title": "Age",
-      "category": "Program data",
-      "attribute": "age"
+      "id": "tanagra-sex-at-birth",
+      "title": "Sex At Birth",
+      "category": "Demographics",
+      "attribute": "sex_at_birth"
     },
     {
       "type": "attribute",

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -795,7 +795,7 @@
       "type": "attribute",
       "id": "tanagra-is-deceased",
       "title": "Deceased",
-      "category": "Program Data",
+      "category": "Demographics",
       "attribute": "is_deceased"
     },
     {

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -596,6 +596,13 @@
       ]
     },
     {
+      "type": "attribute",
+      "id": "tanagra-has-ehr-data",
+      "title": "Has EHR Data",
+      "category": "Domains",
+      "attribute": "has_ehr_data"
+    },
+    {
       "type": "classification",
       "id": "tanagra-cpt4",
       "title": "CPT-4",
@@ -779,45 +786,46 @@
     },
     {
       "type": "attribute",
-      "id": "tanagra-has-ehr-data",
-      "title": "Has EHR Data",
-      "category": "Program data",
-      "attribute": "has_ehr_data"
+      "id": "tanagra-age",
+      "title": "Age",
+      "category": "Demographics",
+      "attribute": "age"
     },
     {
       "type": "attribute",
+      "id": "tanagra-is-deceased",
+      "title": "Deceased",
+      "category": "Program Data",
+      "attribute": "is_deceased"
+    },
+    {
+
+      "type": "attribute",
       "id": "tanagra-ethnicity",
       "title": "Ethnicity",
-      "category": "Program data",
+      "category": "Demographics",
       "attribute": "ethnicity"
     },
     {
       "type": "attribute",
       "id": "tanagra-gender",
       "title": "Gender identity",
-      "category": "Program data",
+      "category": "Demographics",
       "attribute": "gender"
-    },
-    {
-      "type": "attribute",
-      "id": "tanagra-sex-at-birth",
-      "title": "Sex At Birth",
-      "category": "Program data",
-      "attribute": "sex_at_birth"
     },
     {
       "type": "attribute",
       "id": "tanagra-race",
       "title": "Race",
-      "category": "Program data",
+      "category": "Demographics",
       "attribute": "race"
     },
     {
       "type": "attribute",
-      "id": "tanagra-age",
-      "title": "Age",
-      "category": "Program data",
-      "attribute": "age"
+      "id": "tanagra-sex-at-birth",
+      "title": "Sex At Birth",
+      "category": "Demographics",
+      "attribute": "sex_at_birth"
     },
     {
       "type": "attribute",


### PR DESCRIPTION
- Updated underlays for RT and CT to use `is_deceased` attribute from `death` table
- Updated UI for selection of `Deceased` criteria
- Regrouped demographics criteria under `Demographics` category (selection criteria aligns with AoU)
- Moved `Has EHR Data` to `Domains` category (selection criteria aligns with AoU)
  - CT selection criteria showing `Deceased` under `Demographics` and `Has EHR Data` under `Domains` categories respectively <img width="936" alt="image" src="https://github.com/DataBiosphere/tanagra/assets/4452480/39e843aa-1f08-4991-b8c8-a8666030d896">
  - selection of `Deceased` criteria <img width="1265" alt="image" src="https://github.com/DataBiosphere/tanagra/assets/4452480/2f3d7bc2-ccab-4636-a895-eb914b46c9c0">

 


