### PR TITLE
Change group by attribute SQL generation.

### DIFF
--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -1815,17 +1815,11 @@ public class BQFilterTest extends BQRunnerTest {
     Map<Entity, List<Attribute>> groupByAttributesPerOccurrenceEntity =
         Map.of(
             conditionOccurrence,
-            List.of(
-                conditionOccurrence.getAttribute("age_at_occurrence"),
-                conditionOccurrence.getAttribute("start_date")),
+            List.of(conditionOccurrence.getAttribute("start_date")),
             observationOccurrence,
-            List.of(
-                observationOccurrence.getAttribute("age_at_occurrence"),
-                observationOccurrence.getAttribute("date")),
+            List.of(observationOccurrence.getAttribute("date")),
             procedureOccurrence,
-            List.of(
-                procedureOccurrence.getAttribute("age_at_occurrence"),
-                procedureOccurrence.getAttribute("date")));
+            List.of(procedureOccurrence.getAttribute("date")));
     PrimaryWithCriteriaFilter primaryWithCriteriaFilter =
         new PrimaryWithCriteriaFilter(
             underlay,

--- a/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
@@ -253,18 +253,22 @@ public class ApiTranslatorTest {
   @Test
   void having() {
     String tableAlias = "tableAlias";
-    SqlField groupByField = SqlField.of("columnName");
+    SqlField groupByField = SqlField.of("idColumnName");
+    SqlField distinctField = SqlField.of("columnName");
     SqlParams sqlParams = new SqlParams();
     Literal groupByCount = Literal.forInt64(4L);
 
     String havingSql =
         apiTranslator.havingSql(
+            groupByField,
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             groupByCount.getInt64Val().intValue(),
-            List.of(groupByField),
+            distinctField,
             tableAlias,
             sqlParams);
-    assertEquals("GROUP BY tableAlias.columnName HAVING COUNT(*) >= @groupByCount0", havingSql);
+    assertEquals(
+        "GROUP BY tableAlias.idColumnName HAVING COUNT(DISTINCT tableAlias.columnName) >= @groupByCount0",
+        havingSql);
     assertEquals(ImmutableMap.of("groupByCount0", groupByCount), sqlParams.getParams());
   }
 }

--- a/underlay/src/test/resources/sql/BQFilterTest/itemInGroupWithGroupByAttributeWithSubFilterIntTable.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/itemInGroupWithGroupByAttributeWithSubFilterIntTable.sql
@@ -15,8 +15,7 @@
             WHERE
                 fe.standard_concept = @val1              
             GROUP BY
-                entity_B_id,
-                fe.vocabulary              
+                entity_B_id              
             HAVING
-                COUNT(*) > @groupByCount2         
+                COUNT(DISTINCT fe.vocabulary) > @groupByCount2         
         )

--- a/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupByMultipleOccOnlyCriteriaIds.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupByMultipleOccOnlyCriteriaIds.sql
@@ -10,8 +10,7 @@
             FROM
                 (SELECT
                     person_id AS primary_id,
-                    age_at_occurrence AS group_by_0,
-                    start_date AS group_by_1                  
+                    start_date AS group_by_0                  
                 FROM
                     ${ENT_conditionOccurrence}                  
                 WHERE
@@ -34,8 +33,7 @@
                 UNION
                 ALL SELECT
                     person_id AS primary_id,
-                    age_at_occurrence AS group_by_0,
-                    date AS group_by_1                  
+                    date AS group_by_0                  
                 FROM
                     ${ENT_observationOccurrence}                  
                 WHERE
@@ -58,8 +56,7 @@
                 UNION
                 ALL SELECT
                     person_id AS primary_id,
-                    age_at_occurrence AS group_by_0,
-                    date AS group_by_1                  
+                    date AS group_by_0                  
                 FROM
                     ${ENT_procedureOccurrence}                  
                 WHERE
@@ -81,9 +78,7 @@
                     )             
             )          
         GROUP BY
-            primary_id,
-            group_by_0,
-            group_by_1          
+            primary_id          
         HAVING
-            COUNT(*) >= @groupByCountValue12     
+            COUNT(DISTINCT group_by_0) >= @groupByCountValue12     
     )

--- a/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupBySingleOccAttributeSubfilter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupBySingleOccAttributeSubfilter.sql
@@ -32,8 +32,7 @@
                 )             
             )          
         GROUP BY
-            primary_id,
-            group_by_0          
+            primary_id          
         HAVING
-            COUNT(*) = @groupByCountValue4         
+            COUNT(DISTINCT group_by_0) = @groupByCountValue4         
         )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterIdFilterWithGroupBy.sql
@@ -12,8 +12,7 @@
             WHERE
                 person_id = @val0              
             GROUP BY
-                person_id,
-                start_date              
+                person_id              
             HAVING
-                COUNT(*) > @groupByCount1         
+                COUNT(DISTINCT start_date) > @groupByCount1         
         )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNotIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNotIdFilterWithGroupBy.sql
@@ -12,8 +12,7 @@
             WHERE
                 stop_reason IS NULL              
             GROUP BY
-                person_id,
-                start_date              
+                person_id              
             HAVING
-                COUNT(*) > @groupByCount0         
+                COUNT(DISTINCT start_date) > @groupByCount0         
         )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNullFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNullFilterWithGroupBy.sql
@@ -10,8 +10,7 @@
             FROM
                 ${ENT_conditionOccurrence}              
             GROUP BY
-                person_id,
-                start_date              
+                person_id              
             HAVING
-                COUNT(*) > @groupByCount0         
+                COUNT(DISTINCT start_date) > @groupByCount0         
         )


### PR DESCRIPTION
Previously if there was a group by attribute, it was included in the group by clause. e.g.
```
GROUP BY person_id, start_date
HAVING COUNT(*) >= 2
```
This change moves it to the having clause. e.g.
```
GROUP BY person_id
HAVING COUNT(DISTINCT start_date) >= 2
```

BigQuery only allows one field in the `DISTINCT` clause, so we can only handle a single group by attribute for now. In the future if needed, we can expand the SQL generation to handle multiple attributes, but it will be more involved than just passing a comma-separate list of fields to `DISTINCT`. Some SQL dialects allow this, but BigQuery does not, so we'd have to do something like `GROUP BY person_id, start_date, end_date`, and then wrap that in another `GROUP BY` query only on the `person_id` to get an accurate count.