### PR TITLE
Add elapsed time to indexer output report.

### DIFF
--- a/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/command/Entity.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/command/Entity.java
@@ -50,6 +50,7 @@ public abstract class Entity extends BaseCommand {
     new HtmlWriter(
             BaseMain.getArgList(),
             jobRunner.getJobResults(),
+            jobRunner.getElapsedTimeNS(),
             jobExecutorAndDryRun.jobExecutor.name(),
             OUT,
             ERR,

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/command/EntityGroup.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/command/EntityGroup.java
@@ -54,6 +54,7 @@ public abstract class EntityGroup extends BaseCommand {
     new HtmlWriter(
             BaseMain.getArgList(),
             jobRunner.getJobResults(),
+            jobRunner.getElapsedTimeNS(),
             jobExecutorAndDryRun.jobExecutor.name(),
             OUT,
             ERR,

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/command/Underlay.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/command/Underlay.java
@@ -65,6 +65,7 @@ public abstract class Underlay extends BaseCommand {
     new HtmlWriter(
             BaseMain.getArgList(),
             allResults,
+            entityJobRunner.getElapsedTimeNS() + entityGroupJobRunner.getElapsedTimeNS(),
             jobExecutorAndDryRun.jobExecutor.name(),
             OUT,
             ERR,

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/dataflow/WriteRollupCounts.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/dataflow/WriteRollupCounts.java
@@ -110,8 +110,9 @@ public class WriteRollupCounts extends BigQueryJob {
   @Override
   public String getName() {
     return String.format(
-        "%s-%s-%s",
+        "%s-%s-%s-%s",
         this.getClass().getSimpleName(),
+        entityGroup.getName(),
         getOutputTableName(),
         hierarchy == null ? ITEntityMain.NO_HIERARCHY_NAME : hierarchy.getName());
   }

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/JobRunner.java
@@ -13,6 +13,7 @@ public abstract class JobRunner {
   protected final boolean isDryRun;
   protected final IndexingJob.RunType runType;
   protected final List<JobResult> jobResults;
+  private long elapsedTimeNS;
 
   public JobRunner(List<SequencedJobSet> jobSets, boolean isDryRun, IndexingJob.RunType runType) {
     this.jobSets = jobSets;
@@ -25,13 +26,24 @@ public abstract class JobRunner {
   public abstract String getName();
 
   /** Run all job sets. */
-  public abstract void runJobSets();
+  protected abstract void runJobSetsWithoutTimer();
 
   /** Run a single job set. */
   protected abstract void runSingleJobSet(SequencedJobSet sequencedJobSet)
       throws InterruptedException, ExecutionException;
 
+  /** Run all job sets. */
+  public void runJobSets() {
+    long startTime = System.nanoTime();
+    runJobSetsWithoutTimer();
+    elapsedTimeNS = System.nanoTime() - startTime;
+  }
+
   public List<JobResult> getJobResults() {
     return jobResults;
+  }
+
+  public long getElapsedTimeNS() {
+    return elapsedTimeNS;
   }
 }

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/ParallelRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/ParallelRunner.java
@@ -30,7 +30,7 @@ public final class ParallelRunner extends JobRunner {
 
   /** Run all job sets in parallel. */
   @Override
-  public void runJobSets() {
+  public void runJobSetsWithoutTimer() {
     // Create a thread pool to run the job set.
     ThreadPoolExecutor threadPool =
         (ThreadPoolExecutor) Executors.newFixedThreadPool(jobSets.size());

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SerialRunner.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SerialRunner.java
@@ -20,7 +20,7 @@ public final class SerialRunner extends JobRunner {
 
   /** Run all job sets serially. */
   @Override
-  public void runJobSets() {
+  public void runJobSetsWithoutTimer() {
     jobSets.forEach(
         jobSet -> {
           try {

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobresultwriter/JobResultWriter.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobresultwriter/JobResultWriter.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 public abstract class JobResultWriter {
   protected final List<String> commandArgs;
   protected final List<JobResult> jobResults;
+  protected final long elapsedTimeNS;
   protected final String jobRunnerName;
   protected final PrintStream outStream;
   protected final PrintStream errStream;
@@ -25,11 +26,13 @@ public abstract class JobResultWriter {
   protected JobResultWriter(
       List<String> commandArgs,
       List<JobResult> jobResults,
+      long elapsedTimeNS,
       String jobRunnerName,
       PrintStream outStream,
       PrintStream errStream) {
     this.commandArgs = commandArgs;
     this.jobResults = jobResults;
+    this.elapsedTimeNS = elapsedTimeNS;
     this.jobRunnerName = jobRunnerName;
     this.outStream = outStream;
     this.errStream = errStream;
@@ -62,6 +65,10 @@ public abstract class JobResultWriter {
 
   public long getNumFailures() {
     return numFailures;
+  }
+
+  public long getElapsedTimeNS() {
+    return elapsedTimeNS;
   }
 
   protected ImmutableMap<String, Summary> getEntitySummaries() {

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobresultwriter/SysOutWriter.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobresultwriter/SysOutWriter.java
@@ -16,10 +16,11 @@ public class SysOutWriter extends JobResultWriter {
   public SysOutWriter(
       List<String> commandArgs,
       List<JobResult> jobResults,
+      long elapsedTimeNS,
       String jobRunnerName,
       PrintStream outStream,
       PrintStream errStream) {
-    super(commandArgs, jobResults, jobRunnerName, outStream, errStream);
+    super(commandArgs, jobResults, elapsedTimeNS, jobRunnerName, outStream, errStream);
   }
 
   @Override


### PR DESCRIPTION
- Added the total elapsed time to the indexer output report, so I can give collaborators an estimate of how long it takes. Up until now I've timed the indexer runs manually in bash, but have now forgotten multiple times.
- Added the entity group name to the rollup counts indexing jobs, so it's easier to distinguish between the various jobs that all write to the `person` entity table.
- Fixed a bad label in the indexer output report (elapsed time said seconds, but was actually minutes).