### PR TITLE
Build data feature filters for CriteriaOccurrence entity groups.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.api.filter;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 public class OccurrenceForPrimaryFilter extends EntityFilter {
@@ -52,5 +53,27 @@ public class OccurrenceForPrimaryFilter extends EntityFilter {
 
   public @Nullable EntityFilter getCriteriaSubFilter() {
     return criteriaSubFilter;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OccurrenceForPrimaryFilter that = (OccurrenceForPrimaryFilter) o;
+    return underlay.equals(that.underlay)
+        && criteriaOccurrence.equals(that.criteriaOccurrence)
+        && occurrenceEntity.equals(that.occurrenceEntity)
+        && Objects.equals(primarySubFilter, that.primarySubFilter)
+        && Objects.equals(criteriaSubFilter, that.criteriaSubFilter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        underlay, criteriaOccurrence, occurrenceEntity, primarySubFilter, criteriaSubFilter);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/EntityOutput.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/EntityOutput.java
@@ -7,11 +7,11 @@ import javax.annotation.Nullable;
 
 public final class EntityOutput {
   private final Entity entity;
-  private final @Nullable EntityFilter entityFilter;
+  private final @Nullable EntityFilter dataFeatureFilter;
 
-  private EntityOutput(Entity entity, @Nullable EntityFilter entityFilter) {
+  private EntityOutput(Entity entity, @Nullable EntityFilter dataFeatureFilter) {
     this.entity = entity;
-    this.entityFilter = entityFilter;
+    this.dataFeatureFilter = dataFeatureFilter;
   }
 
   public static EntityOutput filtered(Entity entity, EntityFilter entityFilter) {
@@ -26,9 +26,13 @@ public final class EntityOutput {
     return entity;
   }
 
+  public boolean hasDataFeatureFilter() {
+    return dataFeatureFilter != null;
+  }
+
   @Nullable
-  public EntityFilter getEntityFilter() {
-    return entityFilter;
+  public EntityFilter getDataFeatureFilter() {
+    return dataFeatureFilter;
   }
 
   @Override
@@ -40,11 +44,11 @@ public final class EntityOutput {
       return false;
     }
     EntityOutput that = (EntityOutput) o;
-    return entity.equals(that.entity) && Objects.equals(entityFilter, that.entityFilter);
+    return entity.equals(that.entity) && Objects.equals(dataFeatureFilter, that.dataFeatureFilter);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entity, entityFilter);
+    return Objects.hash(entity, dataFeatureFilter);
   }
 }


### PR DESCRIPTION
This is part of the implementation of the filter builder that supports the entity group UI criteria selector plugin. CriteriaOccurrence entity groups are now fully supported (cohorts + data features). Support for GroupItems entity groups is coming in a follow-on PR.