### PR TITLE
Use temporary table for export queries. Parallelize entity export jobs.

### DIFF
--- a/docs/generated/APPLICATION_CONFIG.md
+++ b/docs/generated/APPLICATION_CONFIG.md
@@ -252,6 +252,24 @@ Pointer to the access control model Java class. Currently this must be one of th
 ## Export (Shared)
 Configure the export options shared by all models.
 
+### tanagra.export.shared.bqDatasetIds
+**optional** List [ String ]
+
+Comma separated list of all BQ dataset ids that all export models can use. Required if there are any export models that need to export from BQ to GCS.
+
+*Environment variable:* `TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS`
+
+*Example value:* `service_export_us,service_export_uscentral1`
+
+### tanagra.export.shared.gcpProjectId
+**optional** String
+
+GCP project id that contains the BQ dataset and GCS bucket(s) that all export models can use. Required if there are any export models that need to export from BQ to GCS.
+
+*Environment variable:* `TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID`
+
+*Example value:* `broad-tanagra-dev`
+
 ### tanagra.export.shared.gcsBucketNames
 **optional** List [ String ]
 
@@ -260,15 +278,6 @@ Comma separated list of all GCS bucket names that all export models can use. Onl
 *Environment variable:* `TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES`
 
 *Example value:* `broad-tanagra-dev-bq-export-uscentral1,broad-tanagra-dev-bq-export-useast1`
-
-### tanagra.export.shared.gcsProjectId
-**optional** String
-
-GCP project id that contains the GCS bucket(s) that all export models can use. Required if there are any export models that need to write to GCS.
-
-*Environment variable:* `TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID`
-
-*Example value:* `broad-tanagra-dev`
 
 
 

--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -49,12 +49,13 @@ if [[ ${useVerilyUnderlays} ]]; then
   echo "Using Verily underlays."
   export TANAGRA_UNDERLAY_FILES=cmssynpuf_verily,aouSR2019q4r4_verily,sd20230831_verily,pilotsynthea2022q3_verily
   export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=verily-tanagra-test
-  export TANAGRA_EXPORT_SHARED_BQ_DATASET_ID=service_export_uscentral1
+  export TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS=service_export_us,service_export_uscentral1
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=verily-tanagra-test-export-bucket,verily-tanagra-test-export-bucket-uscentral1
 elif [[ ${useAouUnderlays} ]]; then
   echo "Using AoU test underlays."
   export TANAGRA_UNDERLAY_FILES=aou/SR2023Q3R2_local,aou/SC2023Q3R2_local
-  export TANAGRA_EXPORT_SHARED_GCS_PROJECT_ID=broad-tanagra-dev
+  export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=broad-tanagra-dev
+  export TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS=service_export_us,service_export_uscentral1
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export
   # uncomment both lines below for test AoU Workbench access-control model
   # export TANAGRA_ACCESS_CONTROL_BASE_PATH=https://api-dot-all-of-us-workbench-test.appspot.com
@@ -62,7 +63,7 @@ elif [[ ${useAouUnderlays} ]]; then
 elif [[ ${useSdUnderlays} ]]; then
   echo "Using sd underlay."
   export TANAGRA_UNDERLAY_FILES=sd/sd020230831_local
-  export TANAGRA_EXPORT_SHARED_GCS_PROJECT_ID=sd-vumc-tanagra-test
+  export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=sd-vumc-tanagra-test
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=sd-test-tanagra-exports
   # uncomment both lines below for sd access-control model
   # export TANAGRA_ACCESS_CONTROL_BASE_PATH=https://sd-tanagra-test.victrvumc.org
@@ -70,7 +71,8 @@ elif [[ ${useSdUnderlays} ]]; then
 else
   echo "Using Broad underlays."
   export TANAGRA_UNDERLAY_FILES=cmssynpuf_broad,aouSR2019q4r4_broad
-  export TANAGRA_EXPORT_SHARED_GCS_PROJECT_ID=broad-tanagra-dev
+  export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=broad-tanagra-dev
+  export TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS=service_export_us,service_export_uscentral1
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export
 fi
 

--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -56,7 +56,7 @@ elif [[ ${useAouUnderlays} ]]; then
   export TANAGRA_UNDERLAY_FILES=aou/SR2023Q3R2_local,aou/SC2023Q3R2_local
   export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=broad-tanagra-dev
   export TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS=service_export_us,service_export_uscentral1
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export
+  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export,broad-tanagra-dev-bq-export-uscentral1
   # uncomment both lines below for test AoU Workbench access-control model
   # export TANAGRA_ACCESS_CONTROL_BASE_PATH=https://api-dot-all-of-us-workbench-test.appspot.com
   # export TANAGRA_ACCESS_CONTROL_MODEL=AOU_WORKBENCH
@@ -73,7 +73,7 @@ else
   export TANAGRA_UNDERLAY_FILES=cmssynpuf_broad,aouSR2019q4r4_broad
   export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=broad-tanagra-dev
   export TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS=service_export_us,service_export_uscentral1
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export
+  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export,broad-tanagra-dev-bq-export-uscentral1
 fi
 
 export TANAGRA_FEATURE_ARTIFACT_STORAGE_ENABLED=true

--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -48,12 +48,13 @@ fi
 if [[ ${useVerilyUnderlays} ]]; then
   echo "Using Verily underlays."
   export TANAGRA_UNDERLAY_FILES=cmssynpuf_verily,aouSR2019q4r4_verily,sd20230831_verily,pilotsynthea2022q3_verily
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID=verily-tanagra-dev
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=verily-tanagra-dev-export-bucket
+  export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=verily-tanagra-test
+  export TANAGRA_EXPORT_SHARED_BQ_DATASET_ID=service_export_uscentral1
+  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=verily-tanagra-test-export-bucket,verily-tanagra-test-export-bucket-uscentral1
 elif [[ ${useAouUnderlays} ]]; then
   echo "Using AoU test underlays."
   export TANAGRA_UNDERLAY_FILES=aou/SR2023Q3R2_local,aou/SC2023Q3R2_local
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID=broad-tanagra-dev
+  export TANAGRA_EXPORT_SHARED_GCS_PROJECT_ID=broad-tanagra-dev
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export
   # uncomment both lines below for test AoU Workbench access-control model
   # export TANAGRA_ACCESS_CONTROL_BASE_PATH=https://api-dot-all-of-us-workbench-test.appspot.com
@@ -61,7 +62,7 @@ elif [[ ${useAouUnderlays} ]]; then
 elif [[ ${useSdUnderlays} ]]; then
   echo "Using sd underlay."
   export TANAGRA_UNDERLAY_FILES=sd/sd020230831_local
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID=sd-vumc-tanagra-test
+  export TANAGRA_EXPORT_SHARED_GCS_PROJECT_ID=sd-vumc-tanagra-test
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=sd-test-tanagra-exports
   # uncomment both lines below for sd access-control model
   # export TANAGRA_ACCESS_CONTROL_BASE_PATH=https://sd-tanagra-test.victrvumc.org
@@ -69,7 +70,7 @@ elif [[ ${useSdUnderlays} ]]; then
 else
   echo "Using Broad underlays."
   export TANAGRA_UNDERLAY_FILES=cmssynpuf_broad,aouSR2019q4r4_broad
-  export TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID=broad-tanagra-dev
+  export TANAGRA_EXPORT_SHARED_GCS_PROJECT_ID=broad-tanagra-dev
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=broad-tanagra-dev-bq-export
 fi
 

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/ExportConfiguration.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/ExportConfiguration.java
@@ -39,7 +39,7 @@ public class ExportConfiguration {
 
   /** Write the data export flags into the log. Add an entry here for each new flag. */
   public void log() {
-    LOGGER.info("Export: shared gcs-project-id: {}", shared.getGcsProjectId());
+    LOGGER.info("Export: shared gcs-project-id: {}", shared.getGcpProjectId());
     LOGGER.info(
         "Export: shared gcs-bucket-names: {}",
         shared.getGcsBucketNames().stream().collect(Collectors.joining(",")));
@@ -61,14 +61,24 @@ public class ExportConfiguration {
       markdown = "Configure the export options shared by all models.")
   public static class Shared {
     @AnnotatedField(
-        name = "tanagra.export.shared.gcsProjectId",
+        name = "tanagra.export.shared.gcpProjectId",
         markdown =
-            "GCP project id that contains the GCS bucket(s) that all export models can use. "
-                + "Required if there are any export models that need to write to GCS.",
-        environmentVariable = "TANAGRA_EXPORT_SHARED_GCS_BUCKET_PROJECT_ID",
+            "GCP project id that contains the BQ dataset and GCS bucket(s) that all export models can use. "
+                + "Required if there are any export models that need to export from BQ to GCS.",
+        environmentVariable = "TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID",
         optional = true,
         exampleValue = "broad-tanagra-dev")
-    private String gcsProjectId;
+    private String gcpProjectId;
+
+    @AnnotatedField(
+        name = "tanagra.export.shared.bqDatasetIds",
+        markdown =
+            "Comma separated list of all BQ dataset ids that all export models can use. "
+                + "Required if there are any export models that need to export from BQ to GCS.",
+        environmentVariable = "TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS",
+        optional = true,
+        exampleValue = "service_export_us,service_export_uscentral1")
+    private List<String> bqDatasetIds;
 
     @AnnotatedField(
         name = "tanagra.export.shared.gcsBucketNames",
@@ -81,12 +91,20 @@ public class ExportConfiguration {
         exampleValue = "broad-tanagra-dev-bq-export-uscentral1,broad-tanagra-dev-bq-export-useast1")
     private List<String> gcsBucketNames;
 
-    public String getGcsProjectId() {
-      return gcsProjectId;
+    public String getGcpProjectId() {
+      return gcpProjectId;
     }
 
-    public void setGcsProjectId(String gcsProjectId) {
-      this.gcsProjectId = gcsProjectId;
+    public void setGcpProjectId(String gcpProjectId) {
+      this.gcpProjectId = gcpProjectId;
+    }
+
+    public List<String> getBqDatasetIds() {
+      return bqDatasetIds;
+    }
+
+    public void setBqDatasetIds(List<String> bqDatasetIds) {
+      this.bqDatasetIds = bqDatasetIds;
     }
 
     public List<String> getGcsBucketNames() {

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportService.java
@@ -192,7 +192,8 @@ public class DataExportService {
                       new ExportQueryRequest(
                           qr,
                           wildcardFilename,
-                          shared.getGcsProjectId(),
+                          shared.getGcpProjectId(),
+                          shared.getBqDatasetIds(),
                           shared.getGcsBucketNames());
                   ExportQueryResult exportQueryResult =
                       qr.getUnderlay().getQueryRunner().run(exportQueryRequest);
@@ -244,7 +245,7 @@ public class DataExportService {
   private GoogleCloudStorage getStorageService() {
     if (storageService == null) {
       storageService =
-          GoogleCloudStorage.forApplicationDefaultCredentials(shared.getGcsProjectId());
+          GoogleCloudStorage.forApplicationDefaultCredentials(shared.getGcpProjectId());
     }
     return storageService;
   }

--- a/service/src/main/java/bio/terra/tanagra/service/export/DeploymentConfig.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DeploymentConfig.java
@@ -37,19 +37,26 @@ public final class DeploymentConfig {
 
   public static final class Shared {
     private final String gcpProjectId;
+    private final List<String> bqDatasetIds;
     private final List<String> gcsBucketNames;
 
-    private Shared(String gcpProjectId, List<String> gcsBucketNames) {
+    private Shared(String gcpProjectId, List<String> bqDatasetIds, List<String> gcsBucketNames) {
       this.gcpProjectId = gcpProjectId;
+      this.bqDatasetIds = bqDatasetIds;
       this.gcsBucketNames = gcsBucketNames;
     }
 
     public static Shared fromApplicationConfig(ExportConfiguration.Shared appConfig) {
-      return new Shared(appConfig.getGcsProjectId(), appConfig.getGcsBucketNames());
+      return new Shared(
+          appConfig.getGcpProjectId(), appConfig.getBqDatasetIds(), appConfig.getGcsBucketNames());
     }
 
     public String getGcpProjectId() {
       return gcpProjectId;
+    }
+
+    public List<String> getBqDatasetIds() {
+      return Collections.unmodifiableList(bqDatasetIds);
     }
 
     public List<String> getGcsBucketNames() {

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IndividualFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IndividualFileDownload.java
@@ -45,9 +45,9 @@ public class IndividualFileDownload implements DataExport {
   @Override
   public ExportResult run(ExportRequest request) {
     Map<String, String> entityToGcsUrl =
-        request.writeEntityDataToGcs("tanagra_${entity}_" + Instant.now() + "_*.csv");
+        request.writeEntityDataToGcs("tanagra_${entity}_" + Instant.now());
     Map<Cohort, String> cohortToGcsUrl =
-        request.writeAnnotationDataToGcs("tanagra_${cohort}_" + Instant.now() + "_*.csv");
+        request.writeAnnotationDataToGcs("tanagra_${cohort}_" + Instant.now());
 
     Map<String, String> outputParams = new HashMap<>();
     entityToGcsUrl.entrySet().stream()

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -29,7 +29,7 @@ tanagra:
     shared:
       gcp-project-id: broad-tanagra-dev
       bq-dataset-ids: service_export_us, service_export_uscentral1
-      gcs-bucket-names: broad-tanagra-dev-bq-export
+      gcs-bucket-names: broad-tanagra-dev-bq-export,broad-tanagra-dev-bq-export-uscentral1
     models:
       -
         type: INDIVIDUAL_FILE_DOWNLOAD

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -27,7 +27,8 @@ tanagra:
 
   export:
     shared:
-      gcs-bucket-project-id: broad-tanagra-dev
+      gcp-project-id: broad-tanagra-dev
+      bq-dataset-ids: service_export_us, service_export_uscentral1
       gcs-bucket-names: broad-tanagra-dev-bq-export
     models:
       -

--- a/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
@@ -244,7 +244,7 @@ public class DataExportServiceTest {
             .get("Data:" + underlayService.getUnderlay(UNDERLAY_NAME).getPrimaryEntity().getName());
     assertNotNull(signedUrl);
     LOGGER.info("Entity instances signed URL: {}", signedUrl);
-    String fileContents = GoogleCloudStorage.readFileContentsFromUrl(signedUrl);
+    String fileContents = GoogleCloudStorage.readGzipFileContentsFromUrl(signedUrl);
     assertFalse(fileContents.isEmpty());
     LOGGER.info("Entity instances fileContents: {}", fileContents);
     String fileContentsFirstLine = fileContents.split(System.lineSeparator())[0];
@@ -322,7 +322,9 @@ public class DataExportServiceTest {
     assertEquals(2, annotationsFileContents.split("\n").length); // 1 annotation + header row
 
     String entityInstancesFileContents =
-        annotationsFileContents.equals(fileContents1) ? fileContents2 : fileContents1;
+        annotationsFileContents.equals(fileContents1)
+            ? GoogleCloudStorage.readGzipFileContentsFromUrl(signedUrl2)
+            : GoogleCloudStorage.readGzipFileContentsFromUrl(signedUrl1);
     LOGGER.info("Entity instances fileContents: {}", entityInstancesFileContents);
     String fileContentsFirstLine = entityInstancesFileContents.split(System.lineSeparator())[0];
     assertEquals(

--- a/service/src/test/resources/application-test.yaml
+++ b/service/src/test/resources/application-test.yaml
@@ -22,8 +22,8 @@ tanagra:
   export:
     shared:
       gcp-project-id: broad-tanagra-dev
-      bq-dataset-ids: service_export_us, service_export_uscentral1
-      gcs-bucket-names: broad-tanagra-dev-bq-export
+      bq-dataset-ids: service_export_us,service_export_uscentral1
+      gcs-bucket-names: broad-tanagra-dev-bq-export,broad-tanagra-dev-bq-export-uscentral1
     models:
       -
         type: INDIVIDUAL_FILE_DOWNLOAD

--- a/service/src/test/resources/application-test.yaml
+++ b/service/src/test/resources/application-test.yaml
@@ -21,7 +21,8 @@ tanagra:
 
   export:
     shared:
-      gcs-bucket-project-id: broad-tanagra-dev
+      gcp-project-id: broad-tanagra-dev
+      bq-dataset-ids: service_export_us, service_export_uscentral1
       gcs-bucket-names: broad-tanagra-dev-bq-export
     models:
       -

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
@@ -7,16 +7,19 @@ public class ExportQueryRequest {
   private final ListQueryRequest listQueryRequest;
   private final String fileNamePrefix;
   private final String gcsProjectId;
+  private final List<String> availableBqDatasetIds;
   private final List<String> availableGcsBucketNames;
 
   public ExportQueryRequest(
       ListQueryRequest listQueryRequest,
       String fileNamePrefix,
       String gcsProjectId,
+      List<String> availableBqDatasetIds,
       List<String> availableGcsBucketNames) {
     this.listQueryRequest = listQueryRequest;
     this.fileNamePrefix = fileNamePrefix;
     this.gcsProjectId = gcsProjectId;
+    this.availableBqDatasetIds = availableBqDatasetIds;
     this.availableGcsBucketNames = availableGcsBucketNames;
   }
 
@@ -30,6 +33,10 @@ public class ExportQueryRequest {
 
   public String getGcsProjectId() {
     return gcsProjectId;
+  }
+
+  public List<String> getAvailableBqDatasetIds() {
+    return availableBqDatasetIds;
   }
 
   public List<String> getAvailableGcsBucketNames() {

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 public class ExportQueryRequest {
   private final ListQueryRequest listQueryRequest;
+  private final String fileDisplayName;
   private final String fileNamePrefix;
   private final String gcsProjectId;
   private final List<String> availableBqDatasetIds;
@@ -12,11 +13,13 @@ public class ExportQueryRequest {
 
   public ExportQueryRequest(
       ListQueryRequest listQueryRequest,
+      String fileDisplayName,
       String fileNamePrefix,
       String gcsProjectId,
       List<String> availableBqDatasetIds,
       List<String> availableGcsBucketNames) {
     this.listQueryRequest = listQueryRequest;
+    this.fileDisplayName = fileDisplayName;
     this.fileNamePrefix = fileNamePrefix;
     this.gcsProjectId = gcsProjectId;
     this.availableBqDatasetIds = availableBqDatasetIds;
@@ -25,6 +28,10 @@ public class ExportQueryRequest {
 
   public ListQueryRequest getListQueryRequest() {
     return listQueryRequest;
+  }
+
+  public String getFileDisplayName() {
+    return fileDisplayName;
   }
 
   public String getFileNamePrefix() {

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryResult.java
@@ -1,13 +1,19 @@
 package bio.terra.tanagra.api.query.export;
 
 public class ExportQueryResult {
-  private final String fileName;
+  private final String fileDisplayName;
+  private final String filePath;
 
-  public ExportQueryResult(String fileName) {
-    this.fileName = fileName;
+  public ExportQueryResult(String fileDisplayName, String filePath) {
+    this.fileDisplayName = fileDisplayName;
+    this.filePath = filePath;
   }
 
-  public String getFileName() {
-    return fileName;
+  public String getFileDisplayName() {
+    return fileDisplayName;
+  }
+
+  public String getFilePath() {
+    return filePath;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -124,7 +124,7 @@ public class BQExecutor {
     String bucketName =
         getCloudStorageService()
             .findBucketForBigQueryExport(exportProjectId, exportBucketNames, datasetLocation);
-    String gcsUrl = String.format("gs://%s/%s", bucketName, tempTableName);
+    String gcsUrl = String.format("gs://%s/%s.gzip", bucketName, tempTableName);
     LOGGER.info("Exporting temporary table to GCS file: {}", gcsUrl);
     Job exportJob = getBigQueryService().exportTableToGcs(tempTableId, gcsUrl, "GZIP", "CSV");
     if (exportJob == null) {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,7 @@ public class BQExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(BQExecutor.class);
   private static final String TEMPORARY_TABLE_BASE_NAME = "exporttemptable";
 
+  private static final Random RANDOM = new Random();
   private final String queryProjectId;
   private final String datasetLocation;
 
@@ -99,7 +101,14 @@ public class BQExecutor {
     LOGGER.info("Exporting BQ query: {}", queryRequest.getSql());
 
     // Create a temporary view with the results of the query.
-    final String tempTableName = TEMPORARY_TABLE_BASE_NAME + '_' + Instant.now().toEpochMilli();
+    final String tempTableName =
+        TEMPORARY_TABLE_BASE_NAME
+            + '_'
+            + Instant.now().getEpochSecond()
+            + '_'
+            + Instant.now().getNano()
+            + '_'
+            + RANDOM.nextInt();
     String exportDatasetId =
         getBigQueryService()
             .findDatasetForExportTempTable(exportProjectId, exportDatasetIds, datasetLocation);

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -96,6 +96,8 @@ public class BQExecutor {
       String exportProjectId,
       List<String> exportDatasetIds,
       List<String> exportBucketNames) {
+    LOGGER.info("Exporting BQ query: {}", queryRequest.getSql());
+
     // Create a temporary view with the results of the query.
     final String tempTableName = TEMPORARY_TABLE_BASE_NAME + '_' + Instant.now().toEpochMilli();
     String exportDatasetId =

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -10,18 +10,22 @@ import bio.terra.tanagra.utils.GoogleBigQuery;
 import bio.terra.tanagra.utils.GoogleCloudStorage;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BQExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(BQExecutor.class);
+  private static final String TEMPORARY_TABLE_BASE_NAME = "exporttemptable";
 
   private final String queryProjectId;
   private final String datasetLocation;
@@ -89,37 +93,47 @@ public class BQExecutor {
 
   public String export(
       SqlQueryRequest queryRequest,
-      String fileNamePrefix,
       String exportProjectId,
+      List<String> exportDatasetIds,
       List<String> exportBucketNames) {
-    // Validate the filename.
-    // GCS file name must be in wildcard format.
-    // https://cloud.google.com/bigquery/docs/reference/standard-sql/other-statements#export_option_list:~:text=The%20uri%20option%20must%20be%20a%20single%2Dwildcard%20URI
-    String validatedFilename;
-    if (fileNamePrefix == null || !fileNamePrefix.contains("*")) {
-      validatedFilename = "tanagra_" + System.currentTimeMillis() + "_*.csv";
-      LOGGER.warn(
-          "No (or invalid) filename specified for GCS export ({}), using default: {}",
-          fileNamePrefix,
-          validatedFilename);
-    } else {
-      validatedFilename = fileNamePrefix;
-    }
+    // Create a temporary view with the results of the query.
+    final String tempTableName = TEMPORARY_TABLE_BASE_NAME + '_' + Instant.now().toEpochMilli();
+    String exportDatasetId =
+        getBigQueryService()
+            .findDatasetForExportTempTable(exportProjectId, exportDatasetIds, datasetLocation);
+    TableId tempTableId = TableId.of(exportProjectId, exportDatasetId, tempTableName);
 
-    // Prefix the SQL query with the export to GCS directive.
+    // Pass query parameters to the job.
+    QueryJobConfiguration.Builder queryConfig =
+        QueryJobConfiguration.newBuilder(queryRequest.getSql())
+            .setUseLegacySql(false)
+            .setDestinationTable(tempTableId);
+    queryRequest.getSqlParams().getParams().entrySet().stream()
+        .forEach(
+            sqlParam ->
+                queryConfig.addNamedParameter(
+                    sqlParam.getKey(), toQueryParameterValue(sqlParam.getValue())));
+    getBigQueryService().createTableFromQuery(queryConfig.build());
+    LOGGER.info(
+        "Temporary table created for export: {}.{}.{}",
+        exportProjectId,
+        exportDatasetId,
+        tempTableName);
+
+    // Export the temporary table to a compressed file.
     String bucketName =
         getCloudStorageService()
             .findBucketForBigQueryExport(exportProjectId, exportBucketNames, datasetLocation);
-    String sqlWithExportPrefix =
-        String.format(
-            "EXPORT DATA OPTIONS(uri='gs://%s/%s',format='CSV',overwrite=true,header=true) AS %n%s",
-            bucketName, validatedFilename, queryRequest.getSql());
-    run(queryRequest.cloneAndSetSql(sqlWithExportPrefix));
-
-    // Multiple files will be created only if export is very large (> 1GB). For now, just assume
-    // only "000000000000" was created.
-    // TODO: Detect and handle case where mulitple files are created.
-    return String.format("gs://%s/%s", bucketName, validatedFilename.replace("*", "000000000000"));
+    String gcsUrl = String.format("gs://%s/%s", bucketName, tempTableName);
+    LOGGER.info("Exporting temporary table to GCS file: {}", gcsUrl);
+    Job exportJob = getBigQueryService().exportTableToGcs(tempTableId, gcsUrl, "GZIP", "CSV");
+    if (exportJob == null) {
+      throw new SystemException("BigQuery extract job failed: job no longer exists");
+    } else if (exportJob.getStatus().getError() != null) {
+      throw new SystemException("BigQuery extract job failed: " + exportJob.getStatus().getError());
+    }
+    LOGGER.info("Export of temporary table completed: {}", exportJob.getStatus().getState());
+    return gcsUrl;
   }
 
   private static QueryParameterValue toQueryParameterValue(Literal literal) {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -377,8 +377,8 @@ public class BQQueryRunner implements QueryRunner {
     String exportFileName =
         bigQueryExecutor.export(
             sqlQueryRequest,
-            exportQueryRequest.getFileNamePrefix(),
             exportQueryRequest.getGcsProjectId(),
+            exportQueryRequest.getAvailableBqDatasetIds(),
             exportQueryRequest.getAvailableGcsBucketNames());
 
     return new ExportQueryResult(exportFileName);

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -374,13 +374,13 @@ public class BQQueryRunner implements QueryRunner {
     SqlQueryRequest sqlQueryRequest = buildListQuerySql(exportQueryRequest.getListQueryRequest());
 
     // Execute the SQL query.
-    String exportFileName =
+    String exportFilePath =
         bigQueryExecutor.export(
             sqlQueryRequest,
             exportQueryRequest.getGcsProjectId(),
             exportQueryRequest.getAvailableBqDatasetIds(),
             exportQueryRequest.getAvailableGcsBucketNames());
 
-    return new ExportQueryResult(exportFileName);
+    return new ExportQueryResult(exportQueryRequest.getFileDisplayName(), exportFilePath);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +87,15 @@ public final class GoogleCloudStorage {
     return blob.getBlobId();
   }
 
+  public BlobId writeGzipFile(String bucketName, String fileName, String fileContents) {
+    BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, fileName)).build();
+    Blob blob =
+        callWithRetries(
+            () -> storage.create(blobInfo, fileContents.getBytes(StandardCharsets.UTF_8)),
+            "Error creating blob");
+    return blob.getBlobId();
+  }
+
   public String createSignedUrl(String fullGcsPath) {
     return createSignedUrl(fullGcsPath, DEFAULT_SIGNED_URL_DURATION, DEFAULT_SIGNED_URL_UNIT);
   }
@@ -124,6 +134,20 @@ public final class GoogleCloudStorage {
     return fileContents.toString();
   }
 
+  public static String readGzipFileContentsFromUrl(String signedUrl) throws IOException {
+    try (GZIPInputStream gzipInputStream =
+            new GZIPInputStream(new URL(signedUrl).openConnection().getInputStream());
+        InputStreamReader inputStreamReader = new InputStreamReader(gzipInputStream, "UTF-8");
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+      StringBuffer fileContents = new StringBuffer();
+      String inputLine;
+      while ((inputLine = bufferedReader.readLine()) != null) {
+        fileContents.append(inputLine).append(System.lineSeparator());
+      }
+      return fileContents.toString();
+    }
+  }
+
   @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
   public String findBucketForBigQueryExport(
       String gcsProjectId, List<String> gcsBucketNames, String bigQueryDataLocation) {
@@ -140,10 +164,12 @@ public final class GoogleCloudStorage {
         continue;
       }
       String bucketLocation = bucket.get().getLocation();
-      if (bigQueryDataLocation.equals(bucketLocation)
-          || "US".equalsIgnoreCase(bigQueryDataLocation)
-          || (bigQueryDataLocation.startsWith("us") && "US".equalsIgnoreCase(bucketLocation))
-          || ("EU".equalsIgnoreCase(bigQueryDataLocation) && bucketLocation.startsWith("europe"))) {
+      if (bigQueryDataLocation.equalsIgnoreCase(bucketLocation)) {
+        return bucketName;
+      } else if ("US".equalsIgnoreCase(bigQueryDataLocation)) {
+        return bucketName;
+      } else if ("EU".equalsIgnoreCase(bigQueryDataLocation)
+          && bucketLocation.startsWith("europe")) {
         return bucketName;
       }
     }

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -164,7 +165,7 @@ public final class GoogleCloudStorage {
         continue;
       }
       String bucketLocation = bucket.get().getLocation();
-      if (bigQueryDataLocation.equalsIgnoreCase(bucketLocation)) {
+      if (bucketLocation.equalsIgnoreCase(bigQueryDataLocation)) {
         return bucketName;
       } else if ("US".equalsIgnoreCase(bigQueryDataLocation)) {
         return bucketName;
@@ -175,7 +176,9 @@ public final class GoogleCloudStorage {
     }
     throw new SystemException(
         "No compatible GCS bucket found for export from BQ dataset in location: "
-            + bigQueryDataLocation);
+            + bigQueryDataLocation
+            + ", "
+            + gcsBucketNames.stream().collect(Collectors.joining("/")));
   }
 
   /**

--- a/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/Job.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/Job.java
@@ -1,0 +1,40 @@
+package bio.terra.tanagra.utils.threadpool;
+
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Job<T> implements Callable<JobResult<T>> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Job.class);
+  private final String jobId;
+  private final Supplier<T> jobFn;
+
+  public Job(String jobId, Supplier<T> jobFn) {
+    this.jobId = jobId;
+    this.jobFn = jobFn;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  @Override
+  public JobResult call() {
+    JobResult jobResult = new JobResult(jobId, Thread.currentThread().getName());
+
+    long startTime = System.nanoTime();
+    try {
+      T jobOutput = jobFn.get();
+      jobResult.setJobStatus(JobResult.Status.COMPLETED);
+      jobResult.setJobOutput(jobOutput);
+    } catch (Throwable ex) {
+      jobResult.setJobStatus(JobResult.Status.FAILED);
+      jobResult.saveExceptionThrown(ex);
+      LOGGER.error("Job thread threw error", ex); // Print the stack trace to stdout/logs.
+    }
+    jobResult.setElapsedTimeNS(System.nanoTime() - startTime);
+
+    return jobResult;
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/JobResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/JobResult.java
@@ -1,0 +1,101 @@
+package bio.terra.tanagra.utils.threadpool;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.apache.commons.lang3.StringUtils;
+
+public class JobResult<T> {
+  public enum Status {
+    COMPLETED,
+    FAILED
+  }
+
+  private final String jobId;
+  private final String threadName;
+  private T jobOutput;
+  private Status jobStatus;
+  private boolean jobForceTerminated;
+  private long elapsedTimeNS;
+
+  private boolean exceptionWasThrown;
+  private String exceptionMessage;
+  private String exceptionStackTrace;
+
+  public JobResult(String jobId, String threadName) {
+    this.jobId = jobId;
+    this.threadName = threadName;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public String getThreadName() {
+    return threadName;
+  }
+
+  public T getJobOutput() {
+    return jobOutput;
+  }
+
+  public JobResult<T> setJobOutput(T jobOutput) {
+    this.jobOutput = jobOutput;
+    return this;
+  }
+
+  public Status getJobStatus() {
+    return jobStatus;
+  }
+
+  public JobResult setJobStatus(Status jobStatus) {
+    this.jobStatus = jobStatus;
+    return this;
+  }
+
+  public boolean isJobForceTerminated() {
+    return jobForceTerminated;
+  }
+
+  public JobResult setJobForceTerminated(boolean jobForceTerminated) {
+    this.jobForceTerminated = jobForceTerminated;
+    return this;
+  }
+
+  public long getElapsedTimeNS() {
+    return elapsedTimeNS;
+  }
+
+  public JobResult setElapsedTimeNS(long elapsedTimeNS) {
+    this.elapsedTimeNS = elapsedTimeNS;
+    return this;
+  }
+
+  public boolean isExceptionWasThrown() {
+    return exceptionWasThrown;
+  }
+
+  public String getExceptionMessage() {
+    return exceptionMessage;
+  }
+
+  public String getExceptionStackTrace() {
+    return exceptionStackTrace;
+  }
+
+  /**
+   * Store the exception message and stack trace for the job results. Don't store the full {@link
+   * Throwable} object, because that may not always be serializable. This class may be serialized to
+   * disk as part of writing out the job results, so it needs to be a POJO.
+   */
+  public void saveExceptionThrown(Throwable exceptionThrown) {
+    exceptionWasThrown = true;
+    exceptionMessage =
+        StringUtils.isBlank(exceptionMessage)
+            ? exceptionThrown.getMessage()
+            : String.format("%s%n%s", exceptionMessage, exceptionThrown.getMessage());
+
+    StringWriter stackTraceStr = new StringWriter();
+    exceptionThrown.printStackTrace(new PrintWriter(stackTraceStr));
+    exceptionStackTrace = stackTraceStr.toString();
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/ThreadPoolUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/ThreadPoolUtils.java
@@ -1,0 +1,71 @@
+package bio.terra.tanagra.utils.threadpool;
+
+import bio.terra.tanagra.exception.SystemException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ThreadPoolUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPoolUtils.class);
+  private static final long MAX_TIME_PER_JOB_MIN = 60;
+  private static final long MAX_TIME_FOR_SHUTDOWN_SEC = 60;
+
+  private ThreadPoolUtils() {}
+
+  public static <T> Set<JobResult<T>> runInParallel(int numThreads, Set<Job<T>> jobs) {
+    // Create a thread pool with a fixed number of threads.
+    ThreadPoolExecutor threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(numThreads);
+    LOGGER.info("Created pool with {} threads", numThreads);
+
+    // Kick off each job in a separate thread.
+    List<Future<JobResult<T>>> jobFutures = new ArrayList<>();
+    for (Job<T> job : jobs) {
+      LOGGER.info("Kicking off thread for job: {}", job.getJobId());
+      Future<JobResult<T>> jobFuture = threadPool.submit(job);
+      jobFutures.add(jobFuture);
+    }
+
+    try {
+      LOGGER.info("Waiting for thread pool to shutdown.");
+      shutdownThreadPool(threadPool, MAX_TIME_PER_JOB_MIN, TimeUnit.MINUTES);
+
+      // Compile the results.
+      Set<JobResult<T>> jobResults = new HashSet<>();
+      for (Future<JobResult<T>> jobFuture : jobFutures) {
+        JobResult<T> jobResult = jobFuture.get();
+        jobResults.add(jobResult);
+      }
+      return jobResults;
+    } catch (InterruptedException | ExecutionException intEx) {
+      LOGGER.error("Error running jobs in parallel.");
+      throw new SystemException("Error running jobs in parallel", intEx);
+    }
+  }
+
+  /**
+   * Tell a thread pool to stop accepting new jobs, wait for the existing jobs to finish. If the
+   * jobs time out, then interrupt the threads and force them to terminate.
+   */
+  private static void shutdownThreadPool(
+      ThreadPoolExecutor threadPool, long timeout, TimeUnit timeUnit) throws InterruptedException {
+    // Wait for all threads to finish.
+    threadPool.shutdown();
+    boolean terminatedByItself = threadPool.awaitTermination(timeout, timeUnit);
+
+    // If the threads didn't finish in the expected time, then send them interrupts.
+    if (!terminatedByItself) {
+      threadPool.shutdownNow();
+    }
+    if (!threadPool.awaitTermination(MAX_TIME_FOR_SHUTDOWN_SEC, TimeUnit.SECONDS)) {
+      LOGGER.error("Thread pool failed to shutdown");
+    }
+  }
+}


### PR DESCRIPTION
1. Changed the export from BQ to GCS files to write the query results to a temporary table, and then export the full table. Previously, it used the `EXPORT DATA` [statement](https://cloud.google.com/bigquery/docs/reference/standard-sql/other-statements#export_data_statement) appended to the query to write to GCS without explicitly writing to a table. This should get us to ~1GB maximum size per export file more reliably.

2. Parallelized the export of each file of entity instances. This should reduce the time when exporting data feature sets that span multiple tables. Annotation files are still run serially, plan to parallelize those in a future PR.

-------------

This PR requires some devops changes to existing deployments. In particular, we need a BQ dataset that the service SA can read/write to, and has the default table expiration set very low (e.g. 1 day). This BQ dataset needs to be in the same location as the BQ dataset we're exporting from. If there are >1 underlays, with >1 locations, you can supply a list of available BQ datasets for export and it will pick a compatible one. This is similar to how the GCS buckets used to temporarily host export files work.

I also updated the name of the export project from `gcsProjectId` -> `gcpProjectId` since now it contains GCS buckets and BQ datasets. The new env var names are specified in the generated documentation and example values are in the local server script and application.yml file.

As part of this PR, I created BQ datasets to host these temp tables in the `broad-tanagra-dev` project that we use for GHA testing:
```
bq mk --location=us-central1 --default_table_expiration=86400 broad-tanagra-dev:service_export_uscentral1
bq show --format=prettyjson broad-tanagra-dev:service_export_uscentral1
```