### PR TITLE
Implement TextSearch filter builder.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/TextSearchFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/TextSearchFilter.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.api.filter;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 public class TextSearchFilter extends EntityFilter {
@@ -53,5 +54,26 @@ public class TextSearchFilter extends EntityFilter {
 
   public String getText() {
     return text;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TextSearchFilter that = (TextSearchFilter) o;
+    return underlay.equals(that.underlay)
+        && entity.equals(that.entity)
+        && operator == that.operator
+        && text.equals(that.text)
+        && Objects.equals(attribute, that.attribute);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(underlay, entity, operator, text, attribute);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/TextSearchFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/TextSearchFilterBuilder.java
@@ -1,0 +1,206 @@
+package bio.terra.tanagra.filterbuilder.impl.core;
+
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.filter.PrimaryWithCriteriaFilter;
+import bio.terra.tanagra.api.filter.TextSearchFilter;
+import bio.terra.tanagra.api.shared.Literal;
+import bio.terra.tanagra.exception.InvalidQueryException;
+import bio.terra.tanagra.filterbuilder.EntityOutput;
+import bio.terra.tanagra.filterbuilder.FilterBuilder;
+import bio.terra.tanagra.filterbuilder.impl.core.utils.EntityGroupFilterUtils;
+import bio.terra.tanagra.filterbuilder.impl.core.utils.GroupByCountSchemaUtils;
+import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTTextSearch;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class TextSearchFilterBuilder extends FilterBuilder {
+  public TextSearchFilterBuilder(CriteriaSelector criteriaSelector) {
+    super(criteriaSelector);
+  }
+
+  @Override
+  public EntityFilter buildForCohort(Underlay underlay, List<SelectionData> selectionData) {
+    DTTextSearch.TextSearch textSearchSelectionData =
+        deserializeData(selectionData.get(0).getPluginData());
+    List<SelectionData> modifiersSelectionData = selectionData.subList(1, selectionData.size());
+
+    // Pull the entity group, text search attribute from the config.
+    CFPlaceholder.Placeholder textSearchConfig = deserializeConfig();
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup(textSearchConfig.getEntityGroup());
+    String textSearchAttrName =
+        textSearchConfig.getSearchAttribute() == null
+                || textSearchConfig.getSearchAttribute().isEmpty()
+            ? null
+            : textSearchConfig.getSearchAttribute();
+
+    // Pull the criteria ids and text query from the selection data.
+    List<Literal> criteriaIds =
+        textSearchSelectionData.getCategoriesList().stream()
+            .map(category -> Literal.forInt64(category.getValue().getInt64Value()))
+            .collect(Collectors.toList());
+    String textQuery = textSearchSelectionData.getQuery();
+
+    // Build the sub-filter on the criteria entity.
+    EntityFilter criteriaSubFilter =
+        criteriaIds.isEmpty()
+            ? null
+            : EntityGroupFilterUtils.buildIdSubFilter(
+                underlay, criteriaOccurrence.getCriteriaEntity(), criteriaIds);
+
+    // Build the attribute modifier filters.
+    Map<Entity, List<EntityFilter>> subFiltersPerOccurrenceEntity =
+        EntityGroupFilterUtils.buildAttributeModifierFilters(
+            underlay,
+            criteriaSelector,
+            modifiersSelectionData,
+            criteriaOccurrence.getOccurrenceEntities());
+
+    // Build the text search filter on each of the occurrence entities.
+    if (textQuery != null && !textQuery.isEmpty() && !textQuery.isBlank()) {
+      criteriaOccurrence.getOccurrenceEntities().stream()
+          .forEach(
+              occurrenceEntity -> {
+                List<EntityFilter> subFilters =
+                    subFiltersPerOccurrenceEntity.containsKey(occurrenceEntity)
+                        ? subFiltersPerOccurrenceEntity.get(occurrenceEntity)
+                        : new ArrayList<>();
+                Attribute textSearchAttr =
+                    textSearchAttrName == null
+                        ? null
+                        : occurrenceEntity.getAttribute(textSearchAttrName);
+                subFilters.add(
+                    new TextSearchFilter(
+                        underlay,
+                        occurrenceEntity,
+                        TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+                        textQuery,
+                        textSearchAttr));
+                subFiltersPerOccurrenceEntity.put(occurrenceEntity, subFilters);
+              });
+    }
+
+    Optional<Pair<CFPlaceholder.Placeholder, DTUnhintedValue.UnhintedValue>>
+        groupByModifierConfigAndData =
+            GroupByCountSchemaUtils.getModifier(criteriaSelector, modifiersSelectionData);
+    if (groupByModifierConfigAndData.isEmpty()) {
+      return new PrimaryWithCriteriaFilter(
+          underlay,
+          criteriaOccurrence,
+          criteriaSubFilter,
+          subFiltersPerOccurrenceEntity,
+          null,
+          null,
+          null);
+    }
+
+    // Build the group by filter information.
+    Map<Entity, List<Attribute>> groupByAttributesPerOccurrenceEntity =
+        GroupByCountSchemaUtils.getGroupByAttributesPerOccurrenceEntity(
+            underlay, groupByModifierConfigAndData);
+    DTUnhintedValue.UnhintedValue groupByModifierData =
+        groupByModifierConfigAndData.get().getRight();
+    return new PrimaryWithCriteriaFilter(
+        underlay,
+        criteriaOccurrence,
+        criteriaSubFilter,
+        subFiltersPerOccurrenceEntity,
+        groupByAttributesPerOccurrenceEntity,
+        GroupByCountSchemaUtils.toBinaryOperator(groupByModifierData.getOperator()),
+        (int) groupByModifierData.getMin());
+  }
+
+  @Override
+  public List<EntityOutput> buildForDataFeature(
+      Underlay underlay, List<SelectionData> selectionData) {
+    if (selectionData.size() > 1) {
+      throw new InvalidQueryException("Modifiers are not supported for data features");
+    }
+    DTTextSearch.TextSearch textSearchSelectionData =
+        deserializeData(selectionData.get(0).getPluginData());
+
+    // Pull the entity group, text search attribute from the config.
+    CFPlaceholder.Placeholder textSearchConfig = deserializeConfig();
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup(textSearchConfig.getEntityGroup());
+    String textSearchAttrName =
+        textSearchConfig.getSearchAttribute() == null
+                || textSearchConfig.getSearchAttribute().isEmpty()
+            ? null
+            : textSearchConfig.getSearchAttribute();
+
+    // Pull the criteria ids and text query from the selection data.
+    List<Literal> criteriaIds =
+        textSearchSelectionData.getCategoriesList().stream()
+            .map(category -> Literal.forInt64(category.getValue().getInt64Value()))
+            .collect(Collectors.toList());
+    String textQuery = textSearchSelectionData.getQuery();
+
+    // Create an output for each of the occurrence entities.
+    Map<Entity, List<EntityFilter>> filtersPerEntity = new HashMap<>();
+    criteriaOccurrence.getOccurrenceEntities().stream()
+        .forEach(occurrenceEntity -> filtersPerEntity.put(occurrenceEntity, new ArrayList<>()));
+
+    // Build the criteria filters on each of the occurrence entities.
+    if (!criteriaIds.isEmpty()) {
+      EntityGroupFilterUtils.addOccurrenceFiltersForDataFeature(
+          underlay, criteriaOccurrence, criteriaIds, filtersPerEntity);
+    }
+
+    // Build the text search filter on each of the occurrence entities.
+    if (textQuery != null && !textQuery.isEmpty() && !textQuery.isBlank()) {
+      criteriaOccurrence.getOccurrenceEntities().stream()
+          .forEach(
+              occurrenceEntity -> {
+                List<EntityFilter> subFilters =
+                    filtersPerEntity.containsKey(occurrenceEntity)
+                        ? filtersPerEntity.get(occurrenceEntity)
+                        : new ArrayList<>();
+                Attribute textSearchAttr =
+                    textSearchAttrName == null
+                        ? null
+                        : occurrenceEntity.getAttribute(textSearchAttrName);
+                subFilters.add(
+                    new TextSearchFilter(
+                        underlay,
+                        occurrenceEntity,
+                        TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+                        textQuery,
+                        textSearchAttr));
+                filtersPerEntity.put(occurrenceEntity, subFilters);
+              });
+    }
+
+    // If there are multiple filters for a single entity, OR them together.
+    return EntityGroupFilterUtils.mergeFiltersForDataFeature(
+        filtersPerEntity, BooleanAndOrFilter.LogicalOperator.AND);
+  }
+
+  @Override
+  public CFPlaceholder.Placeholder deserializeConfig() {
+    return deserializeFromJson(
+            criteriaSelector.getPluginConfig(), CFPlaceholder.Placeholder.newBuilder())
+        .build();
+  }
+
+  @Override
+  public DTTextSearch.TextSearch deserializeData(String serialized) {
+    return deserializeFromJson(serialized, DTTextSearch.TextSearch.newBuilder()).build();
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -15,9 +15,13 @@ import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 
 public final class AttributeSchemaUtils {
   private AttributeSchemaUtils() {}
@@ -61,6 +65,30 @@ public final class AttributeSchemaUtils {
           ? rangeFilters.get(0)
           : new BooleanAndOrFilter(BooleanAndOrFilter.LogicalOperator.OR, rangeFilters);
     }
+  }
+
+  public static List<Pair<CFPlaceholder.Placeholder, DTAttribute.Attribute>> getModifiers(
+      CriteriaSelector criteriaSelector, List<SelectionData> selectionData) {
+    return selectionData.stream()
+        .filter(
+            modifierSelectionData ->
+                SZCorePlugin.ATTRIBUTE
+                    .getIdInConfig()
+                    .equals(
+                        criteriaSelector
+                            .getModifier(modifierSelectionData.getModifierName())
+                            .getPlugin()))
+        .map(
+            modifierSelectionData -> {
+              CriteriaSelector.Modifier modifierDefn =
+                  criteriaSelector.getModifier(modifierSelectionData.getModifierName());
+              CFPlaceholder.Placeholder modifierConfig =
+                  deserializeConfig(modifierDefn.getPluginConfig());
+              DTAttribute.Attribute modifierData =
+                  deserializeData(modifierSelectionData.getPluginData());
+              return Pair.of(modifierConfig, modifierData);
+            })
+        .collect(Collectors.toList());
   }
 
   public static CFPlaceholder.Placeholder deserializeConfig(String serialized) {

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
@@ -1,0 +1,133 @@
+package bio.terra.tanagra.filterbuilder.impl.core.utils;
+
+import bio.terra.tanagra.api.filter.AttributeFilter;
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.filter.HierarchyHasAncestorFilter;
+import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
+import bio.terra.tanagra.api.shared.BinaryOperator;
+import bio.terra.tanagra.api.shared.Literal;
+import bio.terra.tanagra.api.shared.NaryOperator;
+import bio.terra.tanagra.filterbuilder.EntityOutput;
+import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class EntityGroupFilterUtils {
+  private EntityGroupFilterUtils() {}
+
+  public static EntityFilter buildIdSubFilter(
+      Underlay underlay, Entity criteriaEntity, List<Literal> criteriaIds) {
+    // Build the criteria sub-filter.
+    if (criteriaEntity.hasHierarchies()) {
+      // Use a has ancestor filter.
+      return new HierarchyHasAncestorFilter(
+          underlay,
+          criteriaEntity,
+          criteriaEntity.getHierarchy(Hierarchy.DEFAULT_NAME),
+          criteriaIds);
+    } else {
+      // Use an attribute filter on the id.
+      return criteriaIds.size() > 1
+          ? new AttributeFilter(
+              underlay,
+              criteriaEntity,
+              criteriaEntity.getIdAttribute(),
+              NaryOperator.IN,
+              criteriaIds)
+          : new AttributeFilter(
+              underlay,
+              criteriaEntity,
+              criteriaEntity.getIdAttribute(),
+              BinaryOperator.EQUALS,
+              criteriaIds.get(0));
+    }
+  }
+
+  public static Map<Entity, List<EntityFilter>> buildAttributeModifierFilters(
+      Underlay underlay,
+      CriteriaSelector criteriaSelector,
+      List<SelectionData> modifiersSelectionData,
+      List<Entity> occurrenceEntities) {
+    Map<Entity, List<EntityFilter>> subFiltersPerOccurrenceEntity = new HashMap<>();
+    AttributeSchemaUtils.getModifiers(criteriaSelector, modifiersSelectionData).stream()
+        .forEach(
+            configAndData -> {
+              CFPlaceholder.Placeholder modifierConfig = configAndData.getLeft();
+              DTAttribute.Attribute modifierData = configAndData.getRight();
+
+              // Add a separate filter for each occurrence entity.
+              occurrenceEntities.stream()
+                  .forEach(
+                      occurrenceEntity -> {
+                        List<EntityFilter> subFilters =
+                            subFiltersPerOccurrenceEntity.containsKey(occurrenceEntity)
+                                ? subFiltersPerOccurrenceEntity.get(occurrenceEntity)
+                                : new ArrayList<>();
+                        subFilters.add(
+                            AttributeSchemaUtils.buildForEntity(
+                                underlay, occurrenceEntity, modifierConfig, modifierData));
+                        subFiltersPerOccurrenceEntity.put(occurrenceEntity, subFilters);
+                      });
+            });
+    return subFiltersPerOccurrenceEntity;
+  }
+
+  public static void addOccurrenceFiltersForDataFeature(
+      Underlay underlay,
+      CriteriaOccurrence criteriaOccurrence,
+      List<Literal> criteriaIds,
+      Map<Entity, List<EntityFilter>> filtersPerEntity) {
+    EntityFilter criteriaSubFilterCO =
+        EntityGroupFilterUtils.buildIdSubFilter(
+            underlay, criteriaOccurrence.getCriteriaEntity(), criteriaIds);
+    criteriaOccurrence.getOccurrenceEntities().stream()
+        .sorted(Comparator.comparing(occurrenceEntity -> occurrenceEntity.getName()))
+        .forEach(
+            occurrenceEntity -> {
+              List<EntityFilter> occurrenceEntityFilters =
+                  filtersPerEntity.containsKey(occurrenceEntity)
+                      ? filtersPerEntity.get(occurrenceEntity)
+                      : new ArrayList<>();
+              if (!criteriaIds.isEmpty()) {
+                occurrenceEntityFilters.add(
+                    new OccurrenceForPrimaryFilter(
+                        underlay, criteriaOccurrence, occurrenceEntity, null, criteriaSubFilterCO));
+              }
+              filtersPerEntity.put(occurrenceEntity, occurrenceEntityFilters);
+            });
+  }
+
+  public static List<EntityOutput> mergeFiltersForDataFeature(
+      Map<Entity, List<EntityFilter>> filtersPerEntity,
+      BooleanAndOrFilter.LogicalOperator logicalOperator) {
+    // If there are multiple filters for a single entity, OR them together.
+    return filtersPerEntity.entrySet().stream()
+        .sorted(Comparator.comparing(entry -> entry.getKey().getName()))
+        .map(
+            entry -> {
+              Entity entity = entry.getKey();
+              List<EntityFilter> entityFilters = entry.getValue();
+              if (entityFilters.isEmpty()) {
+                return EntityOutput.unfiltered(entity);
+              } else if (entityFilters.size() == 1) {
+                return EntityOutput.filtered(entity, entityFilters.get(0));
+              } else {
+                return EntityOutput.filtered(
+                    entity, new BooleanAndOrFilter(logicalOperator, entityFilters));
+              }
+            })
+        .collect(Collectors.toList());
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
@@ -6,11 +6,17 @@ import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
 import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
 import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
 import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
 public final class GroupByCountSchemaUtils {
@@ -48,6 +54,28 @@ public final class GroupByCountSchemaUtils {
     DTUnhintedValue.UnhintedValue groupByModifierData =
         GroupByCountSchemaUtils.deserializeData(groupByCountSelectionData.get().getPluginData());
     return Optional.of(Pair.of(groupByModifierConfig, groupByModifierData));
+  }
+
+  public static Map<Entity, List<Attribute>> getGroupByAttributesPerOccurrenceEntity(
+      Underlay underlay,
+      Optional<Pair<CFPlaceholder.Placeholder, DTUnhintedValue.UnhintedValue>>
+          groupByModifierConfigAndData) {
+    CFPlaceholder.Placeholder groupByModifierConfig = groupByModifierConfigAndData.get().getLeft();
+
+    Map<Entity, List<Attribute>> groupByAttributesPerOccurrenceEntity = new HashMap<>();
+    if (!groupByModifierConfig.getGroupByAttributesPerOccurrenceEntityMap().isEmpty()) {
+      groupByModifierConfig.getGroupByAttributesPerOccurrenceEntityMap().entrySet().stream()
+          .forEach(
+              entry -> {
+                Entity occurrenceEntity = underlay.getEntity(entry.getKey());
+                List<Attribute> groupByAttributes =
+                    entry.getValue().getAttributeList().stream()
+                        .map(attrName -> occurrenceEntity.getAttribute(attrName))
+                        .collect(Collectors.toList());
+                groupByAttributesPerOccurrenceEntity.put(occurrenceEntity, groupByAttributes);
+              });
+    }
+    return groupByAttributesPerOccurrenceEntity;
   }
 
   public static BinaryOperator toBinaryOperator(

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
@@ -1,0 +1,68 @@
+package bio.terra.tanagra.filterbuilder.impl.core.utils;
+
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+
+import bio.terra.tanagra.api.shared.BinaryOperator;
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
+import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.tuple.Pair;
+
+public final class GroupByCountSchemaUtils {
+  private GroupByCountSchemaUtils() {}
+
+  public static CFPlaceholder.Placeholder deserializeConfig(String serialized) {
+    return deserializeFromJson(serialized, CFPlaceholder.Placeholder.newBuilder()).build();
+  }
+
+  public static DTUnhintedValue.UnhintedValue deserializeData(String serialized) {
+    return deserializeFromJson(serialized, DTUnhintedValue.UnhintedValue.newBuilder()).build();
+  }
+
+  public static Optional<Pair<CFPlaceholder.Placeholder, DTUnhintedValue.UnhintedValue>>
+      getModifier(CriteriaSelector criteriaSelector, List<SelectionData> selectionData) {
+    Optional<SelectionData> groupByCountSelectionData =
+        selectionData.stream()
+            .filter(
+                modifierSelectionData ->
+                    SZCorePlugin.UNHINTED_VALUE
+                        .getIdInConfig()
+                        .equals(
+                            criteriaSelector
+                                .getModifier(modifierSelectionData.getModifierName())
+                                .getPlugin()))
+            .findFirst();
+    if (groupByCountSelectionData.isEmpty()) {
+      return Optional.empty();
+    }
+    CFPlaceholder.Placeholder groupByModifierConfig =
+        deserializeConfig(
+            criteriaSelector
+                .getModifier(groupByCountSelectionData.get().getModifierName())
+                .getPluginConfig());
+    DTUnhintedValue.UnhintedValue groupByModifierData =
+        GroupByCountSchemaUtils.deserializeData(groupByCountSelectionData.get().getPluginData());
+    return Optional.of(Pair.of(groupByModifierConfig, groupByModifierData));
+  }
+
+  public static BinaryOperator toBinaryOperator(
+      DTUnhintedValue.UnhintedValue.ComparisonOperator comparisonOperator) {
+    switch (comparisonOperator) {
+      case COMPARISON_OPERATOR_EQUAL:
+        return BinaryOperator.EQUALS;
+      case COMPARISON_OPERATOR_LESS_THAN_EQUAL:
+        return BinaryOperator.LESS_THAN_OR_EQUAL;
+      case COMPARISON_OPERATOR_GREATER_THAN_EQUAL:
+        return BinaryOperator.GREATER_THAN_OR_EQUAL;
+      case COMPARISON_OPERATOR_BETWEEN:
+      default:
+        throw new SystemException(
+            "Unsupported unhinted-value comparison operator: " + comparisonOperator);
+    }
+  }
+}

--- a/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
+++ b/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
@@ -14,4 +14,8 @@ message Placeholder {
     repeated string attribute = 1;
   }
   map<string, GroupByAttributes> groupByAttributesPerOccurrenceEntity = 2;
+
+  // core/search
+  string entityGroup = 3;
+  string searchAttribute = 4;
 }

--- a/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
+++ b/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
@@ -14,4 +14,7 @@ message Placeholder {
     repeated string attribute = 1;
   }
   map<string, GroupByAttributes> groupByAttributesPerOccurrenceEntity = 2;
+
+  // core/search
+  string entity = 3;
 }

--- a/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
+++ b/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
@@ -14,7 +14,4 @@ message Placeholder {
     repeated string attribute = 1;
   }
   map<string, GroupByAttributes> groupByAttributesPerOccurrenceEntity = 2;
-
-  // core/search
-  string entity = 3;
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
@@ -424,7 +424,7 @@ public class TextSearchFilterBuilderTest {
             .putGroupByAttributesPerOccurrenceEntity(
                 "noteOccurrence",
                 CFPlaceholder.Placeholder.GroupByAttributes.newBuilder()
-                    .addAttribute("date")
+                    .addAttribute("start_date")
                     .build())
             .build();
     CriteriaSelector.Modifier groupByModifier =
@@ -479,7 +479,7 @@ public class TextSearchFilterBuilderTest {
             criteriaOccurrence,
             null,
             Map.of(occurrenceEntity, List.of(expectedTextSearchSubFilter)),
-            Map.of(occurrenceEntity, List.of(occurrenceEntity.getAttribute("date"))),
+            Map.of(occurrenceEntity, List.of(occurrenceEntity.getAttribute("start_date"))),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);
@@ -504,7 +504,7 @@ public class TextSearchFilterBuilderTest {
             .putGroupByAttributesPerOccurrenceEntity(
                 "noteOccurrence",
                 CFPlaceholder.Placeholder.GroupByAttributes.newBuilder()
-                    .addAttribute("date")
+                    .addAttribute("start_date")
                     .build())
             .build();
     CriteriaSelector.Modifier groupByModifier =
@@ -613,7 +613,7 @@ public class TextSearchFilterBuilderTest {
                     expectedAgeAtOccurrenceSubFilter,
                     expectedVisitTypeSubFilter,
                     expectedTextSearchSubFilter)),
-            Map.of(occurrenceEntity, List.of(occurrenceEntity.getAttribute("date"))),
+            Map.of(occurrenceEntity, List.of(occurrenceEntity.getAttribute("start_date"))),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
@@ -1,0 +1,756 @@
+package bio.terra.tanagra.filterbuilder;
+
+import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.tanagra.api.filter.AttributeFilter;
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
+import bio.terra.tanagra.api.filter.PrimaryWithCriteriaFilter;
+import bio.terra.tanagra.api.filter.TextSearchFilter;
+import bio.terra.tanagra.api.shared.BinaryOperator;
+import bio.terra.tanagra.api.shared.Literal;
+import bio.terra.tanagra.api.shared.NaryOperator;
+import bio.terra.tanagra.filterbuilder.impl.core.TextSearchFilterBuilder;
+import bio.terra.tanagra.proto.criteriaselector.DataRangeOuterClass;
+import bio.terra.tanagra.proto.criteriaselector.ValueOuterClass;
+import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTTextSearch;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
+import bio.terra.tanagra.underlay.ConfigReader;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
+import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
+import bio.terra.tanagra.underlay.serialization.SZService;
+import bio.terra.tanagra.underlay.serialization.SZUnderlay;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TextSearchFilterBuilderTest {
+  private Underlay underlay;
+
+  @BeforeEach
+  void setup() {
+    ConfigReader configReader = ConfigReader.fromJarResources();
+    SZService szService = configReader.readService("sd20230831_verily");
+    SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
+    underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
+  }
+
+  @Test
+  void textOnlyCohortFilter() {
+    // Text query, no attribute.
+    CFPlaceholder.Placeholder config =
+        CFPlaceholder.Placeholder.newBuilder().setEntityGroup("notePerson").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "note_noAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.TEXT_SEARCH.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    TextSearchFilterBuilder filterBuilder = new TextSearchFilterBuilder(criteriaSelector);
+
+    DTTextSearch.TextSearch data =
+        DTTextSearch.TextSearch.newBuilder().setQuery("ambulance").build();
+    SelectionData selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+
+    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
+    EntityFilter expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            (CriteriaOccurrence) underlay.getEntityGroup("notePerson"),
+            null,
+            Map.of(
+                occurrenceEntity,
+                List.of(
+                    new TextSearchFilter(
+                        underlay,
+                        occurrenceEntity,
+                        TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+                        "ambulance",
+                        null))),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Text query, with attribute.
+    config =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroup("notePerson")
+            .setSearchAttribute("title")
+            .build();
+    criteriaSelector =
+        new CriteriaSelector(
+            "note_withAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.TEXT_SEARCH.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    filterBuilder = new TextSearchFilterBuilder(criteriaSelector);
+
+    selectionData = new SelectionData("note_withAttribute", serializeToJson(data));
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+    expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            (CriteriaOccurrence) underlay.getEntityGroup("notePerson"),
+            null,
+            Map.of(
+                occurrenceEntity,
+                List.of(
+                    new TextSearchFilter(
+                        underlay,
+                        occurrenceEntity,
+                        TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+                        "ambulance",
+                        occurrenceEntity.getAttribute("title")))),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void criteriaOnlyCohortFilter() {
+    CFPlaceholder.Placeholder configNoAttr =
+        CFPlaceholder.Placeholder.newBuilder().setEntityGroup("notePerson").build();
+    CriteriaSelector criteriaSelectorNoAttr =
+        new CriteriaSelector(
+            "note_noAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.TEXT_SEARCH.getIdInConfig(),
+            serializeToJson(configNoAttr),
+            List.of());
+    TextSearchFilterBuilder filterBuilderNoAttr =
+        new TextSearchFilterBuilder(criteriaSelectorNoAttr);
+
+    // Single id, no text search filter.
+    DTTextSearch.TextSearch data =
+        DTTextSearch.TextSearch.newBuilder()
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .build();
+    SelectionData selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    EntityFilter cohortFilter =
+        filterBuilderNoAttr.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup("notePerson");
+    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
+    EntityFilter expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                BinaryOperator.EQUALS,
+                Literal.forInt64(44_814_644L)),
+            Map.of(),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Single id, with text search filter.
+    data =
+        DTTextSearch.TextSearch.newBuilder()
+            .setQuery("ambulance")
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .build();
+    selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    cohortFilter = filterBuilderNoAttr.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+
+    expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                BinaryOperator.EQUALS,
+                Literal.forInt64(44_814_644L)),
+            Map.of(
+                occurrenceEntity,
+                List.of(
+                    new TextSearchFilter(
+                        underlay,
+                        occurrenceEntity,
+                        TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+                        "ambulance",
+                        null))),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Multiple ids, no text search filter.
+    data =
+        DTTextSearch.TextSearch.newBuilder()
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_638L).build())
+                    .setName("Admission note")
+                    .build())
+            .build();
+    selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    cohortFilter = filterBuilderNoAttr.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+
+    expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                NaryOperator.IN,
+                List.of(Literal.forInt64(44_814_644L), Literal.forInt64(44_814_638L))),
+            Map.of(),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Multiple ids, with text search filter.
+    data =
+        DTTextSearch.TextSearch.newBuilder()
+            .setQuery("ambulance")
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_638L).build())
+                    .setName("Admission note")
+                    .build())
+            .build();
+    selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    cohortFilter = filterBuilderNoAttr.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+
+    expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                NaryOperator.IN,
+                List.of(Literal.forInt64(44_814_644L), Literal.forInt64(44_814_638L))),
+            Map.of(
+                occurrenceEntity,
+                List.of(
+                    new TextSearchFilter(
+                        underlay,
+                        occurrenceEntity,
+                        TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+                        "ambulance",
+                        null))),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void criteriaWithAttrModifiersCohortFilter() {
+    CFPlaceholder.Placeholder ageAtOccurrenceConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("age_at_occurrence").build();
+    CriteriaSelector.Modifier ageAtOccurrenceModifier =
+        new CriteriaSelector.Modifier(
+            "age_at_occurrence",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(ageAtOccurrenceConfig));
+    CFPlaceholder.Placeholder visitTypeConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("visit_type").build();
+    CriteriaSelector.Modifier visitTypeModifier =
+        new CriteriaSelector.Modifier(
+            "visit_type", SZCorePlugin.ATTRIBUTE.getIdInConfig(), serializeToJson(visitTypeConfig));
+    CFPlaceholder.Placeholder textSearchConfig =
+        CFPlaceholder.Placeholder.newBuilder().setEntityGroup("notePerson").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "note_noAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(textSearchConfig),
+            List.of(ageAtOccurrenceModifier, visitTypeModifier));
+    TextSearchFilterBuilder filterBuilder = new TextSearchFilterBuilder(criteriaSelector);
+
+    // Single attribute modifier, no text search filter.
+    DTTextSearch.TextSearch textSearchData =
+        DTTextSearch.TextSearch.newBuilder()
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .build();
+    SelectionData textSearchSelectionData =
+        new SelectionData("note_noAttribute", serializeToJson(textSearchData));
+    DTAttribute.Attribute ageAtOccurrenceData =
+        DTAttribute.Attribute.newBuilder()
+            .addDataRanges(DataRangeOuterClass.DataRange.newBuilder().setMin(45).setMax(65).build())
+            .build();
+    SelectionData ageAtOccurrenceSelectionData =
+        new SelectionData("age_at_occurrence", serializeToJson(ageAtOccurrenceData));
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(textSearchSelectionData, ageAtOccurrenceSelectionData));
+    assertNotNull(cohortFilter);
+
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup("notePerson");
+    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
+    EntityFilter expectedAgeAtOccurrenceSubFilter =
+        new AttributeFilter(
+            underlay,
+            occurrenceEntity,
+            occurrenceEntity.getAttribute("age_at_occurrence"),
+            NaryOperator.BETWEEN,
+            List.of(Literal.forDouble(45.0), Literal.forDouble(65.0)));
+    EntityFilter expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                BinaryOperator.EQUALS,
+                Literal.forInt64(44_814_644L)),
+            Map.of(occurrenceEntity, List.of(expectedAgeAtOccurrenceSubFilter)),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Two attribute modifiers, with text search filter.
+    textSearchData = DTTextSearch.TextSearch.newBuilder().setQuery("ambulance").build();
+    textSearchSelectionData =
+        new SelectionData("note_noAttribute", serializeToJson(textSearchData));
+    DTAttribute.Attribute visitTypeData =
+        DTAttribute.Attribute.newBuilder()
+            .addSelected(
+                DTAttribute.Attribute.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(9_202L).build())
+                    .setName("Outpatient Visit")
+                    .build())
+            .build();
+    SelectionData visitTypeSelectionData =
+        new SelectionData("visit_type", serializeToJson(visitTypeData));
+    cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay,
+            List.of(textSearchSelectionData, ageAtOccurrenceSelectionData, visitTypeSelectionData));
+    assertNotNull(cohortFilter);
+    EntityFilter expectedTextSearchSubFilter =
+        new TextSearchFilter(
+            underlay,
+            occurrenceEntity,
+            TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+            "ambulance",
+            null);
+    EntityFilter expectedVisitTypeSubFilter =
+        new AttributeFilter(
+            underlay,
+            occurrenceEntity,
+            occurrenceEntity.getAttribute("visit_type"),
+            BinaryOperator.EQUALS,
+            Literal.forInt64(9_202L));
+    expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            null,
+            Map.of(
+                occurrenceEntity,
+                List.of(
+                    expectedAgeAtOccurrenceSubFilter,
+                    expectedVisitTypeSubFilter,
+                    expectedTextSearchSubFilter)),
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void criteriaWithGroupByModifierCohortFilter() {
+    CFPlaceholder.Placeholder groupByConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .putGroupByAttributesPerOccurrenceEntity(
+                "noteOccurrence",
+                CFPlaceholder.Placeholder.GroupByAttributes.newBuilder()
+                    .addAttribute("date")
+                    .build())
+            .build();
+    CriteriaSelector.Modifier groupByModifier =
+        new CriteriaSelector.Modifier(
+            "group_by_count",
+            SZCorePlugin.UNHINTED_VALUE.getIdInConfig(),
+            serializeToJson(groupByConfig));
+    CFPlaceholder.Placeholder textSearchConfig =
+        CFPlaceholder.Placeholder.newBuilder().setEntityGroup("notePerson").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "note_noAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(textSearchConfig),
+            List.of(groupByModifier));
+    TextSearchFilterBuilder filterBuilder = new TextSearchFilterBuilder(criteriaSelector);
+
+    DTTextSearch.TextSearch textSearchData =
+        DTTextSearch.TextSearch.newBuilder().setQuery("ambulance").build();
+    SelectionData textSearchSelectionData =
+        new SelectionData("note_noAttribute", serializeToJson(textSearchData));
+    DTUnhintedValue.UnhintedValue groupByData =
+        DTUnhintedValue.UnhintedValue.newBuilder()
+            .setOperator(
+                DTUnhintedValue.UnhintedValue.ComparisonOperator
+                    .COMPARISON_OPERATOR_GREATER_THAN_EQUAL)
+            .setMin(2.0)
+            .build();
+    SelectionData groupBySelectionData =
+        new SelectionData("group_by_count", serializeToJson(groupByData));
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(textSearchSelectionData, groupBySelectionData));
+    assertNotNull(cohortFilter);
+
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup("notePerson");
+    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
+    EntityFilter expectedTextSearchSubFilter =
+        new TextSearchFilter(
+            underlay,
+            occurrenceEntity,
+            TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+            "ambulance",
+            null);
+    EntityFilter expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            null,
+            Map.of(occurrenceEntity, List.of(expectedTextSearchSubFilter)),
+            Map.of(occurrenceEntity, List.of(occurrenceEntity.getAttribute("date"))),
+            BinaryOperator.GREATER_THAN_OR_EQUAL,
+            2);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void criteriaWithAttrAndGroupByModifiersCohortFilter() {
+    CFPlaceholder.Placeholder ageAtOccurrenceConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("age_at_occurrence").build();
+    CriteriaSelector.Modifier ageAtOccurrenceModifier =
+        new CriteriaSelector.Modifier(
+            "age_at_occurrence",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(ageAtOccurrenceConfig));
+    CFPlaceholder.Placeholder visitTypeConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("visit_type").build();
+    CriteriaSelector.Modifier visitTypeModifier =
+        new CriteriaSelector.Modifier(
+            "visit_type", SZCorePlugin.ATTRIBUTE.getIdInConfig(), serializeToJson(visitTypeConfig));
+    CFPlaceholder.Placeholder groupByConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .putGroupByAttributesPerOccurrenceEntity(
+                "noteOccurrence",
+                CFPlaceholder.Placeholder.GroupByAttributes.newBuilder()
+                    .addAttribute("date")
+                    .build())
+            .build();
+    CriteriaSelector.Modifier groupByModifier =
+        new CriteriaSelector.Modifier(
+            "group_by_count",
+            SZCorePlugin.UNHINTED_VALUE.getIdInConfig(),
+            serializeToJson(groupByConfig));
+    CFPlaceholder.Placeholder textSearchConfig =
+        CFPlaceholder.Placeholder.newBuilder().setEntityGroup("notePerson").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "note_noAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(textSearchConfig),
+            List.of(ageAtOccurrenceModifier, visitTypeModifier, groupByModifier));
+    TextSearchFilterBuilder filterBuilder = new TextSearchFilterBuilder(criteriaSelector);
+
+    // Single attribute modifier, no text search filter.
+    DTTextSearch.TextSearch textSearchData =
+        DTTextSearch.TextSearch.newBuilder()
+            .setQuery("ambulance")
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .build();
+    SelectionData textSearchSelectionData =
+        new SelectionData("note_noAttribute", serializeToJson(textSearchData));
+    DTAttribute.Attribute ageAtOccurrenceData =
+        DTAttribute.Attribute.newBuilder()
+            .addDataRanges(DataRangeOuterClass.DataRange.newBuilder().setMin(45).setMax(65).build())
+            .build();
+    SelectionData ageAtOccurrenceSelectionData =
+        new SelectionData("age_at_occurrence", serializeToJson(ageAtOccurrenceData));
+    DTAttribute.Attribute visitTypeData =
+        DTAttribute.Attribute.newBuilder()
+            .addSelected(
+                DTAttribute.Attribute.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(9_202L).build())
+                    .setName("Outpatient Visit")
+                    .build())
+            .build();
+    SelectionData visitTypeSelectionData =
+        new SelectionData("visit_type", serializeToJson(visitTypeData));
+    DTUnhintedValue.UnhintedValue groupByData =
+        DTUnhintedValue.UnhintedValue.newBuilder()
+            .setOperator(
+                DTUnhintedValue.UnhintedValue.ComparisonOperator
+                    .COMPARISON_OPERATOR_GREATER_THAN_EQUAL)
+            .setMin(2.0)
+            .build();
+    SelectionData groupBySelectionData =
+        new SelectionData("group_by_count", serializeToJson(groupByData));
+
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay,
+            List.of(
+                textSearchSelectionData,
+                ageAtOccurrenceSelectionData,
+                visitTypeSelectionData,
+                groupBySelectionData));
+    assertNotNull(cohortFilter);
+
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup("notePerson");
+    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
+    EntityFilter expectedAgeAtOccurrenceSubFilter =
+        new AttributeFilter(
+            underlay,
+            occurrenceEntity,
+            occurrenceEntity.getAttribute("age_at_occurrence"),
+            NaryOperator.BETWEEN,
+            List.of(Literal.forDouble(45.0), Literal.forDouble(65.0)));
+    EntityFilter expectedVisitTypeSubFilter =
+        new AttributeFilter(
+            underlay,
+            occurrenceEntity,
+            occurrenceEntity.getAttribute("visit_type"),
+            BinaryOperator.EQUALS,
+            Literal.forInt64(9_202L));
+    EntityFilter expectedTextSearchSubFilter =
+        new TextSearchFilter(
+            underlay,
+            occurrenceEntity,
+            TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+            "ambulance",
+            null);
+    EntityFilter expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            criteriaOccurrence,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                BinaryOperator.EQUALS,
+                Literal.forInt64(44_814_644L)),
+            Map.of(
+                occurrenceEntity,
+                List.of(
+                    expectedAgeAtOccurrenceSubFilter,
+                    expectedVisitTypeSubFilter,
+                    expectedTextSearchSubFilter)),
+            Map.of(occurrenceEntity, List.of(occurrenceEntity.getAttribute("date"))),
+            BinaryOperator.GREATER_THAN_OR_EQUAL,
+            2);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void singleOccurrenceDataFeatureFilter() {
+    CFPlaceholder.Placeholder configNoAttr =
+        CFPlaceholder.Placeholder.newBuilder().setEntityGroup("notePerson").build();
+    CriteriaSelector criteriaSelectorNoAttr =
+        new CriteriaSelector(
+            "note_noAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.TEXT_SEARCH.getIdInConfig(),
+            serializeToJson(configNoAttr),
+            List.of());
+    TextSearchFilterBuilder filterBuilderNoAttr =
+        new TextSearchFilterBuilder(criteriaSelectorNoAttr);
+    CFPlaceholder.Placeholder configWithAttr =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroup("notePerson")
+            .setSearchAttribute("title")
+            .build();
+    CriteriaSelector criteriaSelectorWithAttr =
+        new CriteriaSelector(
+            "note_withAttribute",
+            true,
+            true,
+            "core.TextSearchFilterBuilder",
+            SZCorePlugin.TEXT_SEARCH.getIdInConfig(),
+            serializeToJson(configWithAttr),
+            List.of());
+    TextSearchFilterBuilder filterBuilderWithAttr =
+        new TextSearchFilterBuilder(criteriaSelectorWithAttr);
+
+    // No id, no text search filter.
+    DTTextSearch.TextSearch data = DTTextSearch.TextSearch.newBuilder().build();
+    SelectionData selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    List<EntityOutput> dataFeatureOutputs =
+        filterBuilderNoAttr.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+
+    CriteriaOccurrence criteriaOccurrence =
+        (CriteriaOccurrence) underlay.getEntityGroup("notePerson");
+    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
+    assertEquals(List.of(EntityOutput.unfiltered(occurrenceEntity)), dataFeatureOutputs);
+
+    // No id, with text search filter.
+    data = DTTextSearch.TextSearch.newBuilder().setQuery("ambulance").build();
+    selectionData = new SelectionData("note_withAttribute", serializeToJson(data));
+    dataFeatureOutputs =
+        filterBuilderWithAttr.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    EntityFilter expectedDataFeatureFilter =
+        new TextSearchFilter(
+            underlay,
+            occurrenceEntity,
+            TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+            "ambulance",
+            occurrenceEntity.getAttribute("title"));
+    assertEquals(
+        List.of(EntityOutput.filtered(occurrenceEntity, expectedDataFeatureFilter)),
+        dataFeatureOutputs);
+
+    // Single id, no text search filter.
+    data =
+        DTTextSearch.TextSearch.newBuilder()
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .build();
+    selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    dataFeatureOutputs = filterBuilderNoAttr.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    expectedDataFeatureFilter =
+        new OccurrenceForPrimaryFilter(
+            underlay,
+            criteriaOccurrence,
+            occurrenceEntity,
+            null,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                BinaryOperator.EQUALS,
+                Literal.forInt64(44_814_644L)));
+    assertEquals(
+        List.of(EntityOutput.filtered(occurrenceEntity, expectedDataFeatureFilter)),
+        dataFeatureOutputs);
+
+    // Multiple ids, with text search filter.
+    data =
+        DTTextSearch.TextSearch.newBuilder()
+            .setQuery("ambulance")
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_644L).build())
+                    .setName("Nursing report")
+                    .build())
+            .addCategories(
+                DTTextSearch.TextSearch.Selection.newBuilder()
+                    .setValue(ValueOuterClass.Value.newBuilder().setInt64Value(44_814_638L).build())
+                    .setName("Admission note")
+                    .build())
+            .build();
+    selectionData = new SelectionData("note_noAttribute", serializeToJson(data));
+    dataFeatureOutputs = filterBuilderNoAttr.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    EntityFilter expectedCriteriaFilter =
+        new OccurrenceForPrimaryFilter(
+            underlay,
+            criteriaOccurrence,
+            occurrenceEntity,
+            null,
+            new AttributeFilter(
+                underlay,
+                criteriaOccurrence.getCriteriaEntity(),
+                occurrenceEntity.getIdAttribute(),
+                NaryOperator.IN,
+                List.of(Literal.forInt64(44_814_644L), Literal.forInt64(44_814_638L))));
+    EntityFilter expectedTextSearchFilter =
+        new TextSearchFilter(
+            underlay,
+            occurrenceEntity,
+            TextSearchFilter.TextSearchOperator.EXACT_MATCH,
+            "ambulance",
+            null);
+    expectedDataFeatureFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(expectedCriteriaFilter, expectedTextSearchFilter));
+    assertEquals(
+        List.of(EntityOutput.filtered(occurrenceEntity, expectedDataFeatureFilter)),
+        dataFeatureOutputs);
+  }
+}


### PR DESCRIPTION
- Added a `TextSearchFilterBuilder` and tests. This currently is only used for the `sd/documents` criteria.
- Refactored modifier config/data parsing into shared classes.