### PR TITLE
Handle multiple group by attributes in RelationshipFilter.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -166,17 +166,20 @@ public final class FromApiUtils {
                 ? null
                 : fromApiObject(apiRelationshipFilter.getSubfilter(), relatedEntity, underlay);
 
-        Attribute groupByCountAttribute = null;
+        List<Attribute> groupByCountAttributes = List.of();
         BinaryOperator groupByCountOperator = null;
         Integer groupByCountValue = null;
         if (apiRelationshipFilter.getGroupByCountOperator() != null
             && apiRelationshipFilter.getGroupByCountValue() != null) {
-          groupByCountAttribute =
-              apiRelationshipFilter.getGroupByCountAttribute() == null
-                  ? null
-                  : relatedEntity.getAttribute(apiRelationshipFilter.getGroupByCountAttribute());
           groupByCountOperator = fromApiObject(apiRelationshipFilter.getGroupByCountOperator());
           groupByCountValue = apiRelationshipFilter.getGroupByCountValue();
+          if (apiRelationshipFilter.getGroupByCountAttributes() != null) {
+            apiRelationshipFilter.getGroupByCountAttributes().stream()
+                .forEach(
+                    groupByCountAttrName ->
+                        groupByCountAttributes.add(
+                            relatedEntity.getAttribute(groupByCountAttrName)));
+          }
         }
         return new RelationshipFilter(
             underlay,
@@ -184,7 +187,7 @@ public final class FromApiUtils {
             entity,
             entityGroupAndRelationship.getRight(),
             subFilter,
-            groupByCountAttribute,
+            groupByCountAttributes,
             groupByCountOperator,
             groupByCountValue);
       case BOOLEAN_LOGIC:
@@ -224,17 +227,21 @@ public final class FromApiUtils {
             apiItemInGroupFilter.getGroupSubfilter() == null
                 ? null
                 : fromApiObject(apiItemInGroupFilter.getGroupSubfilter(), underlay);
-        Attribute groupByAttrItemInGroup =
-            apiItemInGroupFilter.getGroupByCountAttribute() == null
-                ? null
-                : groupItemsItemInGroup
-                    .getGroupEntity()
-                    .getAttribute(apiItemInGroupFilter.getGroupByCountAttribute());
+        List<Attribute> groupByAttrsItemInGroup = new ArrayList<>();
+        if (apiItemInGroupFilter.getGroupByCountAttributes() != null) {
+          apiItemInGroupFilter.getGroupByCountAttributes().stream()
+              .forEach(
+                  groupByCountAttrName ->
+                      groupByAttrsItemInGroup.add(
+                          groupItemsItemInGroup
+                              .getGroupEntity()
+                              .getAttribute(groupByCountAttrName)));
+        }
         return new ItemInGroupFilter(
             underlay,
             groupItemsItemInGroup,
             groupSubFilter,
-            groupByAttrItemInGroup,
+            groupByAttrsItemInGroup,
             fromApiObject(apiItemInGroupFilter.getGroupByCountOperator()),
             apiItemInGroupFilter.getGroupByCountValue());
       case GROUP_HAS_ITEMS:
@@ -246,17 +253,21 @@ public final class FromApiUtils {
             apiGroupHasItemsFilter.getItemsSubfilter() == null
                 ? null
                 : fromApiObject(apiGroupHasItemsFilter.getItemsSubfilter(), underlay);
-        Attribute groupByAttrGroupHasItems =
-            apiGroupHasItemsFilter.getGroupByCountAttribute() == null
-                ? null
-                : groupItemsGroupHasItems
-                    .getItemsEntity()
-                    .getAttribute(apiGroupHasItemsFilter.getGroupByCountAttribute());
+        List<Attribute> groupByAttrsGroupHasItems = new ArrayList<>();
+        if (apiGroupHasItemsFilter.getGroupByCountAttributes() != null) {
+          apiGroupHasItemsFilter.getGroupByCountAttributes().stream()
+              .forEach(
+                  groupByCountAttrName ->
+                      groupByAttrsGroupHasItems.add(
+                          groupItemsGroupHasItems
+                              .getItemsEntity()
+                              .getAttribute(groupByCountAttrName)));
+        }
         return new GroupHasItemsFilter(
             underlay,
             groupItemsGroupHasItems,
             itemsSubFilter,
-            groupByAttrGroupHasItems,
+            groupByAttrsGroupHasItems,
             fromApiObject(apiGroupHasItemsFilter.getGroupByCountOperator()),
             apiGroupHasItemsFilter.getGroupByCountValue());
       case OCCURRENCE_FOR_PRIMARY:

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -166,7 +166,7 @@ public final class FromApiUtils {
                 ? null
                 : fromApiObject(apiRelationshipFilter.getSubfilter(), relatedEntity, underlay);
 
-        List<Attribute> groupByCountAttributes = List.of();
+        List<Attribute> groupByCountAttributes = new ArrayList<>();
         BinaryOperator groupByCountOperator = null;
         Integer groupByCountValue = null;
         if (apiRelationshipFilter.getGroupByCountOperator() != null

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1537,11 +1537,13 @@ components:
           type: string
         subfilter:
           $ref: "#/components/schemas/Filter"
-        group_by_count_attribute:
-          type: string
-        group_by_count_operator:
+        groupByCountAttributes:
+          type: array
+          items:
+            type: string
+        groupByCountOperator:
           $ref: "#/components/schemas/BinaryOperator"
-        group_by_count_value:
+        groupByCountValue:
           type: integer
           nullable: true
 
@@ -1574,8 +1576,10 @@ components:
           type: string
         groupSubfilter:
           $ref: "#/components/schemas/Filter"
-        groupByCountAttribute:
-          type: string
+        groupByCountAttributes:
+          type: array
+          items:
+            type: string
         groupByCountOperator:
           $ref: "#/components/schemas/BinaryOperator"
         groupByCountValue:
@@ -1592,8 +1596,10 @@ components:
           type: string
         itemsSubfilter:
           $ref: "#/components/schemas/Filter"
-        groupByCountAttribute:
-          type: string
+        groupByCountAttributes:
+          type: array
+          items:
+            type: string
         groupByCountOperator:
           $ref: "#/components/schemas/BinaryOperator"
         groupByCountValue:

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -1451,7 +1451,9 @@ function generateFilter(
         relationshipFilter: {
           entity: filter.entityId,
           subfilter: subfilter,
-          groupByCountAttribute: filter.groupByCount?.attribute,
+          groupByCountAttributes: filter.groupByCount
+            ? [filter.groupByCount.attribute]
+            : [],
           groupByCountOperator: filter.groupByCount
             ? toAPIBinaryOperator(filter.groupByCount.operator)
             : undefined,

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/GroupHasItemsFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/GroupHasItemsFilter.java
@@ -4,6 +4,8 @@ import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -11,7 +13,7 @@ public class GroupHasItemsFilter extends EntityFilter {
   private final Underlay underlay;
   private final GroupItems groupItems;
   private final EntityFilter itemsSubFilter;
-  private final @Nullable Attribute groupByCountAttribute;
+  private final @Nullable List<Attribute> groupByCountAttributes;
   private final @Nullable BinaryOperator groupByCountOperator;
   private final @Nullable Integer groupByCountValue;
 
@@ -19,13 +21,16 @@ public class GroupHasItemsFilter extends EntityFilter {
       Underlay underlay,
       GroupItems groupItems,
       @Nullable EntityFilter itemsSubFilter,
-      @Nullable Attribute groupByCountAttribute,
+      @Nullable List<Attribute> groupByCountAttributes,
       @Nullable BinaryOperator groupByCountOperator,
       @Nullable Integer groupByCountValue) {
     this.underlay = underlay;
     this.groupItems = groupItems;
     this.itemsSubFilter = itemsSubFilter;
-    this.groupByCountAttribute = groupByCountAttribute;
+    this.groupByCountAttributes =
+        groupByCountAttributes == null
+            ? ImmutableList.of()
+            : ImmutableList.copyOf(groupByCountAttributes);
     this.groupByCountOperator = groupByCountOperator;
     this.groupByCountValue = groupByCountValue;
   }
@@ -43,8 +48,8 @@ public class GroupHasItemsFilter extends EntityFilter {
   }
 
   @Nullable
-  public Attribute getGroupByCountAttribute() {
-    return groupByCountAttribute;
+  public List<Attribute> getGroupByCountAttributes() {
+    return groupByCountAttributes;
   }
 
   @Nullable
@@ -69,7 +74,7 @@ public class GroupHasItemsFilter extends EntityFilter {
     return underlay.equals(that.underlay)
         && groupItems.equals(that.groupItems)
         && Objects.equals(itemsSubFilter, that.itemsSubFilter)
-        && Objects.equals(groupByCountAttribute, that.groupByCountAttribute)
+        && Objects.equals(groupByCountAttributes, that.groupByCountAttributes)
         && groupByCountOperator == that.groupByCountOperator
         && Objects.equals(groupByCountValue, that.groupByCountValue);
   }
@@ -80,7 +85,7 @@ public class GroupHasItemsFilter extends EntityFilter {
         underlay,
         groupItems,
         itemsSubFilter,
-        groupByCountAttribute,
+        groupByCountAttributes,
         groupByCountOperator,
         groupByCountValue);
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/ItemInGroupFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/ItemInGroupFilter.java
@@ -4,6 +4,8 @@ import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -11,7 +13,7 @@ public class ItemInGroupFilter extends EntityFilter {
   private final Underlay underlay;
   private final GroupItems groupItems;
   private final @Nullable EntityFilter groupSubFilter;
-  private final @Nullable Attribute groupByCountAttribute;
+  private final @Nullable List<Attribute> groupByCountAttributes;
   private final @Nullable BinaryOperator groupByCountOperator;
   private final @Nullable Integer groupByCountValue;
 
@@ -19,13 +21,16 @@ public class ItemInGroupFilter extends EntityFilter {
       Underlay underlay,
       GroupItems groupItems,
       @Nullable EntityFilter groupSubFilter,
-      @Nullable Attribute groupByCountAttribute,
+      @Nullable List<Attribute> groupByCountAttributes,
       @Nullable BinaryOperator groupByCountOperator,
       @Nullable Integer groupByCountValue) {
     this.underlay = underlay;
     this.groupItems = groupItems;
     this.groupSubFilter = groupSubFilter;
-    this.groupByCountAttribute = groupByCountAttribute;
+    this.groupByCountAttributes =
+        groupByCountAttributes == null
+            ? ImmutableList.of()
+            : ImmutableList.copyOf(groupByCountAttributes);
     this.groupByCountOperator = groupByCountOperator;
     this.groupByCountValue = groupByCountValue;
   }
@@ -43,8 +48,8 @@ public class ItemInGroupFilter extends EntityFilter {
   }
 
   @Nullable
-  public Attribute getGroupByCountAttribute() {
-    return groupByCountAttribute;
+  public List<Attribute> getGroupByCountAttributes() {
+    return groupByCountAttributes;
   }
 
   @Nullable
@@ -69,7 +74,7 @@ public class ItemInGroupFilter extends EntityFilter {
     return underlay.equals(that.underlay)
         && groupItems.equals(that.groupItems)
         && Objects.equals(groupSubFilter, that.groupSubFilter)
-        && Objects.equals(groupByCountAttribute, that.groupByCountAttribute)
+        && Objects.equals(groupByCountAttributes, that.groupByCountAttributes)
         && groupByCountOperator == that.groupByCountOperator
         && Objects.equals(groupByCountValue, that.groupByCountValue);
   }
@@ -80,7 +85,7 @@ public class ItemInGroupFilter extends EntityFilter {
         underlay,
         groupItems,
         groupSubFilter,
-        groupByCountAttribute,
+        groupByCountAttributes,
         groupByCountOperator,
         groupByCountValue);
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/PrimaryWithCriteriaFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/PrimaryWithCriteriaFilter.java
@@ -94,6 +94,10 @@ public class PrimaryWithCriteriaFilter extends EntityFilter {
     return numGroupByAttributes;
   }
 
+  public boolean hasGroupByAttributes() {
+    return getNumGroupByAttributes() > 0;
+  }
+
   @Nullable
   public BinaryOperator getGroupByCountOperator() {
     return groupByCountOperator;

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
@@ -6,6 +6,8 @@ import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Relationship;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.EntityGroup;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nullable;
 
 public class RelationshipFilter extends EntityFilter {
@@ -15,7 +17,7 @@ public class RelationshipFilter extends EntityFilter {
   private final Entity filterEntity;
   private final Relationship relationship;
   private final @Nullable EntityFilter subFilter;
-  private final @Nullable Attribute groupByCountAttribute;
+  private final @Nullable List<Attribute> groupByCountAttributes;
   private final @Nullable BinaryOperator groupByCountOperator;
   private final @Nullable Integer groupByCountValue;
 
@@ -26,7 +28,7 @@ public class RelationshipFilter extends EntityFilter {
       Entity selectEntity,
       Relationship relationship,
       @Nullable EntityFilter subFilter,
-      @Nullable Attribute groupByCountAttribute,
+      @Nullable List<Attribute> groupByCountAttributes,
       @Nullable BinaryOperator groupByCountOperator,
       @Nullable Integer groupByCountValue) {
     this.underlay = underlay;
@@ -38,7 +40,10 @@ public class RelationshipFilter extends EntityFilter {
             : relationship.getEntityA();
     this.relationship = relationship;
     this.subFilter = subFilter;
-    this.groupByCountAttribute = groupByCountAttribute;
+    this.groupByCountAttributes =
+        groupByCountAttributes == null
+            ? ImmutableList.of()
+            : ImmutableList.copyOf(groupByCountAttributes);
     this.groupByCountOperator = groupByCountOperator;
     this.groupByCountValue = groupByCountValue;
   }
@@ -71,16 +76,16 @@ public class RelationshipFilter extends EntityFilter {
     return subFilter;
   }
 
-  public boolean hasGroupByCountAttribute() {
-    return groupByCountAttribute != null;
+  public boolean hasGroupByCountAttributes() {
+    return !groupByCountAttributes.isEmpty();
   }
 
   public boolean hasGroupByFilter() {
     return groupByCountOperator != null && groupByCountValue != null;
   }
 
-  public Attribute getGroupByCountAttribute() {
-    return groupByCountAttribute;
+  public List<Attribute> getGroupByCountAttributes() {
+    return groupByCountAttributes;
   }
 
   @Nullable

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
@@ -10,7 +10,6 @@ import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.api.shared.NaryOperator;
-import bio.terra.tanagra.exception.InvalidConfigException;
 import bio.terra.tanagra.filterbuilder.EntityOutput;
 import bio.terra.tanagra.proto.criteriaselector.configschema.CFPlaceholder;
 import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
@@ -137,10 +136,12 @@ public final class EntityGroupFilterUtils {
     if (groupByModifierConfigAndData.isEmpty()) {
       if (groupItems.getGroupEntity().isPrimary()) {
         // e.g. vitals, person=group / height=items
-        return new GroupHasItemsFilter(underlay, groupItems, notPrimarySubFilter, null, null, null);
+        return new GroupHasItemsFilter(
+            underlay, groupItems, notPrimarySubFilter, List.of(), null, null);
       } else {
         // e.g. genotyping, genotyping=group / person=items
-        return new ItemInGroupFilter(underlay, groupItems, notPrimarySubFilter, null, null, null);
+        return new ItemInGroupFilter(
+            underlay, groupItems, notPrimarySubFilter, List.of(), null, null);
       }
     }
 
@@ -152,11 +153,6 @@ public final class EntityGroupFilterUtils {
         groupByAttributesPerOccurrenceEntity.containsKey(notPrimaryEntity)
             ? groupByAttributesPerOccurrenceEntity.get(notPrimaryEntity)
             : new ArrayList<>();
-    if (groupByAttributes.size() > 1) {
-      // TODO: Support multiple attributes.
-      throw new InvalidConfigException(
-          "More than one group by attribute is not yet supported for GroupItems entity groups.");
-    }
     DTUnhintedValue.UnhintedValue groupByModifierData =
         groupByModifierConfigAndData.get().getRight();
     if (groupItems.getGroupEntity().isPrimary()) {
@@ -164,7 +160,7 @@ public final class EntityGroupFilterUtils {
           underlay,
           groupItems,
           notPrimarySubFilter,
-          groupByAttributes.size() == 1 ? groupByAttributes.get(0) : null,
+          groupByAttributes,
           GroupByCountSchemaUtils.toBinaryOperator(groupByModifierData.getOperator()),
           (int) groupByModifierData.getMin());
     } else {
@@ -172,7 +168,7 @@ public final class EntityGroupFilterUtils {
           underlay,
           groupItems,
           notPrimarySubFilter,
-          groupByAttributes.size() == 1 ? groupByAttributes.get(0) : null,
+          groupByAttributes,
           GroupByCountSchemaUtils.toBinaryOperator(groupByModifierData.getOperator()),
           (int) groupByModifierData.getMin());
     }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQPrimaryWithCriteriaFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQPrimaryWithCriteriaFilterTranslator.java
@@ -41,7 +41,7 @@ public class BQPrimaryWithCriteriaFilterTranslator extends ApiFilterTranslator {
     //  ...
     // )
 
-    // With GroupBy:
+    // With GroupBy No GroupByAttributes:
     // WHERE primary.id IN (
     //  SELECT primary_id FROM (
     //    SELECT primary_id, group_by_fields FROM occurrence WHERE [FILTER ON criteria] AND
@@ -53,7 +53,22 @@ public class BQPrimaryWithCriteriaFilterTranslator extends ApiFilterTranslator {
     //    ...
     //    )
     //    GROUP BY primary_id
-    //    HAVING COUNT(DISTINCT group_by_fields) group_by_operator group_by_count_val
+    //    HAVING COUNT(*) group_by_operator group_by_count_val
+    // )
+
+    // With GroupBy And GroupByAttributes:
+    // WHERE primary.id IN (
+    //  SELECT primary_id FROM (
+    //    SELECT primary_id, group_by_fields FROM occurrence WHERE [FILTER ON criteria] AND
+    // [sub-filters]
+    //    UNION ALL
+    //    SELECT primary_id, group_by_fields FROM occurrence WHERE [FILTER ON criteria] AND
+    // [sub-filters]
+    //    UNION ALL
+    //    ...
+    //    )
+    //    GROUP BY primary_id
+    //    HAVING COUNT(*) group_by_operator group_by_count_val
     // )
 
     final String primaryIdFieldAlias = "primary_id";

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
@@ -426,7 +426,7 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
               .collect(Collectors.joining(", "))
           + ") GROUP BY "
           + SqlQueryField.of(selectIdIntTable).renderForGroupBy(null, false)
-          + " HAVING COUNT (*) "
+          + " HAVING COUNT(*) "
           + apiTranslator.binaryOperatorSql(relationshipFilter.getGroupByCountOperator())
           + " @"
           + sqlParams.addParam(

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQRelationshipFilterTranslator.java
@@ -226,7 +226,7 @@ public class BQRelationshipFilterTranslator extends ApiFilterTranslator {
               .map(groupByField -> SqlQueryField.of(groupByField).renderForGroupBy(null, false))
               .collect(Collectors.joining(", "))
           + ") GROUP BY "
-          + SqlQueryField.of(foreignKeyField).renderForGroupBy(tableAlias, false)
+          + SqlQueryField.of(foreignKeyField).renderForGroupBy(null, true)
           + " HAVING COUNT(*) "
           + apiTranslator.binaryOperatorSql(relationshipFilter.getGroupByCountOperator())
           + " @"

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
@@ -258,20 +258,13 @@ public interface ApiTranslator {
       SqlField groupByField,
       BinaryOperator havingOperator,
       Integer havingCount,
-      SqlField distinctField,
       @Nullable String tableAlias,
       SqlParams sqlParams) {
     String groupByCountParam =
         sqlParams.addParam("groupByCount", Literal.forInt64(Long.valueOf(havingCount)));
-    String countSql =
-        distinctField == null
-            ? "*"
-            : "DISTINCT " + SqlQueryField.of(distinctField).renderForGroupBy(tableAlias, false);
     return "GROUP BY "
         + SqlQueryField.of(groupByField).renderForGroupBy(tableAlias, false)
-        + " HAVING COUNT("
-        + countSql
-        + ") "
+        + " HAVING COUNT(*) "
         + binaryOperatorSql(havingOperator)
         + " @"
         + groupByCountParam;

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/GroupHasItemsFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/GroupHasItemsFilterTranslator.java
@@ -27,7 +27,7 @@ public class GroupHasItemsFilterTranslator extends ApiFilterTranslator {
             groupItems.getGroupEntity(),
             groupItems.getGroupItemsRelationship(),
             groupHasItemsFilter.getItemsSubFilter(),
-            groupHasItemsFilter.getGroupByCountAttribute(),
+            groupHasItemsFilter.getGroupByCountAttributes(),
             groupHasItemsFilter.getGroupByCountOperator(),
             groupHasItemsFilter.getGroupByCountValue());
     return apiTranslator.translator(relationshipFilter).buildSql(sqlParams, tableAlias);

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/ItemInGroupFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/ItemInGroupFilterTranslator.java
@@ -27,7 +27,7 @@ public class ItemInGroupFilterTranslator extends ApiFilterTranslator {
             groupItems.getItemsEntity(),
             groupItems.getGroupItemsRelationship(),
             itemInGroupFilter.getGroupSubFilter(),
-            itemInGroupFilter.getGroupByCountAttribute(),
+            itemInGroupFilter.getGroupByCountAttributes(),
             itemInGroupFilter.getGroupByCountOperator(),
             itemInGroupFilter.getGroupByCountValue());
     return apiTranslator.translator(relationshipFilter).buildSql(sqlParams, tableAlias);

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/OccurrenceForPrimaryFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/OccurrenceForPrimaryFilterTranslator.java
@@ -31,7 +31,7 @@ public class OccurrenceForPrimaryFilterTranslator extends ApiFilterTranslator {
                 .getOccurrencePrimaryRelationship(
                     occurrenceForPrimaryFilter.getOccurrenceEntity().getName()),
             occurrenceForPrimaryFilter.getPrimarySubFilter(),
-            null,
+            List.of(),
             null,
             null);
 
@@ -45,7 +45,7 @@ public class OccurrenceForPrimaryFilterTranslator extends ApiFilterTranslator {
                 .getOccurrenceCriteriaRelationship(
                     occurrenceForPrimaryFilter.getOccurrenceEntity().getName()),
             occurrenceForPrimaryFilter.getCriteriaSubFilter(),
-            null,
+            List.of(),
             null,
             null);
 

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
@@ -309,7 +309,7 @@ public class EntityGroupFilterBuilderForGroupTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("genotypingPerson"),
             expectedCriteriaSubFilter,
-            underlay.getEntity("genotyping").getAttribute("name"),
+            List.of(underlay.getEntity("genotyping").getAttribute("name")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);
@@ -399,7 +399,7 @@ public class EntityGroupFilterBuilderForGroupTest {
             new BooleanAndOrFilter(
                 BooleanAndOrFilter.LogicalOperator.AND,
                 List.of(expectedCriteriaSubFilter, expectedNameSubFilter)),
-            underlay.getEntity("genotyping").getAttribute("name"),
+            List.of(underlay.getEntity("genotyping").getAttribute("name")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
@@ -150,7 +150,7 @@ public class EntityGroupFilterBuilderForItemsTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
             null,
-            underlay.getEntity("bloodPressure").getAttribute("date"),
+            List.of(underlay.getEntity("bloodPressure").getAttribute("date")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);
@@ -229,7 +229,7 @@ public class EntityGroupFilterBuilderForItemsTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
             expectedSystolicSubFilter,
-            underlay.getEntity("bloodPressure").getAttribute("date"),
+            List.of(underlay.getEntity("bloodPressure").getAttribute("date")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/MultiAttributeFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/MultiAttributeFilterBuilderTest.java
@@ -344,7 +344,7 @@ public class MultiAttributeFilterBuilderTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
             itemsSubFilter,
-            underlay.getEntity("bloodPressure").getAttribute("date"),
+            List.of(underlay.getEntity("bloodPressure").getAttribute("date")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);
@@ -391,7 +391,7 @@ public class MultiAttributeFilterBuilderTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
             itemsSubFilter,
-            underlay.getEntity("bloodPressure").getAttribute("date"),
+            List.of(underlay.getEntity("bloodPressure").getAttribute("date")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);
@@ -489,7 +489,7 @@ public class MultiAttributeFilterBuilderTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
             itemsSubFilter,
-            underlay.getEntity("bloodPressure").getAttribute("date"),
+            List.of(underlay.getEntity("bloodPressure").getAttribute("date")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);
@@ -563,7 +563,7 @@ public class MultiAttributeFilterBuilderTest {
             underlay,
             (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
             itemsSubFilter,
-            underlay.getEntity("bloodPressure").getAttribute("date"),
+            List.of(underlay.getEntity("bloodPressure").getAttribute("date")),
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             2);
     assertEquals(expectedCohortFilter, cohortFilter);

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -1782,7 +1782,11 @@ public class BQFilterTest extends BQRunnerTest {
             criteriaOccurrence,
             criteriaSubFilter,
             Map.of(conditionOccurrence, List.of(ageAtOccurrenceFilter)),
-            Map.of(conditionOccurrence, List.of(conditionOccurrence.getAttribute("start_date"))),
+            Map.of(
+                conditionOccurrence,
+                List.of(
+                    conditionOccurrence.getAttribute("start_date"),
+                    conditionOccurrence.getAttribute("condition"))),
             BinaryOperator.EQUALS,
             4);
     listQueryResult =
@@ -1821,11 +1825,17 @@ public class BQFilterTest extends BQRunnerTest {
     Map<Entity, List<Attribute>> groupByAttributesPerOccurrenceEntity =
         Map.of(
             conditionOccurrence,
-            List.of(conditionOccurrence.getAttribute("start_date")),
+            List.of(
+                conditionOccurrence.getAttribute("start_date"),
+                conditionOccurrence.getAttribute("source_criteria_id")),
             observationOccurrence,
-            List.of(observationOccurrence.getAttribute("date")),
+            List.of(
+                observationOccurrence.getAttribute("date"),
+                observationOccurrence.getAttribute("source_criteria_id")),
             procedureOccurrence,
-            List.of(procedureOccurrence.getAttribute("date")));
+            List.of(
+                procedureOccurrence.getAttribute("date"),
+                procedureOccurrence.getAttribute("source_criteria_id")));
     PrimaryWithCriteriaFilter primaryWithCriteriaFilter =
         new PrimaryWithCriteriaFilter(
             underlay,

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -844,7 +844,7 @@ public class BQFilterTest extends BQRunnerTest {
             underlay.getPrimaryEntity(),
             criteriaOccurrence.getOccurrencePrimaryRelationship(occurrenceEntity.getName()),
             attributeFilter,
-            occurrenceEntity.getAttribute("start_date"),
+            List.of(occurrenceEntity.getAttribute("start_date")),
             BinaryOperator.GREATER_THAN,
             1);
     AttributeField simpleAttribute =
@@ -893,7 +893,7 @@ public class BQFilterTest extends BQRunnerTest {
             underlay.getPrimaryEntity(),
             criteriaOccurrence.getOccurrencePrimaryRelationship(occurrenceEntity.getName()),
             attributeFilter,
-            occurrenceEntity.getAttribute("start_date"),
+            List.of(occurrenceEntity.getAttribute("start_date")),
             BinaryOperator.GREATER_THAN,
             1);
     listQueryResult =
@@ -922,7 +922,7 @@ public class BQFilterTest extends BQRunnerTest {
             underlay.getPrimaryEntity(),
             criteriaOccurrence.getOccurrencePrimaryRelationship(occurrenceEntity.getName()),
             null,
-            occurrenceEntity.getAttribute("start_date"),
+            List.of(occurrenceEntity.getAttribute("start_date")),
             BinaryOperator.GREATER_THAN,
             14);
     listQueryResult =
@@ -2187,7 +2187,7 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems,
             groupSubFilter,
-            groupItems.getItemsEntity().getAttribute("vocabulary"),
+            List.of(groupItems.getItemsEntity().getAttribute("vocabulary")),
             BinaryOperator.GREATER_THAN,
             2);
     listQueryResult =

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -844,7 +844,9 @@ public class BQFilterTest extends BQRunnerTest {
             underlay.getPrimaryEntity(),
             criteriaOccurrence.getOccurrencePrimaryRelationship(occurrenceEntity.getName()),
             attributeFilter,
-            List.of(occurrenceEntity.getAttribute("start_date")),
+            List.of(
+                occurrenceEntity.getAttribute("start_date"),
+                occurrenceEntity.getAttribute("condition")),
             BinaryOperator.GREATER_THAN,
             1);
     AttributeField simpleAttribute =
@@ -893,7 +895,9 @@ public class BQFilterTest extends BQRunnerTest {
             underlay.getPrimaryEntity(),
             criteriaOccurrence.getOccurrencePrimaryRelationship(occurrenceEntity.getName()),
             attributeFilter,
-            List.of(occurrenceEntity.getAttribute("start_date")),
+            List.of(
+                occurrenceEntity.getAttribute("start_date"),
+                occurrenceEntity.getAttribute("condition")),
             BinaryOperator.GREATER_THAN,
             1);
     listQueryResult =
@@ -922,7 +926,9 @@ public class BQFilterTest extends BQRunnerTest {
             underlay.getPrimaryEntity(),
             criteriaOccurrence.getOccurrencePrimaryRelationship(occurrenceEntity.getName()),
             null,
-            List.of(occurrenceEntity.getAttribute("start_date")),
+            List.of(
+                occurrenceEntity.getAttribute("start_date"),
+                occurrenceEntity.getAttribute("condition")),
             BinaryOperator.GREATER_THAN,
             14);
     listQueryResult =
@@ -963,7 +969,7 @@ public class BQFilterTest extends BQRunnerTest {
             groupItems.getItemsEntity(),
             groupItems.getGroupItemsRelationship(),
             attributeFilter,
-            null,
+            List.of(groupItems.getGroupEntity().getAttribute("vocabulary")),
             BinaryOperator.EQUALS,
             1);
     AttributeField simpleAttribute =
@@ -1025,7 +1031,7 @@ public class BQFilterTest extends BQRunnerTest {
             groupItems.getItemsEntity(),
             groupItems.getGroupItemsRelationship(),
             attributeFilter,
-            null,
+            List.of(groupItems.getGroupEntity().getAttribute("vocabulary")),
             BinaryOperator.EQUALS,
             1);
     listQueryResult =

--- a/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
@@ -254,7 +254,6 @@ public class ApiTranslatorTest {
   void having() {
     String tableAlias = "tableAlias";
     SqlField groupByField = SqlField.of("idColumnName");
-    SqlField distinctField = SqlField.of("columnName");
     SqlParams sqlParams = new SqlParams();
     Literal groupByCount = Literal.forInt64(4L);
 
@@ -263,12 +262,9 @@ public class ApiTranslatorTest {
             groupByField,
             BinaryOperator.GREATER_THAN_OR_EQUAL,
             groupByCount.getInt64Val().intValue(),
-            distinctField,
             tableAlias,
             sqlParams);
-    assertEquals(
-        "GROUP BY tableAlias.idColumnName HAVING COUNT(DISTINCT tableAlias.columnName) >= @groupByCount0",
-        havingSql);
+    assertEquals("GROUP BY tableAlias.idColumnName HAVING COUNT(*) >= @groupByCount0", havingSql);
     assertEquals(ImmutableMap.of("groupByCount0", groupByCount), sqlParams.getParams());
   }
 }

--- a/underlay/src/test/resources/sql/BQFilterTest/itemInGroupWithGroupByAttributeWithSubFilterIntTable.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/itemInGroupWithGroupByAttributeWithSubFilterIntTable.sql
@@ -23,5 +23,5 @@
             GROUP BY
                 entity_B_id              
             HAVING
-                COUNT (*) > @groupByCount2             
+                COUNT(*) > @groupByCount2             
             )

--- a/underlay/src/test/resources/sql/BQFilterTest/itemInGroupWithGroupByAttributeWithSubFilterIntTable.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/itemInGroupWithGroupByAttributeWithSubFilterIntTable.sql
@@ -6,16 +6,22 @@
     WHERE
         id IN (
             SELECT
-                it.entity_B_id              
+                entity_B_id              
             FROM
-                ${RIDS_brandIngredient_brand_ingredient} it              
-            JOIN
-                ${ENT_brand} fe                      
-                    ON fe.id = it.entity_A_id              
-            WHERE
-                fe.standard_concept = @val1              
+                (SELECT
+                    it.entity_B_id                  
+                FROM
+                    ${RIDS_brandIngredient_brand_ingredient} AS it                  
+                JOIN
+                    ${ENT_brand} AS fe                          
+                        ON fe.id = it.entity_A_id                  
+                WHERE
+                    fe.standard_concept = @val1                  
+                GROUP BY
+                    entity_B_id,
+                    fe.vocabulary)              
             GROUP BY
                 entity_B_id              
             HAVING
-                COUNT(DISTINCT fe.vocabulary) > @groupByCount2         
-        )
+                COUNT (*) > @groupByCount2             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupByMultipleOccOnlyCriteriaIds.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupByMultipleOccOnlyCriteriaIds.sql
@@ -9,76 +9,89 @@
                 primary_id              
             FROM
                 (SELECT
-                    person_id AS primary_id,
-                    start_date AS group_by_0                  
+                    primary_id,
+                    group_by_0,
+                    group_by_1                  
                 FROM
-                    ${ENT_conditionOccurrence}                  
-                WHERE
-                    source_criteria_id IN (
-                        SELECT
-                            descendant                          
-                        FROM
-                            ${HAD_icd9cm_default}                          
-                        WHERE
-                            ancestor IN (
-                                @val0,@val1                             
-                            )                          
-                        UNION
-                        ALL SELECT
-                            @val2                          
-                        UNION
-                        ALL SELECT
-                            @val3                     
-                    )                  
-                UNION
-                ALL SELECT
-                    person_id AS primary_id,
-                    date AS group_by_0                  
-                FROM
-                    ${ENT_observationOccurrence}                  
-                WHERE
-                    source_criteria_id IN (
-                        SELECT
-                            descendant                          
-                        FROM
-                            ${HAD_icd9cm_default}                          
-                        WHERE
-                            ancestor IN (
-                                @val4,@val5                             
-                            )                          
-                        UNION
-                        ALL SELECT
-                            @val6                          
-                        UNION
-                        ALL SELECT
-                            @val7                     
-                    )                  
-                UNION
-                ALL SELECT
-                    person_id AS primary_id,
-                    date AS group_by_0                  
-                FROM
-                    ${ENT_procedureOccurrence}                  
-                WHERE
-                    source_criteria_id IN (
-                        SELECT
-                            descendant                          
-                        FROM
-                            ${HAD_icd9cm_default}                          
-                        WHERE
-                            ancestor IN (
-                                @val8,@val9                             
-                            )                          
-                        UNION
-                        ALL SELECT
-                            @val10                          
-                        UNION
-                        ALL SELECT
-                            @val11                     
-                    )             
-            )          
-        GROUP BY
-            primary_id          
-        HAVING
-            COUNT(DISTINCT group_by_0) >= @groupByCountValue12     
+                    (SELECT
+                        person_id AS primary_id,
+                        start_date AS group_by_0,
+                        source_criteria_id AS group_by_1                      
+                    FROM
+                        ${ENT_conditionOccurrence}                      
+                    WHERE
+                        source_criteria_id IN (
+                            SELECT
+                                descendant                              
+                            FROM
+                                ${HAD_icd9cm_default}                              
+                            WHERE
+                                ancestor IN (
+                                    @val0,@val1                                 
+                                )                              
+                            UNION
+                            ALL SELECT
+                                @val2                              
+                            UNION
+                            ALL SELECT
+                                @val3                         
+                        )                      
+                    UNION
+                    ALL SELECT
+                        person_id AS primary_id,
+                        date AS group_by_0,
+                        source_criteria_id AS group_by_1                      
+                    FROM
+                        ${ENT_observationOccurrence}                      
+                    WHERE
+                        source_criteria_id IN (
+                            SELECT
+                                descendant                              
+                            FROM
+                                ${HAD_icd9cm_default}                              
+                            WHERE
+                                ancestor IN (
+                                    @val4,@val5                                 
+                                )                              
+                            UNION
+                            ALL SELECT
+                                @val6                              
+                            UNION
+                            ALL SELECT
+                                @val7                         
+                        )                      
+                    UNION
+                    ALL SELECT
+                        person_id AS primary_id,
+                        date AS group_by_0,
+                        source_criteria_id AS group_by_1                      
+                    FROM
+                        ${ENT_procedureOccurrence}                      
+                    WHERE
+                        source_criteria_id IN (
+                            SELECT
+                                descendant                              
+                            FROM
+                                ${HAD_icd9cm_default}                              
+                            WHERE
+                                ancestor IN (
+                                    @val8,@val9                                 
+                                )                              
+                            UNION
+                            ALL SELECT
+                                @val10                              
+                            UNION
+                            ALL SELECT
+                                @val11                         
+                        )                 
+                )              
+            GROUP BY
+                primary_id,
+                group_by_0,
+                group_by_1         
+        )      
+    GROUP BY
+        primary_id      
+    HAVING
+        COUNT(*) >= @groupByCountValue12     
     )

--- a/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupBySingleOccAttributeSubfilter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/primaryWithCriteriaFilterGroupBySingleOccAttributeSubfilter.sql
@@ -9,30 +9,39 @@
                 primary_id              
             FROM
                 (SELECT
-                    person_id AS primary_id,
-                    start_date AS group_by_0                  
+                    primary_id,
+                    group_by_0,
+                    group_by_1                  
                 FROM
-                    ${ENT_conditionOccurrence}                  
-                WHERE
-                    (
-                        condition IN (
-                            SELECT
-                                descendant                              
-                            FROM
-                                ${HAD_condition_default}                              
-                            WHERE
-                                ancestor = @val0                              
-                            UNION
-                            ALL SELECT
-                                @val1                         
-                        )                 
-                )                  
-                AND (
-                    age_at_occurrence BETWEEN @val2 AND @val3                 
-                )             
-            )          
-        GROUP BY
-            primary_id          
-        HAVING
-            COUNT(DISTINCT group_by_0) = @groupByCountValue4         
-        )
+                    (SELECT
+                        person_id AS primary_id,
+                        start_date AS group_by_0,
+                        condition AS group_by_1                      
+                    FROM
+                        ${ENT_conditionOccurrence}                      
+                    WHERE
+                        (
+                            condition IN (
+                                SELECT
+                                    descendant                                  
+                                FROM
+                                    ${HAD_condition_default}                                  
+                                WHERE
+                                    ancestor = @val0                                  
+                                UNION
+                                ALL SELECT
+                                    @val1                             
+                            )                     
+                    )                      
+                    AND (
+                        age_at_occurrence BETWEEN @val2 AND @val3                     
+                    )                 
+                )              
+            GROUP BY
+                primary_id,
+                group_by_0,
+                group_by_1)              
+            GROUP BY
+                primary_id              
+            HAVING
+                COUNT(*) = @groupByCountValue4)

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterIdFilterWithGroupBy.sql
@@ -16,7 +16,8 @@
                     person_id = @val0                  
                 GROUP BY
                     person_id,
-                    start_date)              
+                    start_date,
+                    condition)              
             GROUP BY
                 person_id              
             HAVING

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterIdFilterWithGroupBy.sql
@@ -8,11 +8,17 @@
             SELECT
                 person_id              
             FROM
-                ${ENT_conditionOccurrence}              
-            WHERE
-                person_id = @val0              
+                (SELECT
+                    person_id                  
+                FROM
+                    ${ENT_conditionOccurrence}                  
+                WHERE
+                    person_id = @val0                  
+                GROUP BY
+                    person_id,
+                    start_date)              
             GROUP BY
                 person_id              
             HAVING
-                COUNT(DISTINCT start_date) > @groupByCount1         
-        )
+                COUNT(*) > @groupByCount1             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNotIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNotIdFilterWithGroupBy.sql
@@ -16,7 +16,8 @@
                     stop_reason IS NULL                  
                 GROUP BY
                     person_id,
-                    start_date)              
+                    start_date,
+                    condition)              
             GROUP BY
                 person_id              
             HAVING

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNotIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNotIdFilterWithGroupBy.sql
@@ -8,11 +8,17 @@
             SELECT
                 person_id              
             FROM
-                ${ENT_conditionOccurrence}              
-            WHERE
-                stop_reason IS NULL              
+                (SELECT
+                    person_id                  
+                FROM
+                    ${ENT_conditionOccurrence}                  
+                WHERE
+                    stop_reason IS NULL                  
+                GROUP BY
+                    person_id,
+                    start_date)              
             GROUP BY
                 person_id              
             HAVING
-                COUNT(DISTINCT start_date) > @groupByCount0         
-        )
+                COUNT(*) > @groupByCount0             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNullFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNullFilterWithGroupBy.sql
@@ -8,9 +8,15 @@
             SELECT
                 person_id              
             FROM
-                ${ENT_conditionOccurrence}              
+                (SELECT
+                    person_id                  
+                FROM
+                    ${ENT_conditionOccurrence}                  
+                GROUP BY
+                    person_id,
+                    start_date)              
             GROUP BY
                 person_id              
             HAVING
-                COUNT(DISTINCT start_date) > @groupByCount0         
-        )
+                COUNT(*) > @groupByCount0             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNullFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterFKFilterNullFilterWithGroupBy.sql
@@ -14,7 +14,8 @@
                     ${ENT_conditionOccurrence}                  
                 GROUP BY
                     person_id,
-                    start_date)              
+                    start_date,
+                    condition)              
             GROUP BY
                 person_id              
             HAVING

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterIntTableIdFilterWithGroupByOnId.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterIntTableIdFilterWithGroupByOnId.sql
@@ -8,11 +8,20 @@
             SELECT
                 entity_B_id              
             FROM
-                ${RIDS_brandIngredient_brand_ingredient}              
-            WHERE
-                entity_A_id = @val0              
+                (SELECT
+                    it.entity_B_id                  
+                FROM
+                    ${RIDS_brandIngredient_brand_ingredient} AS it                  
+                JOIN
+                    ${ENT_brand} AS fe                          
+                        ON fe.id = it.entity_A_id                  
+                WHERE
+                    fe.id = @val1                  
+                GROUP BY
+                    entity_B_id,
+                    fe.vocabulary)              
             GROUP BY
                 entity_B_id              
             HAVING
-                COUNT(*) = @groupByCount1         
-        )
+                COUNT(*) = @groupByCount2             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterIntTableNotIdFilterWithGroupBy.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/relationshipFilterIntTableNotIdFilterWithGroupBy.sql
@@ -8,18 +8,20 @@
             SELECT
                 entity_B_id              
             FROM
-                ${RIDS_brandIngredient_brand_ingredient}              
-            WHERE
-                entity_A_id IN (
-                    SELECT
-                        id                      
-                    FROM
-                        ${ENT_brand}                      
-                    WHERE
-                        concept_code = @val0                 
-                )              
+                (SELECT
+                    it.entity_B_id                  
+                FROM
+                    ${RIDS_brandIngredient_brand_ingredient} AS it                  
+                JOIN
+                    ${ENT_brand} AS fe                          
+                        ON fe.id = it.entity_A_id                  
+                WHERE
+                    fe.concept_code = @val1                  
+                GROUP BY
+                    entity_B_id,
+                    fe.vocabulary)              
             GROUP BY
                 entity_B_id              
             HAVING
-                COUNT(*) = @groupByCount1             
+                COUNT(*) = @groupByCount2             
             )


### PR DESCRIPTION
Previously we could only handle up to one group by attribute:
```
SELECT person_id
FROM condition_occurrence
GROUP BY person_id
HAVING COUNT(DISTINCT start_date) >= 2
```
BigQuery only allows one field in the `COUNT(DISTINCT...)` construct, so we were limited to one attribute with the above query structure.

This change allows handling more than one:
```
SELECT person_id
FROM (
  SELECT person_id, start_date, concept_id
  FROM condition_occurrence
  GROUP BY person_id, start_date, concept_id
)
GROUP BY person_id
HAVING COUNT(*) >= 2
```

Tested by copying the count query request from the network tab, adding in the additional group by attribute, and submitting the modified request via Swagger UI.