### PR TITLE
Re-index SD in Verily env.

### DIFF
--- a/underlay/src/main/resources/config/indexer/sd20230831_verily.json
+++ b/underlay/src/main/resources/config/indexer/sd20230831_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "sd20230831_index_020224"
+      "datasetId": "sd20230831_index_022324"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"

--- a/underlay/src/main/resources/config/service/sd20230831_verily.json
+++ b/underlay/src/main/resources/config/service/sd20230831_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "sd20230831_index_020224"
+      "datasetId": "sd20230831_index_022324"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"


### PR DESCRIPTION
To pickup the changes that went in this week to the config files. We need this before updating the Verily `test` environment, so it doesn't break (e.g. with "Attribute not found" errors).

As part of this PR, I also re-indexed the SD 0831 underlay into a Verily project.