### PR TITLE
Hook up backend filterbuilding for export, review creation.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -8,6 +8,7 @@ import static bio.terra.tanagra.service.accesscontrol.ResourceType.UNDERLAY;
 
 import bio.terra.tanagra.api.field.AttributeField;
 import bio.terra.tanagra.api.field.ValueDisplayField;
+import bio.terra.tanagra.api.filter.EntityFilter;
 import bio.terra.tanagra.api.query.list.ListQueryRequest;
 import bio.terra.tanagra.api.query.list.ListQueryResult;
 import bio.terra.tanagra.app.authentication.SpringAuthentication;
@@ -29,8 +30,10 @@ import bio.terra.tanagra.service.accesscontrol.Permissions;
 import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.artifact.CohortService;
 import bio.terra.tanagra.service.artifact.ConceptSetService;
+import bio.terra.tanagra.service.artifact.StudyService;
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.service.artifact.model.ConceptSet;
+import bio.terra.tanagra.service.artifact.model.Study;
 import bio.terra.tanagra.service.export.DataExport;
 import bio.terra.tanagra.service.export.DataExportService;
 import bio.terra.tanagra.service.export.ExportRequest;
@@ -49,6 +52,7 @@ import org.springframework.stereotype.Controller;
 public class ExportApiController implements ExportApi {
   private final AccessControlService accessControlService;
   private final DataExportService dataExportService;
+  private final StudyService studyService;
   private final CohortService cohortService;
   private final ConceptSetService conceptSetService;
   private final UnderlayService underlayService;
@@ -58,12 +62,14 @@ public class ExportApiController implements ExportApi {
   public ExportApiController(
       AccessControlService accessControlService,
       DataExportService dataExportService,
+      StudyService studyService,
       CohortService cohortService,
       ConceptSetService conceptSetService,
       UnderlayService underlayService,
       FilterBuilderService filterBuilderService) {
     this.accessControlService = accessControlService;
     this.dataExportService = dataExportService;
+    this.studyService = studyService;
     this.cohortService = cohortService;
     this.conceptSetService = conceptSetService;
     this.underlayService = underlayService;
@@ -160,20 +166,30 @@ public class ExportApiController implements ExportApi {
         SpringAuthentication.getCurrentUser(),
         Permissions.forActions(UNDERLAY, QUERY_INSTANCES),
         ResourceId.forUnderlay(underlayName));
-    String studyId = body.getStudy();
     for (String cohortId : body.getCohorts()) {
       accessControlService.throwIfUnauthorized(
           SpringAuthentication.getCurrentUser(),
           Permissions.forActions(COHORT, READ),
-          ResourceId.forCohort(studyId, cohortId));
+          ResourceId.forCohort(body.getStudy(), cohortId));
     }
-    ExportRequest.Builder request =
-        ExportRequest.builder()
-            .model(body.getExportModel())
-            .inputs(body.getInputs())
-            .redirectBackUrl(body.getRedirectBackUrl())
-            .includeAnnotations(body.isIncludeAnnotations());
+    for (String conceptSetId : body.getConceptSets()) {
+      accessControlService.throwIfUnauthorized(
+          SpringAuthentication.getCurrentUser(),
+          Permissions.forActions(CONCEPT_SET, READ),
+          ResourceId.forConceptSet(body.getStudy(), conceptSetId));
+    }
+
     Underlay underlay = underlayService.getUnderlay(underlayName);
+    Study study = studyService.getStudy(body.getStudy());
+    List<Cohort> cohorts =
+        body.getCohorts().stream()
+            .map(cohortId -> cohortService.getCohort(body.getStudy(), cohortId))
+            .collect(Collectors.toList());
+    List<ConceptSet> conceptSets =
+        body.getConceptSets().stream()
+            .map(conceptSetId -> conceptSetService.getConceptSet(body.getStudy(), conceptSetId))
+            .collect(Collectors.toList());
+
     List<ListQueryRequest> listQueryRequests =
         body.getInstanceQuerys().stream()
             .map(
@@ -181,20 +197,24 @@ public class ExportApiController implements ExportApi {
                     FromApiUtils.fromApiObject(
                         apiQuery.getQuery(), underlay.getEntity(apiQuery.getEntity()), underlay))
             .collect(Collectors.toList());
-    ExportResult result =
-        dataExportService.run(
-            studyId,
-            body.getCohorts(),
-            request,
-            listQueryRequests,
-            // TODO: Remove the null handling here once the UI is passing the primary entity filter
-            // to the export endpoint.
-            body.getPrimaryEntityFilter() == null
-                ? null
-                : FromApiUtils.fromApiObject(
-                    body.getPrimaryEntityFilter(), underlayService.getUnderlay(underlayName)),
-            SpringAuthentication.getCurrentUser().getEmail());
-    return ResponseEntity.ok(toApiObject(result));
+    EntityFilter primaryEntityFilter =
+        FromApiUtils.fromApiObject(
+            body.getPrimaryEntityFilter(), underlayService.getUnderlay(underlayName));
+
+    ExportRequest exportRequest =
+        new ExportRequest(
+            body.getExportModel(),
+            body.getInputs(),
+            body.getRedirectBackUrl(),
+            body.isIncludeAnnotations(),
+            SpringAuthentication.getCurrentUser().getEmail(),
+            underlay,
+            study,
+            cohorts,
+            conceptSets);
+    ExportResult exportResult =
+        dataExportService.run(exportRequest, listQueryRequests, primaryEntityFilter);
+    return ResponseEntity.ok(toApiObject(exportResult));
   }
 
   private ApiExportModel toApiObject(String implName, String displayName, DataExport dataExport) {

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -198,8 +198,10 @@ public class ExportApiController implements ExportApi {
                         apiQuery.getQuery(), underlay.getEntity(apiQuery.getEntity()), underlay))
             .collect(Collectors.toList());
     EntityFilter primaryEntityFilter =
-        FromApiUtils.fromApiObject(
-            body.getPrimaryEntityFilter(), underlayService.getUnderlay(underlayName));
+        body.getPrimaryEntityFilter() == null
+            ? null
+            : FromApiUtils.fromApiObject(
+                body.getPrimaryEntityFilter(), underlayService.getUnderlay(underlayName));
 
     ExportRequest exportRequest =
         new ExportRequest(

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -172,7 +172,11 @@ public class ExportApiController implements ExportApi {
           Permissions.forActions(COHORT, READ),
           ResourceId.forCohort(body.getStudy(), cohortId));
     }
-    for (String conceptSetId : body.getConceptSets()) {
+    List<String> conceptSetIds = new ArrayList<>();
+    if (body.getConceptSets() != null) {
+      conceptSetIds.addAll(body.getConceptSets());
+    }
+    for (String conceptSetId : conceptSetIds) {
       accessControlService.throwIfUnauthorized(
           SpringAuthentication.getCurrentUser(),
           Permissions.forActions(CONCEPT_SET, READ),
@@ -186,7 +190,7 @@ public class ExportApiController implements ExportApi {
             .map(cohortId -> cohortService.getCohort(body.getStudy(), cohortId))
             .collect(Collectors.toList());
     List<ConceptSet> conceptSets =
-        body.getConceptSets().stream()
+        conceptSetIds.stream()
             .map(conceptSetId -> conceptSetService.getConceptSet(body.getStudy(), conceptSetId))
             .collect(Collectors.toList());
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ReviewsApiController.java
@@ -94,11 +94,12 @@ public class ReviewsApiController implements ReviewsApi {
         Permissions.forActions(COHORT, CREATE_REVIEW),
         ResourceId.forCohort(studyId, cohortId));
 
-    // TODO: Remove the entity filter from here once we store it for the cohort.
     Cohort cohort = cohortService.getCohort(studyId, cohortId);
     EntityFilter entityFilter =
-        FromApiUtils.fromApiObject(
-            body.getFilter(), underlayService.getUnderlay(cohort.getUnderlay()));
+        body.getFilter() == null
+            ? null
+            : FromApiUtils.fromApiObject(
+                body.getFilter(), underlayService.getUnderlay(cohort.getUnderlay()));
 
     Review createdReview =
         reviewService.createReview(

--- a/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
@@ -110,10 +110,16 @@ public class FilterBuilderService {
 
   public EntityFilter buildFilterForCohortRevisions(
       String underlayName, List<CohortRevision> cohortRevisions) {
-    List<EntityFilter> cohortRevisionFilters =
-        cohortRevisions.stream()
-            .map(cohortRevision -> buildFilterForCohortRevision(underlayName, cohortRevision))
-            .collect(Collectors.toList());
+    List<EntityFilter> cohortRevisionFilters = new ArrayList<>();
+    cohortRevisions.stream()
+        .forEach(
+            cohortRevision -> {
+              EntityFilter entityFilter =
+                  buildFilterForCohortRevision(underlayName, cohortRevision);
+              if (entityFilter != null) {
+                cohortRevisionFilters.add(entityFilter);
+              }
+            });
     return cohortRevisionFilters.size() == 1
         ? cohortRevisionFilters.get(0)
         : new BooleanAndOrFilter(BooleanAndOrFilter.LogicalOperator.OR, cohortRevisionFilters);

--- a/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/FilterBuilderService.java
@@ -108,6 +108,17 @@ public class FilterBuilderService {
             BooleanAndOrFilter.LogicalOperator.AND, criteriaGroupSectionFilters);
   }
 
+  public EntityFilter buildFilterForCohortRevisions(
+      String underlayName, List<CohortRevision> cohortRevisions) {
+    List<EntityFilter> cohortRevisionFilters =
+        cohortRevisions.stream()
+            .map(cohortRevision -> buildFilterForCohortRevision(underlayName, cohortRevision))
+            .collect(Collectors.toList());
+    return cohortRevisionFilters.size() == 1
+        ? cohortRevisionFilters.get(0)
+        : new BooleanAndOrFilter(BooleanAndOrFilter.LogicalOperator.OR, cohortRevisionFilters);
+  }
+
   public List<EntityOutput> buildOutputsForConceptSets(List<ConceptSet> conceptSets) {
     // All data feature sets must be for the same underlay.
     String underlayName = conceptSets.get(0).getUnderlay();

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
@@ -95,8 +95,10 @@ public class ReviewService {
           "Review size " + reviewBuilder.getSize() + " exceeds maximum allowed " + MAX_REVIEW_SIZE);
     }
     List<Long> randomSampleQueryResult =
-        cohortService.getRandomSample(studyId, cohortId, entityFilter, reviewBuilder.getSize());
-    long cohortRecordsCount = cohortService.getRecordsCount(studyId, cohortId, entityFilter);
+        cohortService.getRandomSample(studyId, cohortId, reviewBuilder.getSize(), entityFilter);
+    long cohortRecordsCount =
+        cohortService.getRecordsCount(
+            cohortService.getCohort(studyId, cohortId).getUnderlay(), entityFilter);
     LOGGER.info("Created review with {} primary entity ids", randomSampleQueryResult.size());
     return createReviewHelper(
         studyId, cohortId, reviewBuilder, userEmail, randomSampleQueryResult, cohortRecordsCount);

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/Criteria.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/Criteria.java
@@ -172,7 +172,7 @@ public class Criteria {
     }
     Criteria criteria = (Criteria) o;
     return id.equals(criteria.id)
-        && displayName.equals(criteria.displayName)
+        && Objects.equals(displayName, criteria.displayName)
         && pluginName.equals(criteria.pluginName)
         && pluginVersion == criteria.pluginVersion
         && Objects.equals(predefinedId, criteria.predefinedId)

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExport.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExport.java
@@ -44,5 +44,5 @@ public interface DataExport {
     return Collections.emptyMap();
   }
 
-  ExportResult run(ExportRequest request);
+  ExportResult run(ExportRequest request, DataExportHelper helper);
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -317,12 +317,7 @@ public class DataExportHelper {
                         exportRequest.getStudy(), cohort);
                 if (fileContents == null) {
                   exportFileResults.add(
-                      ExportFileResult.forAnnotationData(
-                          null,
-                          null,
-                          cohort,
-                          ExportError.forMessage(
-                              "There are no annotations for this cohort", false)));
+                      ExportFileResult.forAnnotationData(null, null, cohort, null));
                 } else {
                   String fileName =
                       StringSubstitutor.replace(

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -1,0 +1,368 @@
+package bio.terra.tanagra.service.export;
+
+import bio.terra.tanagra.api.field.AttributeField;
+import bio.terra.tanagra.api.field.ValueDisplayField;
+import bio.terra.tanagra.api.filter.EntityFilter;
+import bio.terra.tanagra.api.query.export.ExportQueryRequest;
+import bio.terra.tanagra.api.query.export.ExportQueryResult;
+import bio.terra.tanagra.api.query.list.ListQueryRequest;
+import bio.terra.tanagra.api.query.list.ListQueryResult;
+import bio.terra.tanagra.app.configuration.ExportConfiguration;
+import bio.terra.tanagra.exception.SystemException;
+import bio.terra.tanagra.filterbuilder.EntityOutput;
+import bio.terra.tanagra.service.artifact.ReviewService;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.utils.GoogleCloudStorage;
+import bio.terra.tanagra.utils.NameUtils;
+import bio.terra.tanagra.utils.RandomNumberGenerator;
+import bio.terra.tanagra.utils.threadpool.Job;
+import bio.terra.tanagra.utils.threadpool.JobResult;
+import bio.terra.tanagra.utils.threadpool.ThreadPoolUtils;
+import com.google.cloud.storage.BlobId;
+import com.google.common.collect.ImmutableList;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.text.StringSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataExportHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataExportHelper.class);
+  private final Integer maxChildThreads;
+  private final ExportConfiguration.Shared sharedExportConfig;
+  private final RandomNumberGenerator randomNumberGenerator;
+  private final ReviewService reviewService;
+  private final ExportRequest exportRequest;
+  private final ImmutableList<EntityOutput> entityOutputs;
+  private final EntityFilter primaryEntityFilter;
+  private GoogleCloudStorage googleCloudStorage;
+
+  public DataExportHelper(
+      Integer maxChildThreads,
+      ExportConfiguration.Shared sharedExportConfig,
+      RandomNumberGenerator randomNumberGenerator,
+      ReviewService reviewService,
+      ExportRequest exportRequest,
+      List<EntityOutput> entityOutputs,
+      EntityFilter primaryEntityFilter) {
+    this.maxChildThreads = maxChildThreads;
+    this.sharedExportConfig = sharedExportConfig;
+    this.randomNumberGenerator = randomNumberGenerator;
+    this.reviewService = reviewService;
+    this.exportRequest = exportRequest;
+    this.entityOutputs = ImmutableList.copyOf(entityOutputs);
+    this.primaryEntityFilter = primaryEntityFilter;
+  }
+
+  /**
+   * @param isAgainstSourceDataset True to generate SQL queries against the source dataset.
+   * @return Map of entity -> SQL query with all parameters substituted.
+   */
+  public Map<Entity, String> generateSqlPerExportEntity(
+      List<String> entityNames, boolean isAgainstSourceDataset) {
+    Map<Entity, String> sqlPerEntity = new HashMap<>();
+    entityOutputs.stream()
+        .filter(
+            entityOutput ->
+                entityNames.isEmpty() || entityNames.contains(entityOutput.getEntity().getName()))
+        .forEach(
+            entityOutput -> {
+              List<ValueDisplayField> selectFields =
+                  entityOutput.getAttributes().stream()
+                      .map(
+                          attribute ->
+                              new AttributeField(
+                                  exportRequest.getUnderlay(),
+                                  entityOutput.getEntity(),
+                                  attribute,
+                                  false,
+                                  isAgainstSourceDataset))
+                      .collect(Collectors.toList());
+
+              ListQueryRequest listQueryRequest =
+                  new ListQueryRequest(
+                      exportRequest.getUnderlay(),
+                      entityOutput.getEntity(),
+                      selectFields,
+                      entityOutput.getDataFeatureFilter(),
+                      null,
+                      null,
+                      null,
+                      null,
+                      true);
+              ListQueryResult listQueryResult =
+                  exportRequest
+                      .getUnderlay()
+                      .getQueryRunner()
+                      .run(listQueryRequest.cloneAndSetDryRun());
+              sqlPerEntity.put(entityOutput.getEntity(), listQueryResult.getSqlNoParams());
+            });
+    return sqlPerEntity;
+  }
+
+  /**
+   * @param attributeNames List of attribute names to include in the generated SQL query. An empty
+   *     list means to include all attributes.
+   * @param isAgainstSourceDataset True to generate SQL queries against the source dataset.
+   * @return SQL query with all parameters substituted.
+   */
+  public String generateSqlForPrimaryEntity(
+      List<String> attributeNames, boolean isAgainstSourceDataset) {
+    List<ValueDisplayField> selectedAttributeFields = new ArrayList<>();
+    exportRequest.getUnderlay().getPrimaryEntity().getAttributes().stream()
+        .filter(
+            attribute -> attributeNames.isEmpty() || attributeNames.contains(attribute.getName()))
+        .forEach(
+            attribute ->
+                selectedAttributeFields.add(
+                    new AttributeField(
+                        exportRequest.getUnderlay(),
+                        exportRequest.getUnderlay().getPrimaryEntity(),
+                        attribute,
+                        false,
+                        isAgainstSourceDataset)));
+    ListQueryRequest listQueryRequest =
+        new ListQueryRequest(
+            exportRequest.getUnderlay(),
+            exportRequest.getUnderlay().getPrimaryEntity(),
+            selectedAttributeFields,
+            primaryEntityFilter,
+            null,
+            null,
+            null,
+            null,
+            true);
+    ListQueryResult listQueryResult =
+        exportRequest.getUnderlay().getQueryRunner().run(listQueryRequest);
+    return listQueryResult.getSqlNoParams();
+  }
+
+  /**
+   * @param fileNameTemplate String substitution template for the filename. Must include ${entity}
+   *     and ${random} placeholders (e.g. ${entity}_cohort_${random}).
+   * @return List of entity file outputs, including the full GCS path (e.g.
+   *     gs://bucket/filename.csv.gzip).
+   */
+  public List<ExportFileResult> writeEntityDataToGcs(String fileNameTemplate) {
+    // Build set of export query requests.
+    List<ExportQueryRequest> exportQueryRequests =
+        entityOutputs.stream()
+            .map(
+                entityOutput -> {
+                  // Build the list query request.
+                  List<ValueDisplayField> selectFields =
+                      entityOutput.getAttributes().stream()
+                          .sorted(Comparator.comparing(Attribute::getName))
+                          .map(
+                              attribute ->
+                                  new AttributeField(
+                                      exportRequest.getUnderlay(),
+                                      entityOutput.getEntity(),
+                                      attribute,
+                                      false,
+                                      false))
+                          .collect(Collectors.toList());
+                  ListQueryRequest listQueryRequest =
+                      new ListQueryRequest(
+                          exportRequest.getUnderlay(),
+                          entityOutput.getEntity(),
+                          selectFields,
+                          entityOutput.getDataFeatureFilter(),
+                          null,
+                          null,
+                          null,
+                          null,
+                          false);
+
+                  // Build a map of substitution strings for the filename template.
+                  Map<String, String> substitutions =
+                      Map.of(
+                          "entity",
+                          entityOutput.getEntity().getName(),
+                          "random",
+                          Instant.now().getEpochSecond() + "_" + randomNumberGenerator.getNext());
+                  String substitutedFilename =
+                      StringSubstitutor.replace(fileNameTemplate, substitutions);
+                  return new ExportQueryRequest(
+                      listQueryRequest,
+                      entityOutput.getEntity().getName(),
+                      substitutedFilename,
+                      sharedExportConfig.getGcpProjectId(),
+                      sharedExportConfig.getBqDatasetIds(),
+                      sharedExportConfig.getGcsBucketNames(),
+                      true);
+                })
+            .collect(Collectors.toList());
+
+    List<ExportFileResult> exportFileResults = new ArrayList<>();
+    if (maxChildThreads == null || maxChildThreads > 1) {
+      // Build set of export jobs.
+      Set<Job<ExportQueryRequest, ExportQueryResult>> exportJobs = new HashSet<>();
+      exportQueryRequests.stream()
+          .forEach(
+              exportQueryRequest ->
+                  exportJobs.add(
+                      new Job<>(
+                          exportQueryRequest.getListQueryRequest().getEntity().getName()
+                              + '_'
+                              + Instant.now().toEpochMilli(),
+                          exportQueryRequest,
+                          () ->
+                              exportQueryRequest
+                                  .getListQueryRequest()
+                                  .getUnderlay()
+                                  .getQueryRunner()
+                                  .run(exportQueryRequest))));
+      // Kick off jobs in parallel.
+      int threadPoolSize =
+          maxChildThreads == null
+              ? exportQueryRequests.size()
+              : Math.min(exportQueryRequests.size(), maxChildThreads);
+      LOGGER.info(
+          "Running export requests in parallel, with a thread pool size of {}", threadPoolSize);
+      Map<ExportQueryRequest, JobResult<ExportQueryResult>> exportJobResults =
+          ThreadPoolUtils.runInParallel(threadPoolSize, exportJobs);
+      exportJobResults.entrySet().stream()
+          .forEach(
+              exportJobResult -> {
+                ExportQueryRequest exportQueryRequest = exportJobResult.getKey();
+                JobResult<ExportQueryResult> jobResult = exportJobResult.getValue();
+                if (jobResult == null) {
+                  exportFileResults.add(
+                      ExportFileResult.forEntityData(
+                          null,
+                          null,
+                          exportQueryRequest.getListQueryRequest().getEntity(),
+                          ExportError.forMessage(
+                              "Export job did not complete or timed out", true)));
+                } else {
+                  exportFileResults.add(
+                      ExportFileResult.forEntityData(
+                          jobResult.getJobOutput() == null
+                              ? null
+                              : jobResult.getJobOutput().getFileDisplayName(),
+                          jobResult.getJobOutput() == null
+                              ? null
+                              : jobResult.getJobOutput().getFilePath(),
+                          exportQueryRequest.getListQueryRequest().getEntity(),
+                          JobResult.Status.COMPLETED.equals(jobResult.getJobStatus())
+                              ? null
+                              : ExportError.forException(
+                                  jobResult.getExceptionMessage(),
+                                  jobResult.getExceptionStackTrace(),
+                                  jobResult.isJobForceTerminated())));
+                }
+              });
+    } else {
+      // Kick off jobs in serial.
+      LOGGER.info("Running export requests in serial");
+      exportQueryRequests.stream()
+          .forEach(
+              exportQueryRequest -> {
+                try {
+                  ExportQueryResult exportQueryResult =
+                      exportQueryRequest
+                          .getListQueryRequest()
+                          .getUnderlay()
+                          .getQueryRunner()
+                          .run(exportQueryRequest);
+                  exportFileResults.add(
+                      ExportFileResult.forEntityData(
+                          exportQueryResult.getFileDisplayName(),
+                          exportQueryResult.getFilePath(),
+                          exportQueryRequest.getListQueryRequest().getEntity(),
+                          null));
+                } catch (Exception ex) {
+                  exportFileResults.add(
+                      ExportFileResult.forEntityData(
+                          null,
+                          null,
+                          exportQueryRequest.getListQueryRequest().getEntity(),
+                          ExportError.forException(ex)));
+                }
+              });
+    }
+    return exportFileResults;
+  }
+
+  /**
+   * @param fileNameTemplate String substitution template for the filename. Must include ${cohort}
+   *     and ${random} placeholders (e.g. annotations_cohort${cohort}_${random}).
+   * @return List of annotation file outputs, including the full GCS path (e.g.
+   *     gs://bucket/filename.csv.gzip).
+   */
+  public List<ExportFileResult> writeAnnotationDataToGcs(String fileNameTemplate) {
+    // Just pick the first GCS bucket name.
+    String bucketName = sharedExportConfig.getGcsBucketNames().get(0);
+
+    // Write the annotations for each cohort to a separate file.
+    List<ExportFileResult> exportFileResults = new ArrayList<>();
+    exportRequest.getCohorts().stream()
+        .forEach(
+            cohort -> {
+              try {
+                String fileContents =
+                    reviewService.buildCsvStringForAnnotationValues(
+                        exportRequest.getStudy(), cohort);
+                if (fileContents == null) {
+                  exportFileResults.add(
+                      ExportFileResult.forAnnotationData(
+                          null,
+                          null,
+                          cohort,
+                          ExportError.forMessage(
+                              "There are no annotations for this cohort", false)));
+                } else {
+                  String fileName =
+                      StringSubstitutor.replace(
+                          fileNameTemplate,
+                          Map.of(
+                              "cohort",
+                              NameUtils.simplifyStringForName(
+                                  cohort.getDisplayName() + "_" + cohort.getId()),
+                              "random",
+                              Instant.now().getEpochSecond()
+                                  + "_"
+                                  + randomNumberGenerator.getNext()));
+                  BlobId blobId = getStorageService().writeFile(bucketName, fileName, fileContents);
+                  String gcsUrl = getStorageService().createSignedUrl(blobId.toGsUtilUri());
+                  exportFileResults.add(
+                      ExportFileResult.forAnnotationData(fileName, gcsUrl, cohort, null));
+                }
+              } catch (Exception ex) {
+                exportFileResults.add(
+                    ExportFileResult.forAnnotationData(
+                        null, null, cohort, ExportError.forException(ex)));
+              }
+            });
+    return exportFileResults;
+  }
+
+  /** Maintain a single reference to the GCS client object, so we don't keep recreating it. */
+  public GoogleCloudStorage getStorageService() {
+    if (googleCloudStorage == null) {
+      googleCloudStorage =
+          GoogleCloudStorage.forApplicationDefaultCredentials(sharedExportConfig.getGcpProjectId());
+    }
+    return googleCloudStorage;
+  }
+
+  public static String urlEncode(String param) {
+    try {
+      return URLEncoder.encode(param, StandardCharsets.UTF_8.toString());
+    } catch (UnsupportedEncodingException ueEx) {
+      throw new SystemException("Error encoding URL param: " + param, ueEx);
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportError.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportError.java
@@ -1,0 +1,42 @@
+package bio.terra.tanagra.service.export;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public final class ExportError {
+  private final String message;
+  private final String stackTrace;
+  private final boolean isTimeout;
+
+  private ExportError(String message, String stackTrace, boolean isTimeout) {
+    this.message = message;
+    this.stackTrace = stackTrace;
+    this.isTimeout = isTimeout;
+  }
+
+  public static ExportError forMessage(String message, boolean isTimeout) {
+    return new ExportError(message, null, isTimeout);
+  }
+
+  public static ExportError forException(Exception ex) {
+    StringWriter stackTraceStr = new StringWriter();
+    ex.printStackTrace(new PrintWriter(stackTraceStr));
+    return new ExportError(ex.getMessage(), stackTraceStr.toString(), false);
+  }
+
+  public static ExportError forException(String message, String stackTrace, boolean isTimeout) {
+    return new ExportError(message, stackTrace, isTimeout);
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public String getStackTrace() {
+    return stackTrace;
+  }
+
+  public boolean isTimeout() {
+    return isTimeout;
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportFileResult.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportFileResult.java
@@ -1,0 +1,73 @@
+package bio.terra.tanagra.service.export;
+
+import bio.terra.tanagra.service.artifact.model.Cohort;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import javax.annotation.Nullable;
+
+public final class ExportFileResult {
+  private final String fileDisplayName;
+  private final String fileUrl;
+  private final @Nullable ExportError error;
+  private final Entity entity;
+  private final Cohort cohort;
+
+  private ExportFileResult(
+      String fileDisplayName,
+      String fileUrl,
+      @Nullable ExportError error,
+      Entity entity,
+      Cohort cohort) {
+    this.fileDisplayName = fileDisplayName;
+    this.fileUrl = fileUrl;
+    this.error = error;
+    this.entity = entity;
+    this.cohort = cohort;
+  }
+
+  public static ExportFileResult forAnnotationData(
+      String fileDisplayName, String fileUrl, Cohort cohort, @Nullable ExportError error) {
+    return new ExportFileResult(fileDisplayName, fileUrl, error, null, cohort);
+  }
+
+  public static ExportFileResult forEntityData(
+      String fileDisplayName, String fileUrl, Entity entity, @Nullable ExportError error) {
+    return new ExportFileResult(fileDisplayName, fileUrl, error, entity, null);
+  }
+
+  public static ExportFileResult forFile(
+      String fileDisplayName, String fileUrl, @Nullable ExportError error) {
+    return new ExportFileResult(fileDisplayName, fileUrl, error, null, null);
+  }
+
+  public boolean isSuccessful() {
+    return error == null;
+  }
+
+  public boolean isAnnotationData() {
+    return cohort != null;
+  }
+
+  public boolean isEntityData() {
+    return entity != null;
+  }
+
+  public String getFileDisplayName() {
+    return fileDisplayName;
+  }
+
+  public String getFileUrl() {
+    return fileUrl;
+  }
+
+  public @Nullable ExportError getError() {
+    return error;
+  }
+
+  public Entity getEntity() {
+    return entity;
+  }
+
+  public Cohort getCohort() {
+    return cohort;
+  }
+}

--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportRequest.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportRequest.java
@@ -1,47 +1,45 @@
 package bio.terra.tanagra.service.export;
 
-import bio.terra.tanagra.generated.model.ApiCohort;
-import bio.terra.tanagra.generated.model.ApiStudy;
-import bio.terra.tanagra.generated.model.ApiUnderlaySummary;
 import bio.terra.tanagra.service.artifact.model.Cohort;
-import bio.terra.tanagra.utils.GoogleCloudStorage;
-import java.util.ArrayList;
+import bio.terra.tanagra.service.artifact.model.ConceptSet;
+import bio.terra.tanagra.service.artifact.model.Study;
+import bio.terra.tanagra.underlay.Underlay;
+import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 public class ExportRequest {
   private final String model;
   private final Map<String, String> inputs;
   private final String redirectBackUrl;
   private final boolean includeAnnotations;
-  private final ApiUnderlaySummary underlay;
-  private final ApiStudy study;
-  private final List<ApiCohort> cohorts;
-  private final Supplier<Map<String, String>> generateSqlQueriesFn;
-  private final Function<String, Map<String, String>> writeEntityDataToGcsFn;
-  private final Function<String, Map<Cohort, String>> writeAnnotationDataToGcsFn;
-  private final Supplier<GoogleCloudStorage> getGoogleCloudStorageFn;
+  private final String userEmail;
+  private final Underlay underlay;
+  private final Study study;
+  private final ImmutableList<Cohort> cohorts;
+  private final ImmutableList<ConceptSet> conceptSets;
 
-  private ExportRequest(Builder builder) {
-    this.model = builder.model;
-    this.inputs = builder.inputs;
-    this.redirectBackUrl = builder.redirectBackUrl;
-    this.includeAnnotations = builder.includeAnnotations;
-    this.underlay = builder.underlay;
-    this.study = builder.study;
-    this.cohorts = builder.cohorts;
-    this.generateSqlQueriesFn = builder.generateSqlQueriesFn;
-    this.writeEntityDataToGcsFn = builder.writeEntityDataToGcsFn;
-    this.writeAnnotationDataToGcsFn = builder.writeAnnotationDataToGcsFn;
-    this.getGoogleCloudStorageFn = builder.getGoogleCloudStorageFn;
-  }
-
-  public static Builder builder() {
-    return new Builder();
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public ExportRequest(
+      String model,
+      Map<String, String> inputs,
+      String redirectBackUrl,
+      boolean includeAnnotations,
+      String userEmail,
+      Underlay underlay,
+      Study study,
+      List<Cohort> cohorts,
+      List<ConceptSet> conceptSets) {
+    this.model = model;
+    this.inputs = inputs;
+    this.redirectBackUrl = redirectBackUrl;
+    this.includeAnnotations = includeAnnotations;
+    this.userEmail = userEmail;
+    this.underlay = underlay;
+    this.study = study;
+    this.cohorts = ImmutableList.copyOf(cohorts);
+    this.conceptSets = ImmutableList.copyOf(conceptSets);
   }
 
   public String getModel() {
@@ -56,137 +54,27 @@ public class ExportRequest {
     return redirectBackUrl;
   }
 
-  public boolean includeAnnotations() {
+  public boolean isIncludeAnnotations() {
     return includeAnnotations;
   }
 
-  public ApiUnderlaySummary getUnderlay() {
+  public String getUserEmail() {
+    return userEmail;
+  }
+
+  public Underlay getUnderlay() {
     return underlay;
   }
 
-  public ApiStudy getStudy() {
+  public Study getStudy() {
     return study;
   }
 
-  public List<ApiCohort> getCohorts() {
-    return Collections.unmodifiableList(cohorts);
+  public ImmutableList<Cohort> getCohorts() {
+    return cohorts;
   }
 
-  public Map<String, String> generateSqlQueries() {
-    return generateSqlQueriesFn == null ? Collections.emptyMap() : generateSqlQueriesFn.get();
-  }
-
-  public Map<String, String> writeEntityDataToGcs(String fileNameTemplate) {
-    return writeEntityDataToGcsFn == null
-        ? Collections.emptyMap()
-        : writeEntityDataToGcsFn.apply(fileNameTemplate);
-  }
-
-  public Map<Cohort, String> writeAnnotationDataToGcs(String fileNameTemplate) {
-    return writeAnnotationDataToGcsFn == null
-        ? Collections.emptyMap()
-        : writeAnnotationDataToGcsFn.apply(fileNameTemplate);
-  }
-
-  public GoogleCloudStorage getGoogleCloudStorage() {
-    return getGoogleCloudStorageFn.get();
-  }
-
-  public static class Builder {
-    private String model;
-    private Map<String, String> inputs;
-    private String redirectBackUrl;
-    private boolean includeAnnotations;
-    private ApiUnderlaySummary underlay;
-    private ApiStudy study;
-    private List<ApiCohort> cohorts;
-    private Supplier<Map<String, String>> generateSqlQueriesFn;
-    private Function<String, Map<String, String>> writeEntityDataToGcsFn;
-    private Function<String, Map<Cohort, String>> writeAnnotationDataToGcsFn;
-
-    private Supplier<GoogleCloudStorage> getGoogleCloudStorageFn;
-
-    public Builder model(String model) {
-      this.model = model;
-      return this;
-    }
-
-    public Builder inputs(Map<String, String> inputs) {
-      this.inputs = inputs;
-      return this;
-    }
-
-    public Builder redirectBackUrl(String redirectBackUrl) {
-      this.redirectBackUrl = redirectBackUrl;
-      return this;
-    }
-
-    public Builder includeAnnotations(boolean includeAnnotations) {
-      this.includeAnnotations = includeAnnotations;
-      return this;
-    }
-
-    public Builder underlay(ApiUnderlaySummary underlay) {
-      this.underlay = underlay;
-      return this;
-    }
-
-    public Builder study(ApiStudy study) {
-      this.study = study;
-      return this;
-    }
-
-    public Builder cohorts(List<ApiCohort> cohorts) {
-      this.cohorts = cohorts;
-      return this;
-    }
-
-    public Builder generateSqlQueriesFn(Supplier<Map<String, String>> generateSqlQueriesFn) {
-      this.generateSqlQueriesFn = generateSqlQueriesFn;
-      return this;
-    }
-
-    public Builder writeEntityDataToGcsFn(
-        Function<String, Map<String, String>> writeEntityDataToGcsFn) {
-      this.writeEntityDataToGcsFn = writeEntityDataToGcsFn;
-      return this;
-    }
-
-    public Builder writeAnnotationDataToGcsFn(
-        Function<String, Map<Cohort, String>> writeAnnotationDataToGcsFn) {
-      this.writeAnnotationDataToGcsFn = writeAnnotationDataToGcsFn;
-      return this;
-    }
-
-    public Builder getGoogleCloudStorageFn(Supplier<GoogleCloudStorage> getGoogleCloudStorageFn) {
-      this.getGoogleCloudStorageFn = getGoogleCloudStorageFn;
-      return this;
-    }
-
-    public ExportRequest build() {
-      if (inputs == null) {
-        inputs = new HashMap<>();
-      }
-      if (cohorts == null) {
-        cohorts = new ArrayList<>();
-      }
-      return new ExportRequest(this);
-    }
-
-    public String getModel() {
-      return model;
-    }
-
-    public ApiStudy getStudy() {
-      return study;
-    }
-
-    public List<ApiCohort> getCohorts() {
-      return Collections.unmodifiableList(cohorts);
-    }
-
-    public boolean isIncludeAnnotations() {
-      return includeAnnotations;
-    }
+  public ImmutableList<ConceptSet> getConceptSets() {
+    return conceptSets;
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportResult.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportResult.java
@@ -1,41 +1,76 @@
 package bio.terra.tanagra.service.export;
 
-import java.util.Collections;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 public final class ExportResult {
   public enum Status {
     COMPLETE,
-    RUNNING
+    FAILED
   }
 
-  private final Map<String, String> outputs;
-  private final String redirectAwayUrl;
+  private final ImmutableMap<String, String> outputs;
+  private final @Nullable String redirectAwayUrl;
   private final Status status;
+  private final @Nullable ExportError error;
+  private final ImmutableList<ExportFileResult> fileResults;
 
-  private ExportResult(Map<String, String> outputs, String redirectAwayUrl, Status status) {
-    this.outputs = outputs;
+  private ExportResult(
+      @Nullable Map<String, String> outputs,
+      @Nullable String redirectAwayUrl,
+      Status status,
+      @Nullable ExportError error,
+      @Nullable List<ExportFileResult> fileResults) {
+    this.outputs = outputs == null ? ImmutableMap.of() : ImmutableMap.copyOf(outputs);
     this.redirectAwayUrl = redirectAwayUrl;
     this.status = status;
+    this.error = error;
+    this.fileResults = fileResults == null ? ImmutableList.of() : ImmutableList.copyOf(fileResults);
   }
 
-  public static ExportResult forOutputParams(Map<String, String> outputs, Status status) {
-    return new ExportResult(outputs, null, status);
+  public static ExportResult forOutputParams(
+      Map<String, String> outputs, List<ExportFileResult> fileResults) {
+    return new ExportResult(outputs, null, Status.COMPLETE, null, fileResults);
   }
 
-  public static ExportResult forRedirectUrl(String redirectAwayUrl, Status status) {
-    return new ExportResult(Collections.emptyMap(), redirectAwayUrl, status);
+  public static ExportResult forRedirectUrl(
+      String redirectAwayUrl, List<ExportFileResult> fileResults) {
+    return new ExportResult(Map.of(), redirectAwayUrl, Status.COMPLETE, null, fileResults);
   }
 
-  public Map<String, String> getOutputs() {
-    return Collections.unmodifiableMap(outputs);
+  public static ExportResult forError(ExportError error) {
+    return new ExportResult(Map.of(), null, Status.FAILED, error, null);
   }
 
-  public String getRedirectAwayUrl() {
+  public ImmutableMap<String, String> getOutputs() {
+    return outputs;
+  }
+
+  public @Nullable String getRedirectAwayUrl() {
     return redirectAwayUrl;
   }
 
   public Status getStatus() {
     return status;
+  }
+
+  public boolean isSuccessful() {
+    return error == null
+        && fileResults.stream()
+            .filter(fileResult -> !fileResult.isSuccessful())
+            .collect(Collectors.toList())
+            .isEmpty();
+  }
+
+  public @Nullable ExportError getError() {
+    return error;
+  }
+
+  public ImmutableList<ExportFileResult> getFileResults() {
+    return fileResults;
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/VwbFileImport.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/VwbFileImport.java
@@ -1,23 +1,20 @@
 package bio.terra.tanagra.service.export.impl;
 
+import static bio.terra.tanagra.service.export.DataExportHelper.urlEncode;
 import static bio.terra.tanagra.utils.NameUtils.simplifyStringForName;
 
-import bio.terra.tanagra.exception.SystemException;
-import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.service.export.DataExport;
+import bio.terra.tanagra.service.export.DataExportHelper;
 import bio.terra.tanagra.service.export.DeploymentConfig;
+import bio.terra.tanagra.service.export.ExportFileResult;
 import bio.terra.tanagra.service.export.ExportRequest;
 import bio.terra.tanagra.service.export.ExportResult;
 import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableMap;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
 public class VwbFileImport implements DataExport {
@@ -47,48 +44,46 @@ public class VwbFileImport implements DataExport {
   }
 
   @Override
-  public ExportResult run(ExportRequest request) {
-    // Write the data export files to GCS.
+  public ExportResult run(ExportRequest request, DataExportHelper helper) {
+    // Export the entity and annotation data to GCS.
+    String studyUnderlayRef =
+        simplifyStringForName(request.getStudy().getId() + "_" + request.getUnderlay().getName());
     String cohortRef =
         simplifyStringForName(
                 request.getCohorts().get(0).getDisplayName()
                     + "_"
                     + request.getCohorts().get(0).getId())
             + (request.getCohorts().size() > 1
-                ? "plus" + (request.getCohorts().size() - 1) + "more"
+                ? "_plus" + (request.getCohorts().size() - 1) + "more"
                 : "");
-    Map<String, String> entityToGcsUrl =
-        request.writeEntityDataToGcs("${entity}_cohort" + cohortRef + "_${random}");
-    Map<Cohort, String> cohortToGcsUrl =
-        request.writeAnnotationDataToGcs("annotations_cohort${cohort}_${random}");
-    List<String> unsignedUrls = new ArrayList<>();
-    unsignedUrls.addAll(entityToGcsUrl.values());
-    unsignedUrls.addAll(cohortToGcsUrl.values());
+    List<ExportFileResult> entityExportFileResults =
+        helper.writeEntityDataToGcs(
+            "${entity}_cohort" + cohortRef + "_" + studyUnderlayRef + "_${random}");
+    List<ExportFileResult> annotationExportFileResults =
+        helper.writeAnnotationDataToGcs(
+            "annotations_cohort${cohort}" + "_" + studyUnderlayRef + "_${random}");
+    List<ExportFileResult> allExportFileResults = new ArrayList<>();
+    allExportFileResults.addAll(entityExportFileResults);
+    allExportFileResults.addAll(annotationExportFileResults);
 
-    // Build a list of the TSV rows: signed url
-    List<String> tsvRows =
-        unsignedUrls.stream()
-            .map(unsignedUrl -> request.getGoogleCloudStorage().createSignedUrl(unsignedUrl))
-            .collect(Collectors.toList());
-
-    // Sort the TSV rows lexicographically by signed URL.
-    // Since the signed URL is the first column in each row, we can just sort the full TSV row
-    // string.
+    // Build a list of the signed URLs, sorted lexicographically.
     // Build a TSV-string from the sorted list of rows, prefixed with the format header.
     StringBuilder fileContents = new StringBuilder(FILE_FORMAT_SPECIFIER + "\n");
-    tsvRows.stream().sorted().forEach(tsvRow -> fileContents.append(tsvRow + "\n"));
+    allExportFileResults.stream()
+        .map(ExportFileResult::getFileUrl)
+        .sorted()
+        .forEach(tsvRow -> fileContents.append(tsvRow + "\n"));
 
     // Write the TSV file to GCS. Just pick the first bucket name.
+    String fileName = "tanagra_vwb_export_" + Instant.now() + ".tsv";
     BlobId blobId =
-        request
-            .getGoogleCloudStorage()
-            .writeFile(
-                gcsBucketNames.get(0),
-                "tanagra_export_" + Instant.now() + ".tsv",
-                fileContents.toString());
+        helper
+            .getStorageService()
+            .writeFile(gcsBucketNames.get(0), fileName, fileContents.toString());
 
     // Generate a signed URL for the TSV file.
-    String tsvSignedUrl = request.getGoogleCloudStorage().createSignedUrl(blobId.toGsUtilUri());
+    String tsvSignedUrl = helper.getStorageService().createSignedUrl(blobId.toGsUtilUri());
+    allExportFileResults.add(ExportFileResult.forFile(fileName, tsvSignedUrl, null));
 
     // Generate the redirect URL to VWB.
     Map<String, String> urlParams =
@@ -97,14 +92,6 @@ public class VwbFileImport implements DataExport {
             .put("redirectBackUrl", urlEncode(request.getRedirectBackUrl()))
             .build();
     String expandedRedirectAwayUrl = StringSubstitutor.replace(redirectAwayUrl, urlParams);
-    return ExportResult.forRedirectUrl(expandedRedirectAwayUrl, ExportResult.Status.COMPLETE);
-  }
-
-  private static String urlEncode(String param) {
-    try {
-      return URLEncoder.encode(param, StandardCharsets.UTF_8.toString());
-    } catch (UnsupportedEncodingException ueEx) {
-      throw new SystemException("Error encoding URL param: " + param, ueEx);
-    }
+    return ExportResult.forRedirectUrl(expandedRedirectAwayUrl, allExportFileResults);
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/ActivityLogServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ActivityLogServiceTest.java
@@ -1,6 +1,8 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_3;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_GENDER;
+import static bio.terra.tanagra.service.CriteriaValues.DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,19 +18,23 @@ import bio.terra.tanagra.app.Main;
 import bio.terra.tanagra.app.configuration.VersionConfiguration;
 import bio.terra.tanagra.service.artifact.ActivityLogService;
 import bio.terra.tanagra.service.artifact.CohortService;
+import bio.terra.tanagra.service.artifact.ConceptSetService;
 import bio.terra.tanagra.service.artifact.ReviewService;
 import bio.terra.tanagra.service.artifact.StudyService;
 import bio.terra.tanagra.service.artifact.model.ActivityLog;
 import bio.terra.tanagra.service.artifact.model.ActivityLogResource;
 import bio.terra.tanagra.service.artifact.model.Cohort;
+import bio.terra.tanagra.service.artifact.model.ConceptSet;
 import bio.terra.tanagra.service.artifact.model.Review;
 import bio.terra.tanagra.service.artifact.model.Study;
 import bio.terra.tanagra.service.export.DataExportService;
 import bio.terra.tanagra.service.export.ExportRequest;
 import bio.terra.tanagra.service.export.ExportResult;
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +63,7 @@ public class ActivityLogServiceTest {
   private static final String USER_EMAIL_2 = "def@123.com";
   @Autowired private UnderlayService underlayService;
   @Autowired private StudyService studyService;
+  @Autowired private ConceptSetService conceptSetService;
   @Autowired private CohortService cohortService;
   @Autowired private ReviewService reviewService;
   @Autowired private DataExportService dataExportService;
@@ -111,13 +118,24 @@ public class ActivityLogServiceTest {
 
     TimeUnit.SECONDS.sleep(1); // Wait briefly, so the activity log timestamp differs.
 
+    // CREATE_CONCEPT_SET
+    ConceptSet conceptSet1 =
+        conceptSetService.createConceptSet(
+            study1.getId(),
+            ConceptSet.builder()
+                .underlay(UNDERLAY_NAME)
+                .criteria(List.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getValue())),
+            USER_EMAIL_1);
+    assertNotNull(conceptSet1);
+    LOGGER.info("Created concept set {} at {}", conceptSet1.getId(), conceptSet1.getCreated());
+
     // CREATE_COHORT
     Cohort cohort1 =
         cohortService.createCohort(
             study1.getId(),
             Cohort.builder().underlay(UNDERLAY_NAME),
             USER_EMAIL_1,
-            List.of(CRITERIA_GROUP_SECTION_3));
+            List.of(CRITERIA_GROUP_SECTION_GENDER));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 
@@ -193,30 +211,43 @@ public class ActivityLogServiceTest {
     // Select all attributes.
     List<ValueDisplayField> selectFields = new ArrayList<>();
     primaryEntity.getAttributes().stream()
+        .sorted(Comparator.comparing(Attribute::getName))
         .forEach(
             attribute ->
                 selectFields.add(
                     new AttributeField(underlay, primaryEntity, attribute, false, false)));
-    ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
-            underlay, primaryEntity, selectFields, null, null, 5, null, null, false);
     EntityFilter primaryEntityFilter =
         new AttributeFilter(
             underlay,
             primaryEntity,
-            primaryEntity.getAttribute("year_of_birth"),
-            BinaryOperator.GREATER_THAN_OR_EQUAL,
-            Literal.forInt64(1980L));
-    String exportModel = "IPYNB_FILE_DOWNLOAD";
-    ExportRequest.Builder exportRequest = ExportRequest.builder().model(exportModel);
-    ExportResult exportResult =
-        dataExportService.run(
-            study1.getId(),
-            List.of(cohort1.getId()),
-            exportRequest,
-            List.of(listQueryRequest),
+            primaryEntity.getAttribute("gender"),
+            BinaryOperator.EQUALS,
+            Literal.forInt64(8_532L));
+    ListQueryRequest listQueryRequest =
+        new ListQueryRequest(
+            underlay,
+            primaryEntity,
+            selectFields,
             primaryEntityFilter,
-            USER_EMAIL_2);
+            null,
+            null,
+            null,
+            null,
+            false);
+    String exportModel = "IPYNB_FILE_DOWNLOAD";
+    ExportRequest exportRequest =
+        new ExportRequest(
+            exportModel,
+            Map.of(),
+            null,
+            false,
+            USER_EMAIL_2,
+            underlayService.getUnderlay(UNDERLAY_NAME),
+            study1,
+            List.of(cohort1),
+            List.of(conceptSet1));
+    ExportResult exportResult =
+        dataExportService.run(exportRequest, List.of(listQueryRequest), primaryEntityFilter);
     assertNotNull(exportResult);
 
     activityLogs = activityLogService.listActivityLogs(0, 10, null, false, null, null);
@@ -232,7 +263,7 @@ public class ActivityLogServiceTest {
                             .cohortRevisionId(cohort1.getMostRecentRevision().getId())
                             .build())
                     .exportModel(exportModel)
-                    .recordsCount(12_861L)
+                    .recordsCount(1_292_861L) // 12_861L)
                     .build()));
 
     TimeUnit.SECONDS.sleep(1); // Wait briefly, so the activity log timestamp differs.
@@ -328,7 +359,7 @@ public class ActivityLogServiceTest {
             study1.getId(),
             Cohort.builder().underlay(UNDERLAY_NAME),
             USER_EMAIL_1,
-            List.of(CRITERIA_GROUP_SECTION_3));
+            List.of(CRITERIA_GROUP_SECTION_DEMOGRAPHICS));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 

--- a/service/src/test/java/bio/terra/tanagra/service/ActivityLogServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ActivityLogServiceTest.java
@@ -263,7 +263,7 @@ public class ActivityLogServiceTest {
                             .cohortRevisionId(cohort1.getMostRecentRevision().getId())
                             .build())
                     .exportModel(exportModel)
-                    .recordsCount(1_292_861L) // 12_861L)
+                    .recordsCount(1_292_861L)
                     .build()));
 
     TimeUnit.SECONDS.sleep(1); // Wait briefly, so the activity log timestamp differs.

--- a/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/AnnotationServiceTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -81,7 +81,9 @@ public class AnnotationServiceTest {
                 .displayName("cohort 2")
                 .description("first cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+            List.of(
+                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 
@@ -94,7 +96,7 @@ public class AnnotationServiceTest {
                 .displayName("cohort 2")
                 .description("second cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_2));
+            List.of(CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort2);
     LOGGER.info("Created cohort {} at {}", cohort2.getId(), cohort2.getCreated());
 

--- a/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -260,14 +260,17 @@ public class CohortServiceTest {
             userEmail,
             null,
             null,
-            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+            List.of(
+                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(updatedCohort1);
     LOGGER.info(
         "Updated cohort {} at {}", updatedCohort1.getId(), updatedCohort1.getLastModified());
     assertTrue(updatedCohort1.getLastModified().isAfter(updatedCohort1.getCreated()));
     assertEquals(2, updatedCohort1.getMostRecentRevision().getSections().size());
     assertEquals(
-        List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2),
+        List.of(
+            CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION, CRITERIA_GROUP_SECTION_PROCEDURE),
         updatedCohort1.getMostRecentRevision().getSections());
 
     // Create cohort2 with criteria.
@@ -279,11 +282,12 @@ public class CohortServiceTest {
                 .displayName("cohort 2")
                 .description("second cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_2));
+            List.of(CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort2);
     LOGGER.info("Created cohort {} at {}", cohort2.getId(), cohort2.getCreated());
     assertEquals(1, cohort2.getMostRecentRevision().getSections().size());
-    assertEquals(List.of(CRITERIA_GROUP_SECTION_2), cohort2.getMostRecentRevision().getSections());
+    assertEquals(
+        List.of(CRITERIA_GROUP_SECTION_PROCEDURE), cohort2.getMostRecentRevision().getSections());
 
     // Update cohort2 criteria only.
     TimeUnit.SECONDS.sleep(1); // Wait briefly, so the last modified and created timestamps differ.
@@ -294,13 +298,14 @@ public class CohortServiceTest {
             userEmail,
             null,
             null,
-            List.of(CRITERIA_GROUP_SECTION_1));
+            List.of(CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION));
     assertNotNull(updatedCohort2);
     LOGGER.info(
         "Updated cohort {} at {}", updatedCohort2.getId(), updatedCohort2.getLastModified());
     assertTrue(updatedCohort2.getLastModified().isAfter(updatedCohort2.getCreated()));
     assertEquals(1, updatedCohort2.getMostRecentRevision().getSections().size());
     assertEquals(
-        List.of(CRITERIA_GROUP_SECTION_1), updatedCohort2.getMostRecentRevision().getSections());
+        List.of(CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION),
+        updatedCohort2.getMostRecentRevision().getSections());
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ConceptSetServiceTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaValues.CONDITION_EQ_DIABETES;
-import static bio.terra.tanagra.service.CriteriaValues.ETHNICITY_EQ_JAPANESE;
+import static bio.terra.tanagra.service.CriteriaValues.CONDITION_EQ_TYPE_2_DIABETES;
+import static bio.terra.tanagra.service.CriteriaValues.DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE;
 import static bio.terra.tanagra.service.CriteriaValues.GENDER_EQ_WOMAN;
 import static bio.terra.tanagra.service.CriteriaValues.PROCEDURE_EQ_AMPUTATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -132,7 +132,7 @@ public class ConceptSetServiceTest {
             updatedByEmail,
             displayName2,
             description2,
-            List.of(CONDITION_EQ_DIABETES.getValue()),
+            List.of(CONDITION_EQ_TYPE_2_DIABETES.getValue()),
             Map.of(outputEntity, outputAttributes));
     assertNotNull(updatedConceptSet);
     LOGGER.info(
@@ -145,7 +145,7 @@ public class ConceptSetServiceTest {
     assertEquals(updatedByEmail, updatedConceptSet.getLastModifiedBy());
     assertTrue(updatedConceptSet.getLastModified().isAfter(updatedConceptSet.getCreated()));
     assertEquals(1, updatedConceptSet.getCriteria().size());
-    assertTrue(updatedConceptSet.getCriteria().contains(CONDITION_EQ_DIABETES.getValue()));
+    assertTrue(updatedConceptSet.getCriteria().contains(CONDITION_EQ_TYPE_2_DIABETES.getValue()));
     assertEquals(1, updatedConceptSet.getExcludeOutputAttributesPerEntity().keySet().size());
     assertEquals(
         outputAttributes.stream().sorted().collect(Collectors.toList()),
@@ -183,9 +183,9 @@ public class ConceptSetServiceTest {
                 .underlay(UNDERLAY_NAME)
                 .displayName("concept set 1")
                 .description("first concept set")
-                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue()))
+                .criteria(List.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getRight()))
                 .excludeOutputAttributesPerEntity(
-                    Map.of(ETHNICITY_EQ_JAPANESE.getKey(), PERSON_ATTRIBUTES)),
+                    Map.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getKey(), PERSON_ATTRIBUTES)),
             userEmail);
     assertNotNull(conceptSet1);
     LOGGER.info("Created concept set {} at {}", conceptSet1.getId(), conceptSet1.getCreated());

--- a/service/src/test/java/bio/terra/tanagra/service/CriteriaGroupSectionValues.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CriteriaGroupSectionValues.java
@@ -1,55 +1,65 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaValues.CONDITION_EQ_DIABETES;
-import static bio.terra.tanagra.service.CriteriaValues.ETHNICITY_EQ_JAPANESE;
+import static bio.terra.tanagra.service.CriteriaValues.CONDITION_EQ_TYPE_2_DIABETES;
+import static bio.terra.tanagra.service.CriteriaValues.ETHNICITY_EQ_HISPANIC_OR_LATINO;
 import static bio.terra.tanagra.service.CriteriaValues.GENDER_EQ_WOMAN;
 import static bio.terra.tanagra.service.CriteriaValues.PROCEDURE_EQ_AMPUTATION;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
-import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.service.artifact.model.CohortRevision;
 import java.util.List;
 
 public final class CriteriaGroupSectionValues {
   private CriteriaGroupSectionValues() {}
 
-  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_1 =
+  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_GENDER =
       CohortRevision.CriteriaGroup.builder()
-          .displayName("group 1")
-          .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_JAPANESE.getValue()))
+          .displayName("group gender")
+          .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
           .entity(GENDER_EQ_WOMAN.getKey())
           .build();
-  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_2 =
-      CohortRevision.CriteriaGroup.builder()
-          .displayName("group 2")
-          .criteria(List.of(CONDITION_EQ_DIABETES.getValue()))
-          .entity(CONDITION_EQ_DIABETES.getKey())
-          .groupByCountOperator(BinaryOperator.EQUALS)
-          .groupByCountValue(11)
+
+  public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_GENDER =
+      CohortRevision.CriteriaGroupSection.builder()
+          .displayName("section gender")
+          .criteriaGroups(List.of(CRITERIA_GROUP_GENDER))
           .build();
-  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_3 =
+  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_DEMOGRAPHICS =
       CohortRevision.CriteriaGroup.builder()
-          .displayName("group 3")
+          .displayName("group 1")
+          .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_HISPANIC_OR_LATINO.getValue()))
+          .entity(GENDER_EQ_WOMAN.getKey())
+          .build();
+  public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_DEMOGRAPHICS =
+      CohortRevision.CriteriaGroupSection.builder()
+          .displayName("section demographics")
+          .criteriaGroups(List.of(CRITERIA_GROUP_DEMOGRAPHICS))
+          .build();
+  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_CONDITION =
+      CohortRevision.CriteriaGroup.builder()
+          .displayName("group condition")
+          .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES.getValue()))
+          .entity(CONDITION_EQ_TYPE_2_DIABETES.getKey())
+          .build();
+  public static final CohortRevision.CriteriaGroupSection
+      CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION =
+          CohortRevision.CriteriaGroupSection.builder()
+              .displayName("section demographics and condition")
+              .criteriaGroups(List.of(CRITERIA_GROUP_DEMOGRAPHICS, CRITERIA_GROUP_CONDITION))
+              .operator(BooleanAndOrFilter.LogicalOperator.OR)
+              .build();
+  public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_PROCEDURE =
+      CohortRevision.CriteriaGroup.builder()
+          .displayName("group procedure")
           .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
           .entity(PROCEDURE_EQ_AMPUTATION.getKey())
           .build();
 
-  public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_1 =
+  public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_PROCEDURE =
       CohortRevision.CriteriaGroupSection.builder()
-          .displayName("section 1")
-          .criteriaGroups(List.of(CRITERIA_GROUP_1, CRITERIA_GROUP_2))
-          .operator(BooleanAndOrFilter.LogicalOperator.OR)
-          .build();
-  public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_2 =
-      CohortRevision.CriteriaGroupSection.builder()
-          .displayName("section 2")
-          .criteriaGroups(List.of(CRITERIA_GROUP_3))
+          .displayName("section procedure")
+          .criteriaGroups(List.of(CRITERIA_GROUP_PROCEDURE))
           .operator(BooleanAndOrFilter.LogicalOperator.AND)
           .setIsExcluded(true)
-          .build();
-  public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_3 =
-      CohortRevision.CriteriaGroupSection.builder()
-          .displayName("section 3")
-          .criteriaGroups(List.of(CRITERIA_GROUP_1))
           .build();
 }

--- a/service/src/test/java/bio/terra/tanagra/service/CriteriaValues.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CriteriaValues.java
@@ -1,60 +1,116 @@
 package bio.terra.tanagra.service;
 
+import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
+
+import bio.terra.tanagra.proto.criteriaselector.KeyOuterClass;
+import bio.terra.tanagra.proto.criteriaselector.ValueOuterClass;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTAttribute;
+import bio.terra.tanagra.proto.criteriaselector.dataschema.DTEntityGroup;
 import bio.terra.tanagra.service.artifact.model.Criteria;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 
 public final class CriteriaValues {
   private CriteriaValues() {}
 
-  // TODO: Replace the pluginName, selectionData, and uiConfig values with actual values from the
-  // UI.
+  public static final Pair<String, Criteria> DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE =
+      Pair.of(
+          "person",
+          Criteria.builder()
+              .predefinedId("_demographics")
+              .pluginName("ouptutUnfiltered")
+              .pluginVersion(0)
+              .selectionData("")
+              .uiConfig("")
+              .build());
+
   public static final Pair<String, Criteria> GENDER_EQ_WOMAN =
       Pair.of(
           "person",
           Criteria.builder()
-              .displayName("women")
-              .pluginName("demographic")
-              .pluginVersion(2)
-              .selectionData("{gender:'F'}")
-              .uiConfig("{entity:'person', attribute:'gender'}")
+              .selectorOrModifierName("tanagra-gender")
+              .pluginName("attribute")
+              .pluginVersion(0)
+              .selectionData(
+                  serializeToJson(
+                      DTAttribute.Attribute.newBuilder()
+                          .addSelected(
+                              DTAttribute.Attribute.Selection.newBuilder()
+                                  .setValue(
+                                      ValueOuterClass.Value.newBuilder()
+                                          .setInt64Value(8_532L)
+                                          .build())
+                                  .setName("Female")
+                                  .build())
+                          .build()))
+              .uiConfig("")
               .tags(Map.of("0", "tag1", "1", "tag2", "2", "tag3"))
               .build());
 
-  public static final Pair<String, Criteria> ETHNICITY_EQ_JAPANESE =
+  public static final Pair<String, Criteria> ETHNICITY_EQ_HISPANIC_OR_LATINO =
       Pair.of(
           "person",
           Criteria.builder()
-              .displayName("japanese")
-              .pluginName("demographic")
+              .selectorOrModifierName("tanagra-ethnicity")
+              .pluginName("attribute")
               .pluginVersion(4)
-              .selectionData("{ethnicity:'jpn'}")
-              .uiConfig("{entity:'person', attribute:'ethnicity'}")
+              .selectionData(
+                  serializeToJson(
+                      DTAttribute.Attribute.newBuilder()
+                          .addSelected(
+                              DTAttribute.Attribute.Selection.newBuilder()
+                                  .setValue(
+                                      ValueOuterClass.Value.newBuilder()
+                                          .setInt64Value(38_003_563L)
+                                          .build())
+                                  .setName("Hispanic or Latino")
+                                  .build())
+                          .build()))
+              .uiConfig("")
               .tags(Map.of("1", "tag1"))
               .build());
 
-  public static final Pair<String, Criteria> CONDITION_EQ_DIABETES =
+  public static final Pair<String, Criteria> CONDITION_EQ_TYPE_2_DIABETES =
       Pair.of(
           "condition",
           Criteria.builder()
-              .displayName("diabetes")
-              .pluginName("condition")
+              .selectorOrModifierName("tanagra-conditions")
+              .pluginName("entityGroup")
               .pluginVersion(0)
-              .selectionData("{condition:445645}")
-              .uiConfig("{entity:'condition', attribute:'id'}")
-              .tags(Collections.emptyMap())
+              .selectionData(
+                  serializeToJson(
+                      DTEntityGroup.EntityGroup.newBuilder()
+                          .addSelected(
+                              DTEntityGroup.EntityGroup.Selection.newBuilder()
+                                  .setKey(
+                                      KeyOuterClass.Key.newBuilder().setInt64Key(201_826L).build())
+                                  .setName("Type 2 diabetes mellitus")
+                                  .setEntityGroup("conditionPerson")
+                                  .build())
+                          .build()))
+              .uiConfig("")
+              .tags(Map.of())
               .build());
 
   public static final Pair<String, Criteria> PROCEDURE_EQ_AMPUTATION =
       Pair.of(
           "procedure",
           Criteria.builder()
-              .displayName("amputation")
-              .pluginName("procedure")
+              .selectorOrModifierName("tanagra-procedures")
+              .pluginName("entityGroup")
               .pluginVersion(11)
-              .selectionData("{procedure:234523}")
-              .uiConfig("{entity:'procedure', attribute:'id'}")
+              .selectionData(
+                  serializeToJson(
+                      DTEntityGroup.EntityGroup.newBuilder()
+                          .addSelected(
+                              DTEntityGroup.EntityGroup.Selection.newBuilder()
+                                  .setKey(
+                                      KeyOuterClass.Key.newBuilder().setInt64Key(234_523L).build())
+                                  .setName("Amputation")
+                                  .setEntityGroup("procedurePerson")
+                                  .build())
+                          .build()))
+              .uiConfig("")
               .tags(Map.of("0", "tag4", "2", "tag5"))
               .build());
 }

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewInstanceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewInstanceTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -89,7 +89,9 @@ public class ReviewInstanceTest {
                 .displayName("cohort 2")
                 .description("first cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+            List.of(
+                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort1 {} at {}", cohort1.getId(), cohort1.getCreated());
 

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewPaginationTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewPaginationTest.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_3;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -66,7 +66,7 @@ public class ReviewPaginationTest {
             study1.getId(),
             Cohort.builder().underlay(UNDERLAY_NAME),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_3));
+            List.of(CRITERIA_GROUP_SECTION_DEMOGRAPHICS));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewPaginationTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewPaginationTest.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_GENDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -66,7 +66,7 @@ public class ReviewPaginationTest {
             study1.getId(),
             Cohort.builder().underlay(UNDERLAY_NAME),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_DEMOGRAPHICS));
+            List.of(CRITERIA_GROUP_SECTION_GENDER));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewSampleSizeTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewSampleSizeTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -76,7 +76,9 @@ public class ReviewSampleSizeTest {
                 .displayName("cohort 2")
                 .description("first cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+            List.of(
+                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort1 {} at {}", cohort1.getId(), cohort1.getCreated());
   }

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewSampleSizeTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewSampleSizeTest.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_GENDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -76,9 +75,7 @@ public class ReviewSampleSizeTest {
                 .displayName("cohort 2")
                 .description("first cohort"),
             userEmail,
-            List.of(
-                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
-                CRITERIA_GROUP_SECTION_PROCEDURE));
+            List.of(CRITERIA_GROUP_SECTION_GENDER));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort1 {} at {}", cohort1.getId(), cohort1.getCreated());
   }
@@ -99,8 +96,8 @@ public class ReviewSampleSizeTest {
         cohortService.getRandomSample(
             study1.getId(),
             cohort1.getId(),
-            getCohortFilter(),
-            ListQueryRequest.DEFAULT_PAGE_SIZE - 1);
+            ListQueryRequest.DEFAULT_PAGE_SIZE - 1,
+            getCohortFilter());
     assertEquals(ListQueryRequest.DEFAULT_PAGE_SIZE - 1, randomSample.size());
   }
 
@@ -110,8 +107,8 @@ public class ReviewSampleSizeTest {
         cohortService.getRandomSample(
             study1.getId(),
             cohort1.getId(),
-            getCohortFilter(),
-            ListQueryRequest.DEFAULT_PAGE_SIZE * 2 + 1);
+            ListQueryRequest.DEFAULT_PAGE_SIZE * 2 + 1,
+            getCohortFilter());
     assertEquals(ListQueryRequest.DEFAULT_PAGE_SIZE * 2 + 1, randomSample.size());
   }
 

--- a/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ReviewServiceTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.service;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -70,7 +70,9 @@ public class ReviewServiceTest {
                 .displayName("cohort 2")
                 .description("first cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+            List.of(
+                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 
@@ -83,7 +85,7 @@ public class ReviewServiceTest {
                 .displayName("cohort 2")
                 .description("second cohort"),
             userEmail,
-            List.of(CRITERIA_GROUP_SECTION_2));
+            List.of(CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort2);
     LOGGER.info("Created cohort {} at {}", cohort2.getId(), cohort2.getCreated());
   }

--- a/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/accesscontrol/BaseAccessControlTest.java
@@ -1,8 +1,8 @@
 package bio.terra.tanagra.service.accesscontrol;
 
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_1;
-import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_2;
-import static bio.terra.tanagra.service.CriteriaValues.ETHNICITY_EQ_JAPANESE;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
+import static bio.terra.tanagra.service.CriteriaGroupSectionValues.CRITERIA_GROUP_SECTION_PROCEDURE;
+import static bio.terra.tanagra.service.CriteriaValues.DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE;
 import static bio.terra.tanagra.service.CriteriaValues.PROCEDURE_EQ_AMPUTATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -92,7 +92,9 @@ public class BaseAccessControlTest {
                 .displayName("cohort 2")
                 .description("first cohort"),
             "abc@123.com",
-            List.of(CRITERIA_GROUP_SECTION_1, CRITERIA_GROUP_SECTION_2));
+            List.of(
+                CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort1);
     LOGGER.info("Created cohort {} at {}", cohort1.getId(), cohort1.getCreated());
 
@@ -104,7 +106,7 @@ public class BaseAccessControlTest {
                 .displayName("cohort 2")
                 .description("second cohort"),
             "def@123.com",
-            List.of(CRITERIA_GROUP_SECTION_2));
+            List.of(CRITERIA_GROUP_SECTION_PROCEDURE));
     assertNotNull(cohort2);
     LOGGER.info("Created cohort {} at {}", cohort2.getId(), cohort2.getCreated());
 
@@ -116,9 +118,9 @@ public class BaseAccessControlTest {
                 .underlay(CMS_SYNPUF)
                 .displayName("concept set 1")
                 .description("first concept set")
-                .criteria(List.of(ETHNICITY_EQ_JAPANESE.getValue()))
+                .criteria(List.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getValue()))
                 .excludeOutputAttributesPerEntity(
-                    Map.of(ETHNICITY_EQ_JAPANESE.getKey(), List.of("gender"))),
+                    Map.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getKey(), List.of("gender"))),
             "abc@123.com");
     assertNotNull(conceptSet1);
     LOGGER.info("Created concept set {} at {}", conceptSet1.getId(), conceptSet1.getCreated());

--- a/service/src/test/resources/application-test.yaml
+++ b/service/src/test/resources/application-test.yaml
@@ -5,6 +5,7 @@ tanagra:
   feature:
     artifact-storage-enabled: true
     activity-log-enabled: true
+    backend-filters-enabled: true
 
   db:
     initialize-on-start: true

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
@@ -18,9 +18,9 @@ public class CountQueryRequest {
   private final Underlay underlay;
   private final Entity entity;
   private final ImmutableList<ValueDisplayField> groupByFields;
-  private final EntityFilter filter;
-  private final PageMarker pageMarker;
-  private final Integer pageSize;
+  private final @Nullable EntityFilter filter;
+  private final @Nullable PageMarker pageMarker;
+  private final @Nullable Integer pageSize;
   private final @Nullable HintQueryResult entityLevelHints;
   private final boolean isDryRun;
 
@@ -29,9 +29,9 @@ public class CountQueryRequest {
       Underlay underlay,
       Entity entity,
       List<ValueDisplayField> groupByFields,
-      EntityFilter filter,
-      PageMarker pageMarker,
-      Integer pageSize,
+      @Nullable EntityFilter filter,
+      @Nullable PageMarker pageMarker,
+      @Nullable Integer pageSize,
       @Nullable HintQueryResult entityLevelHints,
       boolean isDryRun) {
     this.underlay = underlay;
@@ -56,15 +56,15 @@ public class CountQueryRequest {
     return groupByFields;
   }
 
-  public EntityFilter getFilter() {
+  public @Nullable EntityFilter getFilter() {
     return filter;
   }
 
-  public PageMarker getPageMarker() {
+  public @Nullable PageMarker getPageMarker() {
     return pageMarker;
   }
 
-  public Integer getPageSize() {
+  public @Nullable Integer getPageSize() {
     return pageSize;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
@@ -10,6 +10,7 @@ public class ExportQueryRequest {
   private final String gcsProjectId;
   private final List<String> availableBqDatasetIds;
   private final List<String> availableGcsBucketNames;
+  private final boolean generateSignedUrl;
 
   public ExportQueryRequest(
       ListQueryRequest listQueryRequest,
@@ -17,13 +18,15 @@ public class ExportQueryRequest {
       String fileNamePrefix,
       String gcsProjectId,
       List<String> availableBqDatasetIds,
-      List<String> availableGcsBucketNames) {
+      List<String> availableGcsBucketNames,
+      boolean generateSignedUrl) {
     this.listQueryRequest = listQueryRequest;
     this.fileDisplayName = fileDisplayName;
     this.fileNamePrefix = fileNamePrefix;
     this.gcsProjectId = gcsProjectId;
     this.availableBqDatasetIds = availableBqDatasetIds;
     this.availableGcsBucketNames = availableGcsBucketNames;
+    this.generateSignedUrl = generateSignedUrl;
   }
 
   public ListQueryRequest getListQueryRequest() {
@@ -48,5 +51,9 @@ public class ExportQueryRequest {
 
   public List<String> getAvailableGcsBucketNames() {
     return availableGcsBucketNames;
+  }
+
+  public boolean isGenerateSignedUrl() {
+    return generateSignedUrl;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -100,7 +100,8 @@ public class BQExecutor {
       String fileNamePrefix,
       String exportProjectId,
       List<String> exportDatasetIds,
-      List<String> exportBucketNames) {
+      List<String> exportBucketNames,
+      boolean generateSignedUrl) {
     LOGGER.info("Exporting BQ query: {}", queryRequest.getSql());
 
     // Create a temporary table with the results of the query.
@@ -157,7 +158,13 @@ public class BQExecutor {
       throw new SystemException("BigQuery extract job failed: " + exportJob.getStatus().getError());
     }
     LOGGER.info("Export of temporary table completed: {}", exportJob.getStatus().getState());
-    return gcsUrl;
+
+    if (!generateSignedUrl) {
+      return gcsUrl;
+    }
+
+    // Generate a signed URL to the file.
+    return getCloudStorageService().createSignedUrl(gcsUrl);
   }
 
   private static QueryParameterValue toQueryParameterValue(Literal literal) {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -373,14 +373,15 @@ public class BQQueryRunner implements QueryRunner {
     // Build the SQL query.
     SqlQueryRequest sqlQueryRequest = buildListQuerySql(exportQueryRequest.getListQueryRequest());
 
-    // Execute the SQL query.
+    // Execute the SQL query and export the results to GCS.
     String exportFilePath =
         bigQueryExecutor.export(
             sqlQueryRequest,
             exportQueryRequest.getFileNamePrefix(),
             exportQueryRequest.getGcsProjectId(),
             exportQueryRequest.getAvailableBqDatasetIds(),
-            exportQueryRequest.getAvailableGcsBucketNames());
+            exportQueryRequest.getAvailableGcsBucketNames(),
+            exportQueryRequest.isGenerateSignedUrl());
 
     return new ExportQueryResult(exportQueryRequest.getFileDisplayName(), exportFilePath);
   }

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
@@ -135,15 +135,18 @@ public final class GoogleCloudStorage {
     return fileContents.toString();
   }
 
-  public static String readGzipFileContentsFromUrl(String signedUrl) throws IOException {
+  public static String readGzipFileContentsFromUrl(String signedUrl, int maxLinesToRead)
+      throws IOException {
     try (GZIPInputStream gzipInputStream =
             new GZIPInputStream(new URL(signedUrl).openConnection().getInputStream());
         InputStreamReader inputStreamReader = new InputStreamReader(gzipInputStream, "UTF-8");
         BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
       StringBuffer fileContents = new StringBuffer();
       String inputLine;
-      while ((inputLine = bufferedReader.readLine()) != null) {
+      int numLinesRead = 0;
+      while ((inputLine = bufferedReader.readLine()) != null && numLinesRead < maxLinesToRead) {
         fileContents.append(inputLine).append(System.lineSeparator());
+        numLinesRead++;
       }
       return fileContents.toString();
     }

--- a/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/Job.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/threadpool/Job.java
@@ -5,18 +5,24 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Job<T> implements Callable<JobResult<T>> {
+public class Job<R, T> implements Callable<JobResult<T>> {
   private static final Logger LOGGER = LoggerFactory.getLogger(Job.class);
   private final String jobId;
+  private final R jobInfo;
   private final Supplier<T> jobFn;
 
-  public Job(String jobId, Supplier<T> jobFn) {
+  public Job(String jobId, R jobInfo, Supplier<T> jobFn) {
     this.jobId = jobId;
+    this.jobInfo = jobInfo;
     this.jobFn = jobFn;
   }
 
   public String getJobId() {
     return jobId;
+  }
+
+  public R getJobInfo() {
+    return jobInfo;
   }
 
   @Override


### PR DESCRIPTION
- Hooked up the backend filter building infrastructure with the export and review creation endpoints. Both of these endpoints will continue to use the filters built on the frontend when the `backend-filters-enabled` feature flag is not set.
- Stored an error per file export, in addition to per export request. Also stored the entity/cohort associated with each file export. Previously, only the first error per request was stored, and the mapping to the entity/cohort that failed wasn't preserved. These aren't being passed through the API yet, but the information is now there.
- Updated the service tests to use valid criteria definitions. Previously, they were using placeholder selection data which didn't matter because the backend wasn't actually reading it.
- Set the `backend-filters-enabled` feature flag to true for all service tests.
- Separated out the data export utility functions into a new `DataExportHelper` class and made it available to all export model implementations. This class is where we will define functions that are potentially useful across models (e.g. export entity/annotation data to GCS).