### PR TITLE
Remove unused CriteriaGroup properties.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -13,7 +13,6 @@ import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
 import bio.terra.tanagra.api.query.PageMarker;
 import bio.terra.tanagra.api.query.count.CountQueryResult;
-import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.app.authentication.SpringAuthentication;
 import bio.terra.tanagra.app.controller.objmapping.FromApiUtils;
 import bio.terra.tanagra.app.controller.objmapping.ToApiUtils;
@@ -202,12 +201,6 @@ public class CohortsApiController implements CohortsApi {
     return CohortRevision.CriteriaGroup.builder()
         .id(apiObj.getId())
         .displayName(apiObj.getDisplayName())
-        .entity(apiObj.getEntity())
-        .groupByCountOperator(
-            apiObj.getGroupByCountOperator() == null
-                ? null
-                : BinaryOperator.valueOf(apiObj.getGroupByCountOperator().name()))
-        .groupByCountValue(apiObj.getGroupByCountValue())
         .criteria(
             apiObj.getCriteria().stream()
                 .map(FromApiUtils::fromApiObject)

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -16,7 +16,6 @@ import bio.terra.tanagra.api.shared.ValueDisplay;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.generated.model.ApiAnnotationValue;
 import bio.terra.tanagra.generated.model.ApiAttribute;
-import bio.terra.tanagra.generated.model.ApiBinaryOperator;
 import bio.terra.tanagra.generated.model.ApiCohort;
 import bio.terra.tanagra.generated.model.ApiCriteria;
 import bio.terra.tanagra.generated.model.ApiCriteriaGroup;
@@ -137,12 +136,6 @@ public final class ToApiUtils {
     return new ApiCriteriaGroup()
         .id(criteriaGroup.getId())
         .displayName(criteriaGroup.getDisplayName())
-        .entity(criteriaGroup.getEntity())
-        .groupByCountOperator(
-            criteriaGroup.getGroupByCountOperator() == null
-                ? null
-                : ApiBinaryOperator.valueOf(criteriaGroup.getGroupByCountOperator().name()))
-        .groupByCountValue(criteriaGroup.getGroupByCountValue())
         .criteria(
             criteriaGroup.getCriteria().stream()
                 .map(criteria -> toApiObject(criteria))

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -5,7 +5,6 @@ import bio.terra.common.db.WriteTransaction;
 import bio.terra.common.exception.MissingRequiredFieldException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
-import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.service.artifact.model.CohortRevision;
@@ -84,7 +83,7 @@ public class CohortDao {
 
   // SQL query and row mapper for reading a criteria group.
   private static final String CRITERIA_GROUP_SELECT_SQL =
-      "SELECT cohort_revision_id, criteria_group_section_id, id, display_name, entity, group_by_count_operator, group_by_count_value FROM criteria_group";
+      "SELECT cohort_revision_id, criteria_group_section_id, id, display_name FROM criteria_group";
   private static final RowMapper<Pair<List<String>, CohortRevision.CriteriaGroup.Builder>>
       CRITERIA_GROUP_ROW_MAPPER =
           (rs, rowNum) ->
@@ -94,13 +93,7 @@ public class CohortDao {
                       rs.getString("cohort_revision_id")),
                   CohortRevision.CriteriaGroup.builder()
                       .id(rs.getString("id"))
-                      .displayName(rs.getString("display_name"))
-                      .entity(rs.getString("entity"))
-                      .groupByCountOperator(
-                          rs.getString("group_by_count_operator") == null
-                              ? null
-                              : BinaryOperator.valueOf(rs.getString("group_by_count_operator")))
-                      .groupByCountValue(rs.getInt("group_by_count_value")));
+                      .displayName(rs.getString("display_name")));
 
   // SQL query and row mapper for reading a criteria.
   private static final String CRITERIA_SELECT_SQL =
@@ -605,13 +598,6 @@ public class CohortDao {
                 .addValue("criteria_group_section_id", cgs.getId())
                 .addValue("id", cg.getId())
                 .addValue("display_name", cg.getDisplayName())
-                .addValue("entity", cg.getEntity())
-                .addValue(
-                    "group_by_count_operator",
-                    cg.getGroupByCountOperator() == null
-                        ? null
-                        : cg.getGroupByCountOperator().name())
-                .addValue("group_by_count_value", cg.getGroupByCountValue())
                 .addValue("list_index", cgListIndex));
 
         for (int cListIndex = 0; cListIndex < cg.getCriteria().size(); cListIndex++) {
@@ -656,8 +642,8 @@ public class CohortDao {
     LOGGER.debug("CREATE criteria_group_section rowsAffected = {}", rowsAffected);
 
     sql =
-        "INSERT INTO criteria_group (cohort_revision_id, criteria_group_section_id, id, display_name, entity, group_by_count_operator, group_by_count_value, list_index) "
-            + "VALUES (:cohort_revision_id, :criteria_group_section_id, :id, :display_name, :entity, :group_by_count_operator, :group_by_count_value, :list_index)";
+        "INSERT INTO criteria_group (cohort_revision_id, criteria_group_section_id, id, display_name, list_index) "
+            + "VALUES (:cohort_revision_id, :criteria_group_section_id, :id, :display_name, :list_index)";
     LOGGER.debug("CREATE criteria_group: {}", sql);
     rowsAffected =
         Arrays.stream(

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/CohortRevision.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/CohortRevision.java
@@ -2,7 +2,6 @@ package bio.terra.tanagra.service.artifact.model;
 
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
-import bio.terra.tanagra.api.shared.BinaryOperator;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -344,23 +343,11 @@ public class CohortRevision {
     private final String id;
     private final String displayName;
     private final List<Criteria> criteria;
-    private final String entity;
-    private final @Nullable BinaryOperator groupByCountOperator;
-    private final int groupByCountValue;
 
-    private CriteriaGroup(
-        String id,
-        String displayName,
-        List<Criteria> criteria,
-        String entity,
-        BinaryOperator groupByCountOperator,
-        int groupByCountValue) {
+    private CriteriaGroup(String id, String displayName, List<Criteria> criteria) {
       this.id = id;
       this.displayName = displayName;
       this.criteria = criteria;
-      this.entity = entity;
-      this.groupByCountOperator = groupByCountOperator;
-      this.groupByCountValue = groupByCountValue;
     }
 
     public static Builder builder() {
@@ -379,25 +366,10 @@ public class CohortRevision {
       return Collections.unmodifiableList(criteria);
     }
 
-    public String getEntity() {
-      return entity;
-    }
-
-    public BinaryOperator getGroupByCountOperator() {
-      return groupByCountOperator;
-    }
-
-    public int getGroupByCountValue() {
-      return groupByCountValue;
-    }
-
     public static class Builder {
       private String id;
       private String displayName;
       private List<Criteria> criteria = new ArrayList<>();
-      private String entity;
-      private BinaryOperator groupByCountOperator;
-      private int groupByCountValue;
 
       public Builder id(String id) {
         this.id = id;
@@ -414,27 +386,11 @@ public class CohortRevision {
         return this;
       }
 
-      public Builder entity(String entity) {
-        this.entity = entity;
-        return this;
-      }
-
-      public Builder groupByCountOperator(BinaryOperator groupByCountOperator) {
-        this.groupByCountOperator = groupByCountOperator;
-        return this;
-      }
-
-      public Builder groupByCountValue(Integer groupByCountValue) {
-        this.groupByCountValue = groupByCountValue == null ? 0 : groupByCountValue;
-        return this;
-      }
-
       public CriteriaGroup build() {
         if (id == null) {
           id = RandomStringUtils.randomAlphanumeric(10);
         }
-        return new CriteriaGroup(
-            id, displayName, criteria, entity, groupByCountOperator, groupByCountValue);
+        return new CriteriaGroup(id, displayName, criteria);
       }
 
       public String getId() {
@@ -455,18 +411,14 @@ public class CohortRevision {
         return false;
       }
       CriteriaGroup that = (CriteriaGroup) o;
-      return groupByCountValue == that.groupByCountValue
-          && id.equals(that.id)
+      return id.equals(that.id)
           && displayName.equals(that.displayName)
-          && criteria.equals(that.criteria)
-          && entity.equals(that.entity)
-          && groupByCountOperator == that.groupByCountOperator;
+          && criteria.equals(that.criteria);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(
-          id, displayName, criteria, entity, groupByCountOperator, groupByCountValue);
+      return Objects.hash(id, displayName, criteria);
     }
   }
 }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2301,21 +2301,10 @@ components:
           description: Set of criteria in the group
           items:
             $ref: "#/components/schemas/Criteria"
-        entity:
-          description: Entity referenced by the criteria
-          type: string
-        groupByCountOperator:
-          description: Operator to use for the optional group by count modifier
-          $ref: "#/components/schemas/BinaryOperator"
-        groupByCountValue:
-          type: integer
-          description: Value to use for the optional group by count modifier
-          nullable: true
       required:
         - id
         - displayName
         - criteria
-        - entity
 
     Criteria:
       type: object
@@ -2340,12 +2329,9 @@ components:
           type: string
           description: Name of the selector or modifier used by this config
         selectionData:
-          type: string # JSON formatted
+          type: string # Protobuf formatted
           description: Serialized plugin-specific representation of the user's selection
         uiConfig:
-          # TODO: Remove this uiConfig property from the service API once we fully support UI plugins, because it
-          # should be identical to the static config stored in the underlay. For now, we save it separately for
-          # each criteria so we can handle schema changes in the UI code instead of in plugin-specific backend code.
           type: string # JSON formatted
           description: Serialized plugin-specific UI configuration for the criteria
         tags:

--- a/service/src/main/resources/db/changesets/20240326_remove_criteria_group_columns.yaml
+++ b/service/src/main/resources/db/changesets/20240326_remove_criteria_group_columns.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: remove_criteria_group_columns
+      author: marikomedlock
+      dbms: postgresql,mariadb,mysql
+      changes:
+        - dropColumn:
+            tableName: criteria_group
+            columnName: entity
+        - dropColumn:
+            tableName: criteria_group
+            columnName: group_by_count_operator
+        - dropColumn:
+            tableName: criteria_group
+            columnName: group_by_count_value

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroup.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroup.java
@@ -15,30 +15,25 @@ public final class CriteriaGroup {
       CohortRevision.CriteriaGroup.builder()
           .displayName("group gender")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
-          .entity(GENDER_EQ_WOMAN.getKey())
           .build();
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_AGE =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group gender")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
-          .entity(GENDER_EQ_WOMAN.getKey())
           .build();
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_DEMOGRAPHICS =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group 1")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_HISPANIC_OR_LATINO.getValue()))
-          .entity(GENDER_EQ_WOMAN.getKey())
           .build();
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_CONDITION =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group condition")
           .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES.getValue()))
-          .entity(CONDITION_EQ_TYPE_2_DIABETES.getKey())
           .build();
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_PROCEDURE =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group procedure")
           .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
-          .entity(PROCEDURE_EQ_AMPUTATION.getKey())
           .build();
 }

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -1980,7 +1980,7 @@ function fromAPICriteriaGroupSections(
     },
     groups: section.criteriaGroups.map((group) => ({
       id: group.id,
-      entity: group.entity,
+      entity: "",
       criteria: group.criteria.map((criteria, i) =>
         fromAPICriteria(
           criteria,


### PR DESCRIPTION
Removed the unused `CriteriaGroup` properties: `entity`, `groupByCountOperator`, `groupByCountValue`. We weren't using any of these properties, so this is just cleanup. The `GROUP BY` properties are now stored in a separate `Criteria` with the `unhinted-value` criteria plugin. The `entity` property is part of the various other criteria plugins.
