### PR TITLE
Choose very large default page size for count queries.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
@@ -11,7 +11,9 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 public class CountQueryRequest {
-  private static final Integer DEFAULT_PAGE_SIZE = 250;
+  // Choose a very large default page size for count queries because, unlike list queries, we expect
+  // callers to always paginate through all results).
+  private static final Integer DEFAULT_PAGE_SIZE = 20_000;
 
   private final Underlay underlay;
   private final Entity entity;


### PR DESCRIPTION
Unlike list queries, I think we expect callers to always paginate through all results of count queries, so try to reduce the number of ui-backend-BQ round-trips as much as possible. This should address the problem of the mismatched group/total counts.
