### PR TITLE
Prefix ipynb export output with colon.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
@@ -20,7 +20,7 @@ import org.apache.commons.text.StringSubstitutor;
 
 public class IpynbFileDownload implements DataExport {
   private static final String IPYNB_TEMPLATE_RESOURCE_FILE = "export/notebook_template.ipynb";
-  public static final String IPYNB_FILE_KEY = "ipynbFile";
+  public static final String IPYNB_FILE_KEY = "Notebook File:tanagra_export.ipynb";
   private List<String> gcsBucketNames;
 
   @Override


### PR DESCRIPTION
This is a quick fix for the `ipynb` export model, so that the UI section-rendering works correctly. The better fix we plan on longer-term is to add dedicated handling for file/link type export outputs, rather than special-casing the `:` character in the output key.
![Screenshot 2024-01-09 at 1 27 54 PM](https://github.com/DataBiosphere/tanagra/assets/12446128/75be6bc5-68e7-47ff-aa64-31b56dd2eaec)
