### PR TITLE
MultiAttribute plugin filter builder implementation.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
@@ -1,0 +1,134 @@
+package bio.terra.tanagra.filterbuilder.impl.core;
+
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.exception.InvalidQueryException;
+import bio.terra.tanagra.filterbuilder.EntityOutput;
+import bio.terra.tanagra.filterbuilder.FilterBuilder;
+import bio.terra.tanagra.filterbuilder.impl.core.utils.AttributeSchemaUtils;
+import bio.terra.tanagra.filterbuilder.impl.core.utils.EntityGroupFilterUtils;
+import bio.terra.tanagra.proto.criteriaselector.ValueDataOuterClass;
+import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTMultiAttribute;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MultiAttributeFilterBuilder extends FilterBuilder {
+  public MultiAttributeFilterBuilder(CriteriaSelector criteriaSelector) {
+    super(criteriaSelector);
+  }
+
+  @Override
+  public EntityFilter buildForCohort(Underlay underlay, List<SelectionData> selectionData) {
+    DTMultiAttribute.MultiAttribute multiAttrSelectionData =
+        deserializeData(selectionData.get(0).getPluginData());
+    List<SelectionData> modifiersSelectionData = selectionData.subList(1, selectionData.size());
+
+    // Pull the entity group from the config.
+    CFPlaceholder.Placeholder multiAttrConfig = deserializeConfig();
+    GroupItems groupItems =
+        (GroupItems) underlay.getEntityGroup(multiAttrConfig.getEntityGroupMultiAttr());
+    Entity notPrimaryEntity =
+        groupItems.getGroupEntity().isPrimary()
+            ? groupItems.getItemsEntity()
+            : groupItems.getGroupEntity();
+
+    // Build the attribute filters on the not-primary entity.
+    List<EntityFilter> subFiltersNotPrimaryEntity = new ArrayList<>();
+    multiAttrSelectionData.getValueDataList().stream()
+        .forEach(
+            valueData -> {
+              // Convert the multi-attribute value_data into the attribute plugin data schema, so we
+              // can share processing code.
+              DTAttribute.Attribute attrSchema = convertToAttrDataSchema(valueData);
+              EntityFilter attrFilter =
+                  AttributeSchemaUtils.buildForEntity(
+                      underlay,
+                      notPrimaryEntity,
+                      notPrimaryEntity.getAttribute(valueData.getAttribute()),
+                      attrSchema);
+              subFiltersNotPrimaryEntity.add(attrFilter);
+            });
+    return EntityGroupFilterUtils.buildGroupItemsFilter(
+        underlay, criteriaSelector, groupItems, subFiltersNotPrimaryEntity, modifiersSelectionData);
+  }
+
+  @Override
+  public List<EntityOutput> buildForDataFeature(
+      Underlay underlay, List<SelectionData> selectionData) {
+    if (selectionData.size() > 1) {
+      throw new InvalidQueryException("Modifiers are not supported for data features");
+    }
+    DTMultiAttribute.MultiAttribute multiAttrSelectionData =
+        deserializeData(selectionData.get(0).getPluginData());
+
+    // Pull the entity group from the config.
+    CFPlaceholder.Placeholder multiAttrConfig = deserializeConfig();
+    GroupItems groupItems =
+        (GroupItems) underlay.getEntityGroup(multiAttrConfig.getEntityGroupMultiAttr());
+    Entity notPrimaryEntity =
+        groupItems.getGroupEntity().isPrimary()
+            ? groupItems.getItemsEntity()
+            : groupItems.getGroupEntity();
+
+    // Build the attribute filters on the not-primary entity.
+    List<EntityFilter> subFiltersNotPrimaryEntity = new ArrayList<>();
+    multiAttrSelectionData.getValueDataList().stream()
+        .forEach(
+            valueData -> {
+              // Convert the multi-attribute value_data into the attribute plugin data schema, so we
+              // can share processing code.
+              DTAttribute.Attribute attrSchema = convertToAttrDataSchema(valueData);
+              EntityFilter attrFilter =
+                  AttributeSchemaUtils.buildForEntity(
+                      underlay,
+                      notPrimaryEntity,
+                      notPrimaryEntity.getAttribute(valueData.getAttribute()),
+                      attrSchema);
+              subFiltersNotPrimaryEntity.add(attrFilter);
+            });
+
+    // Output the not primary entity.
+    return EntityGroupFilterUtils.mergeFiltersForDataFeature(
+        Map.of(notPrimaryEntity, subFiltersNotPrimaryEntity),
+        BooleanAndOrFilter.LogicalOperator.AND);
+  }
+
+  @Override
+  public CFPlaceholder.Placeholder deserializeConfig() {
+    return deserializeFromJson(
+            criteriaSelector.getPluginConfig(), CFPlaceholder.Placeholder.newBuilder())
+        .build();
+  }
+
+  @Override
+  public DTMultiAttribute.MultiAttribute deserializeData(String serialized) {
+    return deserializeFromJson(serialized, DTMultiAttribute.MultiAttribute.newBuilder()).build();
+  }
+
+  private static DTAttribute.Attribute convertToAttrDataSchema(
+      ValueDataOuterClass.ValueData valueData) {
+    DTAttribute.Attribute.Builder attrData = DTAttribute.Attribute.newBuilder();
+    valueData.getSelectedList().stream()
+        .forEach(
+            valueDataSelection -> {
+              DTAttribute.Attribute.Selection attrSelection =
+                  DTAttribute.Attribute.Selection.newBuilder()
+                      .setValue(valueDataSelection.getValue())
+                      .setName(valueDataSelection.getName())
+                      .build();
+              attrData.addSelected(attrSelection);
+            });
+    attrData.addDataRanges(valueData.getRange());
+    return attrData.build();
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/PrimaryEntityFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/PrimaryEntityFilterBuilder.java
@@ -24,7 +24,11 @@ public class PrimaryEntityFilterBuilder extends FilterBuilder {
     }
     CFPlaceholder.Placeholder config = deserializeConfig();
     DTAttribute.Attribute data = deserializeData(selectionData.get(0).getPluginData());
-    return AttributeSchemaUtils.buildForEntity(underlay, underlay.getPrimaryEntity(), config, data);
+    return AttributeSchemaUtils.buildForEntity(
+        underlay,
+        underlay.getPrimaryEntity(),
+        underlay.getPrimaryEntity().getAttribute(config.getAttribute()),
+        data);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -27,11 +27,7 @@ public final class AttributeSchemaUtils {
   private AttributeSchemaUtils() {}
 
   public static EntityFilter buildForEntity(
-      Underlay underlay,
-      Entity entity,
-      CFPlaceholder.Placeholder config,
-      DTAttribute.Attribute data) {
-    Attribute attribute = entity.getAttribute(config.getAttribute());
+      Underlay underlay, Entity entity, Attribute attribute, DTAttribute.Attribute data) {
     if (!data.getSelectedList().isEmpty()) {
       // Enum value filter.
       return data.getSelectedCount() == 1

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
@@ -3,18 +3,24 @@ package bio.terra.tanagra.filterbuilder.impl.core.utils;
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.filter.GroupHasItemsFilter;
 import bio.terra.tanagra.api.filter.HierarchyHasAncestorFilter;
+import bio.terra.tanagra.api.filter.ItemInGroupFilter;
 import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.api.shared.NaryOperator;
+import bio.terra.tanagra.exception.InvalidConfigException;
 import bio.terra.tanagra.filterbuilder.EntityOutput;
 import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
 import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
 import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
 import bio.terra.tanagra.underlay.uiplugin.SelectionData;
 import java.util.ArrayList;
@@ -22,7 +28,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 
 public final class EntityGroupFilterUtils {
   private EntityGroupFilterUtils() {}
@@ -77,11 +85,97 @@ public final class EntityGroupFilterUtils {
                                 : new ArrayList<>();
                         subFilters.add(
                             AttributeSchemaUtils.buildForEntity(
-                                underlay, occurrenceEntity, modifierConfig, modifierData));
+                                underlay,
+                                occurrenceEntity,
+                                occurrenceEntity.getAttribute(modifierConfig.getAttribute()),
+                                modifierData));
                         subFiltersPerOccurrenceEntity.put(occurrenceEntity, subFilters);
                       });
             });
     return subFiltersPerOccurrenceEntity;
+  }
+
+  public static EntityFilter buildGroupItemsFilter(
+      Underlay underlay,
+      CriteriaSelector criteriaSelector,
+      GroupItems groupItems,
+      List<EntityFilter> filtersOnNotPrimaryEntity,
+      List<SelectionData> modifiersSelectionData) {
+    Entity notPrimaryEntity =
+        groupItems.getGroupEntity().isPrimary()
+            ? groupItems.getItemsEntity()
+            : groupItems.getGroupEntity();
+
+    // Compile a list of all sub filters on the non-primary entity, which includes any passed in and
+    // any attribute modifiers.
+    List<EntityFilter> allFiltersNotPrimaryEntity = new ArrayList<>();
+    allFiltersNotPrimaryEntity.addAll(filtersOnNotPrimaryEntity);
+
+    // Build the attribute modifier filters for the non-primary entity.
+    Map<Entity, List<EntityFilter>> attributeModifierFilters =
+        EntityGroupFilterUtils.buildAttributeModifierFilters(
+            underlay, criteriaSelector, modifiersSelectionData, List.of(notPrimaryEntity));
+    if (attributeModifierFilters.containsKey(notPrimaryEntity)) {
+      allFiltersNotPrimaryEntity.addAll(attributeModifierFilters.get(notPrimaryEntity));
+    }
+
+    // If there's more than one filter on the non-primary entity, AND them together.
+    EntityFilter notPrimarySubFilter;
+    if (allFiltersNotPrimaryEntity.isEmpty()) {
+      notPrimarySubFilter = null;
+    } else if (allFiltersNotPrimaryEntity.size() == 1) {
+      notPrimarySubFilter = allFiltersNotPrimaryEntity.get(0);
+    } else {
+      notPrimarySubFilter =
+          new BooleanAndOrFilter(
+              BooleanAndOrFilter.LogicalOperator.AND, allFiltersNotPrimaryEntity);
+    }
+
+    Optional<Pair<CFPlaceholder.Placeholder, DTUnhintedValue.UnhintedValue>>
+        groupByModifierConfigAndData =
+            GroupByCountSchemaUtils.getModifier(criteriaSelector, modifiersSelectionData);
+    if (groupByModifierConfigAndData.isEmpty()) {
+      if (groupItems.getGroupEntity().isPrimary()) {
+        // e.g. vitals, person=group / height=items
+        return new GroupHasItemsFilter(underlay, groupItems, notPrimarySubFilter, null, null, null);
+      } else {
+        // e.g. genotyping, genotyping=group / person=items
+        return new ItemInGroupFilter(underlay, groupItems, notPrimarySubFilter, null, null, null);
+      }
+    }
+
+    // Build the group by filter information.
+    Map<Entity, List<Attribute>> groupByAttributesPerOccurrenceEntity =
+        GroupByCountSchemaUtils.getGroupByAttributesPerOccurrenceEntity(
+            underlay, groupByModifierConfigAndData);
+    List<Attribute> groupByAttributes =
+        groupByAttributesPerOccurrenceEntity.containsKey(notPrimaryEntity)
+            ? groupByAttributesPerOccurrenceEntity.get(notPrimaryEntity)
+            : new ArrayList<>();
+    if (groupByAttributes.size() > 1) {
+      // TODO: Support multiple attributes.
+      throw new InvalidConfigException(
+          "More than one group by attribute is not yet supported for GroupItems entity groups.");
+    }
+    DTUnhintedValue.UnhintedValue groupByModifierData =
+        groupByModifierConfigAndData.get().getRight();
+    if (groupItems.getGroupEntity().isPrimary()) {
+      return new GroupHasItemsFilter(
+          underlay,
+          groupItems,
+          notPrimarySubFilter,
+          groupByAttributes.size() == 1 ? groupByAttributes.get(0) : null,
+          GroupByCountSchemaUtils.toBinaryOperator(groupByModifierData.getOperator()),
+          (int) groupByModifierData.getMin());
+    } else {
+      return new ItemInGroupFilter(
+          underlay,
+          groupItems,
+          notPrimarySubFilter,
+          groupByAttributes.size() == 1 ? groupByAttributes.get(0) : null,
+          GroupByCountSchemaUtils.toBinaryOperator(groupByModifierData.getOperator()),
+          (int) groupByModifierData.getMin());
+    }
   }
 
   public static void addOccurrenceFiltersForDataFeature(

--- a/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
+++ b/underlay/src/main/proto/criteriaselector/configschema/placeholder.proto
@@ -18,4 +18,7 @@ message Placeholder {
   // core/search
   string entityGroup = 3;
   string searchAttribute = 4;
+
+  // core/multiAttribute
+  string entityGroup_multiAttr = 5;
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/MultiAttributeFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/MultiAttributeFilterBuilderTest.java
@@ -1,0 +1,661 @@
+package bio.terra.tanagra.filterbuilder;
+
+import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import bio.terra.tanagra.api.filter.AttributeFilter;
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.filter.GroupHasItemsFilter;
+import bio.terra.tanagra.api.shared.BinaryOperator;
+import bio.terra.tanagra.api.shared.Literal;
+import bio.terra.tanagra.api.shared.NaryOperator;
+import bio.terra.tanagra.filterbuilder.impl.core.MultiAttributeFilterBuilder;
+import bio.terra.tanagra.proto.criteriaselector.DataRangeOuterClass.DataRange;
+import bio.terra.tanagra.proto.criteriaselector.ValueDataOuterClass.ValueData;
+import bio.terra.tanagra.proto.criteriaselector.ValueOuterClass.Value;
+import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTMultiAttribute;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
+import bio.terra.tanagra.underlay.ConfigReader;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
+import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
+import bio.terra.tanagra.underlay.serialization.SZService;
+import bio.terra.tanagra.underlay.serialization.SZUnderlay;
+import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MultiAttributeFilterBuilderTest {
+  private Underlay underlay;
+
+  @BeforeEach
+  void setup() {
+    ConfigReader configReader = ConfigReader.fromJarResources();
+    SZService szService = configReader.readService("sd20230831_verily");
+    SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
+    underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
+  }
+
+  @Test
+  void noModifiersCohortFilter() {
+    CFPlaceholder.Placeholder config =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroupMultiAttr("bloodPressurePerson")
+            .build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.MultiAttributeFilterBuilder",
+            SZCorePlugin.MULTI_ATTRIBUTE.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    MultiAttributeFilterBuilder filterBuilder = new MultiAttributeFilterBuilder(criteriaSelector);
+
+    // Single attribute.
+    DTMultiAttribute.MultiAttribute data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .build();
+    SelectionData selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+    EntityFilter itemsSubFilter =
+        new AttributeFilter(
+            underlay,
+            underlay.getEntity("bloodPressure"),
+            underlay.getEntity("bloodPressure").getAttribute("systolic"),
+            NaryOperator.BETWEEN,
+            List.of(Literal.forDouble(100.0), Literal.forDouble(120.0)));
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Multiple attributes.
+    data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("status_code")
+                    .addSelected(
+                        ValueData.Selection.newBuilder()
+                            .setValue(Value.newBuilder().setInt64Value(3L).build())
+                            .build())
+                    .build())
+            .build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNotNull(cohortFilter);
+    itemsSubFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("status_code"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(3L))));
+    expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void withAttrModifiersCohortFilter() {
+    CFPlaceholder.Placeholder mainConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroupMultiAttr("bloodPressurePerson")
+            .build();
+    CFPlaceholder.Placeholder ageAtOccurrenceConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("age_at_occurrence").build();
+    CriteriaSelector.Modifier ageAtOccurrenceModifier =
+        new CriteriaSelector.Modifier(
+            "age_at_occurrence",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(ageAtOccurrenceConfig));
+    CFPlaceholder.Placeholder visitTypeConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("visit_type").build();
+    CriteriaSelector.Modifier visitTypeModifier =
+        new CriteriaSelector.Modifier(
+            "visit_type", SZCorePlugin.ATTRIBUTE.getIdInConfig(), serializeToJson(visitTypeConfig));
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.MultiAttributeFilterBuilder",
+            SZCorePlugin.MULTI_ATTRIBUTE.getIdInConfig(),
+            serializeToJson(mainConfig),
+            List.of(ageAtOccurrenceModifier, visitTypeModifier));
+    MultiAttributeFilterBuilder filterBuilder = new MultiAttributeFilterBuilder(criteriaSelector);
+
+    // Single attribute.
+    DTMultiAttribute.MultiAttribute data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .build();
+    SelectionData selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    DTAttribute.Attribute ageAtOccurrenceData =
+        DTAttribute.Attribute.newBuilder()
+            .addDataRanges(DataRange.newBuilder().setMin(25.0).setMax(45.0).build())
+            .build();
+    SelectionData ageAtOccurrenceSelectionData =
+        new SelectionData("age_at_occurrence", serializeToJson(ageAtOccurrenceData));
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(selectionData, ageAtOccurrenceSelectionData));
+    assertNotNull(cohortFilter);
+    EntityFilter itemsSubFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("age_at_occurrence"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(25.0), Literal.forDouble(45.0)))));
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Multiple attributes.
+    data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("status_code")
+                    .addSelected(
+                        ValueData.Selection.newBuilder()
+                            .setValue(Value.newBuilder().setInt64Value(3L).build())
+                            .build())
+                    .build())
+            .build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    DTAttribute.Attribute visitTypeData =
+        DTAttribute.Attribute.newBuilder()
+            .addSelected(
+                DTAttribute.Attribute.Selection.newBuilder()
+                    .setValue(Value.newBuilder().setInt64Value(8_870L).build())
+                    .build())
+            .build();
+    SelectionData visitTypeSelectionData =
+        new SelectionData("visit_type", serializeToJson(visitTypeData));
+    cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(selectionData, ageAtOccurrenceSelectionData, visitTypeSelectionData));
+    assertNotNull(cohortFilter);
+    itemsSubFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("status_code"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(3L)),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("age_at_occurrence"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(25.0), Literal.forDouble(45.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("visit_type"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(8_870L))));
+    expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            null,
+            null,
+            null);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void withGroupByModifierCohortFilter() {
+    CFPlaceholder.Placeholder mainConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroupMultiAttr("bloodPressurePerson")
+            .build();
+    CFPlaceholder.Placeholder groupByConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .putGroupByAttributesPerOccurrenceEntity(
+                "bloodPressure",
+                CFPlaceholder.Placeholder.GroupByAttributes.newBuilder()
+                    .addAttribute("date")
+                    .build())
+            .build();
+    CriteriaSelector.Modifier groupByModifier =
+        new CriteriaSelector.Modifier(
+            "group_by_count",
+            SZCorePlugin.UNHINTED_VALUE.getIdInConfig(),
+            serializeToJson(groupByConfig));
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.MultiAttributeFilterBuilder",
+            SZCorePlugin.MULTI_ATTRIBUTE.getIdInConfig(),
+            serializeToJson(mainConfig),
+            List.of(groupByModifier));
+    MultiAttributeFilterBuilder filterBuilder = new MultiAttributeFilterBuilder(criteriaSelector);
+
+    // Single attribute.
+    DTMultiAttribute.MultiAttribute data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .build();
+    SelectionData selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    DTUnhintedValue.UnhintedValue groupByData =
+        DTUnhintedValue.UnhintedValue.newBuilder()
+            .setOperator(
+                DTUnhintedValue.UnhintedValue.ComparisonOperator
+                    .COMPARISON_OPERATOR_GREATER_THAN_EQUAL)
+            .setMin(2.0)
+            .build();
+    SelectionData groupBySelectionData =
+        new SelectionData("group_by_count", serializeToJson(groupByData));
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(underlay, List.of(selectionData, groupBySelectionData));
+    assertNotNull(cohortFilter);
+    EntityFilter itemsSubFilter =
+        new AttributeFilter(
+            underlay,
+            underlay.getEntity("bloodPressure"),
+            underlay.getEntity("bloodPressure").getAttribute("systolic"),
+            NaryOperator.BETWEEN,
+            List.of(Literal.forDouble(100.0), Literal.forDouble(120.0)));
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            underlay.getEntity("bloodPressure").getAttribute("date"),
+            BinaryOperator.GREATER_THAN_OR_EQUAL,
+            2);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Multiple attributes.
+    data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("status_code")
+                    .addSelected(
+                        ValueData.Selection.newBuilder()
+                            .setValue(Value.newBuilder().setInt64Value(3L).build())
+                            .build())
+                    .build())
+            .build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    cohortFilter =
+        filterBuilder.buildForCohort(underlay, List.of(selectionData, groupBySelectionData));
+    assertNotNull(cohortFilter);
+    itemsSubFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("status_code"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(3L))));
+    expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            underlay.getEntity("bloodPressure").getAttribute("date"),
+            BinaryOperator.GREATER_THAN_OR_EQUAL,
+            2);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void withAttrAndGroupByModifiersCohortFilter() {
+    CFPlaceholder.Placeholder mainConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroupMultiAttr("bloodPressurePerson")
+            .build();
+    CFPlaceholder.Placeholder ageAtOccurrenceConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("age_at_occurrence").build();
+    CriteriaSelector.Modifier ageAtOccurrenceModifier =
+        new CriteriaSelector.Modifier(
+            "age_at_occurrence",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(ageAtOccurrenceConfig));
+    CFPlaceholder.Placeholder visitTypeConfig =
+        CFPlaceholder.Placeholder.newBuilder().setAttribute("visit_type").build();
+    CriteriaSelector.Modifier visitTypeModifier =
+        new CriteriaSelector.Modifier(
+            "visit_type", SZCorePlugin.ATTRIBUTE.getIdInConfig(), serializeToJson(visitTypeConfig));
+    CFPlaceholder.Placeholder groupByConfig =
+        CFPlaceholder.Placeholder.newBuilder()
+            .putGroupByAttributesPerOccurrenceEntity(
+                "bloodPressure",
+                CFPlaceholder.Placeholder.GroupByAttributes.newBuilder()
+                    .addAttribute("date")
+                    .build())
+            .build();
+    CriteriaSelector.Modifier groupByModifier =
+        new CriteriaSelector.Modifier(
+            "group_by_count",
+            SZCorePlugin.UNHINTED_VALUE.getIdInConfig(),
+            serializeToJson(groupByConfig));
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.MultiAttributeFilterBuilder",
+            SZCorePlugin.MULTI_ATTRIBUTE.getIdInConfig(),
+            serializeToJson(mainConfig),
+            List.of(ageAtOccurrenceModifier, visitTypeModifier, groupByModifier));
+    MultiAttributeFilterBuilder filterBuilder = new MultiAttributeFilterBuilder(criteriaSelector);
+
+    // Single attribute.
+    DTMultiAttribute.MultiAttribute data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .build();
+    SelectionData selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    DTAttribute.Attribute ageAtOccurrenceData =
+        DTAttribute.Attribute.newBuilder()
+            .addDataRanges(DataRange.newBuilder().setMin(25.0).setMax(45.0).build())
+            .build();
+    SelectionData ageAtOccurrenceSelectionData =
+        new SelectionData("age_at_occurrence", serializeToJson(ageAtOccurrenceData));
+    DTUnhintedValue.UnhintedValue groupByData =
+        DTUnhintedValue.UnhintedValue.newBuilder()
+            .setOperator(
+                DTUnhintedValue.UnhintedValue.ComparisonOperator
+                    .COMPARISON_OPERATOR_GREATER_THAN_EQUAL)
+            .setMin(2.0)
+            .build();
+    SelectionData groupBySelectionData =
+        new SelectionData("group_by_count", serializeToJson(groupByData));
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(selectionData, ageAtOccurrenceSelectionData, groupBySelectionData));
+    assertNotNull(cohortFilter);
+    EntityFilter itemsSubFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("age_at_occurrence"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(25.0), Literal.forDouble(45.0)))));
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            underlay.getEntity("bloodPressure").getAttribute("date"),
+            BinaryOperator.GREATER_THAN_OR_EQUAL,
+            2);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Multiple attributes.
+    data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("status_code")
+                    .addSelected(
+                        ValueData.Selection.newBuilder()
+                            .setValue(Value.newBuilder().setInt64Value(3L).build())
+                            .build())
+                    .build())
+            .build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    DTAttribute.Attribute visitTypeData =
+        DTAttribute.Attribute.newBuilder()
+            .addSelected(
+                DTAttribute.Attribute.Selection.newBuilder()
+                    .setValue(Value.newBuilder().setInt64Value(8_870L).build())
+                    .build())
+            .build();
+    SelectionData visitTypeSelectionData =
+        new SelectionData("visit_type", serializeToJson(visitTypeData));
+    cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay,
+            List.of(
+                selectionData,
+                ageAtOccurrenceSelectionData,
+                visitTypeSelectionData,
+                groupBySelectionData));
+    assertNotNull(cohortFilter);
+    itemsSubFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("status_code"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(3L)),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("age_at_occurrence"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(25.0), Literal.forDouble(45.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("visit_type"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(8_870L))));
+    expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            itemsSubFilter,
+            underlay.getEntity("bloodPressure").getAttribute("date"),
+            BinaryOperator.GREATER_THAN_OR_EQUAL,
+            2);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void noModifiersDataFeatureFilter() {
+    CFPlaceholder.Placeholder config =
+        CFPlaceholder.Placeholder.newBuilder()
+            .setEntityGroupMultiAttr("bloodPressurePerson")
+            .build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.MultiAttributeFilterBuilder",
+            SZCorePlugin.MULTI_ATTRIBUTE.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    MultiAttributeFilterBuilder filterBuilder = new MultiAttributeFilterBuilder(criteriaSelector);
+
+    // No attributes.
+    DTMultiAttribute.MultiAttribute data = DTMultiAttribute.MultiAttribute.newBuilder().build();
+    SelectionData selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    List<EntityOutput> dataFeatureOutputs =
+        filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(
+        dataFeatureOutputs.get(0), EntityOutput.unfiltered(underlay.getEntity("bloodPressure")));
+
+    // Single attribute.
+    data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    EntityFilter expectedDataFeatureFilter =
+        new AttributeFilter(
+            underlay,
+            underlay.getEntity("bloodPressure"),
+            underlay.getEntity("bloodPressure").getAttribute("systolic"),
+            NaryOperator.BETWEEN,
+            List.of(Literal.forDouble(100.0), Literal.forDouble(120.0)));
+    assertEquals(
+        dataFeatureOutputs.get(0),
+        EntityOutput.filtered(underlay.getEntity("bloodPressure"), expectedDataFeatureFilter));
+
+    // Multiple attributes.
+    data =
+        DTMultiAttribute.MultiAttribute.newBuilder()
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("systolic")
+                    .setRange(DataRange.newBuilder().setMin(100).setMax(120).build())
+                    .build())
+            .addValueData(
+                ValueData.newBuilder()
+                    .setAttribute("status_code")
+                    .addSelected(
+                        ValueData.Selection.newBuilder()
+                            .setValue(Value.newBuilder().setInt64Value(3L).build())
+                            .build())
+                    .build())
+            .build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    expectedDataFeatureFilter =
+        new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND,
+            List.of(
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("systolic"),
+                    NaryOperator.BETWEEN,
+                    List.of(Literal.forDouble(100.0), Literal.forDouble(120.0))),
+                new AttributeFilter(
+                    underlay,
+                    underlay.getEntity("bloodPressure"),
+                    underlay.getEntity("bloodPressure").getAttribute("status_code"),
+                    BinaryOperator.EQUALS,
+                    Literal.forInt64(3L))));
+    assertEquals(
+        dataFeatureOutputs.get(0),
+        EntityOutput.filtered(underlay.getEntity("bloodPressure"), expectedDataFeatureFilter));
+  }
+}


### PR DESCRIPTION
- Added the filter builder implementation class for the multi-attribute plugin, including tests.
- Currently this plugin only supports `GroupItems` type entity groups, since that is the only examples we have today (e.g. `bloodPressure`, `weight`).
- Since the multi-attribute plugin has a lot of overlap with the attribute plugin, I converted the multi-attribute schema to the attribute schema to allow code sharing.
- Added support for attribute and unhintedValue modifiers, though we have no examples of those so far.