### PR TITLE
[DT-651-653] Fine tune measurement, visit and device domains

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/device/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/device/all.sql
@@ -4,7 +4,7 @@ SELECT
     c.vocabulary_id,
     v.vocabulary_name,
     c.concept_code,
-    (CASE WHEN c.standard_concept IS NULL THEN 'Standard' WHEN c.standard_concept = 'S' THEN 'Standard' ELSE 'Unknown' END) AS standard_concept
+    'Standard' AS standard_concept
 FROM `${omopDataset}.device_exposure` AS de
 JOIN `${omopDataset}.concept` AS c ON c.concept_id = de.device_concept_id
     AND c.domain_id = 'Device'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/deviceOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/deviceOccurrence/entity.json
@@ -13,5 +13,6 @@
     { "name": "visit_occurrence_id", "dataType": "INT64" },
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true }
   ],
-  "idAttribute": "id"
+  "idAttribute": "id",
+  "optimizeGroupByAttributes": [ "device" ]
 }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementNonHierarchy/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementNonHierarchy/all.sql
@@ -1,4 +1,8 @@
-SELECT DISTINCT c.*
+SELECT DISTINCT concept_id,
+    concept_name,
+    vocabulary_id,
+    concept_code,
+    'Standard' AS standard_concept
 FROM `${omopDataset}.measurement` m
 JOIN `${omopDataset}.concept` c ON m.measurement_concept_id = c.concept_id
 WHERE c.domain_id = 'Measurement'
@@ -7,7 +11,11 @@ WHERE c.domain_id = 'Measurement'
   AND m.measurement_concept_id IS NOT null
   AND m.measurement_concept_id != 0
 UNION DISTINCT
-SELECT DISTINCT c.*
+SELECT DISTINCT concept_id,
+    concept_name,
+    vocabulary_id,
+    concept_code,
+    'Standard' AS standard_concept
 FROM `${omopDataset}.measurement` m
 JOIN `${omopDataset}.concept` c ON m.measurement_concept_id = c.concept_id
 WHERE c.domain_id = 'Measurement'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementSnomed/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementSnomed/all.sql
@@ -3,7 +3,7 @@ SELECT
     concept_name,
     vocabulary_id,
     concept_code,
-    (CASE WHEN standard_concept IS NULL THEN 'Source' WHEN standard_concept = 'S' THEN 'Standard' ELSE 'Unknown' END) AS standard_concept
+    'Standard' AS standard_concept
 FROM `${omopDataset}.concept`
 WHERE
     domain_id = 'Measurement'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/visitOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/visitOccurrence/entity.json
@@ -11,5 +11,6 @@
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "visit_source_concept_id" },
     { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true }
   ],
-  "idAttribute": "id"
+  "idAttribute": "id",
+  "optimizeGroupByAttributes": [ "visit" ]
 }

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -8,18 +8,18 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -47,18 +47,18 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -86,12 +86,12 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -117,18 +117,18 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -164,19 +164,18 @@
       "conceptSet": true,
       "category": "Domains",
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
-        { "key": "id", "width": 150, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 180, "title": "Source/standard" },
+        { "key": "name", "width": "100%", "title": "Name" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 150, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
-        { "key": "concept_code", "width": 420, "title": "Code" },
-        { "key": "name", "width": "100%", "title": "Concept Name" },
-        { "key": "id", "width": 220, "title": "Concept ID" },
-        { "key": "t_rollup_count", "width": 220, "title": "Roll-up count" }
+        { "key": "concept_code", "width": "15%", "title": "Code" },
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -217,9 +216,9 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "name", "width": "100%", "title": "Name" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -243,18 +242,27 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/Standard" },
-        { "key": "vocabulary_id", "width": 120, "title": "Vocabulary" },
+        { "key": "name", "width": "100%", "title": "Name" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
+        { "key": "vocabulary_t_value", "width": 120, "title": "Vocabulary" },
         { "key": "concept_code", "width": 120, "title": "Concept Code" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
+<<<<<<< HEAD
       "classificationEntityGroups": [
         {
           "id": "devicePerson"
         }
       ],
+=======
+      "occurrences": "device_occurrence",
+      "classifications": ["device"],
+      "defaultSort": {
+        "attribute": "name",
+        "direction": "ASC"
+      },
+>>>>>>> 235a6fce (Changed all ui colum widths, titles for all domains: search results and hierarchy views)
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -277,17 +285,17 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -314,16 +322,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -350,16 +358,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -386,16 +394,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -422,16 +430,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -677,7 +685,7 @@
   "criteriaSearchConfig": {
     "criteriaTypeWidth": 120,
     "columns": [
-      { "key": "name", "width": "100%", "title": "Concept Name" },
+      { "key": "name", "width": "100%", "title": "Name" },
       { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
       { "key": "concept_code", "width": 120, "title": "Code" },
       { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" }

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -249,20 +249,15 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
-<<<<<<< HEAD
       "classificationEntityGroups": [
         {
           "id": "devicePerson"
         }
       ],
-=======
-      "occurrences": "device_occurrence",
-      "classifications": ["device"],
       "defaultSort": {
         "attribute": "t_item_count",
         "direction": "DESC"
       },
->>>>>>> 235a6fce (Changed all ui colum widths, titles for all domains: search results and hierarchy views)
       "modifiers": [
         "age_at_occurrence",
         "visit_type",

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -9,11 +9,11 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -48,11 +48,11 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -87,7 +87,7 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
@@ -118,11 +118,11 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -165,11 +165,11 @@
       "category": "Domains",
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -217,7 +217,7 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "classificationEntityGroups": [
@@ -243,10 +243,10 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
-        { "key": "vocabulary_t_value", "width": 120, "title": "Vocabulary" },
-        { "key": "concept_code", "width": 120, "title": "Concept Code" },
+        { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
+        { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
 <<<<<<< HEAD
@@ -259,8 +259,8 @@
       "occurrences": "device_occurrence",
       "classifications": ["device"],
       "defaultSort": {
-        "attribute": "name",
-        "direction": "ASC"
+        "attribute": "t_item_count",
+        "direction": "DESC"
       },
 >>>>>>> 235a6fce (Changed all ui colum widths, titles for all domains: search results and hierarchy views)
       "modifiers": [
@@ -285,11 +285,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -321,11 +321,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -357,11 +357,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -393,11 +393,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -429,11 +429,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -688,7 +688,7 @@
       { "key": "name", "width": "100%", "title": "Name" },
       { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
       { "key": "concept_code", "width": 120, "title": "Code" },
-      { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" }
+      { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" }
     ]
   },
   "cohortReviewConfig": {

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R1/ui.json
@@ -23,11 +23,7 @@
       ],
       "classificationEntityGroups": [
         {
-          "id": "conditionPerson",
-          "defaultSort": {
-            "attribute": "name",
-            "direction": "ASC"
-          }
+          "id": "conditionPerson"
         },
         {
           "id": "conditionNonHierarchyPerson"
@@ -62,20 +58,12 @@
       ],
       "classificationEntityGroups": [
         {
-          "id": "procedurePerson",
-          "defaultSort": {
-            "attribute": "name",
-            "direction": "ASC"
-          }
+          "id": "procedurePerson"
         },
         {
           "id": "procedureNonHierarchyPerson"
         }
      ],
-      "defaultSort": {
-        "attribute": "t_item_count",
-        "direction": "DESC"
-      },
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
     },
     {
@@ -96,9 +84,6 @@
       "classificationEntityGroups": [
         {
           "id": "observationPerson"
-        },
-        {
-          "id": "observationNonHierarchyPerson"
         }
       ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -23,11 +23,7 @@
       ],
       "classificationEntityGroups": [
         {
-          "id": "conditionPerson",
-          "defaultSort": {
-            "attribute": "name",
-            "direction": "ASC"
-          }
+          "id": "conditionPerson"
         },
         {
           "id": "conditionNonHierarchyPerson"
@@ -62,11 +58,7 @@
       ],
       "classificationEntityGroups": [
         {
-          "id": "procedurePerson",
-          "defaultSort": {
-            "attribute": "name",
-            "direction": "ASC"
-          }
+          "id": "procedurePerson"
         },
         {
           "id": "procedureNonHierarchyPerson"
@@ -92,15 +84,8 @@
       "classificationEntityGroups": [
         {
           "id": "observationPerson"
-        },
-        {
-          "id": "observationNonHierarchyPerson"
         }
-     ],
-      "defaultSort": {
-        "attribute": "t_item_count",
-        "direction": "DESC"
-      },
+      ],
       "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
       "valueConfigs": [
         {

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -249,20 +249,15 @@
         { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
-<<<<<<< HEAD
       "classificationEntityGroups": [
         {
           "id": "devicePerson"
         }
       ],
-=======
-      "occurrences": "device_occurrence",
-      "classifications": ["device"],
       "defaultSort": {
         "attribute": "t_item_count",
         "direction": "DESC"
       },
->>>>>>> 235a6fce (Changed all ui colum widths, titles for all domains: search results and hierarchy views)
       "modifiers": [
         "age_at_occurrence",
         "visit_type",

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -9,11 +9,11 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -48,11 +48,11 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -83,7 +83,7 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
@@ -118,11 +118,11 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -165,11 +165,11 @@
       "category": "Domains",
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -217,7 +217,7 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "classificationEntityGroups": [
@@ -243,10 +243,10 @@
       "tags": ["Standard Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
-        { "key": "vocabulary_t_value", "width": 120, "title": "Vocabulary" },
-        { "key": "concept_code", "width": 120, "title": "Concept Code" },
+        { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
+        { "key": "concept_code", "width": 120, "title": "Code" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
 <<<<<<< HEAD
@@ -259,8 +259,8 @@
       "occurrences": "device_occurrence",
       "classifications": ["device"],
       "defaultSort": {
-        "attribute": "name",
-        "direction": "ASC"
+        "attribute": "t_item_count",
+        "direction": "DESC"
       },
 >>>>>>> 235a6fce (Changed all ui colum widths, titles for all domains: search results and hierarchy views)
       "modifiers": [
@@ -285,11 +285,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -321,11 +321,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -357,11 +357,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -393,11 +393,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -429,11 +429,11 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "id", "width": 120, "title": "Concept Id" },
         { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
         { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
@@ -655,7 +655,7 @@
       { "key": "name", "width": "100%", "title": "Name" },
       { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
       { "key": "concept_code", "width": 120, "title": "Code" },
-      { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" }
+      { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" }
     ]
   },
   "cohortReviewConfig": {

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R1/ui.json
@@ -8,18 +8,18 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -47,18 +47,18 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -82,12 +82,12 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -117,18 +117,18 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
+        { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -164,19 +164,18 @@
       "conceptSet": true,
       "category": "Domains",
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
-        { "key": "id", "width": 150, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 180, "title": "Source/standard" },
+        { "key": "name", "width": "100%", "title": "Name" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 150, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
-        { "key": "concept_code", "width": 420, "title": "Code" },
-        { "key": "name", "width": "100%", "title": "Concept Name" },
-        { "key": "id", "width": 220, "title": "Concept ID" },
-        { "key": "t_rollup_count", "width": 220, "title": "Roll-up count" }
+        { "key": "concept_code", "width": "15%", "title": "Code" },
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -217,9 +216,9 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "name", "width": "100%", "title": "Name" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -243,18 +242,27 @@
       "category": "Domains",
       "tags": ["Standard Codes"],
       "columns": [
-        { "key": "name", "width": "100%", "title": "Concept name" },
-        { "key": "id", "width": 120, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/Standard" },
-        { "key": "vocabulary_id", "width": 120, "title": "Vocabulary" },
+        { "key": "name", "width": "100%", "title": "Name" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
+        { "key": "vocabulary_t_value", "width": 120, "title": "Vocabulary" },
         { "key": "concept_code", "width": 120, "title": "Concept Code" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
+<<<<<<< HEAD
       "classificationEntityGroups": [
         {
           "id": "devicePerson"
         }
       ],
+=======
+      "occurrences": "device_occurrence",
+      "classifications": ["device"],
+      "defaultSort": {
+        "attribute": "name",
+        "direction": "ASC"
+      },
+>>>>>>> 235a6fce (Changed all ui colum widths, titles for all domains: search results and hierarchy views)
       "modifiers": [
         "age_at_occurrence",
         "visit_type",
@@ -277,17 +285,17 @@
       "tags": ["Source Codes"],
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
-        { "key": "id", "width": 100, "title": "ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "id", "width": 100, "title": "Concept ID" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -314,16 +322,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -350,16 +358,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -386,16 +394,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -422,16 +430,16 @@
       "columns": [
         { "key": "name", "width": "100%", "title": "Name" },
         { "key": "id", "width": 100, "title": "Concept ID" },
-        { "key": "standard_concept", "width": 120, "title": "Source/standard" },
+        { "key": "standard_concept", "width": 180, "title": "Source/Standard" },
         { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
         { "key": "concept_code", "width": 120, "title": "Code" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" },
-        { "key": "t_item_count", "width": 120, "title": "Item count" }
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" },
+        { "key": "t_item_count", "width": 120, "title": "Item Count" }
       ],
       "hierarchyColumns": [
         { "key": "concept_code", "width": "15%", "title": "Code" },
-        { "key": "name", "width": "60%", "title": "Concept Name" },
-        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up count" }
+        { "key": "name", "width": "60%", "title": "Name" },
+        { "key": "t_rollup_count", "width": "10%", "title": "Roll-up Count" }
       ],
       "classificationEntityGroups": [
         {
@@ -644,7 +652,7 @@
   "criteriaSearchConfig": {
     "criteriaTypeWidth": 120,
     "columns": [
-      { "key": "name", "width": "100%", "title": "Concept Name" },
+      { "key": "name", "width": "100%", "title": "Name" },
       { "key": "vocabulary_t_value", "width": 120, "title": "Vocab" },
       { "key": "concept_code", "width": 120, "title": "Code" },
       { "key": "t_rollup_count", "width": 120, "title": "Roll-up Count" }


### PR DESCRIPTION
- Update sqls for optimization and source/standard values
- Update entity column names
- Update UI to be consistent across all domains and similar to columns in AoU
- **note** Labs and measurements need sorting on both `item_count` and `rollup_count`, Sort on multiple columns is not implemented currently