### PR TITLE
Implement queryCohortCounts endpoint.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -2,23 +2,32 @@ package bio.terra.tanagra.app.controller;
 
 import static bio.terra.tanagra.service.accesscontrol.Action.CREATE_COHORT;
 import static bio.terra.tanagra.service.accesscontrol.Action.DELETE;
+import static bio.terra.tanagra.service.accesscontrol.Action.QUERY_COUNTS;
 import static bio.terra.tanagra.service.accesscontrol.Action.READ;
 import static bio.terra.tanagra.service.accesscontrol.Action.UPDATE;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT;
 import static bio.terra.tanagra.service.accesscontrol.ResourceType.STUDY;
+import static bio.terra.tanagra.service.accesscontrol.ResourceType.UNDERLAY;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.query.PageMarker;
+import bio.terra.tanagra.api.query.count.CountQueryResult;
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.app.authentication.SpringAuthentication;
 import bio.terra.tanagra.app.controller.objmapping.FromApiUtils;
 import bio.terra.tanagra.app.controller.objmapping.ToApiUtils;
 import bio.terra.tanagra.generated.controller.CohortsApi;
 import bio.terra.tanagra.generated.model.ApiCohort;
+import bio.terra.tanagra.generated.model.ApiCohortCountQuery;
 import bio.terra.tanagra.generated.model.ApiCohortCreateInfo;
 import bio.terra.tanagra.generated.model.ApiCohortList;
 import bio.terra.tanagra.generated.model.ApiCohortUpdateInfo;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroup;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroupSection;
+import bio.terra.tanagra.generated.model.ApiInstanceCountList;
+import bio.terra.tanagra.service.FilterBuilderService;
+import bio.terra.tanagra.service.UnderlayService;
 import bio.terra.tanagra.service.accesscontrol.AccessControlService;
 import bio.terra.tanagra.service.accesscontrol.Permissions;
 import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
@@ -26,6 +35,7 @@ import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.artifact.CohortService;
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.service.artifact.model.CohortRevision;
+import bio.terra.tanagra.underlay.Underlay;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,12 +46,19 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class CohortsApiController implements CohortsApi {
   private final CohortService cohortService;
+  private final UnderlayService underlayService;
+  private final FilterBuilderService filterBuilderService;
   private final AccessControlService accessControlService;
 
   @Autowired
   public CohortsApiController(
-      CohortService cohortService, AccessControlService accessControlService) {
+      CohortService cohortService,
+      UnderlayService underlayService,
+      FilterBuilderService filterBuilderService,
+      AccessControlService accessControlService) {
     this.cohortService = cohortService;
+    this.underlayService = underlayService;
+    this.filterBuilderService = filterBuilderService;
     this.accessControlService = accessControlService;
   }
 
@@ -118,6 +135,54 @@ public class CohortsApiController implements CohortsApi {
             body.getDescription(),
             sections);
     return ResponseEntity.ok(ToApiUtils.toApiObject(updatedCohort));
+  }
+
+  @Override
+  public ResponseEntity<ApiInstanceCountList> queryCohortCounts(
+      String studyId, String cohortId, ApiCohortCountQuery body) {
+    accessControlService.throwIfUnauthorized(
+        SpringAuthentication.getCurrentUser(),
+        Permissions.forActions(COHORT, READ),
+        ResourceId.forCohort(studyId, cohortId));
+    Cohort cohort = cohortService.getCohort(studyId, cohortId);
+
+    accessControlService.throwIfUnauthorized(
+        SpringAuthentication.getCurrentUser(),
+        Permissions.forActions(UNDERLAY, QUERY_COUNTS),
+        ResourceId.forUnderlay(cohort.getUnderlay()));
+
+    // Build the entity filter.
+    EntityFilter filter;
+    if (body.getCriteriaGroupId() != null) {
+      filter =
+          filterBuilderService.buildFilterForCriteriaGroup(
+              cohort.getUnderlay(),
+              cohort
+                  .getMostRecentRevision()
+                  .getSection(body.getCriteriaGroupSectionId())
+                  .getCriteriaGroup(body.getCriteriaGroupId()));
+    } else if (body.getCriteriaGroupSectionId() != null) {
+      filter =
+          filterBuilderService.buildFilterForCriteriaGroupSection(
+              cohort.getUnderlay(),
+              cohort.getMostRecentRevision().getSection(body.getCriteriaGroupSectionId()));
+    } else {
+      filter =
+          filterBuilderService.buildFilterForCohortRevision(
+              cohort.getUnderlay(), cohort.getMostRecentRevision());
+    }
+
+    // Run the count query and map the results back to API objects.
+    Underlay underlay = underlayService.getUnderlay(cohort.getUnderlay());
+    CountQueryResult countQueryResult =
+        underlayService.runCountQuery(
+            underlay,
+            underlay.getPrimaryEntity(),
+            body.getAttributes() == null ? List.of() : body.getAttributes(),
+            filter,
+            PageMarker.deserialize(body.getPageMarker()),
+            body.getPageSize());
+    return ResponseEntity.ok(ToApiUtils.toApiObject(countQueryResult));
   }
 
   private static CohortRevision.CriteriaGroupSection fromApiObject(ApiCriteriaGroupSection apiObj) {

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.app.controller.objmapping;
 import bio.terra.tanagra.api.field.AttributeField;
 import bio.terra.tanagra.api.field.ValueDisplayField;
 import bio.terra.tanagra.api.query.count.CountInstance;
+import bio.terra.tanagra.api.query.count.CountQueryResult;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.api.shared.ValueDisplay;
 import bio.terra.tanagra.exception.SystemException;
@@ -15,6 +16,7 @@ import bio.terra.tanagra.generated.model.ApiCriteriaGroup;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroupSection;
 import bio.terra.tanagra.generated.model.ApiDataType;
 import bio.terra.tanagra.generated.model.ApiInstanceCount;
+import bio.terra.tanagra.generated.model.ApiInstanceCountList;
 import bio.terra.tanagra.generated.model.ApiLiteral;
 import bio.terra.tanagra.generated.model.ApiLiteralValueUnion;
 import bio.terra.tanagra.generated.model.ApiProperties;
@@ -29,6 +31,7 @@ import bio.terra.tanagra.service.artifact.model.Criteria;
 import bio.terra.tanagra.service.artifact.model.Study;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.utils.SqlFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -144,6 +147,19 @@ public final class ToApiUtils {
         .selectionData(criteria.getSelectionData())
         .uiConfig(criteria.getUiConfig())
         .tags(criteria.getTags());
+  }
+
+  public static ApiInstanceCountList toApiObject(CountQueryResult countQueryResult) {
+    return new ApiInstanceCountList()
+        .instanceCounts(
+            countQueryResult.getCountInstances().stream()
+                .map(ToApiUtils::toApiObject)
+                .collect(Collectors.toList()))
+        .sql(SqlFormatter.format(countQueryResult.getSql()))
+        .pageMarker(
+            countQueryResult.getPageMarker() == null
+                ? null
+                : countQueryResult.getPageMarker().serialize());
   }
 
   public static ApiInstanceCount toApiObject(CountInstance countInstance) {

--- a/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
@@ -39,8 +39,7 @@ public class FilterBuilderService {
       return null;
     }
 
-    String criteriaSelectorOrModifierName =
-        criteriaGroup.getCriteria().get(0).getSelectorOrModifierName();
+    String criteriaSelectorName = criteriaGroup.getCriteria().get(0).getSelectorOrModifierName();
     List<SelectionData> selectionData =
         criteriaGroup.getCriteria().stream()
             .map(
@@ -51,7 +50,7 @@ public class FilterBuilderService {
 
     Underlay underlay = underlayService.getUnderlay(underlayName);
     FilterBuilder filterBuilder =
-        underlay.getCriteriaSelector(criteriaSelectorOrModifierName).getFilterBuilder();
+        underlay.getCriteriaSelector(criteriaSelectorName).getFilterBuilder();
     return filterBuilder.buildForCohort(underlay, selectionData);
   }
 
@@ -129,12 +128,9 @@ public class FilterBuilderService {
               conceptSet.getCriteria().stream()
                   .forEach(
                       criteria -> {
-                        String criteriaSelectorOrModifierName =
-                            criteria.getSelectorOrModifierName();
+                        String criteriaSelectorName = criteria.getSelectorOrModifierName();
                         FilterBuilder filterBuilder =
-                            underlay
-                                .getCriteriaSelector(criteriaSelectorOrModifierName)
-                                .getFilterBuilder();
+                            underlay.getCriteriaSelector(criteriaSelectorName).getFilterBuilder();
 
                         // Generate the entity outputs for each concept set criteria.
                         List<SelectionData> selectionData =

--- a/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
@@ -45,7 +45,8 @@ public class FilterBuilderService {
         criteriaGroup.getCriteria().stream()
             .map(
                 criteria ->
-                    new SelectionData(criteria.getPluginName(), criteria.getSelectionData()))
+                    new SelectionData(
+                        criteria.getSelectorOrModifierName(), criteria.getSelectionData()))
             .collect(Collectors.toList());
 
     Underlay underlay = underlayService.getUnderlay(underlayName);

--- a/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
@@ -22,7 +22,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class FilterBuilderService {
   private final UnderlayService underlayService;
 
@@ -37,8 +39,8 @@ public class FilterBuilderService {
       return null;
     }
 
-    // TODO: Replace plugin name with criteria selector name, once we're storing that.
-    String criteriaSelectorOrModifierName = criteriaGroup.getCriteria().get(0).getPluginName();
+    String criteriaSelectorOrModifierName =
+        criteriaGroup.getCriteria().get(0).getSelectorOrModifierName();
     List<SelectionData> selectionData =
         criteriaGroup.getCriteria().stream()
             .map(
@@ -125,11 +127,9 @@ public class FilterBuilderService {
               }
               conceptSet.getCriteria().stream()
                   .forEach(
-                      criteriaSelectorData -> {
-                        // TODO: Replace plugin name with criteria selector name, once we're storing
-                        // that.
+                      criteria -> {
                         String criteriaSelectorOrModifierName =
-                            criteriaSelectorData.getPluginName();
+                            criteria.getSelectorOrModifierName();
                         FilterBuilder filterBuilder =
                             underlay
                                 .getCriteriaSelector(criteriaSelectorOrModifierName)
@@ -137,12 +137,10 @@ public class FilterBuilderService {
 
                         // Generate the entity outputs for each concept set criteria.
                         List<SelectionData> selectionData =
-                            criteriaSelectorData.getSelectionData() == null
-                                    || criteriaSelectorData.getSelectionData().isEmpty()
+                            criteria.getSelectionData() == null
+                                    || criteria.getSelectionData().isEmpty()
                                 ? List.of()
-                                : List.of(
-                                    new SelectionData(
-                                        null, criteriaSelectorData.getSelectionData()));
+                                : List.of(new SelectionData(null, criteria.getSelectionData()));
                         List<EntityOutput> entityOutputs =
                             filterBuilder.buildForDataFeature(underlay, selectionData);
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/CohortRevision.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/CohortRevision.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.service.artifact.model;
 
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import java.time.OffsetDateTime;
@@ -60,6 +61,13 @@ public class CohortRevision {
 
   public List<CriteriaGroupSection> getSections() {
     return Collections.unmodifiableList(sections);
+  }
+
+  public CriteriaGroupSection getSection(String id) {
+    return sections.stream()
+        .filter(section -> id.equals(section.getId()))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException("Criteria group section not found for id: " + id));
   }
 
   public int getVersion() {
@@ -245,6 +253,13 @@ public class CohortRevision {
 
     public List<CriteriaGroup> getCriteriaGroups() {
       return Collections.unmodifiableList(criteriaGroups);
+    }
+
+    public CriteriaGroup getCriteriaGroup(String id) {
+      return criteriaGroups.stream()
+          .filter(group -> id.equals(group.getId()))
+          .findFirst()
+          .orElseThrow(() -> new NotFoundException("Criteria group not found for id: " + id));
     }
 
     public BooleanAndOrFilter.LogicalOperator getOperator() {

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.core;
 
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -223,13 +223,14 @@ public class EntityGroupFilterBuilder extends FilterBuilder {
 
   @Override
   public CFEntityGroup.EntityGroup deserializeConfig() {
-    return deserializeFromJson(
+    return deserializeFromJsonOrProtoBytes(
             criteriaSelector.getPluginConfig(), CFEntityGroup.EntityGroup.newBuilder())
         .build();
   }
 
   @Override
   public DTEntityGroup.EntityGroup deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTEntityGroup.EntityGroup.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, DTEntityGroup.EntityGroup.newBuilder())
+        .build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.core;
 
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -112,14 +112,15 @@ public class MultiAttributeFilterBuilder extends FilterBuilder {
 
   @Override
   public CFMultiAttribute.MultiAttribute deserializeConfig() {
-    return deserializeFromJson(
+    return deserializeFromJsonOrProtoBytes(
             criteriaSelector.getPluginConfig(), CFMultiAttribute.MultiAttribute.newBuilder())
         .build();
   }
 
   @Override
   public DTMultiAttribute.MultiAttribute deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTMultiAttribute.MultiAttribute.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, DTMultiAttribute.MultiAttribute.newBuilder())
+        .build();
   }
 
   private static DTAttribute.Attribute convertToAttrDataSchema(

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
@@ -9,9 +9,7 @@ import bio.terra.tanagra.filterbuilder.EntityOutput;
 import bio.terra.tanagra.filterbuilder.FilterBuilder;
 import bio.terra.tanagra.filterbuilder.impl.core.utils.AttributeSchemaUtils;
 import bio.terra.tanagra.filterbuilder.impl.core.utils.EntityGroupFilterUtils;
-import bio.terra.tanagra.proto.criteriaselector.ValueDataOuterClass;
 import bio.terra.tanagra.proto.criteriaselector.configschema.CFMultiAttribute;
-import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
 import bio.terra.tanagra.proto.criteriaselector.dataschema.DTMultiAttribute;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
@@ -51,18 +49,13 @@ public class MultiAttributeFilterBuilder extends FilterBuilder {
     List<EntityFilter> subFiltersNotPrimaryEntity = new ArrayList<>();
     multiAttrSelectionData.getValueDataList().stream()
         .forEach(
-            valueData -> {
-              // Convert the multi-attribute value_data into the attribute plugin data schema, so we
-              // can share processing code.
-              DTAttribute.Attribute attrSchema = convertToAttrDataSchema(valueData);
-              EntityFilter attrFilter =
-                  AttributeSchemaUtils.buildForEntity(
-                      underlay,
-                      notPrimaryEntity,
-                      notPrimaryEntity.getAttribute(valueData.getAttribute()),
-                      attrSchema);
-              subFiltersNotPrimaryEntity.add(attrFilter);
-            });
+            valueData ->
+                subFiltersNotPrimaryEntity.add(
+                    AttributeSchemaUtils.buildForEntity(
+                        underlay,
+                        notPrimaryEntity,
+                        notPrimaryEntity.getAttribute(valueData.getAttribute()),
+                        valueData)));
     return EntityGroupFilterUtils.buildGroupItemsFilter(
         underlay, criteriaSelector, groupItems, subFiltersNotPrimaryEntity, modifiersSelectionData);
   }
@@ -91,18 +84,13 @@ public class MultiAttributeFilterBuilder extends FilterBuilder {
     List<EntityFilter> subFiltersNotPrimaryEntity = new ArrayList<>();
     multiAttrSelectionData.getValueDataList().stream()
         .forEach(
-            valueData -> {
-              // Convert the multi-attribute value_data into the attribute plugin data schema, so we
-              // can share processing code.
-              DTAttribute.Attribute attrSchema = convertToAttrDataSchema(valueData);
-              EntityFilter attrFilter =
-                  AttributeSchemaUtils.buildForEntity(
-                      underlay,
-                      notPrimaryEntity,
-                      notPrimaryEntity.getAttribute(valueData.getAttribute()),
-                      attrSchema);
-              subFiltersNotPrimaryEntity.add(attrFilter);
-            });
+            valueData ->
+                subFiltersNotPrimaryEntity.add(
+                    AttributeSchemaUtils.buildForEntity(
+                        underlay,
+                        notPrimaryEntity,
+                        notPrimaryEntity.getAttribute(valueData.getAttribute()),
+                        valueData)));
 
     // Output the not primary entity.
     return EntityGroupFilterUtils.mergeFiltersForDataFeature(
@@ -121,22 +109,5 @@ public class MultiAttributeFilterBuilder extends FilterBuilder {
   public DTMultiAttribute.MultiAttribute deserializeData(String serialized) {
     return deserializeFromJsonOrProtoBytes(serialized, DTMultiAttribute.MultiAttribute.newBuilder())
         .build();
-  }
-
-  private static DTAttribute.Attribute convertToAttrDataSchema(
-      ValueDataOuterClass.ValueData valueData) {
-    DTAttribute.Attribute.Builder attrData = DTAttribute.Attribute.newBuilder();
-    valueData.getSelectedList().stream()
-        .forEach(
-            valueDataSelection -> {
-              DTAttribute.Attribute.Selection attrSelection =
-                  DTAttribute.Attribute.Selection.newBuilder()
-                      .setValue(valueDataSelection.getValue())
-                      .setName(valueDataSelection.getName())
-                      .build();
-              attrData.addSelected(attrSelection);
-            });
-    attrData.addDataRanges(valueData.getRange());
-    return attrData.build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/OutputUnfilteredFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/OutputUnfilteredFilterBuilder.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.core;
 
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.EntityFilter;
 import bio.terra.tanagra.exception.InvalidQueryException;
@@ -46,14 +46,15 @@ public class OutputUnfilteredFilterBuilder extends FilterBuilder {
 
   @Override
   public CFOutputUnfiltered.OutputUnfiltered deserializeConfig() {
-    return deserializeFromJson(
+    return deserializeFromJsonOrProtoBytes(
             criteriaSelector.getPluginConfig(), CFOutputUnfiltered.OutputUnfiltered.newBuilder())
         .build();
   }
 
   @Override
   public DTOutputUnfiltered.OutputUnfiltered deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTOutputUnfiltered.OutputUnfiltered.newBuilder())
+    return deserializeFromJsonOrProtoBytes(
+            serialized, DTOutputUnfiltered.OutputUnfiltered.newBuilder())
         .build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/TextSearchFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/TextSearchFilterBuilder.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.core;
 
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -201,13 +201,14 @@ public class TextSearchFilterBuilder extends FilterBuilder {
 
   @Override
   public CFTextSearch.TextSearch deserializeConfig() {
-    return deserializeFromJson(
+    return deserializeFromJsonOrProtoBytes(
             criteriaSelector.getPluginConfig(), CFTextSearch.TextSearch.newBuilder())
         .build();
   }
 
   @Override
   public DTTextSearch.TextSearch deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTTextSearch.TextSearch.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, DTTextSearch.TextSearch.newBuilder())
+        .build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -10,6 +10,7 @@ import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.api.shared.NaryOperator;
 import bio.terra.tanagra.proto.criteriaselector.DataRangeOuterClass.DataRange;
+import bio.terra.tanagra.proto.criteriaselector.ValueDataOuterClass;
 import bio.terra.tanagra.proto.criteriaselector.configschema.CFAttribute;
 import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
 import bio.terra.tanagra.underlay.Underlay;
@@ -25,6 +26,14 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public final class AttributeSchemaUtils {
   private AttributeSchemaUtils() {}
+
+  public static EntityFilter buildForEntity(
+      Underlay underlay,
+      Entity entity,
+      Attribute attribute,
+      ValueDataOuterClass.ValueData valueData) {
+    return buildForEntity(underlay, entity, attribute, convertToAttrDataSchema(valueData));
+  }
 
   public static EntityFilter buildForEntity(
       Underlay underlay, Entity entity, Attribute attribute, DTAttribute.Attribute data) {
@@ -93,5 +102,22 @@ public final class AttributeSchemaUtils {
 
   public static DTAttribute.Attribute deserializeData(String serialized) {
     return deserializeFromJsonOrProtoBytes(serialized, DTAttribute.Attribute.newBuilder()).build();
+  }
+
+  private static DTAttribute.Attribute convertToAttrDataSchema(
+      ValueDataOuterClass.ValueData valueData) {
+    DTAttribute.Attribute.Builder attrData = DTAttribute.Attribute.newBuilder();
+    valueData.getSelectedList().stream()
+        .forEach(
+            valueDataSelection -> {
+              DTAttribute.Attribute.Selection attrSelection =
+                  DTAttribute.Attribute.Selection.newBuilder()
+                      .setValue(valueDataSelection.getValue())
+                      .setName(valueDataSelection.getName())
+                      .build();
+              attrData.addSelected(attrSelection);
+            });
+    attrData.addDataRanges(valueData.getRange());
+    return attrData.build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -106,6 +106,8 @@ public final class AttributeSchemaUtils {
 
   private static DTAttribute.Attribute convertToAttrDataSchema(
       ValueDataOuterClass.ValueData valueData) {
+    // Convert the value_data schema into the attribute plugin data schema, so we can share
+    // processing code.
     DTAttribute.Attribute.Builder attrData = DTAttribute.Attribute.newBuilder();
     valueData.getSelectedList().stream()
         .forEach(

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.filterbuilder.impl.core.utils;
 
 import static bio.terra.tanagra.filterbuilder.SchemaUtils.toLiteral;
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
@@ -88,10 +88,10 @@ public final class AttributeSchemaUtils {
   }
 
   public static CFAttribute.Attribute deserializeConfig(String serialized) {
-    return deserializeFromJson(serialized, CFAttribute.Attribute.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, CFAttribute.Attribute.newBuilder()).build();
   }
 
   public static DTAttribute.Attribute deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTAttribute.Attribute.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, DTAttribute.Attribute.newBuilder()).build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.core.utils;
 
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.exception.SystemException;
@@ -22,11 +22,13 @@ public final class GroupByCountSchemaUtils {
   private GroupByCountSchemaUtils() {}
 
   public static CFUnhintedValue.UnhintedValue deserializeConfig(String serialized) {
-    return deserializeFromJson(serialized, CFUnhintedValue.UnhintedValue.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, CFUnhintedValue.UnhintedValue.newBuilder())
+        .build();
   }
 
   public static DTUnhintedValue.UnhintedValue deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTUnhintedValue.UnhintedValue.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, DTUnhintedValue.UnhintedValue.newBuilder())
+        .build();
   }
 
   public static Optional<Pair<CFUnhintedValue.UnhintedValue, DTUnhintedValue.UnhintedValue>>

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/sd/BioVUFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/sd/BioVUFilterBuilder.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.sd;
 
-import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJson;
+import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
@@ -123,12 +123,13 @@ public class BioVUFilterBuilder extends FilterBuilder {
 
   @Override
   public CFBioVU.BioVU deserializeConfig() {
-    return deserializeFromJson(criteriaSelector.getPluginConfig(), CFBioVU.BioVU.newBuilder())
+    return deserializeFromJsonOrProtoBytes(
+            criteriaSelector.getPluginConfig(), CFBioVU.BioVU.newBuilder())
         .build();
   }
 
   @Override
   public DTBioVU.BioVU deserializeData(String serialized) {
-    return deserializeFromJson(serialized, DTBioVU.BioVU.newBuilder()).build();
+    return deserializeFromJsonOrProtoBytes(serialized, DTBioVU.BioVU.newBuilder()).build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/utils/ProtobufUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/ProtobufUtils.java
@@ -4,9 +4,22 @@ import bio.terra.tanagra.exception.InvalidConfigException;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
+import java.util.Base64;
 
 public final class ProtobufUtils {
+
   private ProtobufUtils() {}
+
+  @SuppressWarnings({"checkstyle:EmptyCatchBlock", "PMD.EmptyCatchBlock"})
+  public static <T extends Message.Builder> T deserializeFromJsonOrProtoBytes(
+      String serialized, T builder) {
+    try {
+      return deserializeFromJson(serialized, builder);
+    } catch (InvalidConfigException icEx) {
+      // Don't throw an exception, try to deserialize from Protobuf bytes instead.
+    }
+    return deserializeFromBase64Protobuf(serialized, builder);
+  }
 
   public static <T extends Message.Builder> T deserializeFromJson(String serialized, T builder) {
     try {
@@ -14,6 +27,20 @@ public final class ProtobufUtils {
       return builder;
     } catch (InvalidProtocolBufferException ipbEx) {
       throw new InvalidConfigException("Error deserializing from JSON", ipbEx);
+    }
+  }
+
+  public static <T extends Message.Builder> T deserializeFromBase64Protobuf(
+      String serialized, T builder) {
+    try {
+      return (T)
+          builder
+              .getDefaultInstanceForType()
+              .getParserForType()
+              .parseFrom(Base64.getDecoder().decode(serialized))
+              .toBuilder();
+    } catch (InvalidProtocolBufferException ipbEx) {
+      throw new InvalidConfigException("Error deserializing from protobuf bytes", ipbEx);
     }
   }
 


### PR DESCRIPTION
- Hooked up the `queryCohortCounts` endpoint to the backend filter building infrastructure.
- Changed from using the `pluginName` field of `Criteria` to the new `selectorOrModifierName` field to fix the config lookup.
- Changed proto deserialization to try JSON format first, and then base64-encoded protobuf binary format. The selector and modifier plugin configs will all be in JSON. The plugin data that comes over the wire and is stored verbatim in the application DB is currently all in base64-encoded protobuf binary format, though we may change that to also use JSON in the future. The plugin data that lives in the config as part of the prepackaged criteria definitions will all be in JSON.
- Added support for instance-level modifiers (e.g. labs & measurements concept-specific enum/range) in the entity group plugin for `CriteriaOccurrence` entity groups only.
- I did some basic testing locally with the Swagger UI for each of the plugin types (gender, age, biovu genetic data, biovu dna, measurements, documents, blood pressure), and modifier types (attribute, group by, instance-level) to make sure the counts returned by this endpoint match at the criteria group, criteria group section, and cohort levels.