### PR TITLE
Use protos to store plugin selection data

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -8,6 +8,7 @@
 # generated code
 /src/tanagra-api
 /src/tanagra-ui
+/src/proto
 
 # testing
 /coverage

--- a/ui/codegen.sh
+++ b/ui/codegen.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Generate API OpenAPI code.
+rm -rf src/tanagra-api
+openapi-generator-cli generate -i ../service/src/main/resources/api/service_openapi.yaml -g typescript-fetch -t ./openapi-templates --additional-properties=typescriptThreePlus=true -o src/tanagra-api
+
+# Generate UI OpenAPI code.
+rm -rf src/tanagra-ui
+openapi-generator-cli generate -i ./ui_openapi.yaml -g typescript-fetch -t ./openapi-templates --additional-properties=typescriptThreePlus=true --model-name-prefix UI -o src/tanagra-ui
+
+# Generate plugin proto code.
+rm -rf src/proto
+mkdir src/proto
+npx protoc --proto_path=../underlay/src/main/proto/ --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/proto/ --ts_proto_opt=esModuleInterop=true --ts_proto_opt=outputClientImpl=false ../underlay/src/main/proto/criteriaselector/dataschema/*.proto

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/material": "^5.11.12",
         "@mui/x-data-grid": "^5.0.0-beta.2",
         "@openapitools/openapi-generator-cli": "^2.4.1",
+        "@protobuf-ts/protoc": "^2.9.3",
         "@testing-library/dom": "^8.11.1",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
@@ -44,6 +45,7 @@
         "react-test-renderer": "^17.0.2",
         "recharts": "^2.1.12",
         "swr": "^2.0.0",
+        "ts-proto": "^1.167.2",
         "typescript": "^4.4.2",
         "use-immer": "^0.6.0",
         "web-vitals": "^1.1.2"
@@ -3861,6 +3863,68 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.3.tgz",
+      "integrity": "sha512-TJ0Ycx/CIBqpB4wpKt6K05kjXj6zv36s/qpdCT/wdJBhpayOVBqLF5NpLp3WIiw1PmIxvqalB6QHKjvnLzGKLA==",
+      "bin": {
+        "protoc": "protoc.js"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@remix-run/router": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.0.tgz",
@@ -6628,6 +6692,17 @@
         }
       ]
     },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
@@ -8278,6 +8353,17 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -8511,6 +8597,14 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "node_modules/dprint-node": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
+      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      }
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -14380,6 +14474,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -16769,6 +16868,37 @@
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
       "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
       "optional": true
+    },
+    "node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/@types/node": {
+      "version": "20.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.13.tgz",
+      "integrity": "sha512-5G4zQwdiQBSWYTDAH1ctw2eidqdhMJaNsiIDKHFr55ihz5Trl2qqR8fdrT732yPBho5gkNxXm67OxWFBqX9aPg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -19555,6 +19685,37 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "node_modules/ts-poet": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.6.0.tgz",
+      "integrity": "sha512-4vEH/wkhcjRPFOdBwIh9ItO6jOoumVLRF4aABDX5JSNEubSqwOulihxQPqai+OkuygJm3WYMInxXQX4QwVNMuw==",
+      "dependencies": {
+        "dprint-node": "^1.0.7"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "1.167.2",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.167.2.tgz",
+      "integrity": "sha512-7y/BLjiUZphgCe+SZBEG20DP94VK7BHpHcl5fkeN8lRCeABNIsiI54FkUQ8pe7PsHLVpFKqMO5aRLx74FX+4iA==",
+      "dependencies": {
+        "case-anything": "^2.1.13",
+        "protobufjs": "^7.2.4",
+        "ts-poet": "^6.5.0",
+        "ts-proto-descriptors": "1.15.0"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
+      "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
+      "dependencies": {
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -19702,6 +19863,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "@mui/material": "^5.11.12",
     "@mui/x-data-grid": "^5.0.0-beta.2",
     "@openapitools/openapi-generator-cli": "^2.4.1",
+    "@protobuf-ts/protoc": "^2.9.3",
     "@testing-library/dom": "^8.11.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
@@ -40,6 +41,7 @@
     "react-test-renderer": "^17.0.2",
     "recharts": "^2.1.12",
     "swr": "^2.0.0",
+    "ts-proto": "^1.167.2",
     "typescript": "^4.4.2",
     "use-immer": "^0.6.0",
     "web-vitals": "^1.1.2"
@@ -53,20 +55,13 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "codegen": "rm -rf src/tanagra-api && openapi-generator-cli generate -i ../service/src/main/resources/api/service_openapi.yaml -g typescript-fetch -t ./openapi-templates --additional-properties=typescriptThreePlus=true -o src/tanagra-api && rm -rf src/tanagra-ui && openapi-generator-cli generate -i ./ui_openapi.yaml -g typescript-fetch -t ./openapi-templates --additional-properties=typescriptThreePlus=true --model-name-prefix UI -o src/tanagra-ui"
+    "codegen": "./codegen.sh"
   },
   "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "extends": ["react-app", "react-app/jest"]
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
@@ -93,8 +88,6 @@
     "prettier-plugin-organize-imports": "^2.3.4"
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "node_modules/(?!(@brightspace-ui)/)"
-    ]
+    "transformIgnorePatterns": ["node_modules/(?!(@brightspace-ui)/)"]
   }
 }

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -308,7 +308,7 @@ type InitializeDataFn = (
   underlaySource: UnderlaySource,
   config: CriteriaConfig,
   dataEntry?: DataEntry
-) => object;
+) => string;
 
 type SearchFn = (
   underlaySource: UnderlaySource,
@@ -337,7 +337,7 @@ export function createCriteria(
 export function getCriteriaPlugin(
   criteria: tanagraUI.UICriteria,
   entity?: string
-): CriteriaPlugin<object> {
+): CriteriaPlugin<string> {
   return new (getCriteriaEntry(criteria.type).constructor)(
     criteria.id,
     criteria.config as CriteriaConfig,
@@ -358,9 +358,9 @@ interface CriteriaPluginConstructor {
   new (
     id: string,
     config: CriteriaConfig,
-    data: object,
+    data: string,
     entity?: string
-  ): CriteriaPlugin<object>;
+  ): CriteriaPlugin<string>;
 }
 
 type RegistryEntry = {

--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -279,7 +279,7 @@ export function updateCohortCriteria(
   context: CohortContextData,
   sectionId: string,
   groupId: string,
-  data: object,
+  data: string,
   criteriaId?: string
 ) {
   context.updatePresent((present) => {

--- a/ui/src/criteriaHolder.tsx
+++ b/ui/src/criteriaHolder.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "util/searchState";
 
 export type CriteriaHolderProps = {
   title: string;
-  plugin: CriteriaPlugin<object>;
+  plugin: CriteriaPlugin<string>;
   exitAction?: () => void;
   backURL?: string;
 };

--- a/ui/src/featureSet/featureSetContext.ts
+++ b/ui/src/featureSet/featureSetContext.ts
@@ -211,7 +211,7 @@ export function insertPredefinedFeatureSetCriteria(
 
 export function updateFeatureSetCriteria(
   context: FeatureSetContextData,
-  data: object,
+  data: string,
   criteriaId?: string
 ) {
   context.updatePresent((present) => {

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -177,7 +177,7 @@ export function useUpdateCriteria(groupId?: string, criteriaId?: string) {
     }
 
     if (newCriteria) {
-      return (data: object) => {
+      return (data: string) => {
         if (newCriteria) {
           insertCohortCriteria(cohortContext, section.id, {
             ...newCriteria,
@@ -189,7 +189,7 @@ export function useUpdateCriteria(groupId?: string, criteriaId?: string) {
 
     const gId = groupId ?? group?.id;
     if (gId) {
-      return (data: object) => {
+      return (data: string) => {
         updateCohortCriteria(cohortContext, section.id, gId, data, criteriaId);
       };
     }
@@ -203,7 +203,7 @@ export function useUpdateCriteria(groupId?: string, criteriaId?: string) {
     }
 
     if (newCriteria) {
-      return (data: object) => {
+      return (data: string) => {
         if (newCriteria) {
           insertFeatureSetCriteria(featureSetContext, {
             ...newCriteria,
@@ -216,7 +216,7 @@ export function useUpdateCriteria(groupId?: string, criteriaId?: string) {
     if (!featureSetCriteria) {
       throw new Error("Null feature set criteria when updating it.");
     }
-    return (data: object) => {
+    return (data: string) => {
       updateFeatureSetCriteria(featureSetContext, data, featureSetCriteria.id);
     };
   }

--- a/ui/src/util/base64.ts
+++ b/ui/src/util/base64.ts
@@ -1,0 +1,9 @@
+export function base64ToBytes(base64: string) {
+  const binString = atob(base64);
+  return Uint8Array.from(binString, (m) => m.codePointAt(0) as number);
+}
+
+export function bytesToBase64(bytes: Uint8Array) {
+  const binString = String.fromCodePoint(...bytes);
+  return btoa(binString);
+}

--- a/ui/ui_openapi.yaml
+++ b/ui/ui_openapi.yaml
@@ -185,7 +185,7 @@ components:
           type: string
           description: The plugin type used by this criteria.
         data:
-          type: object
+          type: string
           description: The plugin specific data that defines this criteria.
         config:
           type: object

--- a/underlay/src/main/proto/criteriaselector/data_range.proto
+++ b/underlay/src/main/proto/criteriaselector/data_range.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package tanagra;
+
+message DataRange {
+  string id = 1;
+  double min = 2;
+  double max = 3;
+}

--- a/underlay/src/main/proto/criteriaselector/dataschema/attribute.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/attribute.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package tanagra;
+
+import "criteriaselector/value.proto";
+import "criteriaselector/data_range.proto";
+
+message Attribute {
+  message Selection {
+    Value value = 1;
+    string name = 2;
+  }
+  repeated Selection selected = 1;
+
+  repeated DataRange data_ranges = 2;
+}

--- a/underlay/src/main/proto/criteriaselector/dataschema/biovu.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/biovu.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package tanagra;
+
+message BioVU {
+  enum SampleFilter {
+    SAMPLE_FILTER_UNKNOWN = 0;
+    SAMPLE_FILTER_ANY = 1;
+    SAMPLE_FILTER_ONE_HUNDRED = 2;
+    SAMPLE_FILTER_FIVE_HUNDRED = 3;
+  }
+  SampleFilter sample_filter = 1;
+
+  bool exclude_compromised = 2;
+  bool exclude_internal = 3;
+  bool plasma = 4;
+}

--- a/underlay/src/main/proto/criteriaselector/dataschema/entity_group.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/entity_group.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package tanagra;
+
+import "criteriaselector/key.proto";
+import "criteriaselector/value_data.proto";
+
+message EntityGroup {
+  message Selection {
+    Key key = 1;
+    string name = 2;
+    string entityGroup = 3;
+  }
+  repeated Selection selected = 1;
+
+  optional ValueData value_data = 2;
+}

--- a/underlay/src/main/proto/criteriaselector/dataschema/multi_attribute.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/multi_attribute.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package tanagra;
+
+import "criteriaselector/value_data.proto";
+
+message MultiAttribute {
+  repeated ValueData value_data = 1;
+}

--- a/underlay/src/main/proto/criteriaselector/dataschema/text_search.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/text_search.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package tanagra;
+
+import "criteriaselector/value.proto";
+
+message TextSearch {
+  message Selection {
+    Value value = 1;
+    string name = 2;
+  }
+  repeated Selection categories = 1;
+
+  string query = 2;
+}

--- a/underlay/src/main/proto/criteriaselector/dataschema/unhinted_value.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/unhinted_value.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package tanagra;
+
+message UnhintedValue {
+  enum ComparisonOperator {
+    COMPARISON_OPERATOR_UNKNOWN = 0;
+    COMPARISON_OPERATOR_EQUAL = 1;
+    COMPARISON_OPERATOR_BETWEEN = 2;
+    COMPARISON_OPERATOR_LESS_THAN_EQUAL = 3;
+    COMPARISON_OPERATOR_GREATER_THAN_EQUAL = 4;
+  }
+  ComparisonOperator operator = 1;
+
+  double min = 2;
+  double max = 3;
+}

--- a/underlay/src/main/proto/criteriaselector/key.proto
+++ b/underlay/src/main/proto/criteriaselector/key.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package tanagra;
+
+message Key {
+  oneof key {
+    string string_key = 1;
+    int64 int64_key = 2;
+  }
+}

--- a/underlay/src/main/proto/criteriaselector/value.proto
+++ b/underlay/src/main/proto/criteriaselector/value.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package tanagra;
+
+import "google/protobuf/timestamp.proto";
+
+message Value {
+  oneof value {
+    string string_value = 1;
+    int64 int64_value = 2;
+    bool bool_value = 3;
+    google.protobuf.Timestamp timestamp_value = 4;
+  }
+}

--- a/underlay/src/main/proto/criteriaselector/value_data.proto
+++ b/underlay/src/main/proto/criteriaselector/value_data.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package tanagra;
+
+import "criteriaselector/value.proto";
+import "criteriaselector/data_range.proto";
+
+message ValueData {
+  string attribute = 1;
+  bool numeric = 2;
+
+  message Selection {
+    Value value = 1;
+    string name = 2;
+  }
+  repeated Selection selected = 3;
+
+  DataRange range = 4;
+}


### PR DESCRIPTION
* Add protos that roughly mirror existing selection data. Decode selection data as protos if they fails to parse as JSON to enable backwards compatability.
* Store encoded protobufs in plugins and convert on demand using existing data structures. This minimizes the code changes as part of this conversion. Future PRs might change this behavior but protos don't work naturally with React state so some kind of workaround will be needed.