### PR TITLE
Fix RelationshipFilter ignoring swap field from a nested RelationshipFilter.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
@@ -114,9 +114,11 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
             .getUnderlay()
             .getIndexSchema()
             .getEntityMain(relationshipFilter.getSelectEntity().getName());
+    Attribute selectIdAttribute = relationshipFilter.getSelectEntity().getIdAttribute();
     SqlField selectIdField =
-        selectEntityTable.getAttributeValueField(
-            relationshipFilter.getSelectEntity().getIdAttribute().getName());
+        attributeSwapFields.containsKey(selectIdAttribute)
+            ? attributeSwapFields.get(selectIdAttribute)
+            : selectEntityTable.getAttributeValueField(selectIdAttribute.getName());
 
     if (!relationshipFilter.hasSubFilter()
         && !relationshipFilter.hasGroupByFilter()
@@ -183,9 +185,11 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
             .getUnderlay()
             .getIndexSchema()
             .getEntityMain(relationshipFilter.getSelectEntity().getName());
+    Attribute selectIdAttribute = relationshipFilter.getSelectEntity().getIdAttribute();
     SqlField selectIdField =
-        selectEntityTable.getAttributeValueField(
-            relationshipFilter.getSelectEntity().getIdAttribute().getName());
+        attributeSwapFields.containsKey(selectIdAttribute)
+            ? attributeSwapFields.get(selectIdAttribute)
+            : selectEntityTable.getAttributeValueField(selectIdAttribute.getName());
     ITRelationshipIdPairs idPairsTable =
         relationshipFilter
             .getUnderlay()

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterWithSwapFields.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterWithSwapFields.sql
@@ -1,0 +1,14 @@
+
+    SELECT
+        start_date      
+    FROM
+        ${ENT_conditionOccurrence}      
+    WHERE
+        person_id IN (
+            SELECT
+                person_id              
+            FROM
+                ${ENT_conditionOccurrence}              
+            WHERE
+                condition = @val         
+        )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterIntTableWithSwapFields.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterIntTableWithSwapFields.sql
@@ -1,0 +1,14 @@
+
+    SELECT
+        start_date      
+    FROM
+        ${ENT_ingredientOccurrence}      
+    WHERE
+        ingredient IN (
+            SELECT
+                entity_B_id              
+            FROM
+                ${RIDS_brandIngredient_brand_ingredient}              
+            WHERE
+                entity_A_id = @val         
+        )


### PR DESCRIPTION
When translating a `RelationshipFilter` to SQL, we do some limited query optimization to translate a filter on an id attribute to a filter on a foreign key attribute. This fixes the case of a nested `RelationshipFilter` which was not correctly updating the name of the field being filtered. Also added two tests to cover the two sub-cases.