### PR TITLE
[DT-1417] Workaround for occurrence count modifier for source code

### DIFF
--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -60,7 +60,7 @@ elif [[ ${useAouUnderlays} ]]; then
   # export TANAGRA_ACCESS_CONTROL_MODEL=AOU_WORKBENCH
 elif [[ ${useSdUnderlays} ]]; then
   echo "Using sd underlay."
-  export TANAGRA_UNDERLAY_FILES=sd/sd020230831
+  export TANAGRA_UNDERLAY_FILES=sd/sd020230831_local
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID=sd-vumc-tanagra-test
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=sd-test-tanagra-exports
   # uncomment both lines below for sd access-control model

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementOccurrence/entity.json
@@ -6,7 +6,7 @@
     { "name": "person_id", "dataType": "INT64" },
     { "name": "GRID", "dataType": "STRING", "valueFieldName": "person_source_value"},
     { "name": "measurement", "dataType": "INT64", "valueFieldName": "measurement_concept_id", "displayFieldName": "measurement_concept_name" },
-    { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
+    { "name": "start_date", "dataType": "TIMESTAMP", "valueFieldName": "measurement_date" },
     { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number" },
     { "name": "value_enum", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name" },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name" },

--- a/underlay/src/main/resources/config/datamapping/sd/entity/observationOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/observationOccurrence/entity.json
@@ -6,7 +6,7 @@
     { "name": "person_id", "dataType": "INT64" },
     { "name": "GRID", "dataType": "STRING", "valueFieldName": "person_source_value"},
     { "name": "observation", "dataType": "INT64", "valueFieldName": "observation_concept_id", "displayFieldName": "observation_concept_name" },
-    { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "observation_date" },
+    { "name": "start_date", "dataType": "TIMESTAMP", "valueFieldName": "observation_date" },
     { "name": "value_as_string", "dataType": "STRING" },
     { "name": "value", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name" },
     { "name": "unit", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name" },

--- a/underlay/src/main/resources/config/datamapping/sd/entity/procedureOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/procedureOccurrence/entity.json
@@ -6,7 +6,7 @@
     { "name": "person_id", "dataType": "INT64" },
     { "name": "GRID", "dataType": "STRING", "valueFieldName": "person_source_value"},
     { "name": "procedure", "dataType": "INT64", "valueFieldName": "procedure_concept_id", "displayFieldName": "procedure_concept_name" },
-    { "name": "date", "dataType": "TIMESTAMP", "valueFieldName": "procedure_date" },
+    { "name": "start_date", "dataType": "TIMESTAMP", "valueFieldName": "procedure_date" },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "procedure_source_value" },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id" },
     { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 89 },

--- a/underlay/src/main/resources/config/indexer/sd/sd020230831.json
+++ b/underlay/src/main/resources/config/indexer/sd/sd020230831.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "sd-vumc-tanagra-test",
-      "datasetId": "indexed_sd_20230831_beta"
+      "datasetId": "indexed_sd_20230831_1"
     },
     "queryProjectId": "sd-vumc-tanagra-test",
     "dataLocation": "us-central1"

--- a/underlay/src/main/resources/config/service/sd/sd020230831_local.json
+++ b/underlay/src/main/resources/config/service/sd/sd020230831_local.json
@@ -1,0 +1,20 @@
+{
+  "underlay": "sd",
+  "bigQuery": {
+    "sourceData": {
+      "projectId": "sd-vumc-tanagra-development",
+      "datasetId": "sd_20230831",
+      "sqlSubstitutions": {
+        "omopDataset": "sd-vumc-tanagra-development.sd_20230831",
+        "staticTablesDataset": "sd-vumc-tanagra-development.sd_20230331"
+      }
+    },
+    "indexData": {
+      "projectId": "sd-vumc-tanagra-development",
+      "datasetId": "indexed_sd_20230831_1"
+    },
+    "queryProjectId": "sd-vumc-tanagra-development",
+    "dataLocation": "us-central1"
+  },
+  "uiConfigFile": "ui.json"
+}

--- a/underlay/src/main/resources/config/underlay/sd/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd/ui.json
@@ -93,7 +93,7 @@
         "attribute": "t_item_count",
         "direction": "DESC"
       },
-      "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"],
+      "modifiers": ["age_at_occurrence", "visit_type", "start_date_group_by_count"],
       "valueConfigs": [
         {
           "title": "Categorical value",
@@ -392,7 +392,7 @@
           "id": "procedurePerson"
         }
       ],
-      "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
+      "modifiers": ["age_at_occurrence", "visit_type", "start_date_group_by_count"]
     },
     {
       "type": "entityGroup",
@@ -414,7 +414,7 @@
           "id": "observationPerson"
         }
       ],
-      "modifiers": ["age_at_occurrence", "visit_type", "date_group_by_count"]
+      "modifiers": ["age_at_occurrence", "visit_type", "start_date_group_by_count"]
     },
     {
       "type": "entityGroup",
@@ -577,7 +577,7 @@
     },
     {
       "type": "unhinted-value",
-      "id": "date_group_by_count",
+      "id": "start_date_group_by_count",
       "title": "Occurrence count",
       "attribute": "date",
       "groupByCount": true


### PR DESCRIPTION
 - Updated underlay as workaround for occurrence count modifier for source code criteria - renamed `date` -> `start_date` for entities:
   - measurementOccurrence 
   - observationOccurrence 
   - procedureOccurrence 
 - `ui.json` changed all `date_group_by_count` to `start_date_group_by_count`

For CPT4:
<img width="763" alt="image" src="https://github.com/DataBiosphere/tanagra/assets/4452480/c48db464-4dc9-45d4-8487-c21c6e793f3e">

Verified for other source codes also.