### PR TITLE
Fix list parsing in CLI option.

### DIFF
--- a/docs/generated/indexer-cli/tanagra-clean-entity.adoc
+++ b/docs/generated/indexer-cli/tanagra-clean-entity.adoc
@@ -21,7 +21,8 @@ tanagra-clean-entity - Clean the outputs of all jobs for a single entity, or all
 
 *tanagra clean entity* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                      *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                     [*--output-dir*=_<outputDir>_] [*--names*=_<names>_]...
+                     [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,
+                     _<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -56,7 +57,7 @@ Clean the outputs of all jobs for a single entity, or all entities.
 +
   Default: PARALLEL
 
-*--names*=_<names>_::
+*--names*=_<names>_[,_<names>_...]::
   Entity name(s). Comma-separated list if more than one.
 
 *--output-dir*=_<outputDir>_::

--- a/docs/generated/indexer-cli/tanagra-clean-group.adoc
+++ b/docs/generated/indexer-cli/tanagra-clean-group.adoc
@@ -21,7 +21,7 @@ tanagra-clean-group - Clean the outputs of all jobs for a single entity group, o
 
 *tanagra clean group* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                     *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                    [*--output-dir*=_<outputDir>_] [*--names*=_<names>_]...
+                    [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,_<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -56,7 +56,7 @@ Clean the outputs of all jobs for a single entity group, or all entity groups.
 +
   Default: PARALLEL
 
-*--names*=_<names>_::
+*--names*=_<names>_[,_<names>_...]::
   Entity group name(s). Comma-separated list if more than one.
 
 *--output-dir*=_<outputDir>_::

--- a/docs/generated/indexer-cli/tanagra-index-entity.adoc
+++ b/docs/generated/indexer-cli/tanagra-index-entity.adoc
@@ -21,7 +21,8 @@ tanagra-index-entity - Run all jobs for a single entity, or all entities.
 
 *tanagra index entity* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                      *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                     [*--output-dir*=_<outputDir>_] [*--names*=_<names>_]...
+                     [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,
+                     _<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -56,7 +57,7 @@ Run all jobs for a single entity, or all entities.
 +
   Default: PARALLEL
 
-*--names*=_<names>_::
+*--names*=_<names>_[,_<names>_...]::
   Entity name(s). Comma-separated list if more than one.
 
 *--output-dir*=_<outputDir>_::

--- a/docs/generated/indexer-cli/tanagra-index-group.adoc
+++ b/docs/generated/indexer-cli/tanagra-index-group.adoc
@@ -21,7 +21,7 @@ tanagra-index-group - Run all jobs for a single entity, or all entities.
 
 *tanagra index group* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                     *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                    [*--output-dir*=_<outputDir>_] [*--names*=_<names>_]...
+                    [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,_<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -56,7 +56,7 @@ Run all jobs for a single entity, or all entities.
 +
   Default: PARALLEL
 
-*--names*=_<names>_::
+*--names*=_<names>_[,_<names>_...]::
   Entity group name(s). Comma-separated list if more than one.
 
 *--output-dir*=_<outputDir>_::

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/options/EntityGroupNames.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/options/EntityGroupNames.java
@@ -13,6 +13,7 @@ import picocli.CommandLine;
 public class EntityGroupNames {
   @CommandLine.Option(
       names = "--names",
+      split = ",",
       description = "Entity group name(s). Comma-separated list if more than one.")
   public List<String> names;
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/options/EntityNames.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/options/EntityNames.java
@@ -12,6 +12,7 @@ import picocli.CommandLine;
 public class EntityNames {
   @CommandLine.Option(
       names = "--names",
+      split = ",",
       description = "Entity name(s). Comma-separated list if more than one.")
   public List<String> names;
 


### PR DESCRIPTION
Fix list parsing, change from comma-separated option to a space-separated positional parameter.