### PR TITLE
Include PR title in release description.

### DIFF
--- a/.github/tools/diffReleases.sh
+++ b/.github/tools/diffReleases.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+firstRelease=$1
+lastRelease=$2
+
+if [ -z $firstRelease ] || [ -z $lastRelease ];
+then
+  echo "First and last release tags are required (e.g. 0.0.370).";
+  exit 1;
+fi
+
+git log $1..$2 --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" > diffReleases.txt

--- a/.github/tools/diffReleases.sh
+++ b/.github/tools/diffReleases.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-firstRelease=$1
-lastRelease=$2
+first_release=$1
+last_release=$2
 
-if [ -z $firstRelease ] || [ -z $lastRelease ];
+if [ -z $first_release ] || [ -z $last_release ];
 then
   echo "First and last release tags are required (e.g. 0.0.370).";
   exit 1;
 fi
 
-git log $1..$2 --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" > diffReleases.txt
+diff_output=$(git diff $first_release..$last_release -- underlay/ indexer/)
+if [ -z $diff_output ];
+then
+  echo "REINDEXING NOT NEEDED" > diffReleases.txt
+else
+  echo "REINDEXING RECOMMENDED" > diffReleases.txt
+fi
+
+echo >> diffReleases.txt
+git log $1..$2 --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" >> diffReleases.txt

--- a/.github/workflows/bump-tag-publish.yaml
+++ b/.github/workflows/bump-tag-publish.yaml
@@ -130,4 +130,5 @@ jobs:
         id: create_release
         with:
           tag: ${{ steps.tag.outputs.tag }}
+          generateReleaseNotes: true
           artifacts: "./service/src/main/resources/api/service_openapi.yaml"

--- a/.github/workflows/diff-releases.yaml
+++ b/.github/workflows/diff-releases.yaml
@@ -1,0 +1,26 @@
+name: Diff Releases
+
+on:
+  workflow_dispatch:
+inputs:
+  first-release-tag:
+    description: 'First release tag (e.g. 0.0.365)'
+    required: true
+  last-release-tag:
+    description: 'Last release tag (e.g. 0.0.370)'
+    required: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate git log diff file between two releases
+        run: .github/tools/diffReleases.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save diff file
+        uses: actions/upload-artifact@v4
+        with:
+          name: diff-file
+          path: diffReleases.txt
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ workflow/rendered/
 !**/src/test/**
 */bin
 tanagra-indexing.html
+diffReleases.txt
 
 ### Jenv ###
 .java-version


### PR DESCRIPTION
- Set flag to automatically include PR title and link in the description of the GH release that is auto-generated when we merge a PR.
- Put the command I use locally to list the PRs between two release flags into a GHA so we can run it from the repo page.