### PR TITLE
Handle null criteria selection data.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder.impl.core;
 
+import static bio.terra.tanagra.filterbuilder.impl.core.utils.AttributeSchemaUtils.IGNORED_ATTRIBUTE_NAME_UI_USE_ONLY;
 import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBytes;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
@@ -185,7 +186,9 @@ public class EntityGroupFilterBuilder extends FilterBuilder {
             criteriaOccurrence.getOccurrenceEntities());
 
     // Build the instance-level modifier filters.
-    if (entityGroupSelectionData.hasValueData()) {
+    if (entityGroupSelectionData.hasValueData()
+        && !IGNORED_ATTRIBUTE_NAME_UI_USE_ONLY.equalsIgnoreCase(
+            entityGroupSelectionData.getValueData().getAttribute())) {
       if (criteriaOccurrence.getOccurrenceEntities().size() > 1) {
         throw new InvalidQueryException(
             "Instance-level modifiers are not supported for entity groups with multiple occurrence entities: "

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/OutputUnfilteredFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/OutputUnfilteredFilterBuilder.java
@@ -32,6 +32,10 @@ public class OutputUnfilteredFilterBuilder extends FilterBuilder {
     }
     DTOutputUnfiltered.OutputUnfiltered outputUnfilteredSelectionData =
         deserializeData(selectionData.get(0).getPluginData());
+    if (outputUnfilteredSelectionData == null) {
+      // Empty selection data = no entity outputs.
+      return List.of();
+    }
     List<EntityOutput> entityOutputs = new ArrayList<>();
     outputUnfilteredSelectionData.getEntitiesList().stream()
         .forEach(
@@ -53,8 +57,10 @@ public class OutputUnfilteredFilterBuilder extends FilterBuilder {
 
   @Override
   public DTOutputUnfiltered.OutputUnfiltered deserializeData(String serialized) {
-    return deserializeFromJsonOrProtoBytes(
-            serialized, DTOutputUnfiltered.OutputUnfiltered.newBuilder())
-        .build();
+    return (serialized == null || serialized.isEmpty())
+        ? null
+        : deserializeFromJsonOrProtoBytes(
+                serialized, DTOutputUnfiltered.OutputUnfiltered.newBuilder())
+            .build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 
 public final class AttributeSchemaUtils {
+  public static final String IGNORED_ATTRIBUTE_NAME_UI_USE_ONLY = "t_any";
+
   private AttributeSchemaUtils() {}
 
   public static EntityFilter buildForEntity(

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -37,6 +37,9 @@ public final class AttributeSchemaUtils {
 
   public static EntityFilter buildForEntity(
       Underlay underlay, Entity entity, Attribute attribute, DTAttribute.Attribute data) {
+    if (data == null) {
+      return null;
+    }
     if (!data.getSelectedList().isEmpty()) {
       // Enum value filter.
       return data.getSelectedCount() == 1
@@ -101,7 +104,9 @@ public final class AttributeSchemaUtils {
   }
 
   public static DTAttribute.Attribute deserializeData(String serialized) {
-    return deserializeFromJsonOrProtoBytes(serialized, DTAttribute.Attribute.newBuilder()).build();
+    return (serialized == null || serialized.isEmpty())
+        ? null
+        : deserializeFromJsonOrProtoBytes(serialized, DTAttribute.Attribute.newBuilder()).build();
   }
 
   private static DTAttribute.Attribute convertToAttrDataSchema(

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/EntityGroupFilterUtils.java
@@ -83,13 +83,16 @@ public final class EntityGroupFilterUtils {
                             subFiltersPerOccurrenceEntity.containsKey(occurrenceEntity)
                                 ? subFiltersPerOccurrenceEntity.get(occurrenceEntity)
                                 : new ArrayList<>();
-                        subFilters.add(
+                        EntityFilter modifierSubFilter =
                             AttributeSchemaUtils.buildForEntity(
                                 underlay,
                                 occurrenceEntity,
                                 occurrenceEntity.getAttribute(modifierConfig.getAttribute()),
-                                modifierData));
-                        subFiltersPerOccurrenceEntity.put(occurrenceEntity, subFilters);
+                                modifierData);
+                        if (modifierSubFilter != null) {
+                          subFilters.add(modifierSubFilter);
+                          subFiltersPerOccurrenceEntity.put(occurrenceEntity, subFilters);
+                        }
                       });
             });
     return subFiltersPerOccurrenceEntity;
@@ -134,7 +137,8 @@ public final class EntityGroupFilterUtils {
     Optional<Pair<CFUnhintedValue.UnhintedValue, DTUnhintedValue.UnhintedValue>>
         groupByModifierConfigAndData =
             GroupByCountSchemaUtils.getModifier(criteriaSelector, modifiersSelectionData);
-    if (groupByModifierConfigAndData.isEmpty()) {
+    if (groupByModifierConfigAndData.isEmpty()
+        || groupByModifierConfigAndData.get().getRight() == null) {
       if (groupItems.getGroupEntity().isPrimary()) {
         // e.g. vitals, person=group / height=items
         return new GroupHasItemsFilter(

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/GroupByCountSchemaUtils.java
@@ -23,13 +23,17 @@ public final class GroupByCountSchemaUtils {
   private GroupByCountSchemaUtils() {}
 
   public static CFUnhintedValue.UnhintedValue deserializeConfig(String serialized) {
-    return deserializeFromJsonOrProtoBytes(serialized, CFUnhintedValue.UnhintedValue.newBuilder())
-        .build();
+    return (serialized == null || serialized.isEmpty())
+        ? null
+        : deserializeFromJsonOrProtoBytes(serialized, CFUnhintedValue.UnhintedValue.newBuilder())
+            .build();
   }
 
   public static DTUnhintedValue.UnhintedValue deserializeData(String serialized) {
-    return deserializeFromJsonOrProtoBytes(serialized, DTUnhintedValue.UnhintedValue.newBuilder())
-        .build();
+    return (serialized == null || serialized.isEmpty())
+        ? null
+        : deserializeFromJsonOrProtoBytes(serialized, DTUnhintedValue.UnhintedValue.newBuilder())
+            .build();
   }
 
   public static Optional<Pair<CFUnhintedValue.UnhintedValue, DTUnhintedValue.UnhintedValue>>

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/sd/BioVUFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/sd/BioVUFilterBuilder.java
@@ -36,6 +36,9 @@ public class BioVUFilterBuilder extends FilterBuilder {
       throw new InvalidQueryException("Modifiers are not supported for the biovu plugin");
     }
     DTBioVU.BioVU bioVuSelectionData = deserializeData(selectionData.get(0).getPluginData());
+    if (bioVuSelectionData == null) {
+      return null;
+    }
 
     // Pull the plasma flag from the config.
     CFBioVU.BioVU bioVuConfig = deserializeConfig();
@@ -130,6 +133,8 @@ public class BioVUFilterBuilder extends FilterBuilder {
 
   @Override
   public DTBioVU.BioVU deserializeData(String serialized) {
-    return deserializeFromJsonOrProtoBytes(serialized, DTBioVU.BioVU.newBuilder()).build();
+    return (serialized == null || serialized.isEmpty())
+        ? null
+        : deserializeFromJsonOrProtoBytes(serialized, DTBioVU.BioVU.newBuilder()).build();
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/sd/BioVUFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/sd/BioVUFilterBuilder.java
@@ -37,6 +37,7 @@ public class BioVUFilterBuilder extends FilterBuilder {
     }
     DTBioVU.BioVU bioVuSelectionData = deserializeData(selectionData.get(0).getPluginData());
     if (bioVuSelectionData == null) {
+      // Empty selection data = null filter for a cohort.
       return null;
     }
 

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/BioVUFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/BioVUFilterBuilderTest.java
@@ -274,4 +274,29 @@ public class BioVUFilterBuilderTest {
     EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
     assertNull(cohortFilter);
   }
+
+  @Test
+  void emptySelectionCohortFilter() {
+    CFBioVU.BioVU config = CFBioVU.BioVU.newBuilder().build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "biovu",
+            true,
+            false,
+            "sd.BioVUFilterBuilder",
+            PLUGIN_ID_IN_CONFIG,
+            serializeToJson(config),
+            List.of());
+    BioVUFilterBuilder filterBuilder = new BioVUFilterBuilder(criteriaSelector);
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("biovu", null);
+    EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+
+    // Empty string selection data.
+    selectionData = new SelectionData("biovu", "");
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+  }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
@@ -1049,10 +1049,16 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void emptyCriteriaDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup config =
+        CFEntityGroup.EntityGroup.newBuilder()
+            .addClassificationEntityGroups(
+                CFEntityGroup.EntityGroup.EntityGroupConfig.newBuilder()
+                    .setId("icd9procPerson")
+                    .build())
+            .build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
-            "condition",
+            "icd9proc",
             true,
             true,
             "core.EntityGroupFilterBuilder",
@@ -1060,16 +1066,24 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             serializeToJson(config),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+    EntityOutput expectedEntityOutput1 =
+        EntityOutput.unfiltered(underlay.getEntity("ingredientOccurrence"));
+    EntityOutput expectedEntityOutput2 =
+        EntityOutput.unfiltered(underlay.getEntity("procedureOccurrence"));
 
     // Null selection data.
-    SelectionData selectionData = new SelectionData("condition", null);
+    SelectionData selectionData = new SelectionData("icd9proc", null);
     List<EntityOutput> dataFeatureOutputs =
         filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
-    assertTrue(dataFeatureOutputs.isEmpty());
+    assertEquals(2, dataFeatureOutputs.size());
+    assertTrue(dataFeatureOutputs.contains(expectedEntityOutput1));
+    assertTrue(dataFeatureOutputs.contains(expectedEntityOutput2));
 
     // Empty string selection data.
-    selectionData = new SelectionData("condition", "");
+    selectionData = new SelectionData("icd9proc", "");
     dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
-    assertTrue(dataFeatureOutputs.isEmpty());
+    assertEquals(2, dataFeatureOutputs.size());
+    assertTrue(dataFeatureOutputs.contains(expectedEntityOutput1));
+    assertTrue(dataFeatureOutputs.contains(expectedEntityOutput2));
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
@@ -4,7 +4,6 @@ import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
@@ -676,7 +675,13 @@ public class EntityGroupFilterBuilderForGroupTest {
 
   @Test
   void emptyCriteriaDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup config =
+        CFEntityGroup.EntityGroup.newBuilder()
+            .addClassificationEntityGroups(
+                CFEntityGroup.EntityGroup.EntityGroupConfig.newBuilder()
+                    .setId("genotypingPerson")
+                    .build())
+            .build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "genotyping",
@@ -687,16 +692,19 @@ public class EntityGroupFilterBuilderForGroupTest {
             serializeToJson(config),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+    EntityOutput expectedEntityOutput = EntityOutput.unfiltered(underlay.getEntity("genotyping"));
 
     // Null selection data.
     SelectionData selectionData = new SelectionData("genotyping", null);
     List<EntityOutput> dataFeatureOutputs =
         filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
-    assertTrue(dataFeatureOutputs.isEmpty());
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
 
     // Empty string selection data.
     selectionData = new SelectionData("genotyping", "");
     dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
-    assertTrue(dataFeatureOutputs.isEmpty());
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
@@ -3,6 +3,8 @@ package bio.terra.tanagra.filterbuilder;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -234,6 +236,145 @@ public class EntityGroupFilterBuilderForItemsTest {
   }
 
   @Test
+  void emptyCriteriaCohortFilter() {
+    CFEntityGroup.EntityGroup bloodPressureConfig = CFEntityGroup.EntityGroup.newBuilder().build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.EntityGroupFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(bloodPressureConfig),
+            List.of());
+    EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("genotyping", null);
+    EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+
+    // Empty string selection data.
+    selectionData = new SelectionData("genotyping", "");
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+  }
+
+  @Test
+  void emptyAttrModifierCohortFilter() {
+    CFAttribute.Attribute systolicConfig =
+        CFAttribute.Attribute.newBuilder().setAttribute("systolic").build();
+    CriteriaSelector.Modifier systolicModifier =
+        new CriteriaSelector.Modifier(
+            "systolic", SZCorePlugin.ATTRIBUTE.getIdInConfig(), serializeToJson(systolicConfig));
+    CFEntityGroup.EntityGroup bloodPressureConfig = CFEntityGroup.EntityGroup.newBuilder().build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.EntityGroupFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(bloodPressureConfig),
+            List.of(systolicModifier));
+    EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+
+    DTEntityGroup.EntityGroup entityGroupData =
+        DTEntityGroup.EntityGroup.newBuilder()
+            .addSelected(
+                DTEntityGroup.EntityGroup.Selection.newBuilder()
+                    .setEntityGroup("bloodPressurePerson")
+                    .build())
+            .build();
+    SelectionData entityGroupSelectionData =
+        new SelectionData("bloodPressure", serializeToJson(entityGroupData));
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            null,
+            null,
+            null,
+            null);
+
+    // Null selection data.
+    SelectionData systolicSelectionData = new SelectionData("systolic", null);
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(entityGroupSelectionData, systolicSelectionData));
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Empty string selection data.
+    systolicSelectionData = new SelectionData("systolic", "");
+    cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(entityGroupSelectionData, systolicSelectionData));
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
+  void emptyGroupByModifierCohortFilter() {
+    CFUnhintedValue.UnhintedValue groupByConfig =
+        CFUnhintedValue.UnhintedValue.newBuilder()
+            .putAttributes(
+                "bloodPressure",
+                CFUnhintedValue.UnhintedValue.AttributeList.newBuilder().addValues("date").build())
+            .build();
+    CriteriaSelector.Modifier groupByModifier =
+        new CriteriaSelector.Modifier(
+            "group_by_count",
+            SZCorePlugin.UNHINTED_VALUE.getIdInConfig(),
+            serializeToJson(groupByConfig));
+    CFEntityGroup.EntityGroup bloodPressureConfig = CFEntityGroup.EntityGroup.newBuilder().build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.EntityGroupFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(bloodPressureConfig),
+            List.of(groupByModifier));
+    EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+
+    DTEntityGroup.EntityGroup entityGroupData =
+        DTEntityGroup.EntityGroup.newBuilder()
+            .addSelected(
+                DTEntityGroup.EntityGroup.Selection.newBuilder()
+                    .setEntityGroup("bloodPressurePerson")
+                    .build())
+            .build();
+    SelectionData entityGroupSelectionData =
+        new SelectionData("bloodPressure", serializeToJson(entityGroupData));
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            null,
+            null,
+            null,
+            null);
+
+    // Null selection data.
+    SelectionData groupBySelectionData = new SelectionData("group_by_count", null);
+    EntityFilter cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(entityGroupSelectionData, groupBySelectionData));
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
+
+    // Empty string selection data.
+    groupBySelectionData = new SelectionData("group_by_count", "");
+    cohortFilter =
+        filterBuilder.buildForCohort(
+            underlay, List.of(entityGroupSelectionData, groupBySelectionData));
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
+  }
+
+  @Test
   void criteriaOnlyDataFeatureFilter() {
     CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
     CriteriaSelector criteriaSelector =
@@ -262,5 +403,31 @@ public class EntityGroupFilterBuilderForItemsTest {
     EntityOutput expectedDataFeatureOutput =
         EntityOutput.unfiltered(underlay.getEntity("bloodPressure"));
     assertEquals(expectedDataFeatureOutput, dataFeatureOutputs.get(0));
+  }
+
+  @Test
+  void emptyCriteriaDataFeatureFilter() {
+    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "bloodPressure",
+            true,
+            true,
+            "core.EntityGroupFilterBuilder",
+            SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("bloodPressure", null);
+    List<EntityOutput> dataFeatureOutputs =
+        filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertTrue(dataFeatureOutputs.isEmpty());
+
+    // Empty string selection data.
+    selectionData = new SelectionData("bloodPressure", "");
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertTrue(dataFeatureOutputs.isEmpty());
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
@@ -4,7 +4,6 @@ import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -407,7 +406,13 @@ public class EntityGroupFilterBuilderForItemsTest {
 
   @Test
   void emptyCriteriaDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup config =
+        CFEntityGroup.EntityGroup.newBuilder()
+            .addClassificationEntityGroups(
+                CFEntityGroup.EntityGroup.EntityGroupConfig.newBuilder()
+                    .setId("bloodPressurePerson")
+                    .build())
+            .build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "bloodPressure",
@@ -418,16 +423,20 @@ public class EntityGroupFilterBuilderForItemsTest {
             serializeToJson(config),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+    EntityOutput expectedEntityOutput =
+        EntityOutput.unfiltered(underlay.getEntity("bloodPressure"));
 
     // Null selection data.
     SelectionData selectionData = new SelectionData("bloodPressure", null);
     List<EntityOutput> dataFeatureOutputs =
         filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
-    assertTrue(dataFeatureOutputs.isEmpty());
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
 
     // Empty string selection data.
     selectionData = new SelectionData("bloodPressure", "");
     dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
-    assertTrue(dataFeatureOutputs.isEmpty());
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/OutputUnfilteredFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/OutputUnfilteredFilterBuilderTest.java
@@ -110,4 +110,32 @@ public class OutputUnfilteredFilterBuilderTest {
     assertTrue(dataFeatureOutputs.contains(expectedDataFeatureOutput1));
     assertTrue(dataFeatureOutputs.contains(expectedDataFeatureOutput2));
   }
+
+  @Test
+  void emptyCriteriaDataFeatureFilter() {
+    CFOutputUnfiltered.OutputUnfiltered config =
+        CFOutputUnfiltered.OutputUnfiltered.newBuilder().build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "demographics",
+            false,
+            true,
+            "core.OutputUnfilteredFilterBuilder",
+            SZCorePlugin.OUTPUT_UNFILTERED.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    OutputUnfilteredFilterBuilder filterBuilder =
+        new OutputUnfilteredFilterBuilder(criteriaSelector);
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("demographics", null);
+    List<EntityOutput> dataFeatureOutputs =
+        filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertTrue(dataFeatureOutputs.isEmpty());
+
+    // Empty string selection data.
+    selectionData = new SelectionData("demographics", "");
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertTrue(dataFeatureOutputs.isEmpty());
+  }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/PrimaryEntityFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/PrimaryEntityFilterBuilderTest.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.filterbuilder;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -131,6 +132,57 @@ public class PrimaryEntityFilterBuilderTest {
   }
 
   @Test
+  void emptyEnumValCohortFilter() {
+    CFAttribute.Attribute config =
+        CFAttribute.Attribute.newBuilder().setAttribute("gender").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "gender",
+            true,
+            true,
+            "core.PrimaryEntityFilterBuilder",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    PrimaryEntityFilterBuilder filterBuilder = new PrimaryEntityFilterBuilder(criteriaSelector);
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("gender", null);
+    EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+
+    // Empty string selection data.
+    selectionData = new SelectionData("gender", "");
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+  }
+
+  @Test
+  void emptyNumericRangeCohortFilter() {
+    CFAttribute.Attribute config = CFAttribute.Attribute.newBuilder().setAttribute("age").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "age",
+            true,
+            false,
+            "core.PrimaryEntityFilterBuilder",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    PrimaryEntityFilterBuilder filterBuilder = new PrimaryEntityFilterBuilder(criteriaSelector);
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("gender", null);
+    EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+
+    // Empty string selection data.
+    selectionData = new SelectionData("gender", "");
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+  }
+
+  @Test
   void dataFeatureFilter() {
     CFAttribute.Attribute config =
         CFAttribute.Attribute.newBuilder().setAttribute("gender").build();
@@ -149,5 +201,35 @@ public class PrimaryEntityFilterBuilderTest {
     assertEquals(1, dataFeatureOutputs.size());
     EntityOutput expectedDataFeatureOutput = EntityOutput.unfiltered(underlay.getPrimaryEntity());
     assertEquals(expectedDataFeatureOutput, dataFeatureOutputs.get(0));
+  }
+
+  @Test
+  void emptySelectionDataFeatureFilter() {
+    CFAttribute.Attribute config =
+        CFAttribute.Attribute.newBuilder().setAttribute("gender").build();
+    CriteriaSelector criteriaSelector =
+        new CriteriaSelector(
+            "gender",
+            true,
+            true,
+            "core.PrimaryEntityFilterBuilder",
+            SZCorePlugin.ATTRIBUTE.getIdInConfig(),
+            serializeToJson(config),
+            List.of());
+    PrimaryEntityFilterBuilder filterBuilder = new PrimaryEntityFilterBuilder(criteriaSelector);
+    EntityOutput expectedEntityOutput = EntityOutput.unfiltered(underlay.getPrimaryEntity());
+
+    // Null selection data.
+    SelectionData selectionData = new SelectionData("gender", null);
+    List<EntityOutput> dataFeatureOutputs =
+        filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
+
+    // Empty string selection data.
+    selectionData = new SelectionData("gender", "");
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
   }
 }


### PR DESCRIPTION
- Added explicit handling for null criteria plugin data, for the main plugin and the modifier plugins.
  - attribute plugin
    - cohort: empty selection data = null filter on primary entity e.g. all persons
    - data feature: (not currently used) empty selection data = output primary entity with no sub-filter e.g. all person rows.
  - entityGroup plugin
    - cohort: empty primary selection data = null filter on primary entity e.g. all persons, empty attribute or group by modifiers = ignored.
    - data feature: empty selection data = null filter on all occurrence entities e.g. all ingredientOccurrence and procedureOccurrence rows.
  - multiAttribute plugin
    - cohort: empty primary selection data = null filter on primary entity e.g. all persons, empty attribute or group by modifiers = ignored.
    - data feature: empty selection data = output not-primary entity with no sub-filter e.g. all bloodPressure rows.
  - outputUnfiltered plugin
    - cohort: n/a unsupported
    - data feature: empty selection data = no entity outputs
  - textSearch plugin
    - cohort: empty primary selection data = null filter on primary entity e.g. all persons, empty attribute or group by modifiers = ignored.
    - data feature: occurrence entities with no filter e.g. all noteOccurrence rows.
  - bioVu plugin
    - cohort: empty selection data = null filter on primary entity e.g. all persons
    - data feature: n/a unsupported
- Added tests for all existing filter builder implementations for null and empty string selection data.
- Ignored the `t_any` attribute name in the entityGroup filter builder. This is used by the UI only and for filter purposes, is the same as null.