### PR TITLE
Add CLI option to filter jobs run by classname.

### DIFF
--- a/docs/generated/indexer-cli/tanagra-clean-entity.adoc
+++ b/docs/generated/indexer-cli/tanagra-clean-entity.adoc
@@ -21,8 +21,8 @@ tanagra-clean-entity - Clean the outputs of all jobs for a single entity, or all
 
 *tanagra clean entity* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                      *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                     [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,
-                     _<names>_...]]...
+                     [*--output-dir*=_<outputDir>_] [*--job-filter*=_<classNames>_[,
+                     _<classNames>_...]]... [*--names*=_<names>_[,_<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -56,6 +56,9 @@ Clean the outputs of all jobs for a single entity, or all entities.
   Executor to use when running jobs: PARALLEL, SERIAL. Recommend serial for debugging, parallel otherwise.
 +
   Default: PARALLEL
+
+*--job-filter*=_<classNames>_[,_<classNames>_...]::
+  Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.
 
 *--names*=_<names>_[,_<names>_...]::
   Entity name(s). Comma-separated list if more than one.

--- a/docs/generated/indexer-cli/tanagra-clean-group.adoc
+++ b/docs/generated/indexer-cli/tanagra-clean-group.adoc
@@ -21,7 +21,8 @@ tanagra-clean-group - Clean the outputs of all jobs for a single entity group, o
 
 *tanagra clean group* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                     *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                    [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,_<names>_...]]...
+                    [*--output-dir*=_<outputDir>_] [*--job-filter*=_<classNames>_[,
+                    _<classNames>_...]]... [*--names*=_<names>_[,_<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -55,6 +56,9 @@ Clean the outputs of all jobs for a single entity group, or all entity groups.
   Executor to use when running jobs: PARALLEL, SERIAL. Recommend serial for debugging, parallel otherwise.
 +
   Default: PARALLEL
+
+*--job-filter*=_<classNames>_[,_<classNames>_...]::
+  Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.
 
 *--names*=_<names>_[,_<names>_...]::
   Entity group name(s). Comma-separated list if more than one.

--- a/docs/generated/indexer-cli/tanagra-clean-underlay.adoc
+++ b/docs/generated/indexer-cli/tanagra-clean-underlay.adoc
@@ -21,7 +21,8 @@ tanagra-clean-underlay - Clean the outputs of all jobs for underlay.
 
 *tanagra clean underlay* [*--dry-run*] [*--github-dir*=_<githubDir>_]
                        *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                       [*--output-dir*=_<outputDir>_]
+                       [*--output-dir*=_<outputDir>_] [*--job-filter*=_<classNames>_[,
+                       _<classNames>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -50,6 +51,9 @@ Clean the outputs of all jobs for underlay.
   Executor to use when running jobs: PARALLEL, SERIAL. Recommend serial for debugging, parallel otherwise.
 +
   Default: PARALLEL
+
+*--job-filter*=_<classNames>_[,_<classNames>_...]::
+  Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.
 
 *--output-dir*=_<outputDir>_::
   Absolute path to the directory where the html report will be written. Defaults to the current directory.

--- a/docs/generated/indexer-cli/tanagra-index-entity.adoc
+++ b/docs/generated/indexer-cli/tanagra-index-entity.adoc
@@ -21,8 +21,8 @@ tanagra-index-entity - Run all jobs for a single entity, or all entities.
 
 *tanagra index entity* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                      *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                     [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,
-                     _<names>_...]]...
+                     [*--output-dir*=_<outputDir>_] [*--job-filter*=_<classNames>_[,
+                     _<classNames>_...]]... [*--names*=_<names>_[,_<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -56,6 +56,9 @@ Run all jobs for a single entity, or all entities.
   Executor to use when running jobs: PARALLEL, SERIAL. Recommend serial for debugging, parallel otherwise.
 +
   Default: PARALLEL
+
+*--job-filter*=_<classNames>_[,_<classNames>_...]::
+  Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.
 
 *--names*=_<names>_[,_<names>_...]::
   Entity name(s). Comma-separated list if more than one.

--- a/docs/generated/indexer-cli/tanagra-index-group.adoc
+++ b/docs/generated/indexer-cli/tanagra-index-group.adoc
@@ -21,7 +21,8 @@ tanagra-index-group - Run all jobs for a single entity, or all entities.
 
 *tanagra index group* [*--all*] [*--dry-run*] [*--github-dir*=_<githubDir>_]
                     *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                    [*--output-dir*=_<outputDir>_] [*--names*=_<names>_[,_<names>_...]]...
+                    [*--output-dir*=_<outputDir>_] [*--job-filter*=_<classNames>_[,
+                    _<classNames>_...]]... [*--names*=_<names>_[,_<names>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -55,6 +56,9 @@ Run all jobs for a single entity, or all entities.
   Executor to use when running jobs: PARALLEL, SERIAL. Recommend serial for debugging, parallel otherwise.
 +
   Default: PARALLEL
+
+*--job-filter*=_<classNames>_[,_<classNames>_...]::
+  Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.
 
 *--names*=_<names>_[,_<names>_...]::
   Entity group name(s). Comma-separated list if more than one.

--- a/docs/generated/indexer-cli/tanagra-index-underlay.adoc
+++ b/docs/generated/indexer-cli/tanagra-index-underlay.adoc
@@ -21,7 +21,8 @@ tanagra-index-underlay - Run all jobs for underlay.
 
 *tanagra index underlay* [*--dry-run*] [*--github-dir*=_<githubDir>_]
                        *--indexer-config*=_<name>_ [*--job-executor*=_<jobExecutor>_]
-                       [*--output-dir*=_<outputDir>_]
+                       [*--output-dir*=_<outputDir>_] [*--job-filter*=_<classNames>_[,
+                       _<classNames>_...]]...
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -50,6 +51,9 @@ Run all jobs for underlay.
   Executor to use when running jobs: PARALLEL, SERIAL. Recommend serial for debugging, parallel otherwise.
 +
   Default: PARALLEL
+
+*--job-filter*=_<classNames>_[,_<classNames>_...]::
+  Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.
 
 *--output-dir*=_<outputDir>_::
   Absolute path to the directory where the html report will be written. Defaults to the current directory.

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/options/JobFilter.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/cli/shared/options/JobFilter.java
@@ -1,0 +1,42 @@
+package bio.terra.tanagra.indexing.cli.shared.options;
+
+import bio.terra.tanagra.cli.exception.UserActionableException;
+import bio.terra.tanagra.indexing.job.IndexingJob;
+import java.util.List;
+import java.util.stream.Collectors;
+import picocli.CommandLine;
+
+/**
+ * Command helper class that defines a filter on the jobs that get run.
+ *
+ * <p>This class is meant to be used as a @CommandLine.Mixin.
+ */
+public class JobFilter {
+  @CommandLine.Option(
+      names = "--job-filter",
+      description =
+          "Only run jobs with these class names. Specify the class names relative to the IndexingJob class (e.g. bigquery.ValidateDataTypes, not bio.terra.tanagra.indexing.job.bigquery.ValidateDataTypes). Useful for debugging a particular indexing job.",
+      split = ",")
+  private List<String> classNames;
+
+  public List<String> getClassNamesWithPackage() {
+    final String packageName = IndexingJob.class.getPackageName();
+    return classNames.stream()
+        .map(className -> packageName + '.' + className)
+        .collect(Collectors.toList());
+  }
+
+  public void validate() {
+    for (String className : getClassNamesWithPackage()) {
+      try {
+        Class<?> clazz = Class.forName(className);
+        if (!IndexingJob.class.isAssignableFrom(clazz)) {
+          throw new UserActionableException(
+              "Class name does not reference an indexing job: " + className);
+        }
+      } catch (ClassNotFoundException cnfEx) {
+        throw new UserActionableException("Invalid class name: " + className, cnfEx);
+      }
+    }
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SequencedJobSet.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/jobexecutor/SequencedJobSet.java
@@ -4,13 +4,14 @@ import bio.terra.tanagra.indexing.job.IndexingJob;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Container for a set of jobs and the sequence they must be run in. The stages must be run
  * serially. The jobs within each stage can be run in parallel.
  */
 public class SequencedJobSet {
-  private final List<List<IndexingJob>> stages;
+  private List<List<IndexingJob>> stages;
   private final String description;
 
   public SequencedJobSet(String description) {
@@ -28,6 +29,21 @@ public class SequencedJobSet {
 
   public Iterator<List<IndexingJob>> iterator() {
     return stages.iterator();
+  }
+
+  public SequencedJobSet filterJobs(List<String> jobClassNames) {
+    List<List<IndexingJob>> filteredStages = new ArrayList<>();
+    for (List<IndexingJob> stage : stages) {
+      List<IndexingJob> filteredStage =
+          stage.stream()
+              .filter(indexingJob -> jobClassNames.contains(indexingJob.getClass().getName()))
+              .collect(Collectors.toList());
+      if (!filteredStage.isEmpty()) {
+        filteredStages.add(filteredStage);
+      }
+    }
+    this.stages = filteredStages;
+    return this;
   }
 
   public int getNumStages() {


### PR DESCRIPTION
This is helpful for debugging a particular indexing job or doing a partial indexing run.