### PR TITLE
Prevent duplicate filters in criteria

### DIFF
--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -205,11 +205,15 @@ class _ implements CriteriaPlugin<Data> {
   }
 
   filterEntityIds(underlaySource: UnderlaySource) {
-    return configEntityGroups(this.config)
-      .map((eg) => {
-        return underlaySource.lookupEntityGroup(eg.id).occurrenceEntityIds;
-      })
-      .flat();
+    return [
+      ...new Set(
+        configEntityGroups(this.config)
+          .map((eg) => {
+            return underlaySource.lookupEntityGroup(eg.id).occurrenceEntityIds;
+          })
+          .flat()
+      ),
+    ];
   }
 }
 


### PR DESCRIPTION
EntityGroup criteria with multiple entity groups that contain the same occurrences would generate the same filter multiple times.