### PR TITLE
Plumb page marker for counts query through to OpenAPI spec.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -13,6 +13,7 @@ import bio.terra.tanagra.api.field.HierarchyPathField;
 import bio.terra.tanagra.api.field.RelatedEntityIdCountField;
 import bio.terra.tanagra.api.field.ValueDisplayField;
 import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.query.PageMarker;
 import bio.terra.tanagra.api.query.count.CountQueryRequest;
 import bio.terra.tanagra.api.query.count.CountQueryResult;
 import bio.terra.tanagra.api.query.hint.HintInstance;
@@ -192,7 +193,14 @@ public class UnderlaysApiController implements UnderlaysApi {
 
     CountQueryRequest countQueryRequest =
         new CountQueryRequest(
-            underlay, entity, attributeFields, filter, null, null, entityLevelHints, false);
+            underlay,
+            entity,
+            attributeFields,
+            filter,
+            PageMarker.deserialize(body.getPageMarker()),
+            null,
+            entityLevelHints,
+            false);
 
     // Run the count query and map the results back to API objects.
     CountQueryResult countQueryResult = underlay.getQueryRunner().run(countQueryRequest);
@@ -202,7 +210,11 @@ public class UnderlaysApiController implements UnderlaysApi {
                 countQueryResult.getCountInstances().stream()
                     .map(ToApiUtils::toApiObject)
                     .collect(Collectors.toList()))
-            .sql(SqlFormatter.format(countQueryResult.getSql())));
+            .sql(SqlFormatter.format(countQueryResult.getSql()))
+            .pageMarker(
+                countQueryResult.getPageMarker() == null
+                    ? null
+                    : countQueryResult.getPageMarker().serialize()));
   }
 
   @Override

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1356,6 +1356,10 @@ components:
             type: string
         filter:
           $ref: "#/components/schemas/Filter"
+        pageSize:
+          $ref: "#/components/schemas/PageSize"
+        pageMarker:
+          $ref: "#/components/schemas/PageMarker"
 
     HintQuery:
       type: object
@@ -1726,6 +1730,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/InstanceCount"
+        pageMarker:
+          $ref: "#/components/schemas/PageMarker"
 
     DisplayHint:
       type: object

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/PageMarker.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/PageMarker.java
@@ -2,6 +2,7 @@ package bio.terra.tanagra.api.query;
 
 import bio.terra.tanagra.utils.JacksonMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,10 @@ public final class PageMarker {
     }
   }
 
-  public static PageMarker deserialize(String jsonStr) {
+  public static PageMarker deserialize(@Nullable String jsonStr) {
+    if (jsonStr == null) {
+      return null;
+    }
     try {
       return JacksonMapper.deserializeJavaObject(jsonStr, PageMarker.class);
     } catch (JsonProcessingException jpEx) {

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
@@ -11,8 +11,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public class CountQueryRequest {
-  // TODO: Lower this once the UI paginates through count results.
-  private static final Integer DEFAULT_PAGE_SIZE = 2000;
+  private static final Integer DEFAULT_PAGE_SIZE = 250;
 
   private final Underlay underlay;
   private final Entity entity;


### PR DESCRIPTION
Also lowered the default page size for count queries from 2000->250, which now matches the default for list queries.