### PR TITLE
Remove modifiers from prepackaged criteria.

### DIFF
--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
@@ -45,7 +45,6 @@ public class UnderlayConfigPath extends AnnotationPath {
           SZCriteriaSelector.Display.class,
           SZCriteriaSelector.Modifier.class,
           SZPrepackagedCriteria.class,
-          SZPrepackagedCriteria.SelectionData.class,
           SZCorePlugin.class);
 
   @Override

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -23,7 +23,6 @@ This documentation is generated from annotations in the configuration classes.
 * [SZPrepackagedCriteria](#szprepackagedcriteria)
 * [SZPrimaryCriteriaRelationship](#szprimarycriteriarelationship)
 * [SZPrimaryRelationship](#szprimaryrelationship)
-* [SZSelectionData](#szselectiondata)
 * [SZService](#szservice)
 * [SZSourceData](#szsourcedata)
 * [SZTextSearch](#sztextsearch)
@@ -794,10 +793,19 @@ Name may not include spaces or special characters, only letters and numbers.
 
 This name is stored in the application database for data feature sets, so once there are artifacts associated with a prepackaged criteria, you can't change the criteria name.
 
-### SZPrepackagedCriteria.selectionData
-**required** List [ SZPrepackagedCriteria$SelectionData ]
+### SZPrepackagedCriteria.pluginData
+**required** String
 
-List of selection data.
+Serialized data for the UI display plugin e.g. "{"conceptId":"201826"}".
+
+### SZPrepackagedCriteria.pluginDataFile
+**required** String
+
+Name of the file that contains the serialized data for the UI display plugin.
+
+This file should be in the same directory as the prepackaged criteria (e.g. `condition.json`).
+
+If this property is specified, the value of the `pluginData` property is ignored.
 
 
 
@@ -857,34 +865,6 @@ Name of the field or column name that maps to the occurrence entity id. Required
 Name of the field or column name that maps to the primary entity id. Required if the [id pairs SQL](#szprimaryrelationshipidpairssqlfile) is defined.
 
 *Example value:* `primary_id`
-
-
-
-## SZSelectionData
-Prepackaged criteria selection data, one per UI display plugin.
-
-### SZSelectionData.modifierName
-**optional** String
-
-Name of the modifier (e.g. age_at_occurrence, visit_type).
-
-This name is stored in the application database, so once there are cohorts or data features that use this prepackaged criteria, you can't change the modifier names.
-
-This property is ignored for the first selection data, which is the primary selection.
-
-### SZSelectionData.pluginData
-**required** String
-
-Serialized data for the UI display plugin e.g. "{"conceptId":"201826"}".
-
-### SZSelectionData.pluginDataFile
-**required** String
-
-Name of the file that contains the serialized data for the UI display plugin.
-
-This file should be in the same directory as the prepackaged criteria (e.g. `condition.json`).
-
-If this property is specified, the value of the `pluginData` property is ignored.
 
 
 

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -147,7 +147,8 @@ export type SZPrepackagedCriteria = {
   criteriaSelector: string;
   displayName: string;
   name: string;
-  selectionData: SZSelectionData[];
+  pluginData: string;
+  pluginDataFile: string;
 };
 
 export type SZPrimaryCriteriaRelationship = {
@@ -161,12 +162,6 @@ export type SZPrimaryRelationship = {
   idPairsSqlFile?: string;
   occurrenceEntityIdFieldName?: string;
   primaryEntityIdFieldName?: string;
-};
-
-export type SZSelectionData = {
-  modifierName?: string;
-  pluginData: string;
-  pluginDataFile: string;
 };
 
 export type SZService = {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
@@ -308,19 +308,11 @@ public final class ConfigReader {
 
   private SZPrepackagedCriteria deserializePrepackagedCriteria(String prepackagedCriteriaPath) {
     try {
-      SZPrepackagedCriteria szPrepackagedCriteria =
-          JacksonMapper.readFileIntoJavaObject(
-              getStream(
-                  resolvePrepackagedCriteriaDir(prepackagedCriteriaPath)
-                      .resolve(PREPACKAGED_CRITERIA_FILE_NAME + FILE_EXTENSION)),
-              SZPrepackagedCriteria.class);
-
-      // Initialize null collections to empty collections.
-      szPrepackagedCriteria.selectionData =
-          szPrepackagedCriteria.selectionData == null
-              ? new ArrayList<>()
-              : szPrepackagedCriteria.selectionData;
-      return szPrepackagedCriteria;
+      return JacksonMapper.readFileIntoJavaObject(
+          getStream(
+              resolvePrepackagedCriteriaDir(prepackagedCriteriaPath)
+                  .resolve(PREPACKAGED_CRITERIA_FILE_NAME + FILE_EXTENSION)),
+          SZPrepackagedCriteria.class);
     } catch (IOException ioEx) {
       throw new InvalidConfigException(
           "Error deserializing prepackaged criteria config file", ioEx);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -21,7 +21,6 @@ import bio.terra.tanagra.underlay.serialization.SZPrepackagedCriteria;
 import bio.terra.tanagra.underlay.serialization.SZUnderlay;
 import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
 import bio.terra.tanagra.underlay.uiplugin.PrepackagedCriteria;
-import bio.terra.tanagra.underlay.uiplugin.SelectionData;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -263,9 +262,9 @@ public final class Underlay {
                         szPrepackagedCriteria, prepackagedCriteriaPath, configReader);
 
                 // Update the szPrepackagedCriteria with the contents of the plugin data files.
-                for (int i = 0; i < szPrepackagedCriteria.selectionData.size(); i++) {
-                  szPrepackagedCriteria.selectionData.get(i).pluginData =
-                      prepackagedCriteria.getSelectionData().get(i).getPluginData();
+                if (prepackagedCriteria.hasSelectionData()) {
+                  szPrepackagedCriteria.pluginData =
+                      prepackagedCriteria.getSelectionData().getPluginData();
                 }
 
                 szPrepackagedDataFeatures.add(szPrepackagedCriteria);
@@ -511,22 +510,15 @@ public final class Underlay {
       String prepackagedCriteriaPath,
       ConfigReader configReader) {
     // Read in the plugin config files.
-    List<SelectionData> selectionData = new ArrayList<>();
-    if (szPrepackagedCriteria.selectionData != null) {
-      szPrepackagedCriteria.selectionData.stream()
-          .forEach(
-              szSelectionData -> {
-                if (szSelectionData.pluginDataFile != null
-                    && !szSelectionData.pluginDataFile.isEmpty()) {
-                  szSelectionData.pluginData =
-                      configReader.readPrepackagedCriteriaPluginConfig(
-                          prepackagedCriteriaPath, szSelectionData.pluginDataFile);
-                }
-                selectionData.add(
-                    new SelectionData(szSelectionData.modifierName, szSelectionData.pluginData));
-              });
+    if (szPrepackagedCriteria.pluginDataFile != null
+        && !szPrepackagedCriteria.pluginDataFile.isEmpty()) {
+      szPrepackagedCriteria.pluginData =
+          configReader.readPrepackagedCriteriaPluginConfig(
+              prepackagedCriteriaPath, szPrepackagedCriteria.pluginDataFile);
     }
     return new PrepackagedCriteria(
-        szPrepackagedCriteria.name, szPrepackagedCriteria.criteriaSelector, selectionData);
+        szPrepackagedCriteria.name,
+        szPrepackagedCriteria.criteriaSelector,
+        szPrepackagedCriteria.pluginData);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZPrepackagedCriteria.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZPrepackagedCriteria.java
@@ -2,7 +2,6 @@ package bio.terra.tanagra.underlay.serialization;
 
 import bio.terra.tanagra.annotation.AnnotatedClass;
 import bio.terra.tanagra.annotation.AnnotatedField;
-import java.util.List;
 
 @AnnotatedClass(name = "SZPrepackagedCriteria", markdown = "Prepackaged criteria configuration.")
 public class SZPrepackagedCriteria {
@@ -29,35 +28,15 @@ public class SZPrepackagedCriteria {
   public String criteriaSelector;
 
   @AnnotatedField(
-      name = "SZPrepackagedCriteria.selectionData",
-      markdown = "List of selection data.")
-  public List<SelectionData> selectionData;
+      name = "SZPrepackagedCriteria.pluginData",
+      markdown = "Serialized data for the UI display plugin e.g. \"{\"conceptId\":\"201826\"}\".")
+  public String pluginData;
 
-  @AnnotatedClass(
-      name = "SZSelectionData",
-      markdown = "Prepackaged criteria selection data, one per UI display plugin.")
-  public static class SelectionData {
-    @AnnotatedField(
-        name = "SZSelectionData.modifierName",
-        markdown =
-            "Name of the modifier (e.g. age_at_occurrence, visit_type).\n\n"
-                + "This name is stored in the application database, so once there are cohorts or data features "
-                + "that use this prepackaged criteria, you can't change the modifier names.\n\n"
-                + "This property is ignored for the first selection data, which is the primary selection.",
-        optional = true)
-    public String modifierName;
-
-    @AnnotatedField(
-        name = "SZSelectionData.pluginData",
-        markdown = "Serialized data for the UI display plugin e.g. \"{\"conceptId\":\"201826\"}\".")
-    public String pluginData;
-
-    @AnnotatedField(
-        name = "SZSelectionData.pluginDataFile",
-        markdown =
-            "Name of the file that contains the serialized data for the UI display plugin.\n\n"
-                + "This file should be in the same directory as the prepackaged criteria (e.g. `condition.json`).\n\n"
-                + "If this property is specified, the value of the `pluginData` property is ignored.")
-    public String pluginDataFile;
-  }
+  @AnnotatedField(
+      name = "SZPrepackagedCriteria.pluginDataFile",
+      markdown =
+          "Name of the file that contains the serialized data for the UI display plugin.\n\n"
+              + "This file should be in the same directory as the prepackaged criteria (e.g. `condition.json`).\n\n"
+              + "If this property is specified, the value of the `pluginData` property is ignored.")
+  public String pluginDataFile;
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/uiplugin/PrepackagedCriteria.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/uiplugin/PrepackagedCriteria.java
@@ -1,17 +1,14 @@
 package bio.terra.tanagra.underlay.uiplugin;
 
-import java.util.List;
-
 public class PrepackagedCriteria {
   private final String name;
   private final String criteriaSelector;
-  private final List<SelectionData> selectionData;
+  private final String pluginData;
 
-  public PrepackagedCriteria(
-      String name, String criteriaSelector, List<SelectionData> selectionData) {
+  public PrepackagedCriteria(String name, String criteriaSelector, String pluginData) {
     this.name = name;
     this.criteriaSelector = criteriaSelector;
-    this.selectionData = selectionData;
+    this.pluginData = pluginData;
   }
 
   public String getName() {
@@ -22,7 +19,11 @@ public class PrepackagedCriteria {
     return criteriaSelector;
   }
 
-  public List<SelectionData> getSelectionData() {
-    return selectionData;
+  public boolean hasSelectionData() {
+    return pluginData != null && !pluginData.isEmpty();
+  }
+
+  public SelectionData getSelectionData() {
+    return hasSelectionData() ? new SelectionData(null, pluginData) : null;
   }
 }

--- a/underlay/src/main/resources/config/display/omop/prepackagedcriteria/demographics/prepackaged.json
+++ b/underlay/src/main/resources/config/display/omop/prepackagedcriteria/demographics/prepackaged.json
@@ -2,5 +2,5 @@
   "name": "demographics",
   "displayName": "Demographics",
   "criteriaSelector": "gender",
-  "selectionData": []
+  "pluginData": null
 }

--- a/underlay/src/main/resources/config/display/omop/prepackagedcriteria/type2Diabetes/prepackaged.json
+++ b/underlay/src/main/resources/config/display/omop/prepackagedcriteria/type2Diabetes/prepackaged.json
@@ -2,10 +2,5 @@
   "name": "type2Diabetes",
   "displayName": "Type 2 Diabetes",
   "criteriaSelector": "condition",
-  "selectionData": [
-    {
-      "plugin": "core/entityGroup",
-      "pluginDataFile": "condition.json"
-    }
-  ]
+  "pluginDataFile": "condition.json"
 }

--- a/underlay/src/test/java/bio/terra/tanagra/underlay/ConfigReaderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/underlay/ConfigReaderTest.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.underlay;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,7 +50,7 @@ public class ConfigReaderTest {
             szDemographics, "omop/demographics", ConfigReader.fromJarResources());
     assertNotNull(demographics);
     assertEquals("demographics", demographics.getName());
-    assertTrue(demographics.getSelectionData().isEmpty());
+    assertFalse(demographics.hasSelectionData());
 
     // With selection data.
     SZPrepackagedCriteria szType2Diabetes =
@@ -61,10 +62,9 @@ public class ConfigReaderTest {
     assertNotNull(type2diabetes);
     assertEquals("type2Diabetes", type2diabetes.getName());
     assertEquals("condition", type2diabetes.getCriteriaSelector());
-    assertEquals(1, type2diabetes.getSelectionData().size());
-    assertNull(type2diabetes.getSelectionData().get(0).getModifierName());
-    assertTrue(
-        type2diabetes.getSelectionData().get(0).getPluginData().contains("\"keys\": [ 201826 ]"));
+    assertTrue(type2diabetes.hasSelectionData());
+    assertNull(type2diabetes.getSelectionData().getModifierName());
+    assertTrue(type2diabetes.getSelectionData().getPluginData().contains("\"keys\": [ 201826 ]"));
   }
 
   @Test


### PR DESCRIPTION
We don’t need pluginName for the first selection data, only the pluginData. Also, API doesn’t handle modifiers for concept sets, so remove them from prepackaged criteria also.