### PR TITLE
Fix missing SQL parameter when using the rollup count field for a relationship filter.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
@@ -130,11 +130,7 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
           selectEntityTable.getEntityGroupCountField(
               relationshipFilter.getEntityGroup().getName(), null);
       return apiTranslator.binaryFilterSql(
-          selectRollupField,
-          BinaryOperator.GREATER_THAN,
-          Literal.forInt64(0L),
-          null,
-          new SqlParams());
+          selectRollupField, BinaryOperator.GREATER_THAN, Literal.forInt64(0L), null, sqlParams);
     } else if (relationshipFilter.hasSubFilter()
         && apiTranslator
             .translator(relationshipFilter.getSubFilter())
@@ -215,11 +211,7 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
           selectEntityTable.getEntityGroupCountField(
               relationshipFilter.getEntityGroup().getName(), null);
       return apiTranslator.binaryFilterSql(
-          selectRollupField,
-          BinaryOperator.GREATER_THAN,
-          Literal.forInt64(0L),
-          null,
-          new SqlParams());
+          selectRollupField, BinaryOperator.GREATER_THAN, Literal.forInt64(0L), null, sqlParams);
     } else if (relationshipFilter.hasSubFilter()
         && apiTranslator
             .translator(relationshipFilter.getSubFilter())


### PR DESCRIPTION
This fixes the error when adding a group-items type criteria (e.g. blood pressure in SD underlay) without selecting an enum value. In the query engine overhaul, I was creating a new set of SQL parameters instead of adding to the set that was passed into the translator.