### PR TITLE
Implement exportPreview endpoint.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/ConceptSet.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/ConceptSet.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.service.artifact.model;
 
+import bio.terra.tanagra.underlay.entitymodel.Entity;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -56,6 +57,21 @@ public class ConceptSet {
 
   public Map<String, List<String>> getExcludeOutputAttributesPerEntity() {
     return excludeOutputAttributesPerEntity;
+  }
+
+  public boolean containsExcludeOutputAttributes(Entity entity) {
+    return excludeOutputAttributesPerEntity.containsKey(entity.getName())
+        || (entity.isPrimary() && excludeOutputAttributesPerEntity.containsKey(""));
+  }
+
+  public List<String> getExcludeOutputAttributes(Entity entity) {
+    if (excludeOutputAttributesPerEntity.containsKey(entity.getName())) {
+      return excludeOutputAttributesPerEntity.get(entity.getName());
+    } else if (entity.isPrimary() && excludeOutputAttributesPerEntity.containsKey("")) {
+      return excludeOutputAttributesPerEntity.get("");
+    } else {
+      return null;
+    }
   }
 
   public OffsetDateTime getCreated() {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -840,7 +840,7 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
-  "/v2/underlays/{underlayName}/entities/{entity}/exportPreview":
+  "/v2/underlays/{underlayName}/entities/{entityName}/exportPreview":
     parameters:
       - $ref: "#/components/parameters/UnderlayName"
       - $ref: "#/components/parameters/EntityName"
@@ -2500,6 +2500,7 @@ components:
             type: string
         limit:
           type: integer
+          default: 50
       required:
         - study
 

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/EntityOutput.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/EntityOutput.java
@@ -1,25 +1,40 @@
 package bio.terra.tanagra.filterbuilder;
 
 import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
 public final class EntityOutput {
   private final Entity entity;
   private final @Nullable EntityFilter dataFeatureFilter;
+  private final List<Attribute> attributes;
 
-  private EntityOutput(Entity entity, @Nullable EntityFilter dataFeatureFilter) {
+  private EntityOutput(
+      Entity entity, @Nullable EntityFilter dataFeatureFilter, List<Attribute> attributes) {
     this.entity = entity;
     this.dataFeatureFilter = dataFeatureFilter;
+    this.attributes = attributes;
   }
 
   public static EntityOutput filtered(Entity entity, EntityFilter entityFilter) {
-    return new EntityOutput(entity, entityFilter);
+    return new EntityOutput(entity, entityFilter, entity.getAttributes());
+  }
+
+  public static EntityOutput filtered(
+      Entity entity, EntityFilter entityFilter, List<Attribute> attributes) {
+    return new EntityOutput(entity, entityFilter, attributes);
   }
 
   public static EntityOutput unfiltered(Entity entity) {
-    return new EntityOutput(entity, null);
+    return new EntityOutput(entity, null, entity.getAttributes());
+  }
+
+  public static EntityOutput unfiltered(Entity entity, List<Attribute> attributes) {
+    return new EntityOutput(entity, null, attributes);
   }
 
   public Entity getEntity() {
@@ -35,6 +50,10 @@ public final class EntityOutput {
     return dataFeatureFilter;
   }
 
+  public List<Attribute> getAttributes() {
+    return ImmutableList.copyOf(attributes);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -44,11 +63,13 @@ public final class EntityOutput {
       return false;
     }
     EntityOutput that = (EntityOutput) o;
-    return entity.equals(that.entity) && Objects.equals(dataFeatureFilter, that.dataFeatureFilter);
+    return entity.equals(that.entity)
+        && Objects.equals(dataFeatureFilter, that.dataFeatureFilter)
+        && attributes.equals(that.attributes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entity, dataFeatureFilter);
+    return Objects.hash(entity, dataFeatureFilter, attributes);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/MultiAttributeFilterBuilder.java
@@ -66,8 +66,6 @@ public class MultiAttributeFilterBuilder extends FilterBuilder {
     if (selectionData.size() > 1) {
       throw new InvalidQueryException("Modifiers are not supported for data features");
     }
-    DTMultiAttribute.MultiAttribute multiAttrSelectionData =
-        deserializeData(selectionData.get(0).getPluginData());
 
     // Pull the entity group from the config.
     CFMultiAttribute.MultiAttribute multiAttrConfig = deserializeConfig();
@@ -80,17 +78,22 @@ public class MultiAttributeFilterBuilder extends FilterBuilder {
             ? groupItems.getItemsEntity()
             : groupItems.getGroupEntity();
 
-    // Build the attribute filters on the not-primary entity.
     List<EntityFilter> subFiltersNotPrimaryEntity = new ArrayList<>();
-    multiAttrSelectionData.getValueDataList().stream()
-        .forEach(
-            valueData ->
-                subFiltersNotPrimaryEntity.add(
-                    AttributeSchemaUtils.buildForEntity(
-                        underlay,
-                        notPrimaryEntity,
-                        notPrimaryEntity.getAttribute(valueData.getAttribute()),
-                        valueData)));
+    if (!selectionData.isEmpty()) {
+      DTMultiAttribute.MultiAttribute multiAttrSelectionData =
+          deserializeData(selectionData.get(0).getPluginData());
+
+      // Build the attribute filters on the not-primary entity.
+      multiAttrSelectionData.getValueDataList().stream()
+          .forEach(
+              valueData ->
+                  subFiltersNotPrimaryEntity.add(
+                      AttributeSchemaUtils.buildForEntity(
+                          underlay,
+                          notPrimaryEntity,
+                          notPrimaryEntity.getAttribute(valueData.getAttribute()),
+                          valueData)));
+    }
 
     // Output the not primary entity.
     return EntityGroupFilterUtils.mergeFiltersForDataFeature(

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -179,6 +179,13 @@ public final class Underlay {
     return prepackagedDataFeatures;
   }
 
+  public PrepackagedCriteria getPrepackagedDataFeature(String name) {
+    return prepackagedDataFeatures.stream()
+        .filter(pdf -> name.equals(pdf.getName()))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException("Prepackaged data feature not found: " + name));
+  }
+
   public String getUiConfig() {
     return uiConfig;
   }


### PR DESCRIPTION
- Hooked up the `previewEntityExport` endpoint to the backend filter building infrastructure.
- Specified a default preview size of 50 in this endpoints OpenAPI definition.
- Added support for prepackaged data features in `FilterBuilderService`.
- Added a list of included attributes in the `EntityOutput` generated for a set of concept sets. Previously, all attributes were always included. Now it respects the excluded attributes defined per concept set.
- Treat empty string equivalent to the primary entity name in the concept set list of excluded attributes.
- Handle empty selection data in `MultiAttribute` and `TextSearch` filter builders. This supports data features like "any weight", "any documents".
- I did some basic testing locally with the Swagger UI for data features that use each of the plugin types (condition, CPT-4, documents, measurements, weight), and prepackaged data feature (demographics).