### PR TITLE
Pass the number of rows across all pages to the API.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -172,7 +172,8 @@ public final class ToApiUtils {
         .pageMarker(
             listQueryResult.getPageMarker() == null
                 ? null
-                : listQueryResult.getPageMarker().serialize());
+                : listQueryResult.getPageMarker().serialize())
+        .numRowsAcrossAllPages(Math.toIntExact(listQueryResult.getNumRowsAcrossAllPages()));
   }
 
   private static ApiInstance toApiObject(ListInstance listInstance) {
@@ -243,7 +244,8 @@ public final class ToApiUtils {
         .pageMarker(
             countQueryResult.getPageMarker() == null
                 ? null
-                : countQueryResult.getPageMarker().serialize());
+                : countQueryResult.getPageMarker().serialize())
+        .numRowsAcrossAllPages(Math.toIntExact(countQueryResult.getNumRowsAcrossAllPages()));
   }
 
   public static ApiInstanceCount toApiObject(CountInstance countInstance) {

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1829,6 +1829,8 @@ components:
             $ref: "#/components/schemas/Instance"
         pageMarker:
           $ref: "#/components/schemas/PageMarker"
+        numRowsAcrossAllPages:
+          $ref: "#/components/schemas/NumRowsAcrossAllPages"
 
     InstanceCount:
       type: object
@@ -1855,6 +1857,8 @@ components:
             $ref: "#/components/schemas/InstanceCount"
         pageMarker:
           $ref: "#/components/schemas/PageMarker"
+        numRowsAcrossAllPages:
+          $ref: "#/components/schemas/NumRowsAcrossAllPages"
 
     DisplayHint:
       type: object
@@ -2765,6 +2769,9 @@ components:
 
     PageMarker:
       type: string
+
+    NumRowsAcrossAllPages:
+      type: integer
 
     BinaryOperator:
       type: string

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryResult.java
@@ -8,11 +8,17 @@ public class CountQueryResult {
   private final String sql;
   private final ImmutableList<CountInstance> countInstances;
   private final PageMarker pageMarker;
+  private final Long numRowsAcrossAllPages;
 
-  public CountQueryResult(String sql, List<CountInstance> countInstances, PageMarker pageMarker) {
+  public CountQueryResult(
+      String sql,
+      List<CountInstance> countInstances,
+      PageMarker pageMarker,
+      Long numRowsAcrossAllPages) {
     this.sql = sql;
     this.countInstances = ImmutableList.copyOf(countInstances);
     this.pageMarker = pageMarker;
+    this.numRowsAcrossAllPages = numRowsAcrossAllPages;
   }
 
   public String getSql() {
@@ -25,5 +31,9 @@ public class CountQueryResult {
 
   public PageMarker getPageMarker() {
     return pageMarker;
+  }
+
+  public Long getNumRowsAcrossAllPages() {
+    return numRowsAcrossAllPages;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryResult.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryResult.java
@@ -9,13 +9,19 @@ public class ListQueryResult {
   private final String sqlNoParams;
   private final ImmutableList<ListInstance> listInstances;
   private final PageMarker pageMarker;
+  private final Long numRowsAcrossAllPages;
 
   public ListQueryResult(
-      String sql, String sqlNoParams, List<ListInstance> listInstances, PageMarker pageMarker) {
+      String sql,
+      String sqlNoParams,
+      List<ListInstance> listInstances,
+      PageMarker pageMarker,
+      Long numRowsAcrossAllPages) {
     this.sql = sql;
     this.sqlNoParams = sqlNoParams;
     this.listInstances = ImmutableList.copyOf(listInstances);
     this.pageMarker = pageMarker;
+    this.numRowsAcrossAllPages = numRowsAcrossAllPages;
   }
 
   public String getSql() {
@@ -32,5 +38,9 @@ public class ListQueryResult {
 
   public PageMarker getPageMarker() {
     return pageMarker;
+  }
+
+  public Long getNumRowsAcrossAllPages() {
+    return numRowsAcrossAllPages;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -74,7 +74,8 @@ public class BQQueryRunner implements QueryRunner {
         sqlQueryRequest.getSql(),
         sqlQueryResult.getSqlNoParams(),
         listInstances,
-        sqlQueryResult.getNextPageMarker());
+        sqlQueryResult.getNextPageMarker(),
+        sqlQueryResult.getTotalNumRows());
   }
 
   @VisibleForTesting
@@ -250,7 +251,11 @@ public class BQQueryRunner implements QueryRunner {
               countInstances.add(new CountInstance(count, fieldValues));
             });
 
-    return new CountQueryResult(sql.toString(), countInstances, sqlQueryResult.getNextPageMarker());
+    return new CountQueryResult(
+        sql.toString(),
+        countInstances,
+        sqlQueryResult.getNextPageMarker(),
+        sqlQueryResult.getTotalNumRows());
   }
 
   @Override


### PR DESCRIPTION
BigQuery returns the total number of rows returned by a query across all pages. Pass this through to the API.

This is not immediately useful in the UI, though it could be in the future (e.g. show total number of rows for each exported table). Main purpose for now is to make it easier to compare the backend built queries with the frontend built ones.