### PR TITLE
Increase default limit for list endpoints to 50.

### DIFF
--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1085,12 +1085,12 @@ components:
     Limit:
       name: limit
       in: query
-      description: The maximum number of items to return. Default 15
+      description: The maximum number of items to return. Defaults to 50.
       required: false
       schema:
         type: integer
         minimum: 1
-        default: 15
+        default: 50
 
     StudyFilterDisplayName:
       name: displayName


### PR DESCRIPTION
This is to reduce the amount of paging the UI potentially has to do when listing cohorts (e.g. on study overview page, export page).