### PR TITLE
Download protoc executable from Maven.

### DIFF
--- a/.github/workflows/indexer-test.yaml
+++ b/.github/workflows/indexer-test.yaml
@@ -34,10 +34,6 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull credentials
         id: pull_credentials
         run: |

--- a/.github/workflows/service-test-mariadb.yaml
+++ b/.github/workflows/service-test-mariadb.yaml
@@ -50,10 +50,6 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull credentials
         id: pull_credentials
         run: |

--- a/.github/workflows/service-test-postgres.yaml
+++ b/.github/workflows/service-test-postgres.yaml
@@ -50,10 +50,6 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull credentials
         id: pull_credentials
         run: |

--- a/.github/workflows/ui-integration-test.yaml
+++ b/.github/workflows/ui-integration-test.yaml
@@ -55,11 +55,6 @@ jobs:
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Pull credentials
         id: pull_credentials
         run: |

--- a/.github/workflows/underlay-test.yaml
+++ b/.github/workflows/underlay-test.yaml
@@ -34,10 +34,6 @@ jobs:
             ~/.gradle/wrapper
           key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
           restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull credentials
         id: pull_credentials
         run: |

--- a/underlay/build.gradle
+++ b/underlay/build.gradle
@@ -52,6 +52,11 @@ dependencies {
 }
 
 protobuf {
+    // Configure the protoc executable
+    protoc {
+        // Download from repositories
+        artifact = 'com.google.protobuf:protoc:3.0.0'
+    }
     // By default, the proto plugin generates Java classes in the build/classes/ directory.
     // generatedFilesBaseDir = "$projectDir/src/generated"
 }

--- a/underlay/build.gradle
+++ b/underlay/build.gradle
@@ -55,7 +55,7 @@ protobuf {
     // Configure the protoc executable
     protoc {
         // Download from repositories
-        artifact = "com.google.protobuf:protoc:3.8.0"
+        artifact = "com.google.protobuf:protoc:3.25.2"
     }
     // By default, the proto plugin generates Java classes in the build/classes/ directory.
     // generatedFilesBaseDir = "$projectDir/src/generated"

--- a/underlay/build.gradle
+++ b/underlay/build.gradle
@@ -55,7 +55,7 @@ protobuf {
     // Configure the protoc executable
     protoc {
         // Download from repositories
-        artifact = 'com.google.protobuf:protoc:3.0.0'
+        artifact = 'com.google.protobuf:protoc:2.9.3'
     }
     // By default, the proto plugin generates Java classes in the build/classes/ directory.
     // generatedFilesBaseDir = "$projectDir/src/generated"

--- a/underlay/build.gradle
+++ b/underlay/build.gradle
@@ -55,7 +55,7 @@ protobuf {
     // Configure the protoc executable
     protoc {
         // Download from repositories
-        artifact = 'com.google.protobuf:protoc:2.9.3'
+        artifact = "com.google.protobuf:protoc:3.8.0"
     }
     // By default, the proto plugin generates Java classes in the build/classes/ directory.
     // generatedFilesBaseDir = "$projectDir/src/generated"

--- a/underlay/src/main/proto/criteriaselector/dataschema/entity_group.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/entity_group.proto
@@ -15,5 +15,5 @@ message EntityGroup {
   }
   repeated Selection selected = 1;
 
-  optional ValueData value_data = 2;
+  ValueData value_data = 2;
 }


### PR DESCRIPTION
- Removed `protoc` install step from GHAs.
- Removed the `optional` keyword from the `entity_group.proto`.
- Tested on a Mac with an M1 chip (works with >=3.20) and on the Linux GHA runners.

Thanks to @tjennison-google for pointing out this option to not require a local install of `protoc`.