### PR TITLE
Fix hierarchy paths with invalid root.

### DIFF
--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -93,7 +93,20 @@ public final class JobSequencer {
                 jobSet.addJob(
                     new WriteAncestorDescendant(
                         indexerConfig, hierarchy, sourceChildParent, indexAncestorDescendant));
+              });
 
+      jobSet.startNewStage();
+      entity.getHierarchies().stream()
+          .forEach(
+              hierarchy -> {
+                ITHierarchyChildParent indexChildParent =
+                    underlay
+                        .getIndexSchema()
+                        .getHierarchyChildParent(entity.getName(), hierarchy.getName());
+                ITHierarchyAncestorDescendant indexAncestorDescendant =
+                    underlay
+                        .getIndexSchema()
+                        .getHierarchyAncestorDescendant(entity.getName(), hierarchy.getName());
                 STHierarchyRootFilter sourceRootFilter =
                     underlay
                             .getSourceSchema()
@@ -107,7 +120,8 @@ public final class JobSequencer {
                         indexerConfig,
                         entity,
                         hierarchy,
-                        sourceChildParent,
+                        indexChildParent,
+                        indexAncestorDescendant,
                         sourceRootFilter,
                         indexEntityMain));
               });

--- a/indexer/src/test/java/bio/terra/tanagra/indexing/JobSequencerTest.java
+++ b/indexer/src/test/java/bio/terra/tanagra/indexing/JobSequencerTest.java
@@ -57,7 +57,7 @@ public class JobSequencerTest {
     SequencedJobSet jobs =
         JobSequencer.getJobSetForEntity(szIndexer, underlay, underlay.getEntity("condition"));
 
-    assertEquals(5, jobs.getNumStages());
+    assertEquals(6, jobs.getNumStages());
     Iterator<List<IndexingJob>> jobStageItr = jobs.iterator();
     IndexingJob job = jobStageItr.next().get(0);
     assertEquals(ValidateDataTypes.class, job.getClass());
@@ -94,6 +94,7 @@ public class JobSequencerTest {
             .findFirst();
     assertTrue(writeAncestorDescendantIdPairs.isPresent());
 
+    jobStage = jobStageItr.next();
     Optional<IndexingJob> buildNumChildrenAndPaths =
         jobStage.stream()
             .filter(jobInStage -> jobInStage.getClass().equals(WriteNumChildrenAndPaths.class))

--- a/underlay/src/main/resources/config/indexer/aouSR2019q4r4_verily.json
+++ b/underlay/src/main/resources/config/indexer/aouSR2019q4r4_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "aouSR2019q4r4_index_110623",
+      "datasetId": "aouSR2019q4r4_index_010224",
       "tablePrefix": "T"
     },
     "queryProjectId": "verily-tanagra-dev",

--- a/underlay/src/main/resources/config/indexer/cmssynpuf_verily.json
+++ b/underlay/src/main/resources/config/indexer/cmssynpuf_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "cmssynpuf_index_110623"
+      "datasetId": "cmssynpuf_index_010224"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us"

--- a/underlay/src/main/resources/config/indexer/pilotsynthea2022q3_verily.json
+++ b/underlay/src/main/resources/config/indexer/pilotsynthea2022q3_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "pilotsynthea2022q3_index_110623"
+      "datasetId": "pilotsynthea2022q3_index_010224"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"

--- a/underlay/src/main/resources/config/indexer/sd020230331_verily.json
+++ b/underlay/src/main/resources/config/indexer/sd020230331_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "sd20230331_index_110623"
+      "datasetId": "sd20230331_index_010224"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"

--- a/underlay/src/main/resources/config/service/aouSR2019q4r4_broad.json
+++ b/underlay/src/main/resources/config/service/aouSR2019q4r4_broad.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "aouSR2019q4r4_index_110623",
+      "datasetId": "aouSR2019q4r4_index_010224",
       "tablePrefix": "T"
     },
     "queryProjectId": "broad-tanagra-dev",

--- a/underlay/src/main/resources/config/service/aouSR2019q4r4_verily.json
+++ b/underlay/src/main/resources/config/service/aouSR2019q4r4_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "aouSR2019q4r4_index_110623",
+      "datasetId": "aouSR2019q4r4_index_010224",
       "tablePrefix": "T"
     },
     "queryProjectId": "verily-tanagra-dev",

--- a/underlay/src/main/resources/config/service/cmssynpuf_broad.json
+++ b/underlay/src/main/resources/config/service/cmssynpuf_broad.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "cmssynpuf_index_110623"
+      "datasetId": "cmssynpuf_index_010224"
     },
     "queryProjectId": "broad-tanagra-dev",
     "dataLocation": "us"

--- a/underlay/src/main/resources/config/service/cmssynpuf_verily.json
+++ b/underlay/src/main/resources/config/service/cmssynpuf_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "cmssynpuf_index_110623"
+      "datasetId": "cmssynpuf_index_010224"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us"

--- a/underlay/src/main/resources/config/service/pilotsynthea2022q3_verily.json
+++ b/underlay/src/main/resources/config/service/pilotsynthea2022q3_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "pilotsynthea2022q3_index_110623"
+      "datasetId": "pilotsynthea2022q3_index_010224"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"

--- a/underlay/src/main/resources/config/service/sd020230331_verily.json
+++ b/underlay/src/main/resources/config/service/sd020230331_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "sd20230331_index_110623"
+      "datasetId": "sd20230331_index_010224"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"

--- a/underlay/src/test/java/bio/terra/tanagra/datasetspecific/cmssynpuf/CmsSynpufHintsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/datasetspecific/cmssynpuf/CmsSynpufHintsTest.java
@@ -46,7 +46,7 @@ public class CmsSynpufHintsTest extends BaseHintsTest {
                     54_453L,
                     new ValueDisplay(Literal.forInt64(38_003_564L), "Not Hispanic or Latino"),
                     2_272_403L)),
-            new HintInstance(entity.getAttribute("age"), 39.0, 114.0),
+            new HintInstance(entity.getAttribute("age"), 40.0, 115.0),
             new HintInstance(entity.getAttribute("year_of_birth"), 1909.0, 1983.0));
     assertEntityLevelHintsMatch("person", expectedHints);
   }


### PR DESCRIPTION
If there are >1 possible path from a hierarchy node to a root node, then we just pick one. If there is additionally a filter on the valid root nodes, any nodes that had a path to one of the invalid ones would be thrown out of the hierarchy. Now before finding a possible path, we filter all child-parent relationships to only include those where the parent is either a root node or a descendant of a root node, so that the path will always have a valid root.

This change means the path-numChildren indexing job now depends on the output of the ancestor-descendant indexing job. Previously those two jobs could be run in parallel, now they will be sequenced serially.

As part of this change, I also re-ran indexing for all Broad and Verily underlays to fix any dropped hierarchy nodes in them.