### PR TITLE
Implement query endpoint for filtering on a single primary entity id.

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -152,15 +152,20 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
-  "/v2/underlays/{underlayName}/entities/{entityName}/instances/{primaryEntityId}":
+  "/v2/underlays/{underlayName}/entities/{entityName}/instancesForPrimaryEntity":
     parameters:
       - $ref: "#/components/parameters/UnderlayName"
       - $ref: "#/components/parameters/EntityName"
-      - $ref: "#/components/parameters/PrimaryEntityInstanceId"
-    get:
+    post:
       summary: List output entity instances for a single primary entity id
-      operationId: listOutputInstancesForPrimaryEntityInstance
+      operationId: listInstancesForPrimaryEntity
       tags: [Underlays]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryFilterOnPrimaryEntity"
       responses:
         200:
           description: OK
@@ -1450,6 +1455,39 @@ components:
           $ref: "#/components/schemas/PageSize"
         pageMarker:
           $ref: "#/components/schemas/PageMarker"
+
+    QueryFilterOnPrimaryEntity:
+      type: object
+      description: Query for entity instances filtered for a single primary entity id
+      properties:
+        includeAttributes:
+          description: |
+            Attributes to include in the returned instances.
+            Empty array means to include all attributes.
+          type: array
+          items:
+            type: string
+        orderBys:
+          type: array
+          description: Attributes and direction to order the results by
+          items:
+            type: object
+            description: Attribute field and the direction
+            properties:
+              attribute:
+                type: string
+              direction:
+                $ref: "#/components/schemas/OrderByDirection"
+        primaryEntityId:
+          $ref: "#/components/schemas/Literal"
+        pageSize:
+          $ref: "#/components/schemas/PageSize"
+        pageMarker:
+          $ref: "#/components/schemas/PageMarker"
+      required:
+        - includeAttributes
+        - orderBys
+        - primaryEntityId
 
     CountQuery:
       type: object

--- a/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
@@ -19,6 +19,7 @@ import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSectio
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_EMPTY;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_GENDER_AND_CONDITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +30,7 @@ import bio.terra.tanagra.api.filter.EntityFilter;
 import bio.terra.tanagra.api.filter.HierarchyHasAncestorFilter;
 import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
 import bio.terra.tanagra.api.filter.PrimaryWithCriteriaFilter;
+import bio.terra.tanagra.api.filter.RelationshipFilter;
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.app.Main;
@@ -233,6 +235,34 @@ public class FilterBuilderServiceTest {
     assertTrue(entityOutputs.contains(expectedOutput1));
     assertTrue(entityOutputs.contains(expectedOutput2));
     assertTrue(entityOutputs.contains(expectedOutput3));
+  }
+
+  @Test
+  void primaryEntityId() {
+    EntityFilter filterOnPrimaryEntityId =
+        filterBuilderService.buildFilterForPrimaryEntityId(
+            UNDERLAY_NAME, "conditionOccurrence", Literal.forInt64(123L));
+    assertNotNull(filterOnPrimaryEntityId);
+
+    AttributeFilter expectedPrimaryEntitySubFilter =
+        new AttributeFilter(
+            underlay,
+            underlay.getPrimaryEntity(),
+            underlay.getPrimaryEntity().getIdAttribute(),
+            BinaryOperator.EQUALS,
+            Literal.forInt64(123L));
+    RelationshipFilter expectedOutputEntityFilter =
+        new RelationshipFilter(
+            underlay,
+            underlay.getEntityGroup("icd10cmPerson"),
+            underlay.getEntity("conditionOccurrence"),
+            ((CriteriaOccurrence) underlay.getEntityGroup("icd10cmPerson"))
+                .getOccurrencePrimaryRelationship("conditionOccurrence"),
+            expectedPrimaryEntitySubFilter,
+            null,
+            null,
+            null);
+    assertEquals(expectedOutputEntityFilter, filterOnPrimaryEntityId);
   }
 
   private EntityFilter genderEqWomanCohortFilter() {

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
@@ -8,6 +8,7 @@ import bio.terra.tanagra.underlay.entitymodel.Relationship;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.EntityGroup;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 public class RelationshipFilter extends EntityFilter {
@@ -104,5 +105,39 @@ public class RelationshipFilter extends EntityFilter {
 
   public boolean isForeignKeyOnFilterTable() {
     return relationship.isForeignKeyAttribute(filterEntity);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RelationshipFilter that = (RelationshipFilter) o;
+    return underlay.equals(that.underlay)
+        && entityGroup.equals(that.entityGroup)
+        && selectEntity.equals(that.selectEntity)
+        && filterEntity.equals(that.filterEntity)
+        && relationship.equals(that.relationship)
+        && Objects.equals(subFilter, that.subFilter)
+        && Objects.equals(groupByCountAttributes, that.groupByCountAttributes)
+        && groupByCountOperator == that.groupByCountOperator
+        && Objects.equals(groupByCountValue, that.groupByCountValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        underlay,
+        entityGroup,
+        selectEntity,
+        filterEntity,
+        relationship,
+        subFilter,
+        groupByCountAttributes,
+        groupByCountOperator,
+        groupByCountValue);
   }
 }


### PR DESCRIPTION
- Updated the review tab endpoint defined previously (#782) to include pagination, order by attributes, and specifying a subset of the entity's attributes to return.
- Implemented the updated endpoint.
- Added a test for the filter building piece of the query.