### PR TITLE
Unpeg grpc library version.

### DIFF
--- a/underlay/build.gradle
+++ b/underlay/build.gradle
@@ -45,10 +45,6 @@ dependencies {
     // Static analysis
     compileOnly group: "com.google.code.findbugs", name: "annotations", version: "3.0.1u2"
     testCompileOnly group: "com.google.code.findbugs", name: "annotations", version: "3.0.1u2"
-
-    implementation group: "io.grpc", name: "grpc-protobuf", version: "1.61.0"
-    implementation group: "io.grpc", name: "grpc-stub", version: "1.61.0"
-    implementation group: "io.grpc", name: "grpc-netty", version: "1.61.0"
 }
 
 protobuf {


### PR DESCRIPTION
Test indexing an entity that includes both BQ and Dataflow jobs, completed successfully:
`tanagra index entity --names condition --indexer-config=aouSR2019q4r4_verily`

I'll plan to re-enable dependency locking in a follow-on PR to prevent this kind of problem in the future.