### PR TITLE
Overhaul UI config

### DIFF
--- a/ui/src/apiContext.ts
+++ b/ui/src/apiContext.ts
@@ -19,41 +19,6 @@ class FakeUnderlaysApi {
     const columns = [{ key: "name", width: "100%", title: "Concept name" }];
 
     const uiConfiguration = {
-      dataConfig: {
-        primaryEntity: {
-          entity: "person",
-          key: "id",
-        },
-        occurrences: [
-          {
-            id: "condition_occurrence",
-            entity: "condition_occurrence",
-            key: "id",
-            classifications: [
-              {
-                id: "condition",
-                attribute: "condition_concept_id",
-                entity: "condition",
-                entityAttribute: "id",
-                hierarchy: "standard",
-              },
-            ],
-          },
-          {
-            id: "observation_occurrence",
-            entity: "observation_occurrence",
-            key: "id",
-            classifications: [
-              {
-                id: "observation",
-                attribute: "observation_concept_id",
-                entity: "observation",
-                entityAttribute: "id",
-              },
-            ],
-          },
-        ],
-      },
       criteriaConfigs: [
         {
           type: "classification",
@@ -102,7 +67,7 @@ class FakeUnderlaysApi {
         primaryEntity: "person",
       },
       serializedConfiguration: {
-        underlay: "",
+        underlay: "{}",
         entities: [],
         groupItemsEntityGroups: [],
         criteriaOccurrenceEntityGroups: [],

--- a/ui/src/cohortReview/cohortReview.tsx
+++ b/ui/src/cohortReview/cohortReview.tsx
@@ -42,7 +42,7 @@ export function CohortReview() {
   const baseParams = useBaseParams();
   const params = useReviewParams();
 
-  const primaryKey = underlay.uiConfiguration.dataConfig.primaryEntity.key;
+  const primaryKey = underlaySource.primaryEntity().idAttribute;
   const uiConfig = underlay.uiConfiguration.cohortReviewConfig;
   const participantIdAttribute = uiConfig.participantIdAttribute ?? primaryKey;
 
@@ -130,11 +130,11 @@ export function CohortReview() {
         throw new Error("Instances not loaded yet.");
       }
 
-      const occurrenceIds: string[] = [];
-      pagePlugins.forEach((p) => occurrenceIds.push(...p.occurrences));
+      const entityIds: string[] = [];
+      pagePlugins.forEach((p) => entityIds.push(...p.entities));
 
       const res = await Promise.all(
-        occurrenceIds.map((id) => {
+        entityIds.map((id) => {
           return underlaySource.listData(
             underlaySource.listAttributes(id),
             id,
@@ -149,16 +149,16 @@ export function CohortReview() {
         })
       );
 
-      const occurrences: { [x: string]: DataEntry[] } = {};
+      const rows: { [x: string]: DataEntry[] } = {};
       res.forEach(
         (r, i) =>
-          (occurrences[occurrenceIds[i]] = r.data.map((o) => ({
+          (rows[entityIds[i]] = r.data.map((o) => ({
             ...o,
             timestamp: o["start_date"] as Date,
           })))
       );
       return {
-        occurrences,
+        rows,
       };
     }
   );
@@ -272,7 +272,7 @@ export function CohortReview() {
             <Loading status={instanceDataState}>
               <CohortReviewContext.Provider
                 value={{
-                  occurrences: instanceDataState?.data?.occurrences ?? {},
+                  rows: instanceDataState?.data?.rows ?? {},
                   searchState: <T extends object>(plugin: string) =>
                     (searchState?.plugins?.[plugin] ?? {}) as T,
                   updateSearchState: <T extends object>(

--- a/ui/src/cohortReview/cohortReviewContext.ts
+++ b/ui/src/cohortReview/cohortReviewContext.ts
@@ -1,12 +1,12 @@
 import { DataEntry } from "data/types";
 import { createContext, useContext } from "react";
 
-export type OccurrenceData = {
+export type EntityData = {
   [x: string]: DataEntry[];
 };
 
 export type CohortReviewContextData = {
-  occurrences: OccurrenceData;
+  rows: EntityData;
 
   searchState: <T extends object>(plugin: string) => T;
   updateSearchState: <T extends object>(

--- a/ui/src/cohortReview/newReviewDialog.tsx
+++ b/ui/src/cohortReview/newReviewDialog.tsx
@@ -56,7 +56,7 @@ export function NewReviewDialog(props: NewReviewDialogProps) {
     },
     async () => {
       return await underlaySource.filterCount(
-        generateCohortFilter(props.cohort)
+        generateCohortFilter(underlaySource, props.cohort)
       );
     }
   );

--- a/ui/src/cohortReview/pluginRegistry.ts
+++ b/ui/src/cohortReview/pluginRegistry.ts
@@ -4,7 +4,7 @@ import { CohortReviewPageConfig } from "underlaysSlice";
 export interface CohortReviewPlugin {
   id: string;
   title: string;
-  occurrences: string[];
+  entities: string[];
 
   render: () => ReactNode;
 }

--- a/ui/src/cohortReview/plugins/occurrenceTable.tsx
+++ b/ui/src/cohortReview/plugins/occurrenceTable.tsx
@@ -23,14 +23,14 @@ import { CohortReviewPageConfig } from "underlaysSlice";
 import { safeRegExp } from "util/safeRegExp";
 
 interface Config {
-  occurrence: string;
+  entity: string;
   columns: TreeGridColumn[];
 }
 
-@registerCohortReviewPlugin("occurrenceTable")
+@registerCohortReviewPlugin("entityTable")
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class _ implements CohortReviewPlugin {
-  public occurrences: string[];
+  public entities: string[];
   private config: Config;
 
   constructor(
@@ -39,7 +39,7 @@ class _ implements CohortReviewPlugin {
     config: CohortReviewPageConfig
   ) {
     this.config = config.plugin as Config;
-    this.occurrences = [this.config.occurrence];
+    this.entities = [this.config.entity];
   }
 
   render() {
@@ -66,7 +66,7 @@ function OccurrenceTable({ id, config }: { id: string; config: Config }) {
       root: { data: {}, children },
     };
 
-    context.occurrences[config.occurrence].forEach((o) => {
+    context.rows[config.entity].forEach((o) => {
       data[o.key] = { data: o };
       children.push(o.key);
     });

--- a/ui/src/cohortReview/reviewHooks.ts
+++ b/ui/src/cohortReview/reviewHooks.ts
@@ -21,10 +21,11 @@ export type ReviewParams = {
 };
 
 export function useReviewParams(): ReviewParams {
+  const underlaySource = useUnderlaySource();
   const underlay = useUnderlay();
   const params = useBaseParams();
 
-  const primaryKey = underlay.uiConfiguration.dataConfig.primaryEntity.key;
+  const primaryKey = underlaySource.primaryEntity().idAttribute;
   const uiConfig = underlay.uiConfiguration.cohortReviewConfig;
   const participantIdAttribute = uiConfig.participantIdAttribute ?? primaryKey;
 

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -123,7 +123,7 @@ class _ implements CriteriaPlugin<Data> {
     };
   }
 
-  filterOccurrenceIds() {
+  filterEntityIds() {
     return [""];
   }
 }

--- a/ui/src/criteria/multiAttribute.tsx
+++ b/ui/src/criteria/multiAttribute.tsx
@@ -16,7 +16,7 @@ import { safeRegExp } from "util/safeRegExp";
 import { isValid } from "util/valid";
 
 export interface Config extends CriteriaConfig {
-  occurrence: string;
+  entity: string;
   singleValue?: boolean;
   valueConfigs: ValueConfig[];
 }
@@ -144,8 +144,8 @@ class _ implements CriteriaPlugin<Data> {
     return generateValueDataFilter(this.data.valueData);
   }
 
-  filterOccurrenceIds() {
-    return [this.config.occurrence];
+  filterEntityIds() {
+    return [this.config.entity];
   }
 }
 
@@ -165,7 +165,7 @@ function MultiAttributeInline(props: MultiAttributeInlineProps) {
 
   return (
     <ValueDataEdit
-      occurrence={props.config.occurrence}
+      hintEntity={props.config.entity}
       valueConfigs={props.config.valueConfigs}
       valueData={props.data.valueData}
       update={(valueData) =>
@@ -186,7 +186,7 @@ async function search(
 ): Promise<DataEntry[]> {
   const config = c as Config;
 
-  const allHintData = await underlaySource.getAllHintData(config.occurrence);
+  const allHintData = await underlaySource.getAllHintData(config.entity);
 
   const [re] = safeRegExp(query);
   const results: DataEntry[] = [];

--- a/ui/src/criteria/textSearch.tsx
+++ b/ui/src/criteria/textSearch.tsx
@@ -20,7 +20,7 @@ import { CriteriaConfig } from "underlaysSlice";
 import { isValid } from "util/valid";
 
 interface Config extends CriteriaConfig {
-  occurrenceId: string;
+  entity: string;
   searchAttribute: string;
   categoryAttribute?: string;
 }
@@ -35,8 +35,8 @@ interface Data {
   categories: Selection[];
 }
 
-// "search" plugins select occurrences using a text based search of the fields
-// in the occurrence.
+// "search" plugins select entities using a text based search of the fields in
+// the entity.
 @registerCriteriaPlugin("search", () => {
   return {
     query: "",
@@ -105,8 +105,8 @@ class _ implements CriteriaPlugin<Data> {
     ]);
   }
 
-  filterOccurrenceIds() {
-    return [this.config.occurrenceId];
+  filterEntityIds() {
+    return [this.config.entity];
   }
 }
 
@@ -148,7 +148,7 @@ function TextSearchInline(props: TextSearchInlineProps) {
     async () => {
       const hintData = props.config.categoryAttribute
         ? await underlaySource.getHintData(
-            props.config.occurrenceId,
+            props.config.entity,
             props.config.categoryAttribute
           )
         : undefined;

--- a/ui/src/criteria/unhintedValue.tsx
+++ b/ui/src/criteria/unhintedValue.tsx
@@ -109,7 +109,7 @@ class _ implements CriteriaPlugin<Data> {
     };
   }
 
-  filterOccurrenceIds() {
+  filterEntityIds() {
     return [this.config.attribute ?? ""];
   }
 }

--- a/ui/src/criteria/valueData.tsx
+++ b/ui/src/criteria/valueData.tsx
@@ -49,8 +49,8 @@ export const ANY_VALUE_DATA = {
 };
 
 export type ValueDataEditProps = {
-  occurrence: string;
-  entity?: string;
+  hintEntity: string;
+  relatedEntity?: string;
   hintKey?: DataKey;
 
   singleValue?: boolean;
@@ -65,15 +65,15 @@ export function ValueDataEdit(props: ValueDataEditProps) {
   const hintDataState = useSWRImmutable(
     {
       type: "hintData",
-      occurrence: props.occurrence,
-      entity: props.entity,
+      hintEntity: props.hintEntity,
+      relatedEntity: props.relatedEntity,
       key: props.hintKey,
     },
     async (key) => {
       const hintData = props.valueConfigs
         ? await underlaySource.getAllHintData(
-            key.occurrence,
-            key.entity,
+            key.hintEntity,
+            key.relatedEntity,
             key.key
           )
         : undefined;

--- a/ui/src/data/configuration.ts
+++ b/ui/src/data/configuration.ts
@@ -12,63 +12,10 @@ export type SortOrder = {
   direction: SortDirection;
 };
 
-// Classifications allow occurrences to be filtered using an attribute that
-// refers to another table. An example of this is how OMOP data stores the
-// condition associated with a condition occurrence as a concept_id that
-// references a concept table.
-export type Classification = {
-  id: string;
-  attribute: string;
-
-  entity: string;
-  entityAttribute: string;
-  hierarchy?: string;
-
-  defaultSort: SortOrder;
-
-  groupings?: Grouping[];
-};
-
-export type Grouping = {
-  id: string;
-  entity: string;
-  defaultSort?: SortOrder;
-
-  attributes?: string[];
-};
-
-export type Entity = {
-  entity: string;
-  key: string;
-
-  classifications?: Classification[];
-};
-
-export type PrimaryEntity = Entity;
-
-export type Occurrence = Entity & {
-  id: string;
-};
-
-export type Configuration = {
-  primaryEntity: PrimaryEntity;
-  occurrences?: Occurrence[];
-};
-
 export function findByID<T extends { id: string }>(id: string, list?: T[]): T {
   const item = list?.find((item) => item.id === id);
   if (!item) {
     throw new Error(`Unknown item "${id}" in ${JSON.stringify(list)}.`);
   }
   return item;
-}
-
-export function findEntity(
-  occurrenceID: string,
-  config: Configuration
-): Entity {
-  if (occurrenceID) {
-    return findByID(occurrenceID, config.occurrences);
-  }
-  return config.primaryEntity;
 }

--- a/ui/src/data/filter.ts
+++ b/ui/src/data/filter.ts
@@ -5,7 +5,7 @@ import { DataKey, DataValue } from "./types";
 export enum FilterType {
   Unary = "UNARY",
   Array = "ARRAY",
-  Classification = "CLASSIFICATION",
+  EntityGroup = "ENTITY_GROUP",
   Attribute = "ATTRIBUTE",
   Text = "TEXT",
   Relationship = "RELATIONSHIP",
@@ -92,22 +92,22 @@ export function isRelationshipFilter(
   return filter.type == FilterType.Relationship;
 }
 
-export type ClassificationFilter = BaseFilter & {
-  occurrenceId: string;
-  classificationId: string;
+export type EntityGroupFilter = BaseFilter & {
+  entityGroupId: string;
+  entityId: string;
   keys: DataKey[];
 };
 
-export function isClassificationFilter(
+export function isEntityGroupFilter(
   filter: Filter
-): filter is ClassificationFilter {
-  return filter.type == FilterType.Classification;
+): filter is EntityGroupFilter {
+  return filter.type == FilterType.EntityGroup;
 }
 
 export type Filter =
   | UnaryFilter
   | ArrayFilter
   | AttributeFilter
-  | ClassificationFilter
+  | EntityGroupFilter
   | TextFilter
   | RelationshipFilter;

--- a/ui/src/data/underlaySourceContext.tsx
+++ b/ui/src/data/underlaySourceContext.tsx
@@ -55,19 +55,25 @@ export function UnderlaySourceContextRoot() {
 
       const underlay = {
         name: underlayName,
-        displayName: apiUnderlay.summary.displayName ?? underlayName,
-        primaryEntity: apiUnderlay.summary.primaryEntity,
-        entities: entitiesRes.entities,
         uiConfiguration: JSON.parse(apiUnderlay.uiConfiguration),
+        underlayConfig: JSON.parse(
+          apiUnderlay.serializedConfiguration.underlay
+        ),
+        criteriaOccurrences:
+          apiUnderlay.serializedConfiguration.criteriaOccurrenceEntityGroups.map(
+            (co) => JSON.parse(co)
+          ),
+        groupItems:
+          apiUnderlay.serializedConfiguration.groupItemsEntityGroups.map((gi) =>
+            JSON.parse(gi)
+          ),
+        entities: apiUnderlay.serializedConfiguration.entities.map((e) =>
+          JSON.parse(e)
+        ),
       };
 
       return {
-        source: new BackendUnderlaySource(
-          underlaysApi,
-          exportApi,
-          underlay,
-          underlay.uiConfiguration.dataConfig
-        ),
+        source: new BackendUnderlaySource(underlaysApi, exportApi, underlay),
       };
     }, [underlayName])
   );

--- a/ui/src/demographicCharts.tsx
+++ b/ui/src/demographicCharts.tsx
@@ -178,7 +178,7 @@ export function DemographicCharts({
       underlay.uiConfiguration.demographicChartConfigs.groupByAttributes;
 
     const demographicData = await underlaySource.filterCount(
-      generateCohortFilter(cohort),
+      generateCohortFilter(underlaySource, cohort),
       groupByAttributes
     );
 

--- a/ui/src/export.tsx
+++ b/ui/src/export.tsx
@@ -352,7 +352,9 @@ function Preview(props: PreviewProps) {
     () =>
       makeArrayFilter(
         { min: 1 },
-        filteredCohorts.map((cohort) => generateCohortFilter(cohort))
+        filteredCohorts.map((cohort) =>
+          generateCohortFilter(underlaySource, cohort)
+        )
       ),
     [filteredCohorts]
   );
@@ -744,7 +746,7 @@ function ExportDialog(
       props.cohorts.map((c) => c.id),
       props.occurrenceFilters.map((filters) => ({
         requestedAttributes: filters.attributes,
-        occurrenceID: filters.id,
+        entityId: filters.id,
         cohort: cohortsFilter,
         conceptSet: makeArrayFilter({ min: 1 }, filters.filters),
       }))
@@ -764,14 +766,14 @@ function ExportDialog(
         }[][] = [];
 
         for (const key in result.outputs) {
-          const parts = key.split(":");
-          if (parts.length > 2) {
+          const parts = key.split(/:(.*)/s);
+          if (parts.length != 3) {
             throw new Error(`Invalid output key ${key}.`);
           }
 
           const artifact = {
-            section: parts.length > 1 ? parts[0] : "",
-            name: parts.length > 1 ? parts[1] : parts[0],
+            section: parts[0],
+            name: parts[1],
             url: result.outputs[key],
           };
           const list = artifactLists.find(

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -293,7 +293,7 @@ function Preview() {
   // TODO(tjennison): Look at supporting a "true" filter instead.
   const cohortFilter: Filter = {
     type: FilterType.Attribute,
-    attribute: underlaySource.lookupOccurrence("").key,
+    attribute: underlaySource.primaryEntity().idAttribute,
     ranges: [{ min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER }],
   };
 

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -209,7 +209,7 @@ function ParticipantsGroupSection(props: {
       groupSections: [props.groupSection],
     };
 
-    const filter = generateCohortFilter(cohortForFilter);
+    const filter = generateCohortFilter(underlaySource, cohortForFilter);
     return (await underlaySource.filterCount(filter))[0].count;
   }, [cohort.underlayName, props.sectionIndex, props.groupSection]);
 
@@ -421,7 +421,7 @@ function ParticipantsGroup(props: {
       ],
     };
 
-    const filter = generateCohortFilter(cohortForFilter);
+    const filter = generateCohortFilter(underlaySource, cohortForFilter);
     return (await underlaySource.filterCount(filter))[0].count;
   }, [cohort.underlayName, props.group]);
 
@@ -447,9 +447,13 @@ function ParticipantsGroup(props: {
   const modifierPlugins = useMemo(
     () =>
       modifierCriteria.map((c) => {
-        // TODO: Multiple occurrence: Store entities in an array instead of a
-        // string.
-        const p = getCriteriaPlugin(c, props.group.entity.split(",")[0]);
+        // TODO: Multiple occurrence: This assumes modifiers can apply to all
+        // occurrence entities. There's no way around this without rethinking
+        // how modifiers work.
+        const p = getCriteriaPlugin(
+          c,
+          plugin.filterEntityIds(underlaySource)[0]
+        );
         return { title: getCriteriaTitle(c, p), plugin: p };
       }),
     [modifierCriteria, props.group.entity]

--- a/ui/src/plugins/vumc/biovu.tsx
+++ b/ui/src/plugins/vumc/biovu.tsx
@@ -173,7 +173,7 @@ class _ implements CriteriaPlugin<Data> {
     return makeArrayFilter({}, filters);
   }
 
-  filterOccurrenceIds() {
+  filterEntityIds() {
     return [""];
   }
 }

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -1,27 +1,26 @@
 import { TreeGridColumn } from "components/treegrid";
-import { Configuration } from "data/configuration";
 import { Filter } from "data/filter";
-import * as tanagra from "tanagra-api";
+import * as underlayConfig from "tanagra-underlay/underlayConfig";
 
 export type PrepackagedConceptSet = {
   id: string;
   name: string;
   category?: string;
   tags?: string[];
-  occurrence: string;
+  entity: string;
   filter?: Filter;
 };
 
 export type Underlay = {
   name: string;
-  displayName: string;
-  primaryEntity: string;
-  entities: tanagra.Entity[];
   uiConfiguration: UIConfiguration;
+  underlayConfig: underlayConfig.SZUnderlay;
+  criteriaOccurrences: underlayConfig.SZCriteriaOccurrence[];
+  groupItems: underlayConfig.SZGroupItems[];
+  entities: underlayConfig.SZEntity[];
 };
 
 export type UIConfiguration = {
-  dataConfig: Configuration;
   criteriaConfigs: CriteriaConfig[];
   modifierConfigs: CriteriaConfig[];
   demographicChartConfigs: DemographicChartConfig;

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -1,415 +1,7 @@
 {
-  "dataConfig": {
-    "primaryEntity": {
-      "displayName": "Person",
-      "entity": "person",
-      "key": "id",
-      "classifications": [
-      ]
-    },
-    "occurrences": [
-      {
-        "id": "condition_occurrence",
-        "displayName": "Condition Occurrences",
-        "entity": "conditionOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "condition",
-            "attribute": "condition",
-            "entity": "condition",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy": "default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "condition_non_hierarchy",
-            "attribute": "condition_concept_id",
-            "entity": "conditionNonHierarchy",
-            "entityAttribute": "id"
-          }
-        ]
-      },
-      {
-        "id": "procedure_occurrence",
-        "displayName": "Procedure Occurrences",
-        "entity": "procedureOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "procedure",
-            "attribute": "procedure",
-            "entity": "procedure",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy": "default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd9proc",
-            "attribute": "source_criteria_id",
-            "entity": "icd9proc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10pcs",
-            "attribute": "source_criteria_id",
-            "entity": "icd10pcs",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "procedure_non_hierarchy",
-            "attribute": "procedure_concept_id",
-            "entity": "procedureNonHierarchy",
-            "entityAttribute": "id"
-          }
-        ]
-      },
-      {
-        "id": "observation_occurrence",
-        "displayName": "Observation Occurrence",
-        "entity": "observationOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "observation",
-            "attribute": "observation",
-            "entity": "observation",
-            "entityAttribute": "id",
-            "defaultSort": {
-              "attribute": "t_item_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy":"default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "ingredient_occurrence",
-        "displayName": "Drug Occurrence",
-        "entity": "ingredientOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "ingredient",
-            "attribute": "id",
-            "entity": "ingredient",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "concept_code",
-              "direction": "ASC"
-            },
-            "groupings": [
-              {
-                "id": "brand",
-                "entity": "brand",
-                "defaultSort": {
-                  "attribute": "name",
-                  "direction": "ASC"
-                },
-                "attributes": ["name", "id", "standard_concept", "concept_code"]
-              }
-            ]
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "ingredient_non_hierarchy",
-            "attribute": "drug_concept_id",
-            "entity": "ingredientNonHierarchy",
-            "entityAttribute": "id"
-          }
-        ]
-      },
-      {
-        "id": "measurement_occurrence",
-        "displayName": "Measurement Occurrence",
-        "entity": "measurementOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "measurement_non_hierarchy",
-            "attribute": "measurement_concept_id",
-            "entity": "measurementNonHierarchy",
-            "entityAttribute": "id"
-          },
-          {
-            "id": "loinc",
-            "attribute": "measurement_concept_id",
-            "entity": "measurementLoinc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "snomed",
-            "attribute": "measurement_concept_id",
-            "entity": "measurementSnomed",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy": "default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd9proc",
-            "attribute": "source_criteria_id",
-            "entity": "icd9proc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10pcs",
-            "attribute": "source_criteria_id",
-            "entity": "icd10pcs",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "visit_occurrence",
-        "displayName": "Visit Occurrence",
-        "entity": "visitOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "visit",
-            "attribute": "name",
-            "entity": "visit",
-            "entityAttribute": "name"
-          }
-        ]
-      },
-      {
-        "id": "device_occurrence",
-        "displayName": "Device Occurrence",
-        "entity": "deviceOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "device",
-            "attribute": "name",
-            "entity": "device",
-            "entityAttribute": "name"
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "t_fitbit_activity_summary_id",
-        "displayName": "Fitbit Activity Summary",
-        "entity": "activitySummary",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_steps_intraday_id",
-        "displayName": "Fitbit Steps Intraday",
-        "entity": "stepsIntraday",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_heart_rate_summary_id",
-        "displayName": "Fitbit Heart Rate Summary",
-        "entity": "heartRateSummary",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_heart_rate_level_id",
-        "displayName": "Fitbit Heart Rate Level",
-        "entity": "heartRateLevel",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_sleep_daily_summary_id",
-        "displayName": "Fitbit Sleep Daily Summary",
-        "entity": "sleepDailySummary",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_sleep_level_id",
-        "displayName": "Fitbit Sleep Level",
-        "entity": "sleepLevel",
-        "key": "person_id"
-      },
-      {
-        "id": "t_zipcode_socioeconomic_id",
-        "displayName": "Zip Code Socioeconomic Status Data",
-        "entity": "zipcodeSocioeconomic",
-        "key": "id"
-      }
-    ]
-  },
   "criteriaConfigs": [
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-conditions",
       "title": "Condition",
       "conceptSet": true,
@@ -429,8 +21,18 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": "condition_occurrence",
-      "classifications": ["condition", "condition_non_hierarchy"],
+      "classificationEntityGroups": [
+        {
+          "id": "conditionPerson",
+          "defaultSort": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "conditionNonHierarchyPerson"
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -438,7 +40,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-procedures",
       "title": "Procedure",
       "conceptSet": true,
@@ -458,12 +60,26 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": "procedure_occurrence",
-      "classifications": ["procedure", "procedure_non_hierarchy"],
+      "classificationEntityGroups": [
+        {
+          "id": "procedurePerson",
+          "defaultSort": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "procedureNonHierarchyPerson"
+        }
+     ],
+      "defaultSort": {
+        "attribute": "t_item_count",
+        "direction": "DESC"
+      },
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-observations",
       "title": "Observation",
       "conceptSet": true,
@@ -477,8 +93,14 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
-      "occurrences": "observation_occurrence",
-      "classifications": ["observation"],
+      "classificationEntityGroups": [
+        {
+          "id": "observationPerson"
+        },
+        {
+          "id": "observationNonHierarchyPerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {
@@ -488,7 +110,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-drugs",
       "title": "Drug",
       "conceptSet": true,
@@ -508,8 +130,27 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": "ingredient_occurrence",
-      "classifications": ["ingredient", "ingredient_non_hierarchy"],
+      "classificationEntityGroups": [
+        {
+          "id": "ingredientPerson",
+          "defaultSort": {
+            "attribute": "concept_code",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "ingredientNonHierarchyPerson"
+        }
+      ],
+      "groupingEntityGroups": [
+        {
+          "id": "brandIngredient",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -517,7 +158,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-measurement",
       "title": "Labs and Measurements",
       "conceptSet": true,
@@ -537,12 +178,25 @@
         { "key": "id", "width": 220, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 220, "title": "Roll-up count" }
       ],
-      "occurrences": "measurement_occurrence",
-      "classifications": ["measurement_non_hierarchy", "loinc", "snomed"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "measurementLoincPerson",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "measurementSnomedPerson",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "measurementNonHierarchyPerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {
@@ -556,7 +210,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-visits",
       "title": "Visit",
       "conceptSet": true,
@@ -567,8 +221,11 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
-      "occurrences": "visit_occurrence",
-      "classifications": ["visit"],
+      "classificationEntityGroups": [
+        {
+          "id": "visitPerson"
+        }
+      ],
       "defaultSort": {
         "attribute": "name",
         "direction": "ASC"
@@ -579,7 +236,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-devices",
       "title": "Devices",
       "conceptSet": true,
@@ -593,8 +250,11 @@
         { "key": "concept_code", "width": 120, "title": "Concept Code" },
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
-      "occurrences": "device_occurrence",
-      "classifications": ["device"],
+      "classificationEntityGroups": [
+        {
+          "id": "devicePerson"
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -609,7 +269,7 @@
       "attribute": "has_ehr_data"
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-cpt4",
       "title": "CPT-4",
       "conceptSet": true,
@@ -629,18 +289,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence",
-        "ingredient_occurrence",
-        "device_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "cpt4Person",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["cpt4"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -648,7 +305,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd9cm",
       "title": "ICD-9-CM",
       "conceptSet": true,
@@ -668,17 +325,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "icd9cmPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["icd9cm"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -686,7 +341,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd9proc",
       "title": "ICD-9-Proc",
       "conceptSet": true,
@@ -706,12 +361,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": ["procedure_occurrence"],
-      "classifications": ["icd9proc"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "icd9procPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -719,7 +377,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd10cm",
       "title": "ICD-10-CM",
       "conceptSet": true,
@@ -739,17 +397,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "icd10cmPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["icd10cm"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -757,7 +413,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd10pcs",
       "title": "ICD-10-PCS",
       "conceptSet": true,
@@ -777,12 +433,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": ["procedure_occurrence", "ingredient_occurrence"],
-      "classifications": ["icd10pcs"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "icd10pcsPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -977,42 +636,42 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "entity": ""
     },
     {
       "id": "_fitbit_actvity_summary_id",
       "name": "Fitbit Activity Summary",
-      "occurrence": "t_fitbit_activity_summary_id"
+      "entity": "activitySummary"
     },
     {
       "id": "_fitbit_steps_intraday_id",
       "name": "Fitbit Steps Intraday",
-      "occurrence": "t_fitbit_steps_intraday_id"
+      "entity": "stepsIntraday"
     },
     {
       "id": "_fitbit_heart_rate_summary_id",
       "name": "Fitbit Heart Rate Summary",
-      "occurrence": "t_fitbit_heart_rate_summary_id"
+      "entity": "heartRateSummary"
     },
     {
       "id": "_fitbit_heart_rate_level_id",
       "name": "Fitbit Heart Rate Level",
-      "occurrence": "t_fitbit_heart_rate_level_id"
+      "entity": "heartRateLevel"
     },
     {
       "id": "_fitbit_sleep_daily_summary_id",
       "name": "Fitbit Sleep Daily Summary",
-      "occurrence": "t_fitbit_sleep_daily_summary_id"
+      "entity": "sleepDailySummary"
     },
     {
       "id": "_fitbit_sleep_level_id",
       "name": "Fitbit Sleep Level",
-      "occurrence": "t_fitbit_sleep_level_id"
+      "entity": "sleepLevel"
     },
     {
       "id": "_zipcode_socioeconomic_id",
       "name": "Zip Code Socioeconomic Status Data",
-      "occurrence": "t_zipcode_socioeconomic_id"
+      "entity": "zipcodeSocioeconomic"
     }
   ],
   "criteriaSearchConfig": {
@@ -1052,11 +711,11 @@
     ],
     "pages": [
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "condition",
         "title": "Conditions",
         "plugin": {
-          "occurrence": "condition_occurrence",
+          "entity": "conditionOccurrence",
           "columns": [
             { "key": "condition", "width": "100%", "title": "Condition name" },
             { "key": "start_date", "width": 200, "title": "Start date" },
@@ -1065,11 +724,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "entity": "procedureOccurrence",
           "columns": [
             { "key": "procedure", "width": "100%", "title": "Procedure name" },
             { "key": "date", "width": 200, "title": "Date" }
@@ -1077,11 +736,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "observation",
         "title": "Observations",
         "plugin": {
-          "occurrence": "observation_occurrence",
+          "entity": "observationOccurrence",
           "columns": [
             {
               "key": "observation",
@@ -1093,11 +752,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "ingredient",
         "title": "Drugs",
         "plugin": {
-          "occurrence": "ingredient_occurrence",
+          "entity": "ingredientOccurrence",
           "columns": [
             { "key": "ingredient", "width": "100%", "title": "Drug name" },
             { "key": "start_date", "width": 200, "title": "Start date" },
@@ -1106,11 +765,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "measurements",
         "title": "Labs and measurements",
         "plugin": {
-          "occurrence": "measurement_occurrence",
+          "entity": "measurementOccurrence",
           "columns": [
             {
               "key": "measurement",

--- a/underlay/src/main/resources/config/underlay/aouSR2019q4r4/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2019q4r4/ui.json
@@ -1,102 +1,7 @@
 {
-  "dataConfig": {
-    "primaryEntity": {
-      "displayName": "Person",
-      "entity": "person",
-      "key": "id"
-    },
-    "occurrences": [
-      {
-        "id": "condition_occurrence",
-        "displayName": "Condition Occurrences",
-        "entity": "conditionOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "condition",
-            "attribute": "condition",
-            "entity": "condition",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "procedure_occurrence",
-        "displayName": "Procedure Occurrences",
-        "entity": "procedureOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "procedure",
-            "attribute": "procedure",
-            "entity": "procedure",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "observation_occurrence",
-        "displayName": "Observation Occurrence",
-        "entity": "observationOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "observation",
-            "attribute": "observation",
-            "entity": "observation",
-            "entityAttribute": "id",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "ingredient_occurrence",
-        "displayName": "Drug Occurrence",
-        "entity": "ingredientOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "ingredient",
-            "attribute": "id",
-            "entity": "ingredient",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            },
-            "groupings": [
-              {
-                "id": "brand",
-                "entity": "brand",
-                "defaultSort": {
-                  "attribute": "name",
-                  "direction": "ASC"
-                },
-                "attributes": ["name", "id", "standard_concept", "concept_code"]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
   "criteriaConfigs": [
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-conditions",
       "title": "Condition",
       "conceptSet": true,
@@ -114,11 +19,14 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "condition_occurrence",
-      "classifications": ["condition"]
+      "classificationEntityGroups": [
+        {
+          "id": "conditionPerson"
+        }
+      ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-procedures",
       "title": "Procedure",
       "conceptSet": true,
@@ -136,11 +44,14 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "procedure_occurrence",
-      "classifications": ["procedure"]
+      "classificationEntityGroups": [
+        {
+          "id": "procedurePerson"
+        }
+      ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-observations",
       "title": "Observation",
       "conceptSet": true,
@@ -153,11 +64,14 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "observation_occurrence",
-      "classifications": ["observation"]
+      "classificationEntityGroups": [
+        {
+          "id": "observationPerson"
+        }
+      ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-drugs",
       "title": "Drug",
       "conceptSet": true,
@@ -175,8 +89,20 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "ingredient_occurrence",
-      "classifications": ["ingredient"]
+      "classificationEntityGroups": [
+        {
+          "id": "ingredientPerson"
+        }
+      ],
+      "groupingEntityGroups": [
+        {
+          "id": "brandIngredient",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        }
+      ]
     },
     {
       "type": "attribute",
@@ -253,7 +179,7 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrences": ""
+      "entity": ""
     }
   ],
   "criteriaSearchConfig": {
@@ -293,11 +219,11 @@
     ],
     "pages": [
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "condition",
         "title": "Conditions",
         "plugin": {
-          "occurrence": "condition_occurrence",
+          "entity": "conditionOccurrence",
           "columns": [
             { "key": "condition", "width": "100%", "title": "Condition name", "sortable": true },
             { "key": "start_date", "width": 200, "title": "Start date", "sortable": true },
@@ -306,11 +232,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "entity": "procedureOccurrence",
           "columns": [
             { "key": "procedure", "width": "100%", "title": "Procedure name", "sortable": true },
             { "key": "date", "width": 200, "title": "Date", "sortable": true }
@@ -318,11 +244,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "observation",
         "title": "Observations",
         "plugin": {
-          "occurrence": "observation_occurrence",
+          "entity": "observationOccurrence",
           "columns": [
             {
               "key": "observation",
@@ -335,11 +261,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "ingredient",
         "title": "Drugs",
         "plugin": {
-          "occurrence": "ingredient_occurrence",
+          "entity": "ingredientOccurrence",
           "columns": [
             { "key": "ingredient", "width": "100%", "title": "Drug name", "sortable": true },
             { "key": "start_date", "width": 200, "title": "Start date", "sortable": true },

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -1,409 +1,7 @@
 {
-  "dataConfig": {
-    "primaryEntity": {
-      "displayName": "Person",
-      "entity": "person",
-      "key": "id",
-      "classifications": [
-      ]
-    },
-    "occurrences": [
-      {
-        "id": "condition_occurrence",
-        "displayName": "Condition Occurrences",
-        "entity": "conditionOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "condition",
-            "attribute": "condition",
-            "entity": "condition",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy": "default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "condition_non_hierarchy",
-            "attribute": "condition_concept_id",
-            "entity": "conditionNonHierarchy",
-            "entityAttribute": "id"
-          }
-        ]
-      },
-      {
-        "id": "procedure_occurrence",
-        "displayName": "Procedure Occurrences",
-        "entity": "procedureOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "procedure",
-            "attribute": "procedure",
-            "entity": "procedure",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy": "default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd9proc",
-            "attribute": "source_criteria_id",
-            "entity": "icd9proc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10pcs",
-            "attribute": "source_criteria_id",
-            "entity": "icd10pcs",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "procedure_non_hierarchy",
-            "attribute": "procedure_concept_id",
-            "entity": "procedureNonHierarchy",
-            "entityAttribute": "id"
-          }
-        ]
-      },
-      {
-        "id": "observation_occurrence",
-        "displayName": "Observation Occurrence",
-        "entity": "observationOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "observation",
-            "attribute": "observation",
-            "entity": "observation",
-            "entityAttribute": "id",
-            "defaultSort": {
-              "attribute": "t_item_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy":"default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "ingredient_occurrence",
-        "displayName": "Drug Occurrence",
-        "entity": "ingredientOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "ingredient",
-            "attribute": "id",
-            "entity": "ingredient",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "concept_code",
-              "direction": "ASC"
-            },
-            "groupings": [
-              {
-                "id": "brand",
-                "entity": "brand",
-                "defaultSort": {
-                  "attribute": "name",
-                  "direction": "ASC"
-                },
-                "attributes": ["name", "id", "standard_concept", "concept_code"]
-              }
-            ]
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "ingredient_non_hierarchy",
-            "attribute": "drug_concept_id",
-            "entity": "ingredientNonHierarchy",
-            "entityAttribute": "id"
-          }
-        ]
-      },
-      {
-        "id": "measurement_occurrence",
-        "displayName": "Measurement Occurrence",
-        "entity": "measurementOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "measurement_non_hierarchy",
-            "attribute": "measurement_concept_id",
-            "entity": "measurementNonHierarchy",
-            "entityAttribute": "id"
-          },
-          {
-            "id": "loinc",
-            "attribute": "measurement_concept_id",
-            "entity": "measurementLoinc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "snomed",
-            "attribute": "measurement_concept_id",
-            "entity": "measurementSnomed",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "name",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id":"icd9cm",
-            "attribute":"source_criteria_id",
-            "entity":"icd9cm",
-            "entityAttribute":"id",
-            "hierarchy": "default",
-            "defaultSort":{
-              "attribute":"label",
-              "direction":"ASC"
-            }
-          },
-          {
-            "id": "icd9proc",
-            "attribute": "source_criteria_id",
-            "entity": "icd9proc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10pcs",
-            "attribute": "source_criteria_id",
-            "entity": "icd10pcs",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "visit_occurrence",
-        "displayName": "Visit Occurrence",
-        "entity": "visitOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "visit",
-            "attribute": "name",
-            "entity": "visit",
-            "entityAttribute": "name"
-          }
-        ]
-      },
-      {
-        "id": "device_occurrence",
-        "displayName": "Device Occurrence",
-        "entity": "deviceOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "device",
-            "attribute": "name",
-            "entity": "device",
-            "entityAttribute": "name"
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "t_fitbit_activity_summary_id",
-        "displayName": "Fitbit Activity Summary",
-        "entity": "activitySummary",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_steps_intraday_id",
-        "displayName": "Fitbit Steps Intraday",
-        "entity": "stepsIntraday",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_heart_rate_summary_id",
-        "displayName": "Fitbit Heart Rate Summary",
-        "entity": "heartRateSummary",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_heart_rate_level_id",
-        "displayName": "Fitbit Heart Rate Level",
-        "entity": "heartRateLevel",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_sleep_daily_summary_id",
-        "displayName": "Fitbit Sleep Daily Summary",
-        "entity": "sleepDailySummary",
-        "key": "person_id"
-      },
-      {
-        "id": "t_fitbit_sleep_level_id",
-        "displayName": "Fitbit Sleep Level",
-        "entity": "sleepLevel",
-        "key": "person_id"
-      }
-    ]
-  },
   "criteriaConfigs": [
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-conditions",
       "title": "Condition",
       "conceptSet": true,
@@ -423,8 +21,18 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": "condition_occurrence",
-      "classifications": ["condition", "condition_non_hierarchy"],
+      "classificationEntityGroups": [
+        {
+          "id": "conditionPerson",
+          "defaultSort": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "conditionNonHierarchyPerson"
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -432,7 +40,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-procedures",
       "title": "Procedure",
       "conceptSet": true,
@@ -452,12 +60,22 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": "procedure_occurrence",
-      "classifications": ["procedure", "procedure_non_hierarchy"],
+      "classificationEntityGroups": [
+        {
+          "id": "procedurePerson",
+          "defaultSort": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "procedureNonHierarchyPerson"
+        }
+     ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-observations",
       "title": "Observation",
       "conceptSet": true,
@@ -471,8 +89,18 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
-      "occurrences": "observation_occurrence",
-      "classifications": ["observation"],
+      "classificationEntityGroups": [
+        {
+          "id": "observationPerson"
+        },
+        {
+          "id": "observationNonHierarchyPerson"
+        }
+     ],
+      "defaultSort": {
+        "attribute": "t_item_count",
+        "direction": "DESC"
+      },
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {
@@ -482,7 +110,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-drugs",
       "title": "Drug",
       "conceptSet": true,
@@ -502,8 +130,27 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": "ingredient_occurrence",
-      "classifications": ["ingredient", "ingredient_non_hierarchy"],
+      "classificationEntityGroups": [
+        {
+          "id": "ingredientPerson",
+          "defaultSort": {
+            "attribute": "concept_code",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "ingredientNonHierarchyPerson"
+        }
+      ],
+      "groupingEntityGroups": [
+        {
+          "id": "brandIngredient",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -511,7 +158,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-measurement",
       "title": "Labs and Measurements",
       "conceptSet": true,
@@ -531,12 +178,25 @@
         { "key": "id", "width": 220, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 220, "title": "Roll-up count" }
       ],
-      "occurrences": "measurement_occurrence",
-      "classifications": ["measurement_non_hierarchy", "loinc", "snomed"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "measurementLoincPerson",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "measurementSnomedPerson",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        },
+        {
+          "id": "measurementNonHierarchyPerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {
@@ -550,7 +210,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-visits",
       "title": "Visit",
       "conceptSet": true,
@@ -561,8 +221,11 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
-      "occurrences": "visit_occurrence",
-      "classifications": ["visit"],
+      "classificationEntityGroups": [
+        {
+          "id": "visitPerson"
+        }
+      ],
       "defaultSort": {
         "attribute": "name",
         "direction": "ASC"
@@ -573,7 +236,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-devices",
       "title": "Devices",
       "conceptSet": true,
@@ -587,8 +250,11 @@
         { "key": "concept_code", "width": 120, "title": "Concept Code" },
         { "key": "t_item_count", "width": 120, "title": "Item count" }
       ],
-      "occurrences": "device_occurrence",
-      "classifications": ["device"],
+      "classificationEntityGroups": [
+        {
+          "id": "devicePerson"
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -603,7 +269,7 @@
       "attribute": "has_ehr_data"
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-cpt4",
       "title": "CPT-4",
       "conceptSet": true,
@@ -623,18 +289,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence",
-        "ingredient_occurrence",
-        "device_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "cpt4Person",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["cpt4"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -642,7 +305,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd9cm",
       "title": "ICD-9-CM",
       "conceptSet": true,
@@ -662,17 +325,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "icd9cmPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["icd9cm"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -680,7 +341,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd9proc",
       "title": "ICD-9-Proc",
       "conceptSet": true,
@@ -700,12 +361,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": ["procedure_occurrence"],
-      "classifications": ["icd9proc"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "icd9procPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -713,7 +377,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd10cm",
       "title": "ICD-10-CM",
       "conceptSet": true,
@@ -733,17 +397,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "icd10cmPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["icd10cm"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -751,7 +413,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd10pcs",
       "title": "ICD-10-PCS",
       "conceptSet": true,
@@ -771,12 +433,15 @@
         { "key": "name", "width": "60%", "title": "Concept Name" },
         { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
       ],
-      "occurrences": ["procedure_occurrence", "ingredient_occurrence"],
-      "classifications": ["icd10pcs"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "icd10pcsPerson",
+          "defaultSort": {
+            "attribute": "label",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -943,37 +608,37 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrence": ""
+      "entity": ""
     },
     {
       "id": "_fitbit_actvity_summary_id",
       "name": "Fitbit Activity Summary",
-      "occurrence": "t_fitbit_activity_summary_id"
+      "entity": "activitySummary"
     },
     {
       "id": "_fitbit_steps_intraday_id",
       "name": "Fitbit Steps Intraday",
-      "occurrence": "t_fitbit_steps_intraday_id"
+      "entity": "stepsIntraday"
     },
     {
       "id": "_fitbit_heart_rate_summary_id",
       "name": "Fitbit Heart Rate Summary",
-      "occurrence": "t_fitbit_heart_rate_summary_id"
+      "entity": "heartRateSummary"
     },
     {
       "id": "_fitbit_heart_rate_level_id",
       "name": "Fitbit Heart Rate Level",
-      "occurrence": "t_fitbit_heart_rate_level_id"
+      "entity": "heartRateLevel"
     },
     {
       "id": "_fitbit_sleep_daily_summary_id",
       "name": "Fitbit Sleep Daily Summary",
-      "occurrence": "t_fitbit_sleep_daily_summary_id"
+      "entity": "sleepDailySummary"
     },
     {
       "id": "_fitbit_sleep_level_id",
       "name": "Fitbit Sleep Level",
-      "occurrence": "t_fitbit_sleep_level_id"
+      "entity": "sleepLevel"
     }
   ],
   "criteriaSearchConfig": {
@@ -1013,11 +678,11 @@
     ],
     "pages": [
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "condition",
         "title": "Conditions",
         "plugin": {
-          "occurrence": "condition_occurrence",
+          "entity": "conditionOccurrence",
           "columns": [
             { "key": "condition", "width": "100%", "title": "Condition name" },
             { "key": "start_date", "width": 200, "title": "Start date" },
@@ -1026,11 +691,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "entity": "procedureOccurrence",
           "columns": [
             { "key": "procedure", "width": "100%", "title": "Procedure name" },
             { "key": "date", "width": 200, "title": "Date" }
@@ -1038,11 +703,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "observation",
         "title": "Observations",
         "plugin": {
-          "occurrence": "observation_occurrence",
+          "entity": "observationOccurrence",
           "columns": [
             {
               "key": "observation",
@@ -1054,11 +719,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "ingredient",
         "title": "Drugs",
         "plugin": {
-          "occurrence": "ingredient_occurrence",
+          "entity": "ingredientOccurrence",
           "columns": [
             { "key": "ingredient", "width": "100%", "title": "Drug name" },
             { "key": "start_date", "width": 200, "title": "Start date" },
@@ -1067,11 +732,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "measurements",
         "title": "Labs and measurements",
         "plugin": {
-          "occurrence": "measurement_occurrence",
+          "entity": "measurementOccurrence",
           "columns": [
             {
               "key": "measurement",

--- a/underlay/src/main/resources/config/underlay/cmssynpuf/ui.json
+++ b/underlay/src/main/resources/config/underlay/cmssynpuf/ui.json
@@ -1,102 +1,7 @@
 {
-  "dataConfig": {
-    "primaryEntity": {
-      "displayName": "Person",
-      "entity": "person",
-      "key": "id"
-    },
-    "occurrences": [
-      {
-        "id": "condition_occurrence",
-        "displayName": "Condition Occurrences",
-        "entity": "conditionOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "condition",
-            "attribute": "condition",
-            "entity": "condition",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "procedure_occurrence",
-        "displayName": "Procedure Occurrences",
-        "entity": "procedureOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "procedure",
-            "attribute": "procedure",
-            "entity": "procedure",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "observation_occurrence",
-        "displayName": "Observation Occurrence",
-        "entity": "observationOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "observation",
-            "attribute": "observation",
-            "entity": "observation",
-            "entityAttribute": "id",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "ingredient_occurrence",
-        "displayName": "Drug Occurrence",
-        "entity": "ingredientOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "ingredient",
-            "attribute": "id",
-            "entity": "ingredient",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            },
-            "groupings": [
-              {
-                "id": "brand",
-                "entity": "brand",
-                "defaultSort": {
-                  "attribute": "name",
-                  "direction": "ASC"
-                },
-                "attributes": ["name", "id", "standard_concept", "concept_code"]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
   "criteriaConfigs": [
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-conditions",
       "title": "Condition",
       "conceptSet": true,
@@ -114,15 +19,18 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "condition_occurrence",
-      "classifications": ["condition"],
+      "classificationEntityGroups": [
+        {
+          "id": "conditionPerson"
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "start_date_group_by_count"
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-procedures",
       "title": "Procedure",
       "conceptSet": true,
@@ -140,12 +48,15 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "procedure_occurrence",
-      "classifications": ["procedure"],
+      "classificationEntityGroups": [
+        {
+          "id": "procedurePerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-observations",
       "title": "Observation",
       "conceptSet": true,
@@ -158,12 +69,15 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "observation_occurrence",
-      "classifications": ["observation"],
+      "classificationEntityGroups": [
+        {
+          "id": "observationPerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "date_group_by_count"]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-drugs",
       "title": "Drug",
       "conceptSet": true,
@@ -181,8 +95,20 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "ingredient_occurrence",
-      "classifications": ["ingredient"],
+      "classificationEntityGroups": [
+        {
+          "id": "ingredientPerson"
+        }
+      ],
+      "groupingEntityGroups": [
+        {
+          "id": "brandIngredient",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "start_date_group_by_count"
@@ -215,13 +141,6 @@
       "title": "Age",
       "category": "Program data",
       "attribute": "age"
-    },
-    {
-      "type": "attribute",
-      "id": "tanagra-sex_at_birth",
-      "title": "Sex assigned at birth",
-      "category": "Program data",
-      "attribute": "sex_at_birth"
     }
   ],
   "modifierConfigs": [
@@ -245,46 +164,47 @@
       "title": "Age at occurrence",
       "attribute": "age_at_occurrence"
     }
-  ],  "demographicChartConfigs": {
-  "groupByAttributes": ["gender", "race", "age"],
-  "chartConfigs": [
-    {
-      "title": "Gender identity",
-      "primaryProperties": [{ "key": "gender" }]
-    },
-    {
-      "title": "Gender identity, Current age, Race",
-      "primaryProperties": [
-        { "key": "gender" },
-        {
-          "key": "age",
-          "buckets": [
-            {
-              "min": 18,
-              "max": 45,
-              "displayName": "18-44"
-            },
-            {
-              "min": 45,
-              "max": 65,
-              "displayName": "45-64"
-            },
-            {
-              "min": 65,
-              "displayName": "65+"
-            }
-          ]
-        }
-      ],
-      "stackedProperty": { "key": "race" }
-    }
-  ]
-},
+  ],
+  "demographicChartConfigs": {
+    "groupByAttributes": ["gender", "race", "age"],
+    "chartConfigs": [
+      {
+        "title": "Gender identity",
+        "primaryProperties": [{ "key": "gender" }]
+      },
+      {
+        "title": "Gender identity, Current age, Race",
+        "primaryProperties": [
+          { "key": "gender" },
+          {
+            "key": "age",
+            "buckets": [
+              {
+                "min": 18,
+                "max": 45,
+                "displayName": "18-44"
+              },
+              {
+                "min": 45,
+                "max": 65,
+                "displayName": "45-64"
+              },
+              {
+                "min": 65,
+                "displayName": "65+"
+              }
+            ]
+          }
+        ],
+        "stackedProperty": { "key": "race" }
+      }
+    ]
+  },
   "prepackagedConceptSets": [
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrences": ""
+      "entity": ""
     }
   ],
   "criteriaSearchConfig": {
@@ -324,11 +244,11 @@
     ],
     "pages": [
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "condition",
         "title": "Conditions",
         "plugin": {
-          "occurrence": "condition_occurrence",
+          "entity": "conditionOccurrence",
           "columns": [
             { "key": "condition", "width": "100%", "title": "Condition name", "sortable": true },
             { "key": "start_date", "width": 200, "title": "Start date", "sortable": true },
@@ -337,11 +257,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "entity": "procedureOccurrence",
           "columns": [
             { "key": "procedure", "width": "100%", "title": "Procedure name", "sortable": true },
             { "key": "date", "width": 200, "title": "Date", "sortable": true }
@@ -349,11 +269,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "observation",
         "title": "Observations",
         "plugin": {
-          "occurrence": "observation_occurrence",
+          "entity": "observationOccurrence",
           "columns": [
             {
               "key": "observation",
@@ -366,11 +286,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "ingredient",
         "title": "Drugs",
         "plugin": {
-          "occurrence": "ingredient_occurrence",
+          "entity": "ingredientOccurrence",
           "columns": [
             { "key": "ingredient", "width": "100%", "title": "Drug name", "sortable": true },
             { "key": "start_date", "width": 200, "title": "Start date", "sortable": true },

--- a/underlay/src/main/resources/config/underlay/pilotsynthea2022q3/ui.json
+++ b/underlay/src/main/resources/config/underlay/pilotsynthea2022q3/ui.json
@@ -1,102 +1,7 @@
 {
-  "dataConfig": {
-    "primaryEntity": {
-      "displayName": "Person",
-      "entity": "person",
-      "key": "id"
-    },
-    "occurrences": [
-      {
-        "id": "condition_occurrence",
-        "displayName": "Condition Occurrences",
-        "entity": "conditionOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "condition",
-            "attribute": "condition",
-            "entity": "condition",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "procedure_occurrence",
-        "displayName": "Procedure Occurrences",
-        "entity": "procedureOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "procedure",
-            "attribute": "procedure",
-            "entity": "procedure",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "observation_occurrence",
-        "displayName": "Observation Occurrence",
-        "entity": "observationOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "observation",
-            "attribute": "observation",
-            "entity": "observation",
-            "entityAttribute": "id",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "ingredient_occurrence",
-        "displayName": "Drug Occurrence",
-        "entity": "ingredientOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "ingredient",
-            "attribute": "id",
-            "entity": "ingredient",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            },
-            "groupings": [
-              {
-                "id": "brand",
-                "entity": "brand",
-                "defaultSort": {
-                  "attribute": "name",
-                  "direction": "ASC"
-                },
-                "attributes": ["name", "id", "standard_concept", "concept_code"]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
   "criteriaConfigs": [
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-conditions",
       "title": "Condition",
       "conceptSet": true,
@@ -114,11 +19,14 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "condition_occurrence",
-      "classifications": ["condition"]
+      "classificationEntityGroups": [
+        {
+          "id": "conditionPerson"
+        }
+      ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-procedures",
       "title": "Procedure",
       "conceptSet": true,
@@ -136,11 +44,14 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "procedure_occurrence",
-      "classifications": ["procedure"]
+      "classificationEntityGroups": [
+        {
+          "id": "procedurePerson"
+        }
+      ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-observations",
       "title": "Observation",
       "conceptSet": true,
@@ -153,11 +64,14 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "observation_occurrence",
-      "classifications": ["observation"]
+      "classificationEntityGroups": [
+        {
+          "id": "observationPerson"
+        }
+      ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-drugs",
       "title": "Drug",
       "conceptSet": true,
@@ -175,8 +89,20 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "ingredient_occurrence",
-      "classifications": ["ingredient"]
+      "classificationEntityGroups": [
+        {
+          "id": "ingredientPerson"
+        }
+      ],
+      "groupingEntityGroups": [
+        {
+          "id": "brandIngredient",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        }
+      ]
     },
     {
       "type": "attribute",
@@ -198,13 +124,6 @@
       "title": "Race",
       "category": "Program data",
       "attribute": "race"
-    },
-    {
-      "type": "attribute",
-      "id": "tanagra-sex_at_birth",
-      "title": "Sex assigned at birth",
-      "category": "Program data",
-      "attribute": "sex_at_birth"
     },
     {
       "type": "attribute",
@@ -253,7 +172,7 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrences": ""
+      "entity": ""
     }
   ],
   "criteriaSearchConfig": {
@@ -293,11 +212,11 @@
     ],
     "pages": [
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "condition",
         "title": "Conditions",
         "plugin": {
-          "occurrence": "condition_occurrence",
+          "entity": "conditionOccurrence",
           "columns": [
             { "key": "condition", "width": "100%", "title": "Condition name", "sortable": true },
             { "key": "start_date", "width": 200, "title": "Start date", "sortable": true },
@@ -306,11 +225,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "entity": "procedureOccurrence",
           "columns": [
             { "key": "procedure", "width": "100%", "title": "Procedure name", "sortable": true },
             { "key": "date", "width": 200, "title": "Date", "sortable": true }
@@ -318,11 +237,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "observation",
         "title": "Observations",
         "plugin": {
-          "occurrence": "observation_occurrence",
+          "entity": "observationOccurrence",
           "columns": [
             {
               "key": "observation",
@@ -335,11 +254,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "ingredient",
         "title": "Drugs",
         "plugin": {
-          "occurrence": "ingredient_occurrence",
+          "entity": "ingredientOccurrence",
           "columns": [
             { "key": "ingredient", "width": "100%", "title": "Drug name", "sortable": true },
             { "key": "start_date", "width": 200, "title": "Start date", "sortable": true },

--- a/underlay/src/main/resources/config/underlay/sd020230331/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd020230331/ui.json
@@ -1,417 +1,7 @@
 {
-  "dataConfig": {
-    "primaryEntity": {
-      "displayName": "Person",
-      "entity": "person",
-      "key": "id",
-      "classifications": [
-        {
-          "id": "snp",
-          "attribute": "id",
-          "entity": "snp",
-          "entityAttribute": "id",
-          "defaultSort": {
-            "attribute": "id",
-            "direction": "ASC"
-          }
-        },
-        {
-          "id": "genotyping",
-          "attribute": "id",
-          "entity": "genotyping",
-          "entityAttribute": "id",
-          "hierarchy": "default",
-          "defaultSort": {
-            "attribute": "name",
-            "direction": "ASC"
-          }
-        }
-      ]
-    },
-    "occurrences": [
-      {
-        "id": "condition_occurrence",
-        "displayName": "Condition Occurrences",
-        "entity": "conditionOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "condition",
-            "attribute": "condition",
-            "entity": "condition",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "phewas",
-            "attribute": "source_criteria_id",
-            "entity": "phewas",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "numeric_code",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd9cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd9cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "procedure_occurrence",
-        "displayName": "Procedure Occurrences",
-        "entity": "procedureOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "procedure",
-            "attribute": "procedure",
-            "entity": "procedure",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "phewas",
-            "attribute": "source_criteria_id",
-            "entity": "phewas",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "numeric_code",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd9cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd9cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd9proc",
-            "attribute": "source_criteria_id",
-            "entity": "icd9proc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10pcs",
-            "attribute": "source_criteria_id",
-            "entity": "icd10pcs",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "observation_occurrence",
-        "displayName": "Observation Occurrence",
-        "entity": "observationOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "observation",
-            "attribute": "observation",
-            "entity": "observation",
-            "entityAttribute": "id",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "phewas",
-            "attribute": "source_criteria_id",
-            "entity": "phewas",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "numeric_code",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd9cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd9cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "ingredient_occurrence",
-        "displayName": "Drug Occurrence",
-        "entity": "ingredientOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "ingredient",
-            "attribute": "id",
-            "entity": "ingredient",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_rollup_count",
-              "direction": "DESC"
-            },
-            "groupings": [
-              {
-                "id": "brand",
-                "entity": "brand",
-                "defaultSort": {
-                  "attribute": "name",
-                  "direction": "ASC"
-                },
-                "attributes": ["name", "id", "standard_concept", "concept_code"]
-              }
-            ]
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "note_occurrence",
-        "displayName": "Documents",
-        "entity": "noteOccurrence",
-        "key": "id"
-      },
-      {
-        "id": "measurement_occurrence",
-        "displayName": "Measurement Occurrence",
-        "entity": "measurementOccurrence",
-        "key": "id",
-        "classifications": [
-          {
-            "id": "loinc",
-            "attribute": "measurement",
-            "entity": "measurementLoinc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_item_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "snomed",
-            "attribute": "measurement",
-            "entity": "measurementSnomed",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "t_item_count",
-              "direction": "DESC"
-            }
-          },
-          {
-            "id": "cpt4",
-            "attribute": "source_criteria_id",
-            "entity": "cpt4",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "phewas",
-            "attribute": "source_criteria_id",
-            "entity": "phewas",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "numeric_code",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd9cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd9cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd9proc",
-            "attribute": "source_criteria_id",
-            "entity": "icd9proc",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10cm",
-            "attribute": "source_criteria_id",
-            "entity": "icd10cm",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          },
-          {
-            "id": "icd10pcs",
-            "attribute": "source_criteria_id",
-            "entity": "icd10pcs",
-            "entityAttribute": "id",
-            "hierarchy": "default",
-            "defaultSort": {
-              "attribute": "label",
-              "direction": "ASC"
-            }
-          }
-        ]
-      },
-      {
-        "id": "blood_pressure_occurrence",
-        "displayName": "Blood pressure",
-        "entity": "bloodPressure",
-        "key": "id"
-      },
-      {
-        "id": "bmi_occurrence",
-        "displayName": "BMI",
-        "entity": "bmi",
-        "key": "id"
-      },
-      {
-        "id": "weight_occurrence",
-        "displayName": "Weight",
-        "entity": "weight",
-        "key": "id"
-      },
-      {
-        "id": "height_occurrence",
-        "displayName": "Height",
-        "entity": "height",
-        "key": "id"
-      },
-      {
-        "id": "pulse_occurrence",
-        "displayName": "Pulse",
-        "entity": "pulse",
-        "key": "id"
-      },
-      {
-        "id": "resp_rate_occurrence",
-        "displayName": "Resp rate",
-        "entity": "respiratoryRate",
-        "key": "id"
-      }
-    ]
-  },
   "criteriaConfigs": [
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-genotyping",
       "title": "Genotyping platform",
       "category": "Demographics",
@@ -425,8 +15,11 @@
         { "key": "id", "width": 100, "title": "Id" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "",
-      "classifications": ["genotyping"],
+      "classificationEntityGroups": [
+        {
+          "id": "genotypingPerson"
+        }
+      ],
       "defaultSort": {
         "attribute": "t_rollup_count",
         "direction": "DESC"
@@ -461,7 +54,7 @@
       "attribute": "age"
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-snp",
       "title": "SNP variant",
       "category": "Demographics",
@@ -469,8 +62,15 @@
         { "key": "name", "width": "100%", "title": "SNP variant" },
         { "key": "t_item_count", "width": 120, "title": "Count" }
       ],
-      "occurrences": "",
-      "classifications": ["snp"]
+      "classificationEntityGroups": [
+        {
+          "id": "snpPerson"
+        }
+      ],
+      "defaultSort": {
+        "attribute": "id",
+        "direction": "ASC"
+      }
     },
     {
       "type": "biovu",
@@ -479,7 +79,7 @@
       "category": "BioVU"
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-measurement",
       "title": "Labs and measurements",
       "conceptSet": true,
@@ -497,8 +97,14 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "measurement_occurrence",
-      "classifications": ["loinc", "snomed"],
+      "classificationEntityGroups": [
+        {
+          "id": "measurementLoincPerson"
+        },
+        {
+          "id": "measurementSnomedPerson"
+        }
+      ],
       "defaultSort": {
         "attribute": "t_item_count",
         "direction": "DESC"
@@ -521,7 +127,7 @@
       "title": "Documents",
       "conceptSet": true,
       "category": "Domains",
-      "occurrenceId": "note_occurrence",
+      "entity": "noteOccurrence",
       "categoryAttribute": "note",
       "modifiers": [
         "age_at_occurrence",
@@ -530,7 +136,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-conditions",
       "title": "Condition",
       "conceptSet": true,
@@ -549,8 +155,11 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "condition_occurrence",
-      "classifications": ["condition"],
+      "classificationEntityGroups": [
+        {
+          "id": "conditionPerson"
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -558,7 +167,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-phewas",
       "title": "PheWAS",
       "conceptSet": true,
@@ -575,17 +184,15 @@
         { "key": "id", "width": 120, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "phewasPerson",
+          "defaultSort": {
+            "attribute": "numeric_code",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["phewas"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -594,7 +201,7 @@
       "limit": 1000
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-cpt4",
       "title": "CPT-4",
       "conceptSet": true,
@@ -613,17 +220,15 @@
         { "key": "id", "width": 120, "title": "ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence",
-        "ingredient_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "cpt4Person",
+          "defaultSort": {
+            "attribute": "numeric_code",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["cpt4"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -631,7 +236,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd9cm",
       "title": "ICD-9-CM",
       "conceptSet": true,
@@ -650,17 +255,15 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "icd9cmPerson",
+          "defaultSort": {
+            "attribute": "numeric_code",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["icd9cm"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -668,7 +271,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd9proc",
       "title": "ICD-9-Proc",
       "conceptSet": true,
@@ -687,12 +290,15 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": ["procedure_occurrence"],
-      "classifications": ["icd9proc"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "icd9procPerson",
+          "defaultSort": {
+            "attribute": "numeric_code",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -700,7 +306,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd10cm",
       "title": "ICD-10-CM",
       "conceptSet": true,
@@ -719,17 +325,15 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": [
-        "condition_occurrence",
-        "measurement_occurrence",
-        "observation_occurrence",
-        "procedure_occurrence"
+      "classificationEntityGroups": [
+        {
+          "id": "icd10cmPerson",
+          "defaultSort": {
+            "attribute": "numeric_code",
+            "direction": "ASC"
+          }
+        }
       ],
-      "classifications": ["icd10cm"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -737,7 +341,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-icd10pcs",
       "title": "ICD-10-PCS",
       "conceptSet": true,
@@ -756,12 +360,15 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": ["procedure_occurrence", "ingredient_occurrence"],
-      "classifications": ["icd10pcs"],
-      "defaultSort": {
-        "attribute": "t_rollup_count",
-        "direction": "DESC"
-      },
+      "classificationEntityGroups": [
+        {
+          "id": "icd10pcsPerson",
+          "defaultSort": {
+            "attribute": "numeric_code",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -769,7 +376,7 @@
       ]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-procedures",
       "title": "Procedure",
       "conceptSet": true,
@@ -788,12 +395,15 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "procedure_occurrence",
-      "classifications": ["procedure"],
+      "classificationEntityGroups": [
+        {
+          "id": "procedurePerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-observations",
       "title": "Observation",
       "conceptSet": true,
@@ -807,12 +417,15 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "observation_occurrence",
-      "classifications": ["observation"],
+      "classificationEntityGroups": [
+        {
+          "id": "observationPerson"
+        }
+      ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
-      "type": "classification",
+      "type": "entityGroup",
       "id": "tanagra-drugs",
       "title": "Drug",
       "conceptSet": true,
@@ -831,8 +444,20 @@
         { "key": "id", "width": 120, "title": "Concept ID" },
         { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
       ],
-      "occurrences": "ingredient_occurrence",
-      "classifications": ["ingredient"],
+      "classificationEntityGroups": [
+        {
+          "id": "ingredientPerson"
+        }
+      ],
+      "groupingEntityGroups": [
+        {
+          "id": "brandIngredient",
+          "sortOrder": {
+            "attribute": "name",
+            "direction": "ASC"
+          }
+        }
+      ],
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -844,7 +469,7 @@
       "id": "tanagra-bmi",
       "title": "BMI",
       "category": "Vitals",
-      "occurrence": "bmi_occurrence",
+      "entity": "bmi",
       "valueConfigs": [
         {
           "title": "Cleanliness",
@@ -862,7 +487,7 @@
       "id": "tanagra-blood-pressure",
       "title": "Blood pressure",
       "category": "Vitals",
-      "occurrence": "blood_pressure_occurrence",
+      "entity": "bloodPressure",
       "valueConfigs": [
         {
           "title": "Category",
@@ -883,7 +508,7 @@
       "id": "tanagra-height",
       "title": "Height",
       "category": "Vitals",
-      "occurrence": "height_occurrence",
+      "entity": "height",
       "valueConfigs": [
         {
           "title": "Cleanliness",
@@ -901,7 +526,7 @@
       "id": "tanagra-weight",
       "title": "Weight",
       "category": "Vitals",
-      "occurrence": "weight_occurrence",
+      "entity": "weight",
       "valueConfigs": [
         {
           "title": "Cleanliness",
@@ -919,7 +544,7 @@
       "id": "tanagra-pulse",
       "title": "Pulse",
       "category": "Vitals",
-      "occurrence": "pulse_occurrence",
+      "entity": "pulse",
       "valueConfigs": [
         {
           "title": "",
@@ -933,7 +558,7 @@
       "id": "tanagra-resp-rate",
       "title": "Resp Rate",
       "category": "Vitals",
-      "occurrence": "resp_rate_occurrence",
+      "entity": "respiratoryRate",
       "valueConfigs": [
         {
           "title": "Resp rate in br/min",
@@ -1010,7 +635,7 @@
     {
       "id": "_demographics",
       "name": "Demographics",
-      "occurrences": ""
+      "entity": ""
     }
   ],
   "criteriaSearchConfig": {
@@ -1051,11 +676,11 @@
     ],
     "pages": [
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "condition",
         "title": "Conditions",
         "plugin": {
-          "occurrence": "condition_occurrence",
+          "entity": "conditionOccurrence",
           "columns": [
             {
               "key": "condition",
@@ -1082,11 +707,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "procedure",
         "title": "Procedures",
         "plugin": {
-          "occurrence": "procedure_occurrence",
+          "entity": "procedureOccurrence",
           "columns": [
             {
               "key": "procedure",
@@ -1100,11 +725,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "observation",
         "title": "Observations",
         "plugin": {
-          "occurrence": "observation_occurrence",
+          "entity": "observationOccurrence",
           "columns": [
             {
               "key": "observation",
@@ -1118,11 +743,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "ingredient",
         "title": "Drugs",
         "plugin": {
-          "occurrence": "ingredient_occurrence",
+          "entity": "ingredientOccurrence",
           "columns": [
             {
               "key": "ingredient",
@@ -1147,11 +772,11 @@
         }
       },
       {
-        "type": "occurrenceTable",
+        "type": "entityTable",
         "id": "measurements",
         "title": "Labs and measurements",
         "plugin": {
-          "occurrence": "measurement_occurrence",
+          "entity": "measurementOccurrence",
           "columns": [
             {
               "key": "measurement",
@@ -1184,7 +809,7 @@
         "id": "notes",
         "title": "Documents",
         "plugin": {
-          "occurrence": "note_occurrence",
+          "entity": "noteOccurrence",
           "title": "title",
           "subtitles": ["note", "date"],
           "text": "note_text",


### PR DESCRIPTION
This change is not backwards compatible and breaks existing criteria.

* Remove occurrences from the UI config. Change the config to refer directly to entities and entity groups instead.
* Use backend config to replace classifications and primary entity config.
* Update the classification plugin to use the entity group configuration for related occurrences rather than manually specifying them.