### PR TITLE
Updates for BioVU plugin/config

### DIFF
--- a/ui/src/plugins/vumc/biovu.tsx
+++ b/ui/src/plugins/vumc/biovu.tsx
@@ -56,7 +56,7 @@ const sampleFilterFilters: { [key: string]: Filter } = {
 const EXCLUDE_COMPROMISED = "Exclude Compromised DNA";
 const EXCLUDE_INTERNAL =
   "Include only samples available for external processing";
-const PLASMA = "Any existing banked BioVU Plasma";
+const PLASMA = "Any banked BioVU Plasma";
 
 const EXCLUDE_COMPROMISED_TOOLTIP = `"Compromised" DNA may not represent
   anticipated germline genetic profiles of the subject due to select medical

--- a/underlay/src/main/resources/config/underlay/sd020230331/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd020230331/ui.json
@@ -1,27 +1,6 @@
 {
   "criteriaConfigs": [
     {
-      "type": "entityGroup",
-      "id": "tanagra-genotyping",
-      "title": "BioVU Genetic Data",
-      "category": "Demographics",
-      "columns": [
-        { "key": "name", "width": "100%", "title": "Genotyping platform" },
-        { "key": "id", "width": 100, "title": "Id" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
-      ],
-      "hierarchyColumns": [
-        { "key": "name", "width": "100%", "title": "Genotyping platform" },
-        { "key": "id", "width": 100, "title": "Id" },
-        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
-      ],
-      "classificationEntityGroups": [
-        {
-          "id": "genotypingPerson"
-        }
-      ]
-    },
-    {
       "type": "attribute",
       "id": "tanagra-ethnicity",
       "title": "Ethnicity",
@@ -71,8 +50,36 @@
     {
       "type": "biovu",
       "id": "biovu",
-      "title": "BioVU Samples",
+      "title": "BioVU DNA",
       "category": "BioVU"
+    },
+    {
+      "type": "biovu",
+      "id": "biovu-plasma",
+      "title": "BioVU Plasma",
+      "category": "BioVU",
+      "plasmaFilter": true
+    },
+    {
+      "type": "entityGroup",
+      "id": "tanagra-genotyping",
+      "title": "BioVU Genetic Data",
+      "category": "BioVU",
+      "columns": [
+        { "key": "name", "width": "100%", "title": "Genotyping platform" },
+        { "key": "id", "width": 100, "title": "Id" },
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+      ],
+      "hierarchyColumns": [
+        { "key": "name", "width": "100%", "title": "Genotyping platform" },
+        { "key": "id", "width": 100, "title": "Id" },
+        { "key": "t_rollup_count", "width": 120, "title": "Roll-up count" }
+      ],
+      "classificationEntityGroups": [
+        {
+          "id": "genotypingPerson"
+        }
+      ]
     },
     {
       "type": "entityGroup",


### PR DESCRIPTION
- Add a 'BioVU Plasma' item in BioVU criteria menu with a binary filter to replace the 'any existing banked BioVU plasma' checkbox
- Change 'BioVU Samples' criteria item text to 'BioVU DNA' 
- Move 'BioVU Genetic Data' criteria item from the Demographics category to BioVU
- Remove 'Any SD Records (not requiring BioVU resources)' option (`SampleFilter.NONE`) from the BioVU Samples dropdown. Make the default option 'Any BioVU DNA (no minimum amount or concentration)' (`SampleFilter.ANY`)

<img width="886" alt="Screenshot 2024-01-19 at 8 15 31 AM" src="https://github.com/DataBiosphere/tanagra/assets/40036095/1c05a56e-0182-453e-96f4-816f8b1975e4">
<img width="501" alt="Screenshot 2024-01-19 at 8 16 06 AM" src="https://github.com/DataBiosphere/tanagra/assets/40036095/84e6c32c-7c1c-4e0e-8bb4-8f423a628c08">
