### PR TITLE
OccurrenceForPrimary filter for CriteriaOccurrence entity groups.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
@@ -1,0 +1,40 @@
+package bio.terra.tanagra.api.filter;
+
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
+import javax.annotation.Nullable;
+
+public class OccurrenceForPrimaryFilter extends EntityFilter {
+  private final Underlay underlay;
+  private final CriteriaOccurrence criteriaOccurrence;
+  private final Entity occurrenceEntity;
+  private final @Nullable EntityFilter primarySubFilter;
+
+  public OccurrenceForPrimaryFilter(
+      Underlay underlay,
+      CriteriaOccurrence criteriaOccurrence,
+      Entity occurrenceEntity,
+      @Nullable EntityFilter primarySubFilter) {
+    this.underlay = underlay;
+    this.criteriaOccurrence = criteriaOccurrence;
+    this.occurrenceEntity = occurrenceEntity;
+    this.primarySubFilter = primarySubFilter;
+  }
+
+  public Underlay getUnderlay() {
+    return underlay;
+  }
+
+  public CriteriaOccurrence getCriteriaOccurrence() {
+    return criteriaOccurrence;
+  }
+
+  public Entity getOccurrenceEntity() {
+    return occurrenceEntity;
+  }
+
+  public @Nullable EntityFilter getPrimarySubFilter() {
+    return primarySubFilter;
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
@@ -12,6 +12,7 @@ import bio.terra.tanagra.api.filter.HierarchyHasAncestorFilter;
 import bio.terra.tanagra.api.filter.HierarchyHasParentFilter;
 import bio.terra.tanagra.api.filter.HierarchyIsMemberFilter;
 import bio.terra.tanagra.api.filter.HierarchyIsRootFilter;
+import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
 import bio.terra.tanagra.api.filter.PrimaryWithCriteriaFilter;
 import bio.terra.tanagra.api.filter.RelationshipFilter;
 import bio.terra.tanagra.api.filter.TextSearchFilter;
@@ -27,6 +28,7 @@ import bio.terra.tanagra.query.bigquery.translator.filter.BQHierarchyHasAncestor
 import bio.terra.tanagra.query.bigquery.translator.filter.BQHierarchyHasParentFilterTranslator;
 import bio.terra.tanagra.query.bigquery.translator.filter.BQHierarchyIsMemberFilterTranslator;
 import bio.terra.tanagra.query.bigquery.translator.filter.BQHierarchyIsRootFilterTranslator;
+import bio.terra.tanagra.query.bigquery.translator.filter.BQOccurrenceForPrimaryFilter;
 import bio.terra.tanagra.query.bigquery.translator.filter.BQPrimaryWithCriteriaFilterTranslator;
 import bio.terra.tanagra.query.bigquery.translator.filter.BQRelationshipFilterTranslator;
 import bio.terra.tanagra.query.bigquery.translator.filter.BQTextSearchFilterTranslator;
@@ -93,6 +95,11 @@ public final class BQApiTranslator implements ApiTranslator {
   @Override
   public ApiFilterTranslator translator(HierarchyIsRootFilter hierarchyIsRootFilter) {
     return new BQHierarchyIsRootFilterTranslator(this, hierarchyIsRootFilter);
+  }
+
+  @Override
+  public ApiFilterTranslator translator(OccurrenceForPrimaryFilter occurrenceForPrimaryFilter) {
+    return new BQOccurrenceForPrimaryFilter(this, occurrenceForPrimaryFilter);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQOccurrenceForPrimaryFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQOccurrenceForPrimaryFilter.java
@@ -1,0 +1,41 @@
+package bio.terra.tanagra.query.bigquery.translator.filter;
+
+import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
+import bio.terra.tanagra.api.filter.RelationshipFilter;
+import bio.terra.tanagra.query.sql.SqlParams;
+import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
+import bio.terra.tanagra.query.sql.translator.ApiTranslator;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
+
+public class BQOccurrenceForPrimaryFilter extends ApiFilterTranslator {
+  private final OccurrenceForPrimaryFilter occurrenceForPrimaryFilter;
+
+  public BQOccurrenceForPrimaryFilter(
+      ApiTranslator apiTranslator, OccurrenceForPrimaryFilter occurrenceForPrimaryFilter) {
+    super(apiTranslator);
+    this.occurrenceForPrimaryFilter = occurrenceForPrimaryFilter;
+  }
+
+  @Override
+  public String buildSql(SqlParams sqlParams, String tableAlias) {
+    RelationshipFilter relationshipFilter =
+        new RelationshipFilter(
+            occurrenceForPrimaryFilter.getUnderlay(),
+            occurrenceForPrimaryFilter.getCriteriaOccurrence(),
+            occurrenceForPrimaryFilter.getOccurrenceEntity(),
+            occurrenceForPrimaryFilter
+                .getCriteriaOccurrence()
+                .getOccurrencePrimaryRelationship(
+                    occurrenceForPrimaryFilter.getOccurrenceEntity().getName()),
+            occurrenceForPrimaryFilter.getPrimarySubFilter(),
+            null,
+            null,
+            null);
+    return apiTranslator.translator(relationshipFilter).buildSql(sqlParams, tableAlias);
+  }
+
+  @Override
+  public boolean isFilterOnAttribute(Attribute attribute) {
+    return attribute.isId();
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
@@ -16,6 +16,7 @@ import bio.terra.tanagra.api.filter.HierarchyHasAncestorFilter;
 import bio.terra.tanagra.api.filter.HierarchyHasParentFilter;
 import bio.terra.tanagra.api.filter.HierarchyIsMemberFilter;
 import bio.terra.tanagra.api.filter.HierarchyIsRootFilter;
+import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
 import bio.terra.tanagra.api.filter.PrimaryWithCriteriaFilter;
 import bio.terra.tanagra.api.filter.RelationshipFilter;
 import bio.terra.tanagra.api.filter.TextSearchFilter;
@@ -318,6 +319,8 @@ public interface ApiTranslator {
 
   ApiFilterTranslator translator(HierarchyIsRootFilter hierarchyIsRootFilter);
 
+  ApiFilterTranslator translator(OccurrenceForPrimaryFilter occurrenceForPrimaryFilter);
+
   ApiFilterTranslator translator(PrimaryWithCriteriaFilter primaryWithCriteriaFilter);
 
   ApiFilterTranslator translator(RelationshipFilter relationshipFilter);
@@ -339,6 +342,8 @@ public interface ApiTranslator {
       return translator((HierarchyIsMemberFilter) entityFilter);
     } else if (entityFilter instanceof HierarchyIsRootFilter) {
       return translator((HierarchyIsRootFilter) entityFilter);
+    } else if (entityFilter instanceof OccurrenceForPrimaryFilter) {
+      return translator((OccurrenceForPrimaryFilter) entityFilter);
     } else if (entityFilter instanceof PrimaryWithCriteriaFilter) {
       return translator((PrimaryWithCriteriaFilter) entityFilter);
     } else if (entityFilter instanceof RelationshipFilter) {

--- a/underlay/src/test/resources/sql/BQFilterTest/occurrenceForPrimaryFilterNoSubFilter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/occurrenceForPrimaryFilterNoSubFilter.sql
@@ -1,0 +1,7 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_conditionOccurrence}      
+    WHERE
+        person_id IS NOT NULL

--- a/underlay/src/test/resources/sql/BQFilterTest/occurrenceForPrimaryFilterWithSubFilter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/occurrenceForPrimaryFilterWithSubFilter.sql
@@ -1,0 +1,28 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_conditionOccurrence}      
+    WHERE
+        person_id IN (
+            SELECT
+                id              
+            FROM
+                ${ENT_person}              
+            WHERE
+                (
+                    id IN (
+                        SELECT
+                            person_id AS primary_id                          
+                        FROM
+                            ${ENT_conditionOccurrence}                          
+                        WHERE
+                            condition IN (
+                                @val0,@val1                             
+                            )                     
+                    )                 
+                )                  
+                AND (
+                    gender = @val2                 
+                )             
+            )


### PR DESCRIPTION
Add a new filter for `CriteriaOccurrence` entity groups that filters an occurrence entity by a sub-filter on the primary entity.

Switching to use this filter won't change the generated SQL. It's equivalent to a single `RelationshipFilter`, which is what the UI is already using. Goal of defining these more specific filters is to codify the types of queries we expect and optimize for. A `RelationshipFilter` allows you to query a list of `person`s filtered on a set of `conditionOccurrence` ids, even though that doesn't really make sense and is not optimized by the index jobs.

This PR does not add the new filter to the OpenAPI spec, only implements it on the backend, including tests. Plan to add it to the OpenAPI spec in a follow-on PR.