### PR TITLE
Log activity log entry creation to stdout.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ActivityLogService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ActivityLogService.java
@@ -13,11 +13,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ActivityLogService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ActivityLogService.class);
   private final ActivityLogDao activityLogDao;
   private final FeatureConfiguration featureConfiguration;
   private final VersionConfiguration versionConfiguration;
@@ -133,6 +136,17 @@ public class ActivityLogService {
               .versionBuild(versionConfiguration.getBuild())
               .resources(resources)
               .build());
+
+      String resourcesLogStr =
+          resources.stream().map(ActivityLogResource::getLogStr).collect(Collectors.joining(","));
+      LOGGER.info(
+          "Created activity log: userEmail={}, type={}, versionGitTag={}, versionGitHash={}, versionBuild={}, resources={}",
+          userEmail,
+          type.name(),
+          versionConfiguration.getGitTag(),
+          versionConfiguration.getGitHash(),
+          versionConfiguration.getBuild(),
+          resourcesLogStr);
     }
   }
 

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/ActivityLogResource.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/ActivityLogResource.java
@@ -70,6 +70,19 @@ public class ActivityLogResource {
     return reviewDisplayName;
   }
 
+  public String getLogStr() {
+    switch (type) {
+      case STUDY:
+        return "study-" + studyId;
+      case COHORT:
+        return "cohort-" + cohortId;
+      case REVIEW:
+        return "review-" + reviewId;
+      default:
+        return "unknown type " + type;
+    }
+  }
+
   public static Builder builder() {
     return new Builder();
   }


### PR DESCRIPTION
Activity log entries are always available by querying the application DB. This just adds them to stdout as well so we can see them in Stackdriver.