### PR TITLE
Fix relationship filter bad query optimization.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
@@ -383,6 +383,6 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
 
   @Override
   public boolean isFilterOnAttribute(Attribute attribute) {
-    return attribute.isId() && !relationshipFilter.hasSubFilter();
+    return attribute.isId();
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -1255,8 +1255,16 @@ public class BQFilterTest extends BQRunnerTest {
                 true));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
+    BQTable itemsTable =
+        underlay
+            .getIndexSchema()
+            .getEntityMain(groupItems.getItemsEntity().getName())
+            .getTablePointer();
     assertSqlMatchesWithTableNameOnly(
-        "relationshipFilterNestedNullFilterFKFilter", sqlQueryRequest.getSql(), occurrenceTable);
+        "relationshipFilterNestedNullFilterFKFilter",
+        sqlQueryRequest.getSql(),
+        occurrenceTable,
+        itemsTable);
   }
 
   @Test

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterNestedNullFilterFKFilter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterNestedNullFilterFKFilter.sql
@@ -8,5 +8,5 @@
             SELECT
                 person_id              
             FROM
-                `verily-tanagra-dev.sd20230331_index_010224`.ENT_bmi         
+                ${ENT_bmi}         
         )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterNestedNullFilterFKFilter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterNestedNullFilterFKFilter.sql
@@ -1,0 +1,12 @@
+
+    SELECT
+        start_date      
+    FROM
+        ${ENT_conditionOccurrence}      
+    WHERE
+        person_id IN (
+            SELECT
+                person_id              
+            FROM
+                `verily-tanagra-dev.sd20230331_index_010224`.ENT_bmi         
+        )


### PR DESCRIPTION
When there is a nested relationship filter, and the inner filter has a null sub-filter, there could be a bad query optimization where we skip the join. This PR addresses this. This is the error that was happening when trying to export e.g. the condition occurrence table for people with any bmi reading (setting a specific bmi range would not trigger this). Also added a test for this case, and some debug logging in the SQL building code.