### PR TITLE
Generate SQL string without params for ListQueryRequests.

### DIFF
--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/Main.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/Main.java
@@ -11,7 +11,8 @@ public final class Main {
   private Main() {}
 
   private enum Command {
-    APPLICATION_CONFIG_DOCS(new MarkdownWalker(new ApplicationConfigPath(), "APPLICATION_CONFIG.md")),
+    APPLICATION_CONFIG_DOCS(
+        new MarkdownWalker(new ApplicationConfigPath(), "APPLICATION_CONFIG.md")),
     UNDERLAY_CONFIG_DOCS(new MarkdownWalker(new UnderlayConfigPath(), "UNDERLAY_CONFIG.md")),
     UNDERLAY_CONFIG_TYPESCRIPT(new TypescriptWalker(new UnderlayConfigPath(), "underlayConfig.ts"));
     private final AnnotationWalker annotationWalker;

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -144,7 +144,7 @@ public class UnderlaysApiController implements UnderlaysApi {
                 listQueryResult.getListInstances().stream()
                     .map(listInstance -> toApiObject(listInstance))
                     .collect(Collectors.toList()))
-            .sql(SqlFormatter.format(listQueryResult.getSql()))
+            .sql(SqlFormatter.format(listQueryResult.getSqlNoParams()))
             .pageMarker(
                 listQueryResult.getPageMarker() == null
                     ? null

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportService.java
@@ -168,7 +168,7 @@ public class DataExportService {
                 qr -> qr.getEntity().getName(),
                 qr -> {
                   ListQueryRequest dryRunQueryRequest = qr.cloneAndSetDryRun();
-                  return qr.getUnderlay().getQueryRunner().run(dryRunQueryRequest).getSql();
+                  return qr.getUnderlay().getQueryRunner().run(dryRunQueryRequest).getSqlNoParams();
                 }));
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryResult.java
@@ -6,17 +6,24 @@ import java.util.List;
 
 public class ListQueryResult {
   private final String sql;
+  private final String sqlNoParams;
   private final ImmutableList<ListInstance> listInstances;
   private final PageMarker pageMarker;
 
-  public ListQueryResult(String sql, List<ListInstance> listInstances, PageMarker pageMarker) {
+  public ListQueryResult(
+      String sql, String sqlNoParams, List<ListInstance> listInstances, PageMarker pageMarker) {
     this.sql = sql;
+    this.sqlNoParams = sqlNoParams;
     this.listInstances = ImmutableList.copyOf(listInstances);
     this.pageMarker = pageMarker;
   }
 
   public String getSql() {
     return sql;
+  }
+
+  public String getSqlNoParams() {
+    return sqlNoParams;
   }
 
   public ImmutableList<ListInstance> getListInstances() {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -45,17 +45,14 @@ public class BQExecutor {
     queryConfig.setDryRun(queryRequest.isDryRun());
     queryConfig.setUseQueryCache(true);
 
-    String nonParameterizedSql = queryRequest.getSql();
+    String sqlNoParams = queryRequest.getSql();
     for (String paramName : queryRequest.getSqlParams().getParamNamesLongestFirst()) {
-      LOGGER.info(
-          "param val: {}",
-          toQueryParameterValue(queryRequest.getSqlParams().getParamValue(paramName)));
-      nonParameterizedSql =
-          nonParameterizedSql.replaceAll(
+      sqlNoParams =
+          sqlNoParams.replaceAll(
               '@' + paramName,
               toSql(toQueryParameterValue(queryRequest.getSqlParams().getParamValue(paramName))));
     }
-    LOGGER.info("non-parameterized SQL: {}", nonParameterizedSql);
+    LOGGER.info("SQL no parameters: {}", sqlNoParams);
 
     LOGGER.info("Running SQL against BigQuery: {}", queryRequest.getSql());
     if (queryRequest.isDryRun()) {
@@ -67,7 +64,7 @@ public class BQExecutor {
           queryStatistics.getCacheHit(),
           queryStatistics.getTotalBytesProcessed(),
           queryStatistics.getTotalSlotMs());
-      return new SqlQueryResult(List.of(), null, 0, nonParameterizedSql);
+      return new SqlQueryResult(List.of(), null, 0, sqlNoParams);
     } else {
       TableResult tableResult =
           getBigQueryService()
@@ -86,7 +83,7 @@ public class BQExecutor {
       PageMarker nextPageMarker =
           tableResult.hasNextPage() ? PageMarker.forToken(tableResult.getNextPageToken()) : null;
       return new SqlQueryResult(
-          rowResults, nextPageMarker, tableResult.getTotalRows(), nonParameterizedSql);
+          rowResults, nextPageMarker, tableResult.getTotalRows(), sqlNoParams);
     }
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -71,7 +71,10 @@ public class BQQueryRunner implements QueryRunner {
             });
 
     return new ListQueryResult(
-        sqlQueryRequest.getSql(), listInstances, sqlQueryResult.getNextPageMarker());
+        sqlQueryRequest.getSql(),
+        sqlQueryResult.getNonParameterizedSql(),
+        listInstances,
+        sqlQueryResult.getNextPageMarker());
   }
 
   @VisibleForTesting

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -72,7 +72,7 @@ public class BQQueryRunner implements QueryRunner {
 
     return new ListQueryResult(
         sqlQueryRequest.getSql(),
-        sqlQueryResult.getNonParameterizedSql(),
+        sqlQueryResult.getSqlNoParams(),
         listInstances,
         sqlQueryResult.getNextPageMarker());
   }

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlParams.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlParams.java
@@ -2,8 +2,11 @@ package bio.terra.tanagra.query.sql;
 
 import bio.terra.tanagra.api.shared.Literal;
 import com.google.common.collect.ImmutableMap;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SqlParams {
   private final Map<String, Literal> params = new HashMap<>();
@@ -16,5 +19,15 @@ public class SqlParams {
 
   public ImmutableMap<String, Literal> getParams() {
     return ImmutableMap.copyOf(params);
+  }
+
+  public Literal getParamValue(String paramName) {
+    return params.get(paramName);
+  }
+
+  public List<String> getParamNamesLongestFirst() {
+    return params.keySet().stream()
+        .sorted(Comparator.comparing(String::length).reversed())
+        .collect(Collectors.toList());
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlQueryResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlQueryResult.java
@@ -7,17 +7,17 @@ public class SqlQueryResult {
   private final PageMarker nextPageMarker;
   private final long totalNumRows;
 
-  private final String nonParameterizedSql;
+  private final String sqlNoParams;
 
   public SqlQueryResult(
       Iterable<SqlRowResult> rowResults,
       PageMarker nextPageMarker,
       long totalNumRows,
-      String nonParameterizedSql) {
+      String sqlNoParams) {
     this.rowResults = rowResults;
     this.nextPageMarker = nextPageMarker;
     this.totalNumRows = totalNumRows;
-    this.nonParameterizedSql = nonParameterizedSql;
+    this.sqlNoParams = sqlNoParams;
   }
 
   public Iterable<SqlRowResult> getRowResults() {
@@ -32,7 +32,7 @@ public class SqlQueryResult {
     return totalNumRows;
   }
 
-  public String getNonParameterizedSql() {
-    return nonParameterizedSql;
+  public String getSqlNoParams() {
+    return sqlNoParams;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlQueryResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlQueryResult.java
@@ -7,11 +7,17 @@ public class SqlQueryResult {
   private final PageMarker nextPageMarker;
   private final long totalNumRows;
 
+  private final String nonParameterizedSql;
+
   public SqlQueryResult(
-      Iterable<SqlRowResult> rowResults, PageMarker nextPageMarker, long totalNumRows) {
+      Iterable<SqlRowResult> rowResults,
+      PageMarker nextPageMarker,
+      long totalNumRows,
+      String nonParameterizedSql) {
     this.rowResults = rowResults;
     this.nextPageMarker = nextPageMarker;
     this.totalNumRows = totalNumRows;
+    this.nonParameterizedSql = nonParameterizedSql;
   }
 
   public Iterable<SqlRowResult> getRowResults() {
@@ -24,5 +30,9 @@ public class SqlQueryResult {
 
   public long getTotalNumRows() {
     return totalNumRows;
+  }
+
+  public String getNonParameterizedSql() {
+    return nonParameterizedSql;
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
@@ -1,0 +1,224 @@
+package bio.terra.tanagra.query.bigquery.sqlbuilding;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.tanagra.api.field.AttributeField;
+import bio.terra.tanagra.api.filter.AttributeFilter;
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.query.list.ListQueryRequest;
+import bio.terra.tanagra.api.query.list.ListQueryResult;
+import bio.terra.tanagra.api.shared.BinaryOperator;
+import bio.terra.tanagra.api.shared.Literal;
+import bio.terra.tanagra.query.bigquery.BQQueryRunner;
+import bio.terra.tanagra.query.bigquery.BQRunnerTest;
+import bio.terra.tanagra.query.bigquery.BQTable;
+import bio.terra.tanagra.underlay.ConfigReader;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.serialization.SZService;
+import bio.terra.tanagra.underlay.serialization.SZUnderlay;
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class BQRemoveParamsTest extends BQRunnerTest {
+  @Override
+  protected String getServiceConfigName() {
+    return "aouSR2019q4r4_broad";
+  }
+
+  @Test
+  void int64RemoveParam() throws IOException {
+    Entity entity = underlay.getPrimaryEntity();
+    AttributeField simpleAttribute =
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+    AttributeFilter attributeFilter =
+        new AttributeFilter(
+            underlay,
+            entity,
+            entity.getIdAttribute(),
+            BinaryOperator.EQUALS,
+            Literal.forInt64(25L));
+    ListQueryResult listQueryResult =
+        bqQueryRunner.run(
+            new ListQueryRequest(
+                underlay,
+                entity,
+                List.of(simpleAttribute),
+                attributeFilter,
+                null,
+                null,
+                null,
+                null,
+                true));
+
+    BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly("int64", listQueryResult.getSqlNoParams(), table);
+  }
+
+  @Test
+  void float64RemoveParam() throws IOException {
+    Entity entity = underlay.getEntity("measurementOccurrence");
+    AttributeField simpleAttribute =
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+    AttributeFilter attributeFilter =
+        new AttributeFilter(
+            underlay,
+            entity,
+            entity.getAttribute("value_numeric"),
+            BinaryOperator.EQUALS,
+            Literal.forDouble(26.54));
+    ListQueryResult listQueryResult =
+        bqQueryRunner.run(
+            new ListQueryRequest(
+                underlay,
+                entity,
+                List.of(simpleAttribute),
+                attributeFilter,
+                null,
+                null,
+                null,
+                null,
+                true));
+
+    BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly("float64", listQueryResult.getSqlNoParams(), table);
+  }
+
+  @Test
+  void stringRemoveParam() throws IOException {
+    Entity entity = underlay.getPrimaryEntity();
+    AttributeField simpleAttribute =
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+    AttributeFilter attributeFilter =
+        new AttributeFilter(
+            underlay,
+            entity,
+            entity.getAttribute("person_source_value"),
+            BinaryOperator.EQUALS,
+            Literal.forString("id12345"));
+    ListQueryResult listQueryResult =
+        bqQueryRunner.run(
+            new ListQueryRequest(
+                underlay,
+                entity,
+                List.of(simpleAttribute),
+                attributeFilter,
+                null,
+                null,
+                null,
+                null,
+                true));
+
+    BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly("string", listQueryResult.getSqlNoParams(), table);
+  }
+
+  @Test
+  void dateRemoveParam() throws IOException {
+    // The aouSR2019q4r4 underlay does not have an example of a field with DATE type.
+    // So for this test, we use the cmssynpuf underlay.
+    ConfigReader configReader = ConfigReader.fromJarResources();
+    SZService szService = configReader.readService("cmssynpuf_broad");
+    SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
+    Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
+    BQQueryRunner bqQueryRunner =
+        new BQQueryRunner(szService.bigQuery.queryProjectId, szService.bigQuery.dataLocation);
+
+    Entity entity = underlay.getEntity("conditionOccurrence");
+    AttributeField simpleAttribute =
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+    AttributeFilter attributeFilter =
+        new AttributeFilter(
+            underlay,
+            entity,
+            entity.getAttribute("end_date"),
+            BinaryOperator.EQUALS,
+            Literal.forDate(Date.valueOf("2024-01-24")));
+    ListQueryResult listQueryResult =
+        bqQueryRunner.run(
+            new ListQueryRequest(
+                underlay,
+                entity,
+                List.of(simpleAttribute),
+                attributeFilter,
+                null,
+                null,
+                null,
+                null,
+                true));
+
+    BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly("date", listQueryResult.getSqlNoParams(), table);
+  }
+
+  @Test
+  void timestampRemoveParam() throws IOException {
+    Entity entity = underlay.getEntity("conditionOccurrence");
+    AttributeField simpleAttribute =
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+    AttributeFilter attributeFilter =
+        new AttributeFilter(
+            underlay,
+            entity,
+            entity.getAttribute("end_date"),
+            BinaryOperator.EQUALS,
+            Literal.forTimestamp(Timestamp.valueOf("2024-01-24 11:54:32")));
+    ListQueryResult listQueryResult =
+        bqQueryRunner.run(
+            new ListQueryRequest(
+                underlay,
+                entity,
+                List.of(simpleAttribute),
+                attributeFilter,
+                null,
+                null,
+                null,
+                null,
+                true));
+
+    BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly("timestamp", listQueryResult.getSqlNoParams(), table);
+  }
+
+  @Test
+  void overlappingParams() throws IOException {
+    Entity entity = underlay.getPrimaryEntity();
+    AttributeField simpleAttribute =
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+    List<EntityFilter> attributeFilters = new ArrayList<>();
+    for (int i = 0; i < 11; i++) {
+      attributeFilters.add(
+          new AttributeFilter(
+              underlay,
+              entity,
+              entity.getIdAttribute(),
+              BinaryOperator.EQUALS,
+              Literal.forInt64(25L + i)));
+    }
+    BooleanAndOrFilter booleanAndOrFilter =
+        new BooleanAndOrFilter(BooleanAndOrFilter.LogicalOperator.OR, attributeFilters);
+    ListQueryResult listQueryResult =
+        bqQueryRunner.run(
+            new ListQueryRequest(
+                underlay,
+                entity,
+                List.of(simpleAttribute),
+                booleanAndOrFilter,
+                null,
+                null,
+                null,
+                null,
+                true));
+
+    assertTrue(listQueryResult.getSql().contains("val1"));
+    assertTrue(listQueryResult.getSql().contains("val10"));
+
+    BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly("overlapping", listQueryResult.getSqlNoParams(), table);
+  }
+}

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/date.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/date.sql
@@ -1,0 +1,7 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_conditionOccurrence}      
+    WHERE
+        end_date = DATE('2024-01-24')

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/float64.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/float64.sql
@@ -1,0 +1,7 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_measurementOccurrence}      
+    WHERE
+        value_numeric = 26.54

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/int64.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/int64.sql
@@ -1,0 +1,7 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_person}      
+    WHERE
+        id = 25

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/overlapping.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/overlapping.sql
@@ -1,0 +1,39 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_person}      
+    WHERE
+        (
+            id = 25         
+        )          
+        OR (
+            id = 26         
+        )          
+        OR (
+            id = 27         
+        )          
+        OR (
+            id = 28         
+        )          
+        OR (
+            id = 29         
+        )          
+        OR (
+            id = 30         
+        )          
+        OR (
+            id = 31         
+        )          
+        OR (
+            id = 32         
+        )          
+        OR (
+            id = 33         
+        )          
+        OR (
+            id = 34         
+        )          
+        OR (
+            id = 35         
+        )

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/string.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/string.sql
@@ -1,0 +1,7 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_person}      
+    WHERE
+        person_source_value = 'id12345'

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/timestamp.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/timestamp.sql
@@ -1,0 +1,7 @@
+
+    SELECT
+        id      
+    FROM
+        ${ENT_conditionOccurrence}      
+    WHERE
+        end_date = TIMESTAMP('2024-01-24 11:54:32.0')


### PR DESCRIPTION
For list queries, generate a SQL query string without parameters (i.e. substitute the parameter values back into the SQL). This query string is not the one that will be run, so this doesn't open us up to SQL injection attacks. This query string is for displaying in the UI and including the exported notebook file.