### PR TITLE
Define entity outputs preview endpoint.

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -866,6 +866,31 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  "/v2/underlays/{underlayName}/entityOutputsPreview":
+    parameters:
+      - $ref: "#/components/parameters/UnderlayName"
+    post:
+      summary: Preview the entity outputs that will be exported
+      operationId: previewEntityOutputs
+      tags: [Export]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExportPreviewRequest"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityOutputPreviewList"
+        404:
+          $ref: "#/components/responses/NotFound"
+        500:
+          $ref: "#/components/responses/ServerError"
+
   "/v2/underlays/{underlayName}/export":
     parameters:
       - $ref: "#/components/parameters/UnderlayName"
@@ -2503,6 +2528,31 @@ components:
           default: 50
       required:
         - study
+
+    EntityOutputPreview:
+      type: object
+      properties:
+        entity:
+          description: Entity name
+          type: string
+        includedAttributes:
+          type: array
+          description: Names of attributes included in the output
+          items:
+            type: string
+      required:
+        - entity
+        - includedAttributes
+
+    EntityOutputPreviewList:
+      type: object
+      properties:
+        entityOutputs:
+          type: array
+          items:
+            $ref: "#/components/schemas/EntityOutputPreview"
+      required:
+        - entityOutputs
 
     ExportRequest:
       type: object


### PR DESCRIPTION
This endpoint can be used by the UI to:
- Get a list of the output entities. It can then call the `previewEntityExport` to run the preview query for each one separately.
- Generate the export text summary.

This PR does not include any implementation, that'll come in a follow-on PR.