### PR TITLE
Fix input indentation and gh pull depth in diff releases workflow.

### DIFF
--- a/.github/tools/diffReleases.sh
+++ b/.github/tools/diffReleases.sh
@@ -9,8 +9,10 @@ then
   echo "First and last release tags are required (e.g. 0.0.370).";
   exit 1;
 fi
+echo "First release tag: $first_release"
+echo "Last release tag: $last_release"
 
-diff_output=$(git diff $first_release..$last_release -- underlay/ indexer/)
+diff_output=$(git diff "$first_release..$last_release" -- underlay/ indexer/)
 if [ -z $diff_output ];
 then
   echo "REINDEXING NOT NEEDED" > $output_file
@@ -22,7 +24,7 @@ echo >> $output_file
 echo "diff_output done"
 echo "$diff_output"
 
-log_output=$(git log $first_release..$last_release --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s")
+log_output=$(git log "$first_release..$last_release" --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s")
 echo $log_output >> $output_file
 
 echo "log_output done"

--- a/.github/tools/diffReleases.sh
+++ b/.github/tools/diffReleases.sh
@@ -16,6 +16,7 @@ then
 else
   echo "REINDEXING RECOMMENDED" > diffReleases.txt
 fi
+echo "diff output done"
 
 echo >> diffReleases.txt
-git log $1..$2 --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" >> diffReleases.txt
+git log $first_release..$last_release --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" >> diffReleases.txt

--- a/.github/tools/diffReleases.sh
+++ b/.github/tools/diffReleases.sh
@@ -21,11 +21,6 @@ else
 fi
 echo >> $output_file
 
-echo "diff_output done"
-echo "$diff_output"
+git log "$first_release..$last_release" --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" >> $output_file
 
-log_output=$(git log "$first_release..$last_release" --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s")
-echo $log_output >> $output_file
-
-echo "log_output done"
-echo "$log_output"
+cat $output_file

--- a/.github/tools/diffReleases.sh
+++ b/.github/tools/diffReleases.sh
@@ -2,6 +2,7 @@
 
 first_release=$1
 last_release=$2
+output_file="diffReleases.txt"
 
 if [ -z $first_release ] || [ -z $last_release ];
 then
@@ -12,11 +13,17 @@ fi
 diff_output=$(git diff $first_release..$last_release -- underlay/ indexer/)
 if [ -z $diff_output ];
 then
-  echo "REINDEXING NOT NEEDED" > diffReleases.txt
+  echo "REINDEXING NOT NEEDED" > $output_file
 else
-  echo "REINDEXING RECOMMENDED" > diffReleases.txt
+  echo "REINDEXING RECOMMENDED" > $output_file
 fi
-echo "diff output done"
+echo >> $output_file
 
-echo >> diffReleases.txt
-git log $first_release..$last_release --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s" >> diffReleases.txt
+echo "diff_output done"
+echo "$diff_output"
+
+log_output=$(git log $first_release..$last_release --grep='^bump' --invert-grep --pretty=format:"%h %as %an%x09%s")
+echo $log_output >> $output_file
+
+echo "log_output done"
+echo "$log_output"

--- a/.github/workflows/diff-releases.yaml
+++ b/.github/workflows/diff-releases.yaml
@@ -31,3 +31,4 @@ jobs:
           name: diff-file
           path: diffReleases.txt
           retention-days: 1
+          compression-level: 0 # No compression

--- a/.github/workflows/diff-releases.yaml
+++ b/.github/workflows/diff-releases.yaml
@@ -6,16 +6,22 @@ on:
       first-release-tag:
         description: 'First release tag (e.g. 0.0.365)'
         required: true
+        default: 0.0.365
       last-release-tag:
         description: 'Last release tag (e.g. 0.0.370)'
         required: true
+        default: 0.0.370
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Generate git log diff file between two releases
-        run: .github/tools/diffReleases.sh $FIRST_RELEASE_TAG $LAST_RELEASE_TAG
+        run: |
+          git status
+          git diff 0.0.365..0.0.370 -- underlay/ indexer/
+          git diff "$first_release..$last_release" -- underlay/ indexer/
+          .github/tools/diffReleases.sh $FIRST_RELEASE_TAG $LAST_RELEASE_TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FIRST_RELEASE_TAG: ${{ github.event.inputs.first-release-tag }}

--- a/.github/workflows/diff-releases.yaml
+++ b/.github/workflows/diff-releases.yaml
@@ -2,13 +2,13 @@ name: Diff Releases
 
 on:
   workflow_dispatch:
-inputs:
-  first-release-tag:
-    description: 'First release tag (e.g. 0.0.365)'
-    required: true
-  last-release-tag:
-    description: 'Last release tag (e.g. 0.0.370)'
-    required: true
+    inputs:
+      first-release-tag:
+        description: 'First release tag (e.g. 0.0.365)'
+        required: true
+      last-release-tag:
+        description: 'Last release tag (e.g. 0.0.370)'
+        required: true
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/diff-releases.yaml
+++ b/.github/workflows/diff-releases.yaml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Generate git log diff file between two releases
-        run: .github/tools/diffReleases.sh
+        run: .github/tools/diffReleases.sh $FIRST_RELEASE_TAG $LAST_RELEASE_TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIRST_RELEASE_TAG: ${{ github.event.inputs.first-release-tag }}
+          LAST_RELEASE_TAG: ${{ github.event.inputs.last-release-tag }}
       - name: Save diff file
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/diff-releases.yaml
+++ b/.github/workflows/diff-releases.yaml
@@ -16,11 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Generate git log diff file between two releases
         run: |
-          git status
-          git diff 0.0.365..0.0.370 -- underlay/ indexer/
-          git diff "$first_release..$last_release" -- underlay/ indexer/
           .github/tools/diffReleases.sh $FIRST_RELEASE_TAG $LAST_RELEASE_TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         company-and-underlay: [ "broad/aou_synthetic", "broad/cms_synpuf" ]
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
     - uses: actions/checkout@v3
     - name: Pull credentials

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         company-and-underlay: [ "broad/aou_synthetic", "broad/cms_synpuf" ]
     runs-on: ubuntu-latest
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
     - uses: actions/checkout@v3
     - name: Pull credentials

--- a/.github/workflows/service-test-mariadb.yaml
+++ b/.github/workflows/service-test-mariadb.yaml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:3306
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/service-test-mariadb.yaml
+++ b/.github/workflows/service-test-mariadb.yaml
@@ -30,6 +30,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:3306
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/service-test-mariadb.yaml
+++ b/.github/workflows/service-test-mariadb.yaml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:3306
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/service-test-postgres.yaml
+++ b/.github/workflows/service-test-postgres.yaml
@@ -30,6 +30,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/service-test-postgres.yaml
+++ b/.github/workflows/service-test-postgres.yaml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/service-test-postgres.yaml
+++ b/.github/workflows/service-test-postgres.yaml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -31,7 +31,7 @@ jobs:
         ports:
           - 5432:5432
 
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -31,6 +31,7 @@ jobs:
         ports:
           - 5432:5432
 
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -31,7 +31,7 @@ jobs:
         ports:
           - 5432:5432
 
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [19.x]
 
-    if: "!contains( github.event.sender.login, 'broadbot')"
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         node-version: [19.x]
 
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [19.x]
 
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/underlay-test.yaml
+++ b/.github/workflows/underlay-test.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'marikomedlock')"
+    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11

--- a/.github/workflows/underlay-test.yaml
+++ b/.github/workflows/underlay-test.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: "!contains( github.event.sender.login, 'marikomedlock')"
     steps:
       - uses: actions/checkout@v3
       - name: Set up AdoptOpenJDK 11


### PR DESCRIPTION
We should now be able to run this on demand from the GH UI:
<img width="1263" alt="Screenshot 2024-02-09 at 12 35 29 PM" src="https://github.com/DataBiosphere/tanagra/assets/12446128/cf4824ce-4fd6-4edf-b03c-18cdd3205941">

Download the output file:
<img width="1101" alt="Screenshot 2024-02-09 at 12 38 53 PM" src="https://github.com/DataBiosphere/tanagra/assets/12446128/f100e50e-13f3-4192-8054-c9c42848a313">

And open it in a text editor on your local machine:
<img width="1081" alt="Screenshot 2024-02-09 at 12 39 52 PM" src="https://github.com/DataBiosphere/tanagra/assets/12446128/8fad3a00-95fd-4d55-ae4f-224a52b2a2aa">

------

I also updated the test actions to skip when the merger is `broadbot`. This is to skip automated tests on the `bump` merges. We already run all tests on PR merge, so no need to run them twice for each PR (once for the PR merge and once for the bump merge). Hopefully this will reduce competition for the GHA runners so less things get queued for a long time.