### PR TITLE
Filter builder service.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -239,7 +239,7 @@ public class UnderlaysApiController implements UnderlaysApi {
               entity,
               relatedEntity,
               FromApiUtils.fromApiObject(body.getRelatedEntity().getId()),
-              FromApiUtils.getRelationship(underlay.getEntityGroups(), entity, relatedEntity)
+              UnderlayService.getRelationship(underlay.getEntityGroups(), entity, relatedEntity)
                   .getLeft(),
               false);
     }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -1,6 +1,5 @@
 package bio.terra.tanagra.app.controller.objmapping;
 
-import bio.terra.common.exception.NotFoundException;
 import bio.terra.tanagra.api.field.AttributeField;
 import bio.terra.tanagra.api.field.HierarchyIsMemberField;
 import bio.terra.tanagra.api.field.HierarchyIsRootField;
@@ -48,6 +47,7 @@ import bio.terra.tanagra.generated.model.ApiQueryIncludeHierarchyFields;
 import bio.terra.tanagra.generated.model.ApiQueryIncludeRelationshipFields;
 import bio.terra.tanagra.generated.model.ApiRelationshipFilter;
 import bio.terra.tanagra.generated.model.ApiTextFilter;
+import bio.terra.tanagra.service.UnderlayService;
 import bio.terra.tanagra.service.artifact.model.Criteria;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
@@ -58,7 +58,6 @@ import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.EntityGroup;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -161,7 +160,7 @@ public final class FromApiUtils {
             apiFilter.getFilterUnion().getRelationshipFilter();
         Entity relatedEntity = underlay.getEntity(apiRelationshipFilter.getEntity());
         Pair<EntityGroup, Relationship> entityGroupAndRelationship =
-            getRelationship(underlay.getEntityGroups(), entity, relatedEntity);
+            UnderlayService.getRelationship(underlay.getEntityGroups(), entity, relatedEntity);
         EntityFilter subFilter =
             apiRelationshipFilter.getSubfilter() == null
                 ? null
@@ -463,23 +462,9 @@ public final class FromApiUtils {
         underlay,
         entity,
         relatedEntity,
-        getRelationship(underlay.getEntityGroups(), entity, relatedEntity).getLeft(),
+        UnderlayService.getRelationship(underlay.getEntityGroups(), entity, relatedEntity)
+            .getLeft(),
         hierarchy);
-  }
-
-  public static Pair<EntityGroup, Relationship> getRelationship(
-      Collection<EntityGroup> entityGroups, Entity entity1, Entity entity2) {
-    for (EntityGroup entityGroup : entityGroups) {
-      Optional<Relationship> relationship =
-          entityGroup.getRelationships().stream()
-              .filter(r -> r.matchesEntities(entity1, entity2))
-              .findAny();
-      if (relationship.isPresent()) {
-        return Pair.of(entityGroup, relationship.get());
-      }
-    }
-    throw new NotFoundException(
-        "Relationship not found for entities: " + entity1.getName() + ", " + entity2.getName());
   }
 
   public static Literal fromApiObject(ApiLiteral apiLiteral) {

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
@@ -7,15 +7,20 @@ import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
 import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.Relationship;
+import bio.terra.tanagra.underlay.entitymodel.entitygroup.EntityGroup;
 import bio.terra.tanagra.underlay.serialization.SZService;
 import bio.terra.tanagra.underlay.serialization.SZUnderlay;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -75,6 +80,21 @@ public class UnderlayService {
   public void cacheEntityLevelHints(
       String underlayName, String entityName, HintQueryResult hintQueryResult) {
     underlayCache.get(underlayName).putEntityLevelHints(entityName, hintQueryResult);
+  }
+
+  public static Pair<EntityGroup, Relationship> getRelationship(
+      Collection<EntityGroup> entityGroups, Entity entity1, Entity entity2) {
+    for (EntityGroup entityGroup : entityGroups) {
+      Optional<Relationship> relationship =
+          entityGroup.getRelationships().stream()
+              .filter(r -> r.matchesEntities(entity1, entity2))
+              .findAny();
+      if (relationship.isPresent()) {
+        return Pair.of(entityGroup, relationship.get());
+      }
+    }
+    throw new NotFoundException(
+        "Relationship not found for entities: " + entity1.getName() + ", " + entity2.getName());
   }
 
   private static class CachedUnderlay {

--- a/service/src/main/java/bio/terra/tanagra/service/filterbuilder/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/filterbuilder/FilterBuilderService.java
@@ -1,0 +1,174 @@
+package bio.terra.tanagra.service.filterbuilder;
+
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.BooleanNotFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.filterbuilder.EntityOutput;
+import bio.terra.tanagra.filterbuilder.FilterBuilder;
+import bio.terra.tanagra.service.UnderlayService;
+import bio.terra.tanagra.service.artifact.model.Cohort;
+import bio.terra.tanagra.service.artifact.model.CohortRevision;
+import bio.terra.tanagra.service.artifact.model.ConceptSet;
+import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.uiplugin.SelectionData;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class FilterBuilderService {
+  private final UnderlayService underlayService;
+
+  @Autowired
+  public FilterBuilderService(UnderlayService underlayService) {
+    this.underlayService = underlayService;
+  }
+
+  public EntityFilter buildFilterForCriteriaGroup(
+      String underlayName, CohortRevision.CriteriaGroup criteriaGroup) {
+    if (criteriaGroup.getCriteria().isEmpty()) {
+      return null;
+    }
+
+    // TODO: Replace plugin name with criteria selector name, once we're storing that.
+    String criteriaSelectorName = criteriaGroup.getCriteria().get(0).getPluginName();
+    List<SelectionData> selectionData =
+        criteriaGroup.getCriteria().stream()
+            .map(
+                criteria ->
+                    new SelectionData(criteria.getPluginName(), criteria.getSelectionData()))
+            .collect(Collectors.toList());
+
+    Underlay underlay = underlayService.getUnderlay(underlayName);
+    FilterBuilder filterBuilder =
+        underlay.getCriteriaSelector(criteriaSelectorName).getFilterBuilder();
+    return filterBuilder.buildForCohort(underlay, selectionData);
+  }
+
+  public EntityFilter buildFilterForCriteriaGroupSection(
+      String underlayName, CohortRevision.CriteriaGroupSection criteriaGroupSection) {
+    List<EntityFilter> criteriaGroupFilters = new ArrayList<>();
+    criteriaGroupSection.getCriteriaGroups().stream()
+        .forEach(
+            criteriaGroup -> {
+              EntityFilter criteriaGroupFilter =
+                  buildFilterForCriteriaGroup(underlayName, criteriaGroup);
+              if (criteriaGroupFilter != null) {
+                criteriaGroupFilters.add(criteriaGroupFilter);
+              }
+            });
+    if (criteriaGroupFilters.isEmpty()) {
+      return null;
+    }
+
+    EntityFilter combinedFilter =
+        criteriaGroupFilters.size() == 1
+            ? criteriaGroupFilters.get(0)
+            : new BooleanAndOrFilter(criteriaGroupSection.getOperator(), criteriaGroupFilters);
+    return criteriaGroupSection.isExcluded()
+        ? new BooleanNotFilter(combinedFilter)
+        : combinedFilter;
+  }
+
+  public EntityFilter buildFilterForCohortRevision(
+      String underlayName, CohortRevision cohortRevision) {
+    List<EntityFilter> criteriaGroupSectionFilters = new ArrayList<>();
+    cohortRevision.getSections().stream()
+        .forEach(
+            criteriaGroupSection -> {
+              EntityFilter criteriaGroupSectionFilter =
+                  buildFilterForCriteriaGroupSection(underlayName, criteriaGroupSection);
+              if (criteriaGroupSectionFilter != null) {
+                criteriaGroupSectionFilters.add(criteriaGroupSectionFilter);
+              }
+            });
+    if (criteriaGroupSectionFilters.isEmpty()) {
+      return null;
+    }
+
+    return criteriaGroupSectionFilters.size() == 1
+        ? criteriaGroupSectionFilters.get(0)
+        : new BooleanAndOrFilter(
+            BooleanAndOrFilter.LogicalOperator.AND, criteriaGroupSectionFilters);
+  }
+
+  public List<EntityOutput> buildOutputsForConceptSet(ConceptSet conceptSet) {
+    if (conceptSet.getCriteria().isEmpty()) {
+      return List.of();
+    }
+
+    // TODO: Replace plugin name with criteria selector name, once we're storing that.
+    String criteriaSelectorName = conceptSet.getCriteria().get(0).getPluginName();
+    List<SelectionData> selectionData =
+        conceptSet.getCriteria().stream()
+            .map(
+                criteria ->
+                    new SelectionData(criteria.getPluginName(), criteria.getSelectionData()))
+            .collect(Collectors.toList());
+
+    Underlay underlay = underlayService.getUnderlay(conceptSet.getUnderlay());
+    FilterBuilder filterBuilder =
+        underlay.getCriteriaSelector(criteriaSelectorName).getFilterBuilder();
+    return filterBuilder.buildForDataFeature(underlay, selectionData);
+  }
+
+  public List<EntityOutput> buildOutputsForExport(
+      List<Cohort> cohorts, List<ConceptSet> conceptSets) {
+    // Build a single filter on the primary entity by OR-ing all the individual cohort filters
+    // together.
+    List<EntityFilter> cohortFilters = new ArrayList<>();
+    cohorts.stream()
+        .forEach(
+            cohort -> {
+              EntityFilter cohortFilter =
+                  buildFilterForCohortRevision(
+                      cohort.getUnderlay(), cohort.getMostRecentRevision());
+              if (cohortFilter != null) {
+                cohortFilters.add(cohortFilter);
+              }
+            });
+    EntityFilter primaryEntityFilter;
+    if (cohortFilters.isEmpty()) {
+      primaryEntityFilter = null;
+    } else if (cohortFilters.size() == 1) {
+      primaryEntityFilter = cohortFilters.get(0);
+    } else {
+      primaryEntityFilter =
+          new BooleanAndOrFilter(BooleanAndOrFilter.LogicalOperator.OR, cohortFilters);
+    }
+
+    // Build a list of output entities and the filters on them from the data feature sets.
+    Map<Entity, List<EntityFilter>> outputEntitiesAndFilters = new HashMap<>();
+    conceptSets.stream()
+        .forEach(
+            conceptSet -> {
+              List<EntityOutput> entityOutputs = buildOutputsForConceptSet(conceptSet);
+              entityOutputs.stream()
+                  .forEach(
+                      entityOutput -> {
+                        List<EntityFilter> entityFilters =
+                            outputEntitiesAndFilters.containsKey(entityOutput.getEntity())
+                                ? outputEntitiesAndFilters.get(entityOutput.getEntity())
+                                : new ArrayList<>();
+                        if (entityOutput.hasDataFeatureFilter()) {
+                          entityFilters.add(entityOutput.getDataFeatureFilter());
+                        }
+                        outputEntitiesAndFilters.put(entityOutput.getEntity(), entityFilters);
+                      });
+            });
+
+    // Build a single filter for each output entity that includes the data feature filters and the
+    // primary entity filter.
+    List<EntityOutput> entityOutputs = new ArrayList<>();
+    outputEntitiesAndFilters.entrySet().stream()
+        .forEach(
+            entry -> {
+              // Find the relationship between this output entity and the primary entity.
+              // TODO
+            });
+    return entityOutputs;
+  }
+}


### PR DESCRIPTION
Implement filter builder service for building filters for:

- Criteria groups (for count queries on cohort builder page)
- Criteria group sections (for count queries on cohort builder page)
- Cohort revisions (for count queries and breakdowns on cohort builder page, and review creation)
- Data feature sets (for data feature set previews)
- Cohorts + Data feature sets (for export and export previews)

I didn't add any specific tests for this code, yet. Plan to do that in a future PR, once we have the plugin configs all converted to the new format. That way, I can write tests for cohorts and concept sets using the configured underlays. All existing tests for the filter builders construct the plugin configs programmatically -- for this next set of tests, I'm going to use the actual configurations.