### PR TITLE
Skip writing empty annotation export files.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
@@ -408,7 +408,17 @@ public class ReviewService {
     return underlay.getQueryRunner().run(countQueryRequest);
   }
 
-  public String buildCsvStringForAnnotationValues(Study study, Cohort cohort) {
+  /**
+   * Build a CSV string, with annotation keys as the header and values as the body. Return null if
+   * there are no annotation values.
+   */
+  public @Nullable String buildCsvStringForAnnotationValues(Study study, Cohort cohort) {
+    // Get all the annotation values for the latest revision.
+    List<AnnotationValue> annotationValues = listAnnotationValues(study.getId(), cohort.getId());
+    if (annotationValues.isEmpty()) {
+      return null; // Don't generate a file with no data.
+    }
+
     // Build the column headers: id column name in source data, then annotation key display names.
     // Sort the annotation keys by display name, so that we get a consistent ordering.
     // e.g. person_id, key1, key2
@@ -438,9 +448,6 @@ public class ReviewService {
             columnHeaders.append(
                 String.format(",%s", StringEscapeUtils.escapeCsv(annotation.getDisplayName()))));
     StringBuilder fileContents = new StringBuilder(columnHeaders + "\n");
-
-    // Get all the annotation values for the latest revision.
-    List<AnnotationValue> annotationValues = listAnnotationValues(study.getId(), cohort.getId());
 
     // Convert the list of annotation values to a CSV-ready table.
     Table<String, String, String> csvValues = HashBasedTable.create();

--- a/ui/cypress/e2e/export.cy.js
+++ b/ui/cypress/e2e/export.cy.js
@@ -8,10 +8,10 @@ function generateName(type) {
 describe("Basic tests", () => {
   it("Export", () => {
     const cohort1 = "export1";
-    cy.createCohortFromSearch(cohort1, "Red color", "tanagra-conditions");
+    cy.createCohortFromSearchThenAddAnnotationData(cohort1, "Red color", "tanagra-conditions");
 
     const cohort2 = "export2";
-    cy.createCohortFromSearch(cohort2, "Papule of skin");
+    cy.createCohortFromSearchThenAddAnnotationData(cohort2, "Papule of skin");
 
     cy.get("button:Contains(New feature set)").click();
     cy.wait(2000);
@@ -47,8 +47,8 @@ describe("Basic tests", () => {
     cy.iframe().find("li:Contains(Download individual files)").click();
     cy.iframe().find("button:Contains(Export)").last().click();
 
-//    cy.iframe().find(`a:Contains(${cohort1})`, { timeout: 20000 });
-//    cy.iframe().find(`a:Contains(${cohort2})`);
+    cy.iframe().find(`a:Contains(${cohort1})`, { timeout: 20000 });
+    cy.iframe().find(`a:Contains(${cohort2})`);
     cy.iframe().find("a:Contains(person)");
     cy.iframe().find("a:Contains(conditionOccurrence)");
   });

--- a/ui/cypress/e2e/export.cy.js
+++ b/ui/cypress/e2e/export.cy.js
@@ -47,8 +47,8 @@ describe("Basic tests", () => {
     cy.iframe().find("li:Contains(Download individual files)").click();
     cy.iframe().find("button:Contains(Export)").last().click();
 
-    cy.iframe().find(`a:Contains(${cohort1})`, { timeout: 20000 });
-    cy.iframe().find(`a:Contains(${cohort2})`);
+//    cy.iframe().find(`a:Contains(${cohort1})`, { timeout: 20000 });
+//    cy.iframe().find(`a:Contains(${cohort2})`);
     cy.iframe().find("a:Contains(person)");
     cy.iframe().find("a:Contains(conditionOccurrence)");
   });

--- a/ui/cypress/support/e2e.js
+++ b/ui/cypress/support/e2e.js
@@ -31,6 +31,49 @@ Cypress.Commands.add("createCohortFromSearch", (name, search, domain) => {
   cy.iframe().find("button[aria-label=back]").click();
 });
 
+Cypress.Commands.add("createCohortFromSearchThenAddAnnotationData", (name, search, domain) => {
+  cy.get("button:Contains(New cohort)").click();
+  cy.wait(2000);
+
+  cy.iframe().find("[data-testid='EditIcon']").first().click();
+  cy.iframe()
+    .find("input[name=text]")
+    .type("{selectall}" + name);
+  cy.iframe().find("button:Contains(Update)").click();
+  cy.iframe().find("a:Contains(Add some criteria)").first().click();
+  if (domain) {
+    cy.iframe().find(`[data-testid='${domain}']`).click();
+  }
+  cy.iframe().find("input").type(search);
+
+  cy.possiblyMultiSelect(search);
+
+  cy.iframe().contains("Review").click();
+
+  cy.iframe().find("[data-testid='AddIcon']").first().click();
+  cy.iframe().find("input[name=name]").type("Initial");
+  cy.iframe().find("input[name=size]").type("2");
+  cy.iframe().find("button:Contains(Create)").click();
+
+  cy.iframe().find("button:Contains(Annotations)").click();
+
+  cy.iframe().contains("Add annotation field").click();
+  cy.iframe().find(".MuiSelect-select:Contains(Free text)").click();
+  cy.iframe().find("li:Contains(Review status)").click();
+  cy.iframe().find("input[name=displayName]").type("Test status");
+  cy.iframe().find("button:Contains(Create)").click().should("not.exist");
+
+  cy.iframe().find("button:Contains(Reviews)").click();
+  cy.iframe().find("button:Contains(Review individual participants)").click();
+
+  cy.iframe().find(".MuiSelect-select").click();
+  cy.iframe().find("li:Contains(Included)").click();
+
+  cy.iframe().find("[data-testid='ArrowBackIcon']").first().click();
+  cy.iframe().find("[data-testid='ArrowBackIcon']").first().click();
+  cy.iframe().find("button[aria-label=back]", { timeout: 20000 }).click();
+});
+
 Cypress.Commands.add("multiSelect", (search) => {
   cy.iframe()
     .find(`p:Contains(${search}), button:Contains(${search})`, {


### PR DESCRIPTION
Previously, exporting data for a cohort would always write a csv file with annotation data. If there was no annotation data, the csv file just contained column headers (= the annotation keys). This PR address this problem, and we no longer generate empty annotation csv files.