### PR TITLE
Handle null values in SQL no-parameters string.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -148,7 +148,7 @@ public class BQExecutor {
       case INT64:
       case BOOL:
       case FLOAT64:
-        return queryParameterValue.getValue();
+        return queryParameterValue.getValue() == null ? "null" : queryParameterValue.getValue();
       case STRING:
         return "'" + queryParameterValue.getValue() + "'";
       case DATE:


### PR DESCRIPTION
This was causing errors in the indexing job that writes entity-level display hints, which writes `null` values for the enum value or numeric range columns, depending on the attribute.