### PR TITLE
Pass out tags and per-file errors to updated export API.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -19,6 +19,7 @@ import bio.terra.tanagra.filterbuilder.EntityOutput;
 import bio.terra.tanagra.generated.controller.ExportApi;
 import bio.terra.tanagra.generated.model.ApiEntityOutputPreview;
 import bio.terra.tanagra.generated.model.ApiEntityOutputPreviewList;
+import bio.terra.tanagra.generated.model.ApiExportLinkResult;
 import bio.terra.tanagra.generated.model.ApiExportModel;
 import bio.terra.tanagra.generated.model.ApiExportModelList;
 import bio.terra.tanagra.generated.model.ApiExportPreviewRequest;
@@ -38,6 +39,7 @@ import bio.terra.tanagra.service.artifact.model.ConceptSet;
 import bio.terra.tanagra.service.artifact.model.Study;
 import bio.terra.tanagra.service.export.DataExport;
 import bio.terra.tanagra.service.export.DataExportService;
+import bio.terra.tanagra.service.export.ExportFileResult;
 import bio.terra.tanagra.service.export.ExportRequest;
 import bio.terra.tanagra.service.export.ExportResult;
 import bio.terra.tanagra.underlay.Underlay;
@@ -263,7 +265,8 @@ public class ExportApiController implements ExportApi {
     return ResponseEntity.ok(toApiObject(exportResult));
   }
 
-  private ApiExportModel toApiObject(String implName, String displayName, DataExport dataExport) {
+  private static ApiExportModel toApiObject(
+      String implName, String displayName, DataExport dataExport) {
     return new ApiExportModel()
         .name(implName)
         .displayName(displayName)
@@ -272,13 +275,26 @@ public class ExportApiController implements ExportApi {
         .outputs(dataExport.describeOutputs());
   }
 
-  private ApiExportResult toApiObject(ExportResult exportResult) {
+  private static ApiExportResult toApiObject(ExportResult exportResult) {
     return new ApiExportResult()
         .status(
             exportResult.isSuccessful()
                 ? ApiExportResult.StatusEnum.SUCCEEDED
                 : ApiExportResult.StatusEnum.FAILED)
         .outputs(exportResult.getOutputs())
+        .links(
+            exportResult.getFileResults().stream()
+                .map(ExportApiController::toApiObject)
+                .collect(Collectors.toList()))
         .redirectAwayUrl(exportResult.getRedirectAwayUrl());
+  }
+
+  private static ApiExportLinkResult toApiObject(ExportFileResult exportFileResult) {
+    return new ApiExportLinkResult()
+        .displayName(exportFileResult.getFileDisplayName())
+        .url(exportFileResult.getFileUrl())
+        .tags(exportFileResult.getTags())
+        .message(exportFileResult.getMessage())
+        .error(exportFileResult.getError().getMessage());
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportFileResult.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportFileResult.java
@@ -2,6 +2,9 @@ package bio.terra.tanagra.service.export;
 
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
 
 public final class ExportFileResult {
@@ -11,6 +14,7 @@ public final class ExportFileResult {
   private final @Nullable ExportError error;
   private final Entity entity;
   private final Cohort cohort;
+  private final List<String> tags = new ArrayList<>();
 
   private ExportFileResult(
       String fileDisplayName,
@@ -91,5 +95,13 @@ public final class ExportFileResult {
 
   public Cohort getCohort() {
     return cohort;
+  }
+
+  public void addTags(List<String> newTags) {
+    tags.addAll(newTags);
+  }
+
+  public ImmutableList<String> getTags() {
+    return ImmutableList.copyOf(tags);
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
@@ -107,8 +107,10 @@ public class IpynbFileDownload implements DataExport {
     // TODO: Skip populating this output parameter once the UI is processing the file result
     // directly.
     Map<String, String> outputParams = Map.of(IPYNB_FILE_KEY, ipynbSignedUrl);
+
     ExportFileResult exportFileResult =
         ExportFileResult.forFile(fileName, ipynbSignedUrl, null, null);
+    exportFileResult.addTags(List.of("Notebook File"));
     return ExportResult.forOutputParams(outputParams, List.of(exportFileResult));
   }
 }


### PR DESCRIPTION
The export implementation classes now have more control over the display of the result in the UI. They can set tags to control the (nested) sections where the file links and/or error messages appear.

- Updated each implementation class to set tags to match the current display. (e.g. Data > Person for entity data, Annotations > Cohort Name for annotations data).
- Changed the export tests to validate against the output file result objects, instead of the `outputs` key-value map, which is deprecated and will be removed once the UI switches over to use the new properties.
- Updated the individual file download and vwb import export implementations to suppress results for empty files. Previously they were passing these results on, with a message that no data was found. Now they just won't be included in the output display.