### PR TITLE
Re-index SD 0831 underlay in Verily env.

### DIFF
--- a/underlay/src/main/resources/config/indexer/sd20230831_verily.json
+++ b/underlay/src/main/resources/config/indexer/sd20230831_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "sd20230831_index_022324"
+      "datasetId": "sd20230831_index_030624"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"

--- a/underlay/src/main/resources/config/service/sd20230831_verily.json
+++ b/underlay/src/main/resources/config/service/sd20230831_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "verily-tanagra-dev",
-      "datasetId": "sd20230831_index_022324"
+      "datasetId": "sd20230831_index_030624"
     },
     "queryProjectId": "verily-tanagra-dev",
     "dataLocation": "us-central1"


### PR DESCRIPTION
To pick up recent config changes re: start_date/date attribute names.

As part of this PR, I re-ran indexing.