### PR TITLE
Allow BigQuery to use cached results for all service queries.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -43,6 +43,7 @@ public class BQExecutor {
                 queryConfig.addNamedParameter(
                     sqlParam.getKey(), toQueryParameterValue(sqlParam.getValue())));
     queryConfig.setDryRun(queryRequest.isDryRun());
+    queryConfig.setUseQueryCache(true);
 
     LOGGER.info("Running SQL against BigQuery: {}", queryRequest.getSql());
     if (queryRequest.isDryRun()) {


### PR DESCRIPTION
This would only possibly help the criteria queries (e.g. searching conditions) and the count queries in the cohort overview (e.g. count for each criteria). Unfortunately, it won't help the breakdown chart because the `person.age` attribute uses a runtime SQL function that references the current time, which causes BigQuery to [re-run the query](https://cloud.google.com/bigquery/docs/cached-results#cache-exceptions) each time. But it's good practice to use cached query results when possible to save runtime and costs.