### PR TITLE
Generate queries against source data.

### DIFF
--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
@@ -1,14 +1,18 @@
 package bio.terra.tanagra.annotation;
 
+import bio.terra.tanagra.underlay.serialization.SZAttribute;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
 import bio.terra.tanagra.underlay.serialization.SZCriteriaOccurrence;
 import bio.terra.tanagra.underlay.serialization.SZCriteriaSelector;
+import bio.terra.tanagra.underlay.serialization.SZDataType;
 import bio.terra.tanagra.underlay.serialization.SZEntity;
 import bio.terra.tanagra.underlay.serialization.SZGroupItems;
+import bio.terra.tanagra.underlay.serialization.SZHierarchy;
 import bio.terra.tanagra.underlay.serialization.SZIndexer;
 import bio.terra.tanagra.underlay.serialization.SZPrepackagedCriteria;
 import bio.terra.tanagra.underlay.serialization.SZService;
+import bio.terra.tanagra.underlay.serialization.SZTextSearch;
 import bio.terra.tanagra.underlay.serialization.SZUnderlay;
 import java.util.List;
 
@@ -31,10 +35,11 @@ public class UnderlayConfigPath extends AnnotationPath {
           SZUnderlay.class,
           SZUnderlay.Metadata.class,
           SZEntity.class,
-          SZEntity.Attribute.class,
-          SZEntity.Hierarchy.class,
-          SZEntity.TextSearch.class,
-          SZEntity.DataType.class,
+          SZAttribute.class,
+          SZAttribute.SourceQuery.class,
+          SZHierarchy.class,
+          SZTextSearch.class,
+          SZDataType.class,
           SZGroupItems.class,
           SZCriteriaOccurrence.class,
           SZCriteriaOccurrence.OccurrenceEntity.class,

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -982,8 +982,6 @@ True if this attribute doesn't map to a specific field in the source table.
 
 *Default value:* `false`
 
-*Example value:* `condition_concept_id`
-
 ### SZSourceQuery.valueFieldName
 **optional** String
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -25,6 +25,7 @@ This documentation is generated from annotations in the configuration classes.
 * [SZPrimaryRelationship](#szprimaryrelationship)
 * [SZService](#szservice)
 * [SZSourceData](#szsourcedata)
+* [SZSourceQuery](#szsourcequery)
 * [SZTextSearch](#sztextsearch)
 * [SZUnderlay](#szunderlay)
 
@@ -92,6 +93,13 @@ If the [runtime SQL wrapper](#szattributeruntimesqlfunctionwrapper) is set, this
 SQL function to apply at runtime (i.e. when running the query), instead of at indexing time. Useful for attributes we expect to be updated dynamically (e.g. a person's age).
 
 For a simple function call that just wraps the column (e.g. `UPPER(column)`), you can specify just the function name (e.g. `UPPER`). For a more complicated function call, put `${fieldSql}` where the column name should be substituted (e.g. `CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)`).
+
+### SZAttribute.sourceQuery
+**optional** [SZSourceQuery](#szsourcequery)
+
+How to generate a query against the source data that includes this attribute.
+
+If unspecified and exporting queries against the source data is supported for this entity is enabled (i.e. #szentitysourcequerytablename is specified), we assume the field name in the source table (#szentitysourcequerytablename) corresponding to this attribute is the same as the #szattributevaluefieldname.
 
 ### SZAttribute.valueFieldName
 **optional** String
@@ -467,7 +475,7 @@ File must be in the same directory as the entity file. Name includes file extens
 *Example value:* `all.sql`
 
 ### SZEntity.attributes
-**required** List [ SZEntity$Attribute ]
+**required** List [ SZAttribute ]
 
 List of all the entity attributes.
 
@@ -486,7 +494,7 @@ Display name for the entity.
 Unlike the entity [name](#szentityname), it may include spaces and special characters.
 
 ### SZEntity.hierarchies
-**optional** Set [ SZEntity$Hierarchy ]
+**optional** Set [ SZHierarchy ]
 
 List of hierarchies.
 
@@ -516,6 +524,17 @@ List of attributes to optimize for group by queries.
 The typical use case for this is to optimize cohort breakdown queries on the primary entity. For example, to optimize breakdowns by age, race, gender, specify those attributes here. Order matters.
 
 You can currently specify a maximum of four attributes, because we implement this using BigQuery clustering which has this [limitation](https://cloud.google.com/bigquery/docs/clustered-tables#limitations).
+
+### SZEntity.sourceQueryTableName
+**optional** String
+
+Full name of the table to use when exporting a query against the source data.
+
+SQL substitutions are supported in this table name.
+
+If unspecified, exporting a query against the source data is unsupported.
+
+*Example value:* `${omopDataset}.condition_occurrence`
 
 ### SZEntity.textSearch
 **optional** [SZTextSearch](#sztextsearch)
@@ -915,6 +934,55 @@ Key-value map of substitutions to make in the input SQL files.
 Wherever the keys appear in the input SQL files wrapped in braces and preceded by a dollar sign, they will be substituted by the values before running the queries. For example, [key] `omopDataset` -> [value] `bigquery-public-data.cms_synthetic_patient_data_omop` means `${omopDataset}` in any of the input SQL files will be replaced by `bigquery-public-data.cms_synthetic_patient_data_omop`.
 
 Keys may not include spaces or special characters, only letters and numbers. This is simple string substitution logic and does not handle more complicated cases, such as nested substitutions.
+
+
+
+## SZSourceQuery
+Information to generate a SQL query against the source dataset for a given attribute.
+
+This query isn't actually run by the service, only generated as an export option (e.g. as part of a notebook file).
+
+### SZSourceQuery.displayFieldName
+**optional** String
+
+Name of the field to use for the attribute display in the source dataset.
+
+If unspecified, exporting a query with this attribute against the source data will not include a separate display field.
+
+The table can optionally be specified in #szsourcequerydisplayfieldtable.
+
+*Example value:* `concept_name`
+
+### SZSourceQuery.displayFieldTable
+**optional** String
+
+Full name of the table to JOIN with the main table (#szentitysourcequerytablename) to get the attribute display field in the source dataset.
+
+SQL substitutions are supported in this table name.
+
+If unspecified, and #szsourcequerydisplayfieldname is specified, then we assume that the source display field is also in the main table, same as the source value field.
+
+The #szsourcequerydisplayfieldtablejoinfieldname is required if this property is specified.
+
+*Example value:* `${omopDataset}.concept`
+
+### SZSourceQuery.displayFieldTableJoinFieldName
+**optional** String
+
+Name of the field in the display table (#szsourcequerydisplayfieldtable) that is used to JOIN to the main table (#szentitysourcequerytablename) using the source value field (#szsourcequeryvaluefieldname).
+
+This is required if the #szsourcequerydisplayfieldtable is specified.
+
+*Example value:* `concept_id`
+
+### SZSourceQuery.valueFieldName
+**optional** String
+
+Name of the field to use for the attribute value in the source dataset table (#szentitysourcequerytablename).
+
+If unspecified, we assume the field name in the source table (#szentitysourcequerytablename) corresponding to this attribute is the same as the #szattributevaluefieldname.
+
+*Example value:* `condition_concept_id`
 
 
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -975,6 +975,15 @@ This is required if the #szsourcequerydisplayfieldtable is specified.
 
 *Example value:* `concept_id`
 
+### SZSourceQuery.isSuppressed
+**optional** boolean
+
+True if this attribute doesn't map to a specific field in the source table.
+
+*Default value:* `false`
+
+*Example value:* `condition_concept_id`
+
 ### SZSourceQuery.valueFieldName
 **optional** String
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -140,11 +140,11 @@ public class ExportApiController implements ExportApi {
             attribute ->
                 attributeFields.add(
                     new AttributeField(
-                        underlay, previewEntityOutput.getEntity(), attribute, false, false)));
+                        underlay, previewEntityOutput.getEntity(), attribute, false)));
 
     // Run the list query and map the results back to API objects.
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             previewEntityOutput.getEntity(),
             attributeFields,
@@ -152,8 +152,7 @@ public class ExportApiController implements ExportApi {
             null,
             null,
             null,
-            body.getLimit(),
-            false);
+            body.getLimit());
     ListQueryResult listQueryResult = underlay.getQueryRunner().run(listQueryRequest);
     return ResponseEntity.ok(ToApiUtils.toApiObject(listQueryResult));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -46,6 +46,7 @@ import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -236,11 +237,22 @@ public class ExportApiController implements ExportApi {
                     FromApiUtils.fromApiObject(
                         apiQuery.getQuery(), underlay.getEntity(apiQuery.getEntity()), underlay))
             .collect(Collectors.toList());
-    EntityFilter primaryEntityFilter =
-        body.getPrimaryEntityFilter() == null
-            ? null
-            : FromApiUtils.fromApiObject(
-                body.getPrimaryEntityFilter(), underlayService.getUnderlay(underlayName));
+    EntityFilter primaryEntityFilter;
+    if (body.getPrimaryEntityFilter() != null) {
+      primaryEntityFilter =
+          FromApiUtils.fromApiObject(
+              body.getPrimaryEntityFilter(), underlayService.getUnderlay(underlayName));
+    } else {
+      Optional<ListQueryRequest> primaryEntityListQueryRequest =
+          listQueryRequests.stream()
+              .filter(listQueryRequest -> listQueryRequest.getEntity().isPrimary())
+              .findFirst();
+      if (primaryEntityListQueryRequest.isPresent()) {
+        primaryEntityFilter = primaryEntityListQueryRequest.get().getFilter();
+      } else {
+        primaryEntityFilter = null;
+      }
+    }
 
     ExportRequest exportRequest =
         new ExportRequest(

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -155,7 +155,7 @@ public class UnderlaysApiController implements UnderlaysApi {
                     body.getIncludeAttributes() == null
                         || body.getIncludeAttributes().isEmpty()
                         || body.getIncludeAttributes().contains(attribute.getName()))
-            .map(attribute -> new AttributeField(underlay, outputEntity, attribute, false, false))
+            .map(attribute -> new AttributeField(underlay, outputEntity, attribute, false))
             .collect(Collectors.toList());
 
     // Build the filter on the output entity.
@@ -172,7 +172,7 @@ public class UnderlaysApiController implements UnderlaysApi {
               orderByField -> {
                 Attribute attribute = outputEntity.getAttribute(orderByField.getAttribute());
                 ValueDisplayField valueDisplayField =
-                    new AttributeField(underlay, outputEntity, attribute, false, false);
+                    new AttributeField(underlay, outputEntity, attribute, false);
                 OrderByDirection direction =
                     OrderByDirection.valueOf(orderByField.getDirection().name());
                 orderByFields.add(new ListQueryRequest.OrderBy(valueDisplayField, direction));
@@ -181,7 +181,7 @@ public class UnderlaysApiController implements UnderlaysApi {
 
     // Run the list query and map the results back to API objects.
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             outputEntity,
             selectFields,
@@ -189,8 +189,7 @@ public class UnderlaysApiController implements UnderlaysApi {
             orderByFields,
             null,
             PageMarker.deserialize(body.getPageMarker()),
-            body.getPageSize(),
-            false);
+            body.getPageSize());
     ListQueryResult listQueryResult = underlay.getQueryRunner().run(listQueryRequest);
     return ResponseEntity.ok(ToApiUtils.toApiObject(listQueryResult));
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -404,7 +404,7 @@ public final class FromApiUtils {
               });
     }
 
-    return new ListQueryRequest(
+    return ListQueryRequest.againstIndexData(
         underlay,
         entity,
         selectFields,
@@ -412,14 +412,12 @@ public final class FromApiUtils {
         orderByFields,
         apiObj.getLimit(),
         PageMarker.deserialize(apiObj.getPageMarker()),
-        apiObj.getPageSize(),
-        false);
+        apiObj.getPageSize());
   }
 
   public static AttributeField buildAttributeField(
       Underlay underlay, Entity entity, String attributeName, boolean excludeDisplay) {
-    return new AttributeField(
-        underlay, entity, entity.getAttribute(attributeName), excludeDisplay, false);
+    return new AttributeField(underlay, entity, entity.getAttribute(attributeName), excludeDisplay);
   }
 
   private static Set<ValueDisplayField> buildHierarchyFields(

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
@@ -113,7 +113,7 @@ public class UnderlayService {
             attributeName ->
                 attributeFields.add(
                     new AttributeField(
-                        underlay, entity, entity.getAttribute(attributeName), false, false)));
+                        underlay, entity, entity.getAttribute(attributeName), false)));
 
     CountQueryRequest countQueryRequest =
         new CountQueryRequest(

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/CohortService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/CohortService.java
@@ -192,10 +192,9 @@ public class CohortService {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getIdAttribute(),
-            false,
             false);
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             underlay.getPrimaryEntity(),
             List.of(idAttributeField),
@@ -206,8 +205,7 @@ public class CohortService {
             // BQ does not allow paginating through a query that is ordered randomly, unless we
             // manually persist the results in a temp table (i.e. BQ does not cache the query
             // results in an anonymous dataset for us).
-            sampleSize,
-            false);
+            sampleSize);
     ListQueryResult listQueryResult = underlay.getQueryRunner().run(listQueryRequest);
     LOGGER.debug("RANDOM SAMPLE primary entity instance ids: {}", listQueryResult.getSql());
     return listQueryResult.getListInstances().stream()

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
@@ -305,10 +305,9 @@ public class ReviewService {
     reviewQueryRequest.getAttributes().stream()
         .forEach(
             attribute ->
-                attributeFields.add(
-                    new AttributeField(underlay, primaryEntity, attribute, false, false)));
+                attributeFields.add(new AttributeField(underlay, primaryEntity, attribute, false)));
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             primaryEntity,
             attributeFields,
@@ -316,8 +315,7 @@ public class ReviewService {
             null,
             null,
             null,
-            MAX_REVIEW_SIZE,
-            false);
+            MAX_REVIEW_SIZE);
     ListQueryResult listQueryResult = underlay.getQueryRunner().run(listQueryRequest);
     List<ListInstance> listInstances = new ArrayList<>();
     listQueryResult.getListInstances().stream()
@@ -326,7 +324,7 @@ public class ReviewService {
       // Using the MAX_REVIEW_SIZE as the page size should mean we get all results back in a single
       // page, but that's not guaranteed, so paginate here just in case.
       listQueryRequest =
-          new ListQueryRequest(
+          ListQueryRequest.againstIndexData(
               underlay,
               primaryEntity,
               attributeFields,
@@ -334,8 +332,7 @@ public class ReviewService {
               null,
               null,
               listQueryResult.getPageMarker(),
-              MAX_REVIEW_SIZE,
-              false);
+              MAX_REVIEW_SIZE);
       listQueryResult = underlay.getQueryRunner().run(listQueryRequest);
       listQueryResult.getListInstances().stream()
           .forEach(listInstance -> listInstances.add(listInstance));
@@ -428,8 +425,7 @@ public class ReviewService {
         groupByAttributeNames.stream()
             .map(
                 attrName ->
-                    new AttributeField(
-                        underlay, entity, entity.getAttribute(attrName), true, false))
+                    new AttributeField(underlay, entity, entity.getAttribute(attrName), true))
             .collect(Collectors.toList());
 
     EntityFilter entityFilter =

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -86,26 +86,25 @@ public class DataExportHelper {
                                   exportRequest.getUnderlay(),
                                   entityOutput.getEntity(),
                                   attribute,
-                                  false,
-                                  isAgainstSourceDataset))
+                                  false))
                       .collect(Collectors.toList());
 
               ListQueryRequest listQueryRequest =
-                  new ListQueryRequest(
-                      exportRequest.getUnderlay(),
-                      entityOutput.getEntity(),
-                      selectFields,
-                      entityOutput.getDataFeatureFilter(),
-                      null,
-                      null,
-                      null,
-                      null,
-                      true);
+                  isAgainstSourceDataset
+                      ? ListQueryRequest.dryRunAgainstSourceData(
+                          exportRequest.getUnderlay(),
+                          entityOutput.getEntity(),
+                          selectFields,
+                          entityOutput.getDataFeatureFilter())
+                      : ListQueryRequest.dryRunAgainstIndexData(
+                          exportRequest.getUnderlay(),
+                          entityOutput.getEntity(),
+                          selectFields,
+                          entityOutput.getDataFeatureFilter(),
+                          null,
+                          null);
               ListQueryResult listQueryResult =
-                  exportRequest
-                      .getUnderlay()
-                      .getQueryRunner()
-                      .run(listQueryRequest.cloneAndSetDryRun());
+                  exportRequest.getUnderlay().getQueryRunner().run(listQueryRequest);
               sqlPerEntity.put(entityOutput.getEntity(), listQueryResult.getSqlNoParams());
             });
     return sqlPerEntity;
@@ -130,19 +129,21 @@ public class DataExportHelper {
                         exportRequest.getUnderlay(),
                         exportRequest.getUnderlay().getPrimaryEntity(),
                         attribute,
-                        false,
-                        isAgainstSourceDataset)));
+                        false)));
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
-            exportRequest.getUnderlay(),
-            exportRequest.getUnderlay().getPrimaryEntity(),
-            selectedAttributeFields,
-            primaryEntityFilter,
-            null,
-            null,
-            null,
-            null,
-            true);
+        isAgainstSourceDataset
+            ? ListQueryRequest.dryRunAgainstSourceData(
+                exportRequest.getUnderlay(),
+                exportRequest.getUnderlay().getPrimaryEntity(),
+                selectedAttributeFields,
+                primaryEntityFilter)
+            : ListQueryRequest.dryRunAgainstIndexData(
+                exportRequest.getUnderlay(),
+                exportRequest.getUnderlay().getPrimaryEntity(),
+                selectedAttributeFields,
+                primaryEntityFilter,
+                null,
+                null);
     ListQueryResult listQueryResult =
         exportRequest.getUnderlay().getQueryRunner().run(listQueryRequest);
     return listQueryResult.getSqlNoParams();
@@ -170,11 +171,10 @@ public class DataExportHelper {
                                       exportRequest.getUnderlay(),
                                       entityOutput.getEntity(),
                                       attribute,
-                                      false,
                                       false))
                           .collect(Collectors.toList());
                   ListQueryRequest listQueryRequest =
-                      new ListQueryRequest(
+                      ListQueryRequest.againstIndexData(
                           exportRequest.getUnderlay(),
                           entityOutput.getEntity(),
                           selectFields,
@@ -182,8 +182,7 @@ public class DataExportHelper {
                           null,
                           null,
                           null,
-                          null,
-                          false);
+                          null);
 
                   // Build a map of substitution strings for the filename template.
                   Map<String, String> substitutions =

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
@@ -76,7 +76,7 @@ public class IpynbFileDownload implements DataExport {
 
     // Generate the SQL for the primary entity and escape it to substitute into a notebook cell (=
     // JSON property).
-    String primaryEntitySql = helper.generateSqlForPrimaryEntity(List.of(), false);
+    String primaryEntitySql = helper.generateSqlForPrimaryEntity(List.of(), true);
     String primaryEntitySqlFormattedAndEscaped =
         StringEscapeUtils.escapeJson(SqlFormatter.format(primaryEntitySql));
 

--- a/service/src/test/java/bio/terra/tanagra/service/ActivityLogServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/ActivityLogServiceTest.java
@@ -214,8 +214,7 @@ public class ActivityLogServiceTest {
         .sorted(Comparator.comparing(Attribute::getName))
         .forEach(
             attribute ->
-                selectFields.add(
-                    new AttributeField(underlay, primaryEntity, attribute, false, false)));
+                selectFields.add(new AttributeField(underlay, primaryEntity, attribute, false)));
     EntityFilter primaryEntityFilter =
         new AttributeFilter(
             underlay,
@@ -224,16 +223,8 @@ public class ActivityLogServiceTest {
             BinaryOperator.EQUALS,
             Literal.forInt64(8_532L));
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
-            underlay,
-            primaryEntity,
-            selectFields,
-            primaryEntityFilter,
-            null,
-            null,
-            null,
-            null,
-            false);
+        ListQueryRequest.againstIndexData(
+            underlay, primaryEntity, selectFields, primaryEntityFilter, null, null, null, null);
     String exportModel = "IPYNB_FILE_DOWNLOAD";
     ExportRequest exportRequest =
         new ExportRequest(

--- a/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
@@ -610,10 +610,10 @@ public class DataExportServiceTest {
     List<ValueDisplayField> selectFields =
         primaryEntity.getAttributes().stream()
             .sorted(Comparator.comparing(Attribute::getName))
-            .map(attribute -> new AttributeField(underlay, primaryEntity, attribute, false, false))
+            .map(attribute -> new AttributeField(underlay, primaryEntity, attribute, false))
             .collect(Collectors.toList());
-    return new ListQueryRequest(
-        underlay, primaryEntity, selectFields, null, null, 5, null, null, false);
+    return ListQueryRequest.againstIndexData(
+        underlay, primaryEntity, selectFields, null, null, 5, null, null);
   }
 
   private EntityFilter buildPrimaryEntityFilter() {

--- a/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
@@ -511,6 +511,9 @@ public class DataExportServiceTest {
     assertFalse(fileContents.isEmpty());
     LOGGER.info("ipynb fileContents: {}", fileContents);
     assertTrue(fileContents.contains("# This query was generated for"));
+    assertTrue(
+        fileContents.contains(
+            "bigquery-public-data.cms_synthetic_patient_data_omop")); // Source BQ dataset.
     assertTrue(fileContents.split("\n").length >= 36); // Length of notebook template file = 36.
     assertDoesNotThrow(
         () -> new ObjectMapper().readTree(fileContents)); // Notebook file is valid json.

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -182,6 +182,7 @@ export type SZSourceQuery = {
   displayFieldName?: string;
   displayFieldTable?: string;
   displayFieldTableJoinFieldName?: string;
+  isSuppressed?: boolean;
   valueFieldName?: string;
 };
 

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -7,6 +7,7 @@ export type SZAttribute = {
   name: string;
   runtimeDataType?: SZDataType;
   runtimeSqlFunctionWrapper?: string;
+  sourceQuery?: SZSourceQuery;
   valueFieldName?: string;
 };
 
@@ -93,6 +94,7 @@ export type SZEntity = {
   idAttribute: string;
   name: string;
   optimizeGroupByAttributes?: string[];
+  sourceQueryTableName?: string;
   textSearch?: SZTextSearch;
 };
 
@@ -174,6 +176,13 @@ export type SZSourceData = {
   datasetId: string;
   projectId: string;
   sqlSubstitutions?: { [key: string]: string };
+};
+
+export type SZSourceQuery = {
+  displayFieldName?: string;
+  displayFieldTable?: string;
+  displayFieldTableJoinFieldName?: string;
+  valueFieldName?: string;
 };
 
 export type SZTextSearch = {

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/AttributeField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/AttributeField.java
@@ -10,19 +10,13 @@ public class AttributeField extends ValueDisplayField {
   private final Entity entity;
   private final Attribute attribute;
   private final boolean excludeDisplay;
-  private final boolean isSource;
 
   public AttributeField(
-      Underlay underlay,
-      Entity entity,
-      Attribute attribute,
-      boolean excludeDisplay,
-      boolean isSource) {
+      Underlay underlay, Entity entity, Attribute attribute, boolean excludeDisplay) {
     this.underlay = underlay;
     this.entity = entity;
     this.attribute = attribute;
     this.excludeDisplay = excludeDisplay;
-    this.isSource = isSource;
   }
 
   public Underlay getUnderlay() {
@@ -44,9 +38,5 @@ public class AttributeField extends ValueDisplayField {
 
   public boolean isExcludeDisplay() {
     return excludeDisplay;
-  }
-
-  public boolean isSource() {
-    return isSource;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/AttributeField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/AttributeField.java
@@ -10,13 +10,33 @@ public class AttributeField extends ValueDisplayField {
   private final Entity entity;
   private final Attribute attribute;
   private final boolean excludeDisplay;
+  private final boolean isAgainstSourceDataset;
 
-  public AttributeField(
-      Underlay underlay, Entity entity, Attribute attribute, boolean excludeDisplay) {
+  private AttributeField(
+      Underlay underlay,
+      Entity entity,
+      Attribute attribute,
+      boolean excludeDisplay,
+      boolean isAgainstSourceDataset) {
     this.underlay = underlay;
     this.entity = entity;
     this.attribute = attribute;
     this.excludeDisplay = excludeDisplay;
+    this.isAgainstSourceDataset = isAgainstSourceDataset;
+  }
+
+  public AttributeField(
+      Underlay underlay, Entity entity, Attribute attribute, boolean excludeDisplay) {
+    this(underlay, entity, attribute, excludeDisplay, false);
+  }
+
+  public static AttributeField againstSourceDataset(AttributeField attributeField) {
+    return new AttributeField(
+        attributeField.getUnderlay(),
+        attributeField.getEntity(),
+        attributeField.getAttribute(),
+        attributeField.isExcludeDisplay(),
+        true);
   }
 
   public Underlay getUnderlay() {
@@ -38,5 +58,9 @@ public class AttributeField extends ValueDisplayField {
 
   public boolean isExcludeDisplay() {
     return excludeDisplay;
+  }
+
+  public boolean isAgainstSourceDataset() {
+    return isAgainstSourceDataset;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryRequest.java
@@ -23,8 +23,9 @@ public class ListQueryRequest {
   private final @Nullable PageMarker pageMarker;
   private final Integer pageSize;
   private final boolean isDryRun;
+  private final boolean isAgainstSourceData;
 
-  @SuppressWarnings("checkstyle:ParameterNumber")
+  @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
   public ListQueryRequest(
       Underlay underlay,
       Entity entity,
@@ -34,7 +35,8 @@ public class ListQueryRequest {
       @Nullable Integer limit,
       @Nullable PageMarker pageMarker,
       @Nullable Integer pageSize,
-      boolean isDryRun) {
+      boolean isDryRun,
+      boolean isAgainstSourceData) {
     this.underlay = underlay;
     this.entity = entity;
     this.selectFields =
@@ -45,6 +47,50 @@ public class ListQueryRequest {
     this.pageMarker = pageMarker;
     this.pageSize = (pageMarker == null && pageSize == null) ? DEFAULT_PAGE_SIZE : pageSize;
     this.isDryRun = isDryRun;
+    this.isAgainstSourceData = isAgainstSourceData;
+  }
+
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public static ListQueryRequest againstIndexData(
+      Underlay underlay,
+      Entity entity,
+      List<ValueDisplayField> selectFields,
+      @Nullable EntityFilter filter,
+      @Nullable List<OrderBy> orderBys,
+      @Nullable Integer limit,
+      @Nullable PageMarker pageMarker,
+      @Nullable Integer pageSize) {
+    return new ListQueryRequest(
+        underlay,
+        entity,
+        selectFields,
+        filter,
+        orderBys,
+        limit,
+        pageMarker,
+        pageSize,
+        false,
+        false);
+  }
+
+  public static ListQueryRequest dryRunAgainstIndexData(
+      Underlay underlay,
+      Entity entity,
+      List<ValueDisplayField> selectFields,
+      @Nullable EntityFilter filter,
+      @Nullable List<OrderBy> orderBys,
+      @Nullable Integer limit) {
+    return new ListQueryRequest(
+        underlay, entity, selectFields, filter, orderBys, limit, null, null, true, false);
+  }
+
+  public static ListQueryRequest dryRunAgainstSourceData(
+      Underlay underlay,
+      Entity entity,
+      List<ValueDisplayField> selectFields,
+      @Nullable EntityFilter filter) {
+    return new ListQueryRequest(
+        underlay, entity, selectFields, filter, null, null, null, null, true, true);
   }
 
   public Underlay getUnderlay() {
@@ -83,9 +129,8 @@ public class ListQueryRequest {
     return isDryRun;
   }
 
-  public ListQueryRequest cloneAndSetDryRun() {
-    return new ListQueryRequest(
-        underlay, entity, selectFields, filter, orderBys, limit, pageMarker, pageSize, true);
+  public boolean isAgainstSourceData() {
+    return isAgainstSourceData;
   }
 
   public static class OrderBy {

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/list/ListQueryRequest.java
@@ -26,7 +26,7 @@ public class ListQueryRequest {
   private final boolean isAgainstSourceData;
 
   @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
-  public ListQueryRequest(
+  private ListQueryRequest(
       Underlay underlay,
       Entity entity,
       List<ValueDisplayField> selectFields,

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -180,7 +180,6 @@ public class BQQueryRunner implements QueryRunner {
     // Select only the id attribute, which we need to JOIN to the source table.
     // SELECT id FROM [index table] WHERE [filter]
     StringBuilder sql = new StringBuilder(50);
-    SqlParams sqlParams = new SqlParams();
     BQApiTranslator bqTranslator = new BQApiTranslator();
     AttributeField indexIdAttributeField =
         new AttributeField(
@@ -228,7 +227,7 @@ public class BQQueryRunner implements QueryRunner {
 
                   StringBuilder joinSql = new StringBuilder();
                   joinSql
-                      .append(" JOIN ")
+                      .append(" LEFT JOIN ")
                       .append(fromFullTablePath(attrSourcePointer.getDisplayFieldTable()).render())
                       .append(" AS ")
                       .append(joinTableAlias)
@@ -267,7 +266,7 @@ public class BQQueryRunner implements QueryRunner {
         .append(')');
     return new SqlQueryRequest(
         sql.toString(),
-        sqlParams,
+        indexDataSqlRequest.getSqlParams(),
         listQueryRequest.getPageMarker(),
         listQueryRequest.getPageSize(),
         listQueryRequest.isDryRun());

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -167,9 +167,6 @@ public class BQQueryRunner implements QueryRunner {
       throw new InvalidConfigException(
           "Entity " + listQueryRequest.getEntity().getName() + " does not support source queries");
     }
-    if (listQueryRequest.getSelectFields().isEmpty()) {
-      throw new InvalidQueryException("List query must include at least one select field");
-    }
     listQueryRequest.getSelectFields().stream()
         .forEach(
             selectField -> {
@@ -246,6 +243,9 @@ public class BQQueryRunner implements QueryRunner {
                 }
               }
             });
+    if (selectFields.isEmpty()) {
+      throw new InvalidQueryException("List query must include at least one select field");
+    }
     AttributeField sourceIdAttrField = AttributeField.againstSourceDataset(indexIdAttributeField);
     SqlQueryField sourceIdAttrSqlField =
         bqTranslator.translator(sourceIdAttrField).buildSqlFieldsForListSelect().get(0);

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/field/BQAttributeFieldTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/field/BQAttributeFieldTranslator.java
@@ -55,17 +55,29 @@ public class BQAttributeFieldTranslator implements ApiFieldTranslator {
   private List<SqlQueryField> buildSqlFields(
       boolean includeValueField, boolean includeDisplayField) {
     Attribute attribute = attributeField.getAttribute();
-    SqlField valueField = indexTable.getAttributeValueField(attribute.getName());
-    if (attribute.hasRuntimeSqlFunctionWrapper()) {
-      valueField = valueField.cloneWithFunctionWrapper(attribute.getRuntimeSqlFunctionWrapper());
-    }
 
-    SqlQueryField valueSqlQueryField = SqlQueryField.of(valueField, getValueFieldAlias());
-    if (attribute.isSimple() || attributeField.isExcludeDisplay()) {
+    SqlQueryField valueSqlQueryField;
+    boolean hasDisplayField;
+    if (attributeField.isAgainstSourceDataset()) {
+      SqlField valueField = SqlField.of(attribute.getSourceQuery().getValueFieldName());
+      valueSqlQueryField = SqlQueryField.of(valueField, getValueFieldAlias());
+      hasDisplayField = attribute.getSourceQuery().hasDisplayField();
+    } else {
+      SqlField valueField = indexTable.getAttributeValueField(attribute.getName());
+      if (attribute.hasRuntimeSqlFunctionWrapper()) {
+        valueField = valueField.cloneWithFunctionWrapper(attribute.getRuntimeSqlFunctionWrapper());
+      }
+      valueSqlQueryField = SqlQueryField.of(valueField, getValueFieldAlias());
+      hasDisplayField = !attribute.isSimple();
+    }
+    if (!hasDisplayField || attributeField.isExcludeDisplay()) {
       return List.of(valueSqlQueryField);
     }
 
-    SqlField displayField = indexTable.getAttributeDisplayField(attribute.getName());
+    SqlField displayField =
+        attributeField.isAgainstSourceDataset()
+            ? SqlField.of(attribute.getSourceQuery().getDisplayFieldName())
+            : indexTable.getAttributeDisplayField(attribute.getName());
     SqlQueryField displaySqlQueryField = SqlQueryField.of(displayField, getDisplayFieldAlias());
     List<SqlQueryField> sqlQueryFields = new ArrayList<>();
     if (includeValueField) {
@@ -78,9 +90,11 @@ public class BQAttributeFieldTranslator implements ApiFieldTranslator {
   }
 
   private String getValueFieldAlias() {
-    return indexTable
-        .getAttributeValueField(attributeField.getAttribute().getName())
-        .getColumnName();
+    return attributeField.isAgainstSourceDataset()
+        ? null
+        : indexTable
+            .getAttributeValueField(attributeField.getAttribute().getName())
+            .getColumnName();
   }
 
   private String getDisplayFieldAlias() {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/field/BQAttributeFieldTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/field/BQAttributeFieldTranslator.java
@@ -60,7 +60,7 @@ public class BQAttributeFieldTranslator implements ApiFieldTranslator {
     boolean hasDisplayField;
     if (attributeField.isAgainstSourceDataset()) {
       SqlField valueField = SqlField.of(attribute.getSourceQuery().getValueFieldName());
-      valueSqlQueryField = SqlQueryField.of(valueField, getValueFieldAlias());
+      valueSqlQueryField = SqlQueryField.of(valueField);
       hasDisplayField = attribute.getSourceQuery().hasDisplayField();
     } else {
       SqlField valueField = indexTable.getAttributeValueField(attribute.getName());
@@ -90,11 +90,9 @@ public class BQAttributeFieldTranslator implements ApiFieldTranslator {
   }
 
   private String getValueFieldAlias() {
-    return attributeField.isAgainstSourceDataset()
-        ? null
-        : indexTable
-            .getAttributeValueField(attributeField.getAttribute().getName())
-            .getColumnName();
+    return indexTable
+        .getAttributeValueField(attributeField.getAttribute().getName())
+        .getColumnName();
   }
 
   private String getDisplayFieldAlias() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -333,9 +333,21 @@ public final class Underlay {
                 szAttribute -> {
                   Attribute.SourceQuery sourceQuery =
                       szAttribute.sourceQuery == null
-                          ? null
+                          ? new Attribute.SourceQuery(
+                              false,
+                              szAttribute.valueFieldName == null
+                                  ? szAttribute.name
+                                  : szAttribute.valueFieldName,
+                              null,
+                              null,
+                              null)
                           : new Attribute.SourceQuery(
-                              szAttribute.sourceQuery.valueFieldName,
+                              szAttribute.sourceQuery.isSuppressed,
+                              szAttribute.sourceQuery.valueFieldName == null
+                                  ? (szAttribute.valueFieldName == null
+                                      ? szAttribute.name
+                                      : szAttribute.valueFieldName)
+                                  : szAttribute.sourceQuery.valueFieldName,
                               szAttribute.sourceQuery.displayFieldTable,
                               szAttribute.sourceQuery.displayFieldName,
                               szAttribute.sourceQuery.displayFieldTableJoinFieldName);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -330,15 +330,25 @@ public final class Underlay {
     List<Attribute> attributes =
         szEntity.attributes.stream()
             .map(
-                szAttribute ->
-                    new Attribute(
-                        szAttribute.name,
-                        ConfigReader.deserializeDataType(szAttribute.dataType),
-                        szAttribute.displayFieldName != null,
-                        szAttribute.name.equals(szEntity.idAttribute),
-                        szAttribute.runtimeSqlFunctionWrapper,
-                        ConfigReader.deserializeDataType(szAttribute.runtimeDataType),
-                        szAttribute.isComputeDisplayHint))
+                szAttribute -> {
+                  Attribute.SourceQuery sourceQuery =
+                      szAttribute.sourceQuery == null
+                          ? null
+                          : new Attribute.SourceQuery(
+                              szAttribute.sourceQuery.valueFieldName,
+                              szAttribute.sourceQuery.displayFieldTable,
+                              szAttribute.sourceQuery.displayFieldName,
+                              szAttribute.sourceQuery.displayFieldTableJoinFieldName);
+                  return new Attribute(
+                      szAttribute.name,
+                      ConfigReader.deserializeDataType(szAttribute.dataType),
+                      szAttribute.displayFieldName != null,
+                      szAttribute.name.equals(szEntity.idAttribute),
+                      szAttribute.runtimeSqlFunctionWrapper,
+                      ConfigReader.deserializeDataType(szAttribute.runtimeDataType),
+                      szAttribute.isComputeDisplayHint,
+                      sourceQuery);
+                })
             .collect(Collectors.toList());
 
     List<Attribute> optimizeGroupByAttributes = new ArrayList<>();
@@ -380,7 +390,8 @@ public final class Underlay {
         hierarchies,
         optimizeGroupByAttributes,
         szEntity.textSearch != null,
-        optimizeTextSearchAttributes);
+        optimizeTextSearchAttributes,
+        szEntity.sourceQueryTableName);
   }
 
   private static GroupItems fromConfigGroupItems(SZGroupItems szGroupItems, List<Entity> entities) {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
@@ -107,6 +107,7 @@ public final class Attribute {
 
   public static class SourceQuery {
     private final boolean isSuppressed;
+
     private final String valueFieldName;
 
     private final String displayFieldTable;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
@@ -69,10 +69,6 @@ public final class Attribute {
     return isComputeDisplayHint;
   }
 
-  public boolean hasSourceQuery() {
-    return sourceQuery != null;
-  }
-
   public SourceQuery getSourceQuery() {
     return sourceQuery;
   }
@@ -110,6 +106,7 @@ public final class Attribute {
   }
 
   public static class SourceQuery {
+    private final boolean isSuppressed;
     private final String valueFieldName;
 
     private final String displayFieldTable;
@@ -119,14 +116,20 @@ public final class Attribute {
     private final String displayFieldTableJoinFieldName;
 
     public SourceQuery(
+        boolean isSuppressed,
         String valueFieldName,
         String displayFieldTable,
         String displayFieldName,
         String displayFieldTableJoinFieldName) {
+      this.isSuppressed = isSuppressed;
       this.valueFieldName = valueFieldName;
       this.displayFieldTable = displayFieldTable;
       this.displayFieldName = displayFieldName;
       this.displayFieldTableJoinFieldName = displayFieldTableJoinFieldName;
+    }
+
+    public boolean isSuppressed() {
+      return isSuppressed;
     }
 
     public String getValueFieldName() {
@@ -141,12 +144,42 @@ public final class Attribute {
       return displayFieldName;
     }
 
+    public boolean hasDisplayField() {
+      return displayFieldName != null;
+    }
+
     public String getDisplayFieldTableJoinFieldName() {
       return displayFieldTableJoinFieldName;
     }
 
-    public boolean hasJoin() {
+    public boolean hasDisplayFieldTableJoin() {
       return displayFieldTable != null && !displayFieldTable.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      SourceQuery that = (SourceQuery) o;
+      return isSuppressed == that.isSuppressed
+          && valueFieldName.equals(that.valueFieldName)
+          && Objects.equals(displayFieldTable, that.displayFieldTable)
+          && Objects.equals(displayFieldName, that.displayFieldName)
+          && Objects.equals(displayFieldTableJoinFieldName, that.displayFieldTableJoinFieldName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          isSuppressed,
+          valueFieldName,
+          displayFieldTable,
+          displayFieldName,
+          displayFieldTableJoinFieldName);
     }
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
@@ -11,6 +11,7 @@ public final class Attribute {
   private final String runtimeSqlFunctionWrapper;
   private final DataType runtimeDataType;
   private final boolean isComputeDisplayHint;
+  private final SourceQuery sourceQuery;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public Attribute(
@@ -20,7 +21,8 @@ public final class Attribute {
       boolean isId,
       String runtimeSqlFunctionWrapper,
       DataType runtimeDataType,
-      boolean isComputeDisplayHint) {
+      boolean isComputeDisplayHint,
+      SourceQuery sourceQuery) {
     this.name = name;
     this.dataType = dataType;
     this.isValueDisplay = isValueDisplay;
@@ -28,6 +30,7 @@ public final class Attribute {
     this.runtimeSqlFunctionWrapper = runtimeSqlFunctionWrapper;
     this.runtimeDataType = runtimeDataType;
     this.isComputeDisplayHint = isComputeDisplayHint && !isId;
+    this.sourceQuery = sourceQuery;
   }
 
   public String getName() {
@@ -66,6 +69,14 @@ public final class Attribute {
     return isComputeDisplayHint;
   }
 
+  public boolean hasSourceQuery() {
+    return sourceQuery != null;
+  }
+
+  public SourceQuery getSourceQuery() {
+    return sourceQuery;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -81,7 +92,8 @@ public final class Attribute {
         && name.equals(attribute.name)
         && dataType == attribute.dataType
         && Objects.equals(runtimeSqlFunctionWrapper, attribute.runtimeSqlFunctionWrapper)
-        && runtimeDataType == attribute.runtimeDataType;
+        && runtimeDataType == attribute.runtimeDataType
+        && Objects.equals(sourceQuery, attribute.sourceQuery);
   }
 
   @Override
@@ -93,6 +105,48 @@ public final class Attribute {
         isId,
         runtimeSqlFunctionWrapper,
         runtimeDataType,
-        isComputeDisplayHint);
+        isComputeDisplayHint,
+        sourceQuery);
+  }
+
+  public static class SourceQuery {
+    private final String valueFieldName;
+
+    private final String displayFieldTable;
+
+    private final String displayFieldName;
+
+    private final String displayFieldTableJoinFieldName;
+
+    public SourceQuery(
+        String valueFieldName,
+        String displayFieldTable,
+        String displayFieldName,
+        String displayFieldTableJoinFieldName) {
+      this.valueFieldName = valueFieldName;
+      this.displayFieldTable = displayFieldTable;
+      this.displayFieldName = displayFieldName;
+      this.displayFieldTableJoinFieldName = displayFieldTableJoinFieldName;
+    }
+
+    public String getValueFieldName() {
+      return valueFieldName;
+    }
+
+    public String getDisplayFieldTable() {
+      return displayFieldTable;
+    }
+
+    public String getDisplayFieldName() {
+      return displayFieldName;
+    }
+
+    public String getDisplayFieldTableJoinFieldName() {
+      return displayFieldTableJoinFieldName;
+    }
+
+    public boolean hasJoin() {
+      return displayFieldTable != null && !displayFieldTable.isEmpty();
+    }
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
@@ -16,8 +16,9 @@ public final class Entity {
   private final ImmutableList<Attribute> optimizeGroupByAttributes;
   private final boolean hasTextSearch;
   private final ImmutableList<Attribute> optimizeTextSearchAttributes;
+  private final String sourceQueryTableName;
 
-  @SuppressWarnings("checkstyle:ParameterNumber")
+  @SuppressWarnings({"checkstyle:ParameterNumber", "PMD.ExcessiveParameterList"})
   public Entity(
       String name,
       String displayName,
@@ -27,7 +28,8 @@ public final class Entity {
       List<Hierarchy> hierarchies,
       List<Attribute> optimizeGroupByAttributes,
       boolean hasTextSearch,
-      List<Attribute> optimizeTextSearchAttributes) {
+      List<Attribute> optimizeTextSearchAttributes,
+      String sourceQueryTableName) {
     this.name = name;
     this.displayName = displayName;
     this.description = description;
@@ -37,6 +39,7 @@ public final class Entity {
     this.optimizeGroupByAttributes = ImmutableList.copyOf(optimizeGroupByAttributes);
     this.hasTextSearch = hasTextSearch;
     this.optimizeTextSearchAttributes = ImmutableList.copyOf(optimizeTextSearchAttributes);
+    this.sourceQueryTableName = sourceQueryTableName;
   }
 
   public String getName() {
@@ -104,5 +107,9 @@ public final class Entity {
 
   public ImmutableList<Attribute> getOptimizeTextSearchAttributes() {
     return optimizeTextSearchAttributes;
+  }
+
+  public String getSourceQueryTableName() {
+    return sourceQueryTableName;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
@@ -112,4 +112,8 @@ public final class Entity {
   public String getSourceQueryTableName() {
     return sourceQueryTableName;
   }
+
+  public boolean supportsSourceQueries() {
+    return sourceQueryTableName != null;
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityMain.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityMain.java
@@ -6,8 +6,9 @@ import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.NameHelper;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.serialization.SZAttribute;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
-import bio.terra.tanagra.underlay.serialization.SZEntity;
+import bio.terra.tanagra.underlay.serialization.SZHierarchy;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,8 +25,8 @@ public final class ITEntityMain extends IndexTable {
       NameHelper namer,
       SZBigQuery.IndexData bigQueryConfig,
       String entity,
-      List<SZEntity.Attribute> szAttributes,
-      Set<SZEntity.Hierarchy> szHierarchies,
+      List<SZAttribute> szAttributes,
+      Set<SZHierarchy> szHierarchies,
       boolean hasTextSearch,
       Set<String> entityGroupsWithCounts) {
     super(namer, bigQueryConfig);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
@@ -1,0 +1,176 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.AnnotatedClass;
+import bio.terra.tanagra.annotation.AnnotatedField;
+
+@AnnotatedClass(
+    name = "SZAttribute",
+    markdown =
+        "Attribute or property of an entity.\n\n"
+            + "Define an attribute for each column you want to display (e.g. `condition.vocabulary_id`) "
+            + "or filter on (e.g. `conditionOccurrence.person_id`).")
+public class SZAttribute {
+  @AnnotatedField(
+      name = "SZAttribute.name",
+      markdown =
+          "Name of the attribute.\n\n"
+              + "This is the unique identifier for the attribute. In a single entity, the attribute names "
+              + "cannot overlap.\n\n"
+              + "Name may not include spaces or special characters, only letters and numbers. The first "
+              + "character must be a letter.")
+  public String name;
+
+  @AnnotatedField(name = "SZAttribute.dataType", markdown = "Data type of the attribute.")
+  public SZDataType dataType;
+
+  @AnnotatedField(
+      name = "SZAttribute.valueFieldName",
+      markdown =
+          "Field or column name in the [all instances SQL file](${SZEntity.allInstancesSqlFile}) that "
+              + "maps to the value of this attribute. If unset, we assume the field name is the same "
+              + "as the attribute name.",
+      optional = true)
+  public String valueFieldName;
+
+  @AnnotatedField(
+      name = "SZAttribute.displayFieldName",
+      markdown =
+          "Field or column name in the [all instances SQL file](${SZEntity.allInstancesSqlFile}) that "
+              + "maps to the display string of this attribute. If unset, we assume the attribute has only "
+              + "a value, no separate display.\n\n"
+              + "A separate display field is useful for enum-type attributes, which often use a foreign-key "
+              + "to another table to get a readable string from a code (e.g. in OMOP, `person.gender_concept_id` "
+              + "and `concept.concept_name`).",
+      optional = true)
+  public String displayFieldName;
+
+  @AnnotatedField(
+      name = "SZAttribute.runtimeSqlFunctionWrapper",
+      markdown =
+          "SQL function to apply at runtime (i.e. when running the query), instead of at indexing time. "
+              + "Useful for attributes we expect to be updated dynamically (e.g. a person's age).\n\n"
+              + "For a simple function call that just wraps the column (e.g. `UPPER(column)`), "
+              + "you can specify just the function name (e.g. `UPPER`). For a more complicated "
+              + "function call, put `${fieldSql}` where the column name should be substituted "
+              + "(e.g. `CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)`).",
+      optional = true)
+  public String runtimeSqlFunctionWrapper;
+
+  @AnnotatedField(
+      name = "SZAttribute.runtimeDataType",
+      markdown =
+          "Data type of the attribute at runtime.\n\n"
+              + "If the [runtime SQL wrapper](${SZAttribute.runtimeSqlFunctionWrapper}) is set, this field must also be set. "
+              + "The data type at runtime may be different from the data type at rest when the column is "
+              + "passed to a function at runtime. Otherwise, the data type at runtime will always match the "
+              + "attribute [data type](${SZDataType}), so no need to specify it again here.",
+      optional = true)
+  public SZDataType runtimeDataType;
+
+  @AnnotatedField(
+      name = "SZAttribute.isComputeDisplayHint",
+      markdown =
+          "When set to true, an indexing job will try to compute a display hint for this attribute "
+              + "(e.g. set of enum values and counts, range of numeric values). Not all data types are supported by "
+              + "the indexing job, yet.",
+      optional = true,
+      defaultValue = "false")
+  public boolean isComputeDisplayHint;
+
+  @AnnotatedField(
+      name = "SZAttribute.displayHintRangeMin",
+      markdown =
+          "The minimum value to display when filtering on this attribute. This is useful when the underlying "
+              + "data has outliers that we want to exclude from the display, but not from the available data.\n\n"
+              + "e.g. A person has an invalid date of birth that produces an age range that spans negative "
+              + "numbers. This causes the slider when filtering by age to span negative numbers also. Setting this "
+              + "property sets the left end of the slider. It does not remove the person with the invalid date of "
+              + "birth from the table. So if they have asthma, they would still show up in a cohort filtering on "
+              + "this condition.\n\n"
+              + "The ${SZAttribute.displayHintRangeMax} may be set as well, but they are not required to be set "
+              + "together. The ${SZAttribute.isComputeDisplayHint} is also independent of this property. You can "
+              + "still calculate the actual minimum in the data, if you set this property.",
+      optional = true)
+  public Double displayHintRangeMin;
+
+  @AnnotatedField(
+      name = "SZAttribute.displayHintRangeMax",
+      markdown =
+          "The maximum value to display when filtering on this attribute. This is useful when the underlying "
+              + "data has outliers that we want to exclude from the display, but not from the available data.\n\n"
+              + "e.g. A person has an invalid date of birth that produces an age range that spans very large "
+              + "numbers. This causes the slider when filtering by age to span very large numbers also. Setting this "
+              + "property sets the right end of the slider. It does not remove the person with the invalid date of "
+              + "birth from the table. So if they have asthma, they would still show up in a cohort filtering on "
+              + "this condition.\n\n"
+              + "The ${SZAttribute.displayHintRangeMin} may be set as well, but they are not required to be set "
+              + "together. The ${SZAttribute.isComputeDisplayHint} is also independent of this property. You can "
+              + "still calculate the actual maximum in the data, if you set this property.",
+      optional = true)
+  public Double displayHintRangeMax;
+
+  @AnnotatedField(
+      name = "SZAttribute.sourceQuery",
+      markdown =
+          "How to generate a query against the source data that includes this attribute.\n\n"
+              + "If unspecified and exporting queries against the source data is supported for this entity is enabled "
+              + "(i.e. ${SZEntity.sourceQueryTableName} is specified), we assume the field name in the source table "
+              + "(${SZEntity.sourceQueryTableName}) corresponding to this attribute is the same as the "
+              + "${SZAttribute.valueFieldName}.",
+      optional = true)
+  public SourceQuery sourceQuery;
+
+  @AnnotatedClass(
+      name = "SZSourceQuery",
+      markdown =
+          "Information to generate a SQL query against the source dataset for a given attribute.\n\n"
+              + "This query isn't actually run by the service, only generated as an export option "
+              + "(e.g. as part of a notebook file).")
+  public static class SourceQuery {
+    @AnnotatedField(
+        name = "SZSourceQuery.valueFieldName",
+        markdown =
+            "Name of the field to use for the attribute value in the source dataset table "
+                + "(${SZEntity.sourceQueryTableName}).\n\n"
+                + "If unspecified, we assume the field name in the source table (${SZEntity.sourceQueryTableName}) "
+                + "corresponding to this attribute is the same as the ${SZAttribute.valueFieldName}.",
+        exampleValue = "condition_concept_id",
+        optional = true)
+    public String valueFieldName;
+
+    @AnnotatedField(
+        name = "SZSourceQuery.displayFieldName",
+        markdown =
+            "Name of the field to use for the attribute display in the source dataset.\n\n"
+                + "If unspecified, exporting a query with this attribute against the source data will not include "
+                + "a separate display field.\n\n"
+                + "The table can optionally be specified in ${SZSourceQuery.displayFieldTable}.",
+        exampleValue = "concept_name",
+        optional = true)
+    public String displayFieldName;
+
+    @AnnotatedField(
+        name = "SZSourceQuery.displayFieldTable",
+        markdown =
+            "Full name of the table to JOIN with the main table (${SZEntity.sourceQueryTableName}) to get the attribute "
+                + "display field in the source dataset.\n\n"
+                + "SQL substitutions are supported in this table name.\n\n"
+                + "If unspecified, and ${SZSourceQuery.displayFieldName} is specified, then we assume that the source "
+                + "display field is also in the main table, same as the source value field.\n\n"
+                + "The ${SZSourceQuery.displayFieldTableJoinFieldName} is required if this property is specified.",
+        exampleValue = "${omopDataset}.concept",
+        optional = true)
+    public String displayFieldTable;
+
+    @AnnotatedField(
+        name = "SZSourceQuery.displayFieldTableJoinFieldName",
+        markdown =
+            "Name of the field in the display table (${SZSourceQuery.displayFieldTable}) that is used to "
+                + "JOIN to the main table (${SZEntity.sourceQueryTableName}) using the source value field "
+                + "(${SZSourceQuery.valueFieldName}).\n\n"
+                + "This is required if the ${SZSourceQuery.displayFieldTable} is specified.",
+        exampleValue = "concept_id",
+        optional = true)
+    public String displayFieldTableJoinFieldName;
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
@@ -130,7 +130,6 @@ public class SZAttribute {
     @AnnotatedField(
         name = "SZSourceQuery.isSuppressed",
         markdown = "True if this attribute doesn't map to a specific field in the source table.",
-        exampleValue = "condition_concept_id",
         optional = true,
         defaultValue = "false")
     public boolean isSuppressed;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
@@ -128,6 +128,14 @@ public class SZAttribute {
               + "(e.g. as part of a notebook file).")
   public static class SourceQuery {
     @AnnotatedField(
+        name = "SZSourceQuery.isSuppressed",
+        markdown = "True if this attribute doesn't map to a specific field in the source table.",
+        exampleValue = "condition_concept_id",
+        optional = true,
+        defaultValue = "false")
+    public boolean isSuppressed;
+
+    @AnnotatedField(
         name = "SZSourceQuery.valueFieldName",
         markdown =
             "Name of the field to use for the attribute value in the source dataset table "

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZDataType.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZDataType.java
@@ -1,0 +1,32 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.AnnotatedClass;
+import bio.terra.tanagra.annotation.AnnotatedField;
+
+@AnnotatedClass(
+    name = "SZDataType",
+    markdown =
+        "Supported data types. Each type corresponds to one or more data types in the underlying database.")
+public enum SZDataType {
+  @AnnotatedField(name = "SZDataType.INT64", markdown = "Maps to BigQuery `INTEGER` data type.")
+  INT64,
+
+  @AnnotatedField(name = "SZDataType.STRING", markdown = "Maps to BigQuery `STRING` data type.")
+  STRING,
+
+  @AnnotatedField(name = "SZDataType.BOOLEAN", markdown = "Maps to BigQuery `BOOLEAN` data type.")
+  BOOLEAN,
+
+  @AnnotatedField(name = "SZDataType.DATE", markdown = "Maps to BigQuery `DATE` data type.")
+  DATE,
+
+  @AnnotatedField(
+      name = "SZDataType.DOUBLE",
+      markdown = "Maps to BigQuery `NUMERIC` and `FLOAT` data types.")
+  DOUBLE,
+
+  @AnnotatedField(
+      name = "SZDataType.TIMESTAMP",
+      markdown = "Maps to BigQuery `TIMESTAMP` data type.")
+  TIMESTAMP
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
@@ -45,7 +45,7 @@ public class SZEntity {
           "List of all the entity attributes.\n\n"
               + "The generated index table will preserve the order of the attributes as defined here. "
               + "The list must include the id attribute.")
-  public List<Attribute> attributes;
+  public List<SZAttribute> attributes;
 
   @AnnotatedField(
       name = "SZEntity.idAttribute",
@@ -72,7 +72,7 @@ public class SZEntity {
           "List of hierarchies.\n\n"
               + "While the code supports multiple hierarchies, we currently only have examples with zero or one hierarchy.",
       optional = true)
-  public Set<Hierarchy> hierarchies;
+  public Set<SZHierarchy> hierarchies;
 
   @AnnotatedField(
       name = "SZEntity.textSearch",
@@ -81,278 +81,15 @@ public class SZEntity {
               + "This is used when filtering a list of instances of this entity (e.g. list of conditions) by "
               + "text. If unset, filtering by text is unsupported.",
       optional = true)
-  public TextSearch textSearch;
+  public SZTextSearch textSearch;
 
-  @AnnotatedClass(
-      name = "SZAttribute",
+  @AnnotatedField(
+      name = "SZEntity.sourceQueryTableName",
       markdown =
-          "Attribute or property of an entity.\n\n"
-              + "Define an attribute for each column you want to display (e.g. `condition.vocabulary_id`) "
-              + "or filter on (e.g. `conditionOccurrence.person_id`).")
-  public static class Attribute {
-    @AnnotatedField(
-        name = "SZAttribute.name",
-        markdown =
-            "Name of the attribute.\n\n"
-                + "This is the unique identifier for the attribute. In a single entity, the attribute names "
-                + "cannot overlap.\n\n"
-                + "Name may not include spaces or special characters, only letters and numbers. The first "
-                + "character must be a letter.")
-    public String name;
-
-    @AnnotatedField(name = "SZAttribute.dataType", markdown = "Data type of the attribute.")
-    public DataType dataType;
-
-    @AnnotatedField(
-        name = "SZAttribute.valueFieldName",
-        markdown =
-            "Field or column name in the [all instances SQL file](${SZEntity.allInstancesSqlFile}) that "
-                + "maps to the value of this attribute. If unset, we assume the field name is the same "
-                + "as the attribute name.",
-        optional = true)
-    public String valueFieldName;
-
-    @AnnotatedField(
-        name = "SZAttribute.displayFieldName",
-        markdown =
-            "Field or column name in the [all instances SQL file](${SZEntity.allInstancesSqlFile}) that "
-                + "maps to the display string of this attribute. If unset, we assume the attribute has only "
-                + "a value, no separate display.\n\n"
-                + "A separate display field is useful for enum-type attributes, which often use a foreign-key "
-                + "to another table to get a readable string from a code (e.g. in OMOP, `person.gender_concept_id` "
-                + "and `concept.concept_name`).",
-        optional = true)
-    public String displayFieldName;
-
-    @AnnotatedField(
-        name = "SZAttribute.runtimeSqlFunctionWrapper",
-        markdown =
-            "SQL function to apply at runtime (i.e. when running the query), instead of at indexing time. "
-                + "Useful for attributes we expect to be updated dynamically (e.g. a person's age).\n\n"
-                + "For a simple function call that just wraps the column (e.g. `UPPER(column)`), "
-                + "you can specify just the function name (e.g. `UPPER`). For a more complicated "
-                + "function call, put `${fieldSql}` where the column name should be substituted "
-                + "(e.g. `CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)`).",
-        optional = true)
-    public String runtimeSqlFunctionWrapper;
-
-    @AnnotatedField(
-        name = "SZAttribute.runtimeDataType",
-        markdown =
-            "Data type of the attribute at runtime.\n\n"
-                + "If the [runtime SQL wrapper](${SZAttribute.runtimeSqlFunctionWrapper}) is set, this field must also be set. "
-                + "The data type at runtime may be different from the data type at rest when the column is "
-                + "passed to a function at runtime. Otherwise, the data type at runtime will always match the "
-                + "attribute [data type](${SZDataType}), so no need to specify it again here.",
-        optional = true)
-    public DataType runtimeDataType;
-
-    @AnnotatedField(
-        name = "SZAttribute.isComputeDisplayHint",
-        markdown =
-            "When set to true, an indexing job will try to compute a display hint for this attribute "
-                + "(e.g. set of enum values and counts, range of numeric values). Not all data types are supported by "
-                + "the indexing job, yet.",
-        optional = true,
-        defaultValue = "false")
-    public boolean isComputeDisplayHint;
-
-    @AnnotatedField(
-        name = "SZAttribute.displayHintRangeMin",
-        markdown =
-            "The minimum value to display when filtering on this attribute. This is useful when the underlying "
-                + "data has outliers that we want to exclude from the display, but not from the available data.\n\n"
-                + "e.g. A person has an invalid date of birth that produces an age range that spans negative "
-                + "numbers. This causes the slider when filtering by age to span negative numbers also. Setting this "
-                + "property sets the left end of the slider. It does not remove the person with the invalid date of "
-                + "birth from the table. So if they have asthma, they would still show up in a cohort filtering on "
-                + "this condition.\n\n"
-                + "The ${SZAttribute.displayHintRangeMax} may be set as well, but they are not required to be set "
-                + "together. The ${SZAttribute.isComputeDisplayHint} is also independent of this property. You can "
-                + "still calculate the actual minimum in the data, if you set this property.",
-        optional = true)
-    public Double displayHintRangeMin;
-
-    @AnnotatedField(
-        name = "SZAttribute.displayHintRangeMax",
-        markdown =
-            "The maximum value to display when filtering on this attribute. This is useful when the underlying "
-                + "data has outliers that we want to exclude from the display, but not from the available data.\n\n"
-                + "e.g. A person has an invalid date of birth that produces an age range that spans very large "
-                + "numbers. This causes the slider when filtering by age to span very large numbers also. Setting this "
-                + "property sets the right end of the slider. It does not remove the person with the invalid date of "
-                + "birth from the table. So if they have asthma, they would still show up in a cohort filtering on "
-                + "this condition.\n\n"
-                + "The ${SZAttribute.displayHintRangeMin} may be set as well, but they are not required to be set "
-                + "together. The ${SZAttribute.isComputeDisplayHint} is also independent of this property. You can "
-                + "still calculate the actual maximum in the data, if you set this property.",
-        optional = true)
-    public Double displayHintRangeMax;
-  }
-
-  @AnnotatedClass(name = "SZHierarchy", markdown = "Hierarchy for an entity.")
-  public static class Hierarchy {
-    @AnnotatedField(
-        name = "SZHierarchy.name",
-        markdown =
-            "Name of the hierarchy.\n\n"
-                + "This is the unique identifier for the hierarchy. In a single entity, the hierarchy names cannot overlap. "
-                + "Name may not include spaces or special characters, only letters and numbers. "
-                + "The first character must be a letter.\n\n"
-                + "If there is only one hierarchy, the name is optional and, if unspecified, will be set to `default`. "
-                + "If there are multiple hierarchies, the name is required for each one.",
-        optional = true,
-        defaultValue = "default")
-    public String name;
-
-    @AnnotatedField(
-        name = "SZHierarchy.childParentIdPairsSqlFile",
-        markdown =
-            "Name of the child parent id pairs SQL file.\n\n"
-                + "File must be in the same directory as the entity file. Name includes file extension.\n\n"
-                + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), "
-                + "but the child and parent ids are required.",
-        exampleValue = "childParent.sql")
-    public String childParentIdPairsSqlFile;
-
-    @AnnotatedField(
-        name = "SZHierarchy.childIdFieldName",
-        markdown =
-            "Name of the field or column name in the [child parent id pairs SQL](${SZHierarchy.childParentIdPairsSqlFile}) "
-                + "that maps to the child id.",
-        exampleValue = "child")
-    public String childIdFieldName;
-
-    @AnnotatedField(
-        name = "SZHierarchy.parentIdFieldName",
-        markdown =
-            "Name of the field or column name in the [child parent id pairs SQL](${SZHierarchy.childParentIdPairsSqlFile}) "
-                + "that maps to the parent id.",
-        exampleValue = "parent")
-    public String parentIdFieldName;
-
-    @AnnotatedField(
-        name = "SZHierarchy.rootNodeIds",
-        markdown =
-            "Set of root ids. Indexing jobs will filter out any hierarchy root nodes that are not in this set. "
-                + "If the [root node ids SQL](${SZHierarchy.rootNodeIdsSqlFile}) is defined, then this property "
-                + "must be unset.",
-        optional = true)
-    public Set<Long> rootNodeIds;
-
-    @AnnotatedField(
-        name = "SZHierarchy.rootNodeIdsSqlFile",
-        markdown =
-            "Name of the root id SQL file. File must be in the same directory as the entity file. Name includes file extension.\n\n"
-                + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM roots`), but the root id is required. "
-                + "Indexing jobs will filter out any hierarchy root nodes that are not returned by this query. "
-                + "If the [root node ids set](${SZHierarchy.rootNodeIds}) is defined, then this property must be unset.",
-        optional = true,
-        exampleValue = "rootNode.sql")
-    public String rootNodeIdsSqlFile;
-
-    @AnnotatedField(
-        name = "SZHierarchy.rootIdFieldName",
-        markdown =
-            "Name of the field or column name that maps to the root id.\n\n"
-                + "If the [root node ids SQL](${SZHierarchy.rootNodeIdsSqlFile}) is defined, then this property is required. "
-                + "If the [root node ids set](${SZHierarchy.rootNodeIds}) is defined, then this property must be unset.",
-        optional = true,
-        exampleValue = "root_id")
-    public String rootIdFieldName;
-
-    @AnnotatedField(
-        name = "SZHierarchy.maxDepth",
-        markdown =
-            "Maximum depth of the hierarchy. If there are branches of the hierarchy that are deeper "
-                + "than the number specified here, they will be truncated.")
-    public int maxDepth;
-
-    @AnnotatedField(
-        name = "SZHierarchy.keepOrphanNodes",
-        markdown =
-            "An orphan node has no parents or children. "
-                + "When false, indexing jobs will filter out orphan nodes. "
-                + "When true, indexing jobs skip this filtering step and we keep the orphan nodes in the hierarchy.",
-        optional = true,
-        defaultValue = "false")
-    public boolean keepOrphanNodes;
-
-    @AnnotatedField(
-        name = "SZHierarchy.cleanHierarchyNodesWithZeroCounts",
-        markdown =
-            "When false, indexing jobs will not clean hierarchy nodes with both a zero item and rollup counts. "
-                + "When true, indexing jobs will clean hierarchy nodes with both a zero item and rollup counts.",
-        optional = true,
-        defaultValue = "false")
-    public boolean cleanHierarchyNodesWithZeroCounts;
-  }
-
-  @AnnotatedClass(name = "SZTextSearch", markdown = "Text search configuration for an entity.")
-  public static class TextSearch {
-
-    @AnnotatedField(
-        name = "SZTextSearch.attributes",
-        markdown =
-            "Set of attributes to allow text search on. Text search on attributes not included here is unsupported.",
-        optional = true)
-    public Set<String> attributes;
-
-    @AnnotatedField(
-        name = "SZTextSearch.idTextPairsSqlFile",
-        markdown =
-            "Name of the id text pairs SQL file. "
-                + "File must be in the same directory as the entity file. Name includes file extension.\n\n"
-                + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM synonyms`), "
-                + "but the entity id and text string is required. The SQL query may return multiple rows per entity id.",
-        optional = true,
-        exampleValue = "textSearch.sql")
-    public String idTextPairsSqlFile;
-
-    @AnnotatedField(
-        name = "SZTextSearch.idFieldName",
-        markdown =
-            "Name of the field or column name that maps to the entity id. "
-                + "If the [id text pairs SQL](${SZTextSearch.idTextPairsSqlFile}) is defined, then this property is required.",
-        optional = true,
-        exampleValue = "id")
-    public String idFieldName;
-
-    @AnnotatedField(
-        name = "SZTextSearch.textFieldName",
-        markdown =
-            "Name of the field or column name that maps to the text search string. "
-                + "If the [id text pairs SQL](${SZTextSearch.idTextPairsSqlFile}) is defined, then this property is required.",
-        optional = true,
-        exampleValue = "text")
-    public String textFieldName;
-  }
-
-  @AnnotatedClass(
-      name = "SZDataType",
-      markdown =
-          "Supported data types. Each type corresponds to one or more data types in the underlying database.")
-  public enum DataType {
-    @AnnotatedField(name = "SZDataType.INT64", markdown = "Maps to BigQuery `INTEGER` data type.")
-    INT64,
-
-    @AnnotatedField(name = "SZDataType.STRING", markdown = "Maps to BigQuery `STRING` data type.")
-    STRING,
-
-    @AnnotatedField(name = "SZDataType.BOOLEAN", markdown = "Maps to BigQuery `BOOLEAN` data type.")
-    BOOLEAN,
-
-    @AnnotatedField(name = "SZDataType.DATE", markdown = "Maps to BigQuery `DATE` data type.")
-    DATE,
-
-    @AnnotatedField(
-        name = "SZDataType.DOUBLE",
-        markdown = "Maps to BigQuery `NUMERIC` and `FLOAT` data types.")
-    DOUBLE,
-
-    @AnnotatedField(
-        name = "SZDataType.TIMESTAMP",
-        markdown = "Maps to BigQuery `TIMESTAMP` data type.")
-    TIMESTAMP
-  }
+          "Full name of the table to use when exporting a query against the source data.\n\n"
+              + "SQL substitutions are supported in this table name.\n\n"
+              + "If unspecified, exporting a query against the source data is unsupported.",
+      exampleValue = "${omopDataset}.condition_occurrence",
+      optional = true)
+  public String sourceQueryTableName;
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZHierarchy.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZHierarchy.java
@@ -1,0 +1,103 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.AnnotatedClass;
+import bio.terra.tanagra.annotation.AnnotatedField;
+import java.util.Set;
+
+@AnnotatedClass(name = "SZHierarchy", markdown = "Hierarchy for an entity.")
+public class SZHierarchy {
+  @AnnotatedField(
+      name = "SZHierarchy.name",
+      markdown =
+          "Name of the hierarchy.\n\n"
+              + "This is the unique identifier for the hierarchy. In a single entity, the hierarchy names cannot overlap. "
+              + "Name may not include spaces or special characters, only letters and numbers. "
+              + "The first character must be a letter.\n\n"
+              + "If there is only one hierarchy, the name is optional and, if unspecified, will be set to `default`. "
+              + "If there are multiple hierarchies, the name is required for each one.",
+      optional = true,
+      defaultValue = "default")
+  public String name;
+
+  @AnnotatedField(
+      name = "SZHierarchy.childParentIdPairsSqlFile",
+      markdown =
+          "Name of the child parent id pairs SQL file.\n\n"
+              + "File must be in the same directory as the entity file. Name includes file extension.\n\n"
+              + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), "
+              + "but the child and parent ids are required.",
+      exampleValue = "childParent.sql")
+  public String childParentIdPairsSqlFile;
+
+  @AnnotatedField(
+      name = "SZHierarchy.childIdFieldName",
+      markdown =
+          "Name of the field or column name in the [child parent id pairs SQL](${SZHierarchy.childParentIdPairsSqlFile}) "
+              + "that maps to the child id.",
+      exampleValue = "child")
+  public String childIdFieldName;
+
+  @AnnotatedField(
+      name = "SZHierarchy.parentIdFieldName",
+      markdown =
+          "Name of the field or column name in the [child parent id pairs SQL](${SZHierarchy.childParentIdPairsSqlFile}) "
+              + "that maps to the parent id.",
+      exampleValue = "parent")
+  public String parentIdFieldName;
+
+  @AnnotatedField(
+      name = "SZHierarchy.rootNodeIds",
+      markdown =
+          "Set of root ids. Indexing jobs will filter out any hierarchy root nodes that are not in this set. "
+              + "If the [root node ids SQL](${SZHierarchy.rootNodeIdsSqlFile}) is defined, then this property "
+              + "must be unset.",
+      optional = true)
+  public Set<Long> rootNodeIds;
+
+  @AnnotatedField(
+      name = "SZHierarchy.rootNodeIdsSqlFile",
+      markdown =
+          "Name of the root id SQL file. File must be in the same directory as the entity file. Name includes file extension.\n\n"
+              + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM roots`), but the root id is required. "
+              + "Indexing jobs will filter out any hierarchy root nodes that are not returned by this query. "
+              + "If the [root node ids set](${SZHierarchy.rootNodeIds}) is defined, then this property must be unset.",
+      optional = true,
+      exampleValue = "rootNode.sql")
+  public String rootNodeIdsSqlFile;
+
+  @AnnotatedField(
+      name = "SZHierarchy.rootIdFieldName",
+      markdown =
+          "Name of the field or column name that maps to the root id.\n\n"
+              + "If the [root node ids SQL](${SZHierarchy.rootNodeIdsSqlFile}) is defined, then this property is required. "
+              + "If the [root node ids set](${SZHierarchy.rootNodeIds}) is defined, then this property must be unset.",
+      optional = true,
+      exampleValue = "root_id")
+  public String rootIdFieldName;
+
+  @AnnotatedField(
+      name = "SZHierarchy.maxDepth",
+      markdown =
+          "Maximum depth of the hierarchy. If there are branches of the hierarchy that are deeper "
+              + "than the number specified here, they will be truncated.")
+  public int maxDepth;
+
+  @AnnotatedField(
+      name = "SZHierarchy.keepOrphanNodes",
+      markdown =
+          "An orphan node has no parents or children. "
+              + "When false, indexing jobs will filter out orphan nodes. "
+              + "When true, indexing jobs skip this filtering step and we keep the orphan nodes in the hierarchy.",
+      optional = true,
+      defaultValue = "false")
+  public boolean keepOrphanNodes;
+
+  @AnnotatedField(
+      name = "SZHierarchy.cleanHierarchyNodesWithZeroCounts",
+      markdown =
+          "When false, indexing jobs will not clean hierarchy nodes with both a zero item and rollup counts. "
+              + "When true, indexing jobs will clean hierarchy nodes with both a zero item and rollup counts.",
+      optional = true,
+      defaultValue = "false")
+  public boolean cleanHierarchyNodesWithZeroCounts;
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZTextSearch.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZTextSearch.java
@@ -1,0 +1,45 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.AnnotatedClass;
+import bio.terra.tanagra.annotation.AnnotatedField;
+import java.util.Set;
+
+@AnnotatedClass(name = "SZTextSearch", markdown = "Text search configuration for an entity.")
+public class SZTextSearch {
+
+  @AnnotatedField(
+      name = "SZTextSearch.attributes",
+      markdown =
+          "Set of attributes to allow text search on. Text search on attributes not included here is unsupported.",
+      optional = true)
+  public Set<String> attributes;
+
+  @AnnotatedField(
+      name = "SZTextSearch.idTextPairsSqlFile",
+      markdown =
+          "Name of the id text pairs SQL file. "
+              + "File must be in the same directory as the entity file. Name includes file extension.\n\n"
+              + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM synonyms`), "
+              + "but the entity id and text string is required. The SQL query may return multiple rows per entity id.",
+      optional = true,
+      exampleValue = "textSearch.sql")
+  public String idTextPairsSqlFile;
+
+  @AnnotatedField(
+      name = "SZTextSearch.idFieldName",
+      markdown =
+          "Name of the field or column name that maps to the entity id. "
+              + "If the [id text pairs SQL](${SZTextSearch.idTextPairsSqlFile}) is defined, then this property is required.",
+      optional = true,
+      exampleValue = "id")
+  public String idFieldName;
+
+  @AnnotatedField(
+      name = "SZTextSearch.textFieldName",
+      markdown =
+          "Name of the field or column name that maps to the text search string. "
+              + "If the [id text pairs SQL](${SZTextSearch.idTextPairsSqlFile}) is defined, then this property is required.",
+      optional = true,
+      exampleValue = "text")
+  public String textFieldName;
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STEntityAttributes.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STEntityAttributes.java
@@ -5,7 +5,7 @@ import bio.terra.tanagra.query.bigquery.BQTable;
 import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
-import bio.terra.tanagra.underlay.serialization.SZEntity;
+import bio.terra.tanagra.underlay.serialization.SZAttribute;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -18,7 +18,7 @@ public class STEntityAttributes extends SourceTable {
   private final ImmutableMap<String, ColumnSchema> attributeValueColumnSchemas;
   private final ImmutableMap<String, ColumnSchema> attributeDisplayColumnSchemas;
 
-  public STEntityAttributes(BQTable bqTable, String entity, List<SZEntity.Attribute> szAttributes) {
+  public STEntityAttributes(BQTable bqTable, String entity, List<SZAttribute> szAttributes) {
     super(bqTable);
     this.entity = entity;
 

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STHierarchyChildParent.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STHierarchyChildParent.java
@@ -4,7 +4,7 @@ import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.query.bigquery.BQTable;
 import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.underlay.ColumnSchema;
-import bio.terra.tanagra.underlay.serialization.SZEntity;
+import bio.terra.tanagra.underlay.serialization.SZHierarchy;
 import com.google.common.collect.ImmutableList;
 
 public class STHierarchyChildParent extends SourceTable {
@@ -13,7 +13,7 @@ public class STHierarchyChildParent extends SourceTable {
   private final ColumnSchema childColumnSchema;
   private final ColumnSchema parentColumnSchema;
 
-  public STHierarchyChildParent(BQTable bqTable, String entity, SZEntity.Hierarchy szHierarchy) {
+  public STHierarchyChildParent(BQTable bqTable, String entity, SZHierarchy szHierarchy) {
     super(bqTable);
     this.entity = entity;
     this.hierarchy = szHierarchy.name;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STHierarchyRootFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STHierarchyRootFilter.java
@@ -3,7 +3,7 @@ package bio.terra.tanagra.underlay.sourcetable;
 import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.query.bigquery.BQTable;
 import bio.terra.tanagra.underlay.ColumnSchema;
-import bio.terra.tanagra.underlay.serialization.SZEntity;
+import bio.terra.tanagra.underlay.serialization.SZHierarchy;
 import com.google.common.collect.ImmutableList;
 
 public class STHierarchyRootFilter extends SourceTable {
@@ -11,7 +11,7 @@ public class STHierarchyRootFilter extends SourceTable {
   private final String hierarchy;
   private final ColumnSchema idColumnSchema;
 
-  public STHierarchyRootFilter(BQTable bqTable, String entity, SZEntity.Hierarchy szHierarchy) {
+  public STHierarchyRootFilter(BQTable bqTable, String entity, SZHierarchy szHierarchy) {
     super(bqTable);
     this.entity = entity;
     this.hierarchy = szHierarchy.name;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STTextSearchTerms.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STTextSearchTerms.java
@@ -4,7 +4,7 @@ import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.query.bigquery.BQTable;
 import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.underlay.ColumnSchema;
-import bio.terra.tanagra.underlay.serialization.SZEntity;
+import bio.terra.tanagra.underlay.serialization.SZTextSearch;
 import com.google.common.collect.ImmutableList;
 
 public class STTextSearchTerms extends SourceTable {
@@ -12,7 +12,7 @@ public class STTextSearchTerms extends SourceTable {
   private final ColumnSchema idColumnSchema;
   private final ColumnSchema textColumnSchema;
 
-  public STTextSearchTerms(BQTable bqTable, String entity, SZEntity.TextSearch szTextSearch) {
+  public STTextSearchTerms(BQTable bqTable, String entity, SZTextSearch szTextSearch) {
     super(bqTable);
     this.entity = entity;
     this.idColumnSchema = new ColumnSchema(szTextSearch.idFieldName, DataType.INT64);

--- a/underlay/src/main/resources/config/datamapping/cmssynpuf/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/cmssynpuf/entity/person/entity.json
@@ -6,10 +6,29 @@
     { "name": "year_of_birth", "dataType": "INT64", "isComputeDisplayHint": true },
     { "name": "age", "dataType": "TIMESTAMP", "valueFieldName": "birth_datetime", "runtimeSqlFunctionWrapper": "CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)", "runtimeDataType": "INT64", "isComputeDisplayHint": true },
     { "name": "person_source_value", "dataType": "STRING" },
-    { "name": "gender", "dataType": "INT64", "valueFieldName": "gender_concept_id", "displayFieldName": "gender_concept_name", "isComputeDisplayHint": true },
-    { "name": "race", "dataType": "INT64", "valueFieldName": "race_concept_id", "displayFieldName": "race_concept_name", "isComputeDisplayHint": true },
-    { "name": "ethnicity", "dataType": "INT64", "valueFieldName": "ethnicity_concept_id", "displayFieldName": "ethnicity_concept_name", "isComputeDisplayHint": true }
+    { "name": "gender", "dataType": "INT64", "valueFieldName": "gender_concept_id", "displayFieldName": "gender_concept_name", "isComputeDisplayHint": true,
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
+    { "name": "race", "dataType": "INT64", "valueFieldName": "race_concept_id", "displayFieldName": "race_concept_name", "isComputeDisplayHint": true,
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
+    { "name": "ethnicity", "dataType": "INT64", "valueFieldName": "ethnicity_concept_id", "displayFieldName": "ethnicity_concept_name", "isComputeDisplayHint": true,
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    }
   ],
   "idAttribute": "id",
-  "optimizeGroupByAttributes": [ "gender", "race", "age" ]
+  "optimizeGroupByAttributes": [ "gender", "race", "age" ],
+  "sourceQueryTableName": "${omopDataset}.person"
 }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
@@ -166,7 +166,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 BinaryOperator.EQUALS,
                 Literal.forInt64(44_814_644L)),
             Map.of(),
@@ -196,7 +196,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 BinaryOperator.EQUALS,
                 Literal.forInt64(44_814_644L)),
             Map.of(
@@ -238,7 +238,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 NaryOperator.IN,
                 List.of(Literal.forInt64(44_814_644L), Literal.forInt64(44_814_638L))),
             Map.of(),
@@ -273,7 +273,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 NaryOperator.IN,
                 List.of(Literal.forInt64(44_814_644L), Literal.forInt64(44_814_638L))),
             Map.of(
@@ -357,7 +357,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 BinaryOperator.EQUALS,
                 Literal.forInt64(44_814_644L)),
             Map.of(occurrenceEntity, List.of(expectedAgeAtOccurrenceSubFilter)),
@@ -603,7 +603,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 BinaryOperator.EQUALS,
                 Literal.forInt64(44_814_644L)),
             Map.of(
@@ -679,7 +679,6 @@ public class TextSearchFilterBuilderTest {
 
     CriteriaOccurrence criteriaOccurrence =
         (CriteriaOccurrence) underlay.getEntityGroup("notePerson");
-    Entity occurrenceEntity = underlay.getEntity("noteOccurrence");
     EntityFilter expectedCohortFilter =
         new PrimaryWithCriteriaFilter(
             underlay,
@@ -687,7 +686,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 BinaryOperator.EQUALS,
                 Literal.forInt64(44_814_644L)),
             null,
@@ -861,7 +860,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 BinaryOperator.EQUALS,
                 Literal.forInt64(44_814_644L)));
     assertEquals(
@@ -895,7 +894,7 @@ public class TextSearchFilterBuilderTest {
             new AttributeFilter(
                 underlay,
                 criteriaOccurrence.getCriteriaEntity(),
-                occurrenceEntity.getIdAttribute(),
+                criteriaOccurrence.getCriteriaEntity().getIdAttribute(),
                 NaryOperator.IN,
                 List.of(Literal.forInt64(44_814_644L), Literal.forInt64(44_814_638L))));
     EntityFilter expectedTextSearchFilter =

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQListQueryPaginationTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQListQueryPaginationTest.java
@@ -38,9 +38,9 @@ public class BQListQueryPaginationTest {
 
     // Select and order by the id attribute.
     AttributeField idAttributeField =
-        new AttributeField(underlay, primaryEntity, primaryEntity.getIdAttribute(), false, false);
+        new AttributeField(underlay, primaryEntity, primaryEntity.getIdAttribute(), false);
     ListQueryRequest listQueryRequest =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             primaryEntity,
             List.of(idAttributeField),
@@ -48,8 +48,7 @@ public class BQListQueryPaginationTest {
             List.of(new ListQueryRequest.OrderBy(idAttributeField, OrderByDirection.DESCENDING)),
             10,
             null,
-            null,
-            false);
+            null);
     ListQueryResult listQueryResult = underlay.getQueryRunner().run(listQueryRequest);
 
     assertNotNull(listQueryResult.getSql());
@@ -63,9 +62,9 @@ public class BQListQueryPaginationTest {
 
     // Select and order by the id attribute.
     AttributeField idAttributeField =
-        new AttributeField(underlay, primaryEntity, primaryEntity.getIdAttribute(), false, false);
+        new AttributeField(underlay, primaryEntity, primaryEntity.getIdAttribute(), false);
     ListQueryRequest listQueryRequest1 =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             primaryEntity,
             List.of(idAttributeField),
@@ -73,8 +72,7 @@ public class BQListQueryPaginationTest {
             List.of(new ListQueryRequest.OrderBy(idAttributeField, OrderByDirection.DESCENDING)),
             10,
             null,
-            3,
-            false);
+            3);
 
     // First query request gets the first page of results.
     ListQueryResult listQueryResult1 = underlay.getQueryRunner().run(listQueryRequest1);
@@ -86,7 +84,7 @@ public class BQListQueryPaginationTest {
 
     // Second query request gets the second and final page of results.
     ListQueryRequest listQueryRequest2 =
-        new ListQueryRequest(
+        ListQueryRequest.againstIndexData(
             underlay,
             primaryEntity,
             List.of(idAttributeField),
@@ -94,8 +92,7 @@ public class BQListQueryPaginationTest {
             List.of(new ListQueryRequest.OrderBy(idAttributeField, OrderByDirection.DESCENDING)),
             10,
             listQueryResult1.getPageMarker(),
-            7,
-            false);
+            7);
     ListQueryResult listQueryResult2 = underlay.getQueryRunner().run(listQueryRequest2);
 
     assertNotNull(listQueryResult2.getSql());

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQCountQueryResultsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQCountQueryResultsTest.java
@@ -33,13 +33,13 @@ public class BQCountQueryResultsTest extends BQRunnerTest {
   void attributeField() {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     AttributeField valueDisplayAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("gender"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("gender"), false);
     AttributeField valueDisplayAttributeWithoutDisplay =
-        new AttributeField(underlay, entity, entity.getAttribute("race"), true, false);
+        new AttributeField(underlay, entity, entity.getAttribute("race"), true);
     AttributeField runtimeCalculatedAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("age"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("age"), false);
 
     List<ValueDisplayField> groupBys =
         List.of(

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQListQueryResultsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQListQueryResultsTest.java
@@ -30,15 +30,15 @@ public class BQListQueryResultsTest extends BQRunnerTest {
   void attributeField() {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     AttributeField valueDisplayAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("gender"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("gender"), false);
     AttributeField valueDisplayAttributeWithoutDisplay =
-        new AttributeField(underlay, entity, entity.getAttribute("race"), true, false);
+        new AttributeField(underlay, entity, entity.getAttribute("race"), true);
     AttributeField runtimeCalculatedAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("age"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("age"), false);
     AttributeField idAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
 
     List<ValueDisplayField> selectAttributes =
         List.of(
@@ -51,8 +51,8 @@ public class BQListQueryResultsTest extends BQRunnerTest {
     int limit = 5;
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, selectAttributes, null, orderBys, limit, null, null, false));
+            ListQueryRequest.againstIndexData(
+                underlay, entity, selectAttributes, null, orderBys, limit, null, null));
 
     // Make sure we got the right number of results back.
     assertEquals(limit, listQueryResult.getListInstances().size());
@@ -105,8 +105,8 @@ public class BQListQueryResultsTest extends BQRunnerTest {
     int limit = 11;
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, selectAttributes, null, orderBys, limit, null, null, false));
+            ListQueryRequest.againstIndexData(
+                underlay, entity, selectAttributes, null, orderBys, limit, null, null));
 
     // Make sure we got the right number of results back.
     assertEquals(1, listQueryResult.getListInstances().size());
@@ -147,8 +147,8 @@ public class BQListQueryResultsTest extends BQRunnerTest {
     int limit = 9;
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, selectAttributes, null, orderBys, limit, null, null, false));
+            ListQueryRequest.againstIndexData(
+                underlay, entity, selectAttributes, null, orderBys, limit, null, null));
 
     // Make sure we got the right number of results back.
     assertEquals(limit, listQueryResult.getListInstances().size());
@@ -209,16 +209,8 @@ public class BQListQueryResultsTest extends BQRunnerTest {
     int limit = 14;
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                countForEntity,
-                selectAttributes,
-                null,
-                orderBys,
-                limit,
-                null,
-                null,
-                false));
+            ListQueryRequest.againstIndexData(
+                underlay, countForEntity, selectAttributes, null, orderBys, limit, null, null));
 
     // Make sure we got the right number of results back.
     assertEquals(limit, listQueryResult.getListInstances().size());

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQCountQueryTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQCountQueryTest.java
@@ -25,7 +25,7 @@ public class BQCountQueryTest extends BQRunnerTest {
             BinaryOperator.NOT_EQUALS,
             Literal.forInt64(8_207L));
     AttributeField groupByAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     CountQueryResult countQueryResult =
         bqQueryRunner.run(
             new CountQueryRequest(
@@ -46,7 +46,7 @@ public class BQCountQueryTest extends BQRunnerTest {
   void noFilter() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField groupByAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     CountQueryResult countQueryResult =
         bqQueryRunner.run(
             new CountQueryRequest(
@@ -72,7 +72,7 @@ public class BQCountQueryTest extends BQRunnerTest {
   void groupByRuntimeCalculatedField() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField groupByAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("age"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("age"), false);
     CountQueryResult countQueryResult =
         bqQueryRunner.run(
             new CountQueryRequest(
@@ -87,7 +87,7 @@ public class BQCountQueryTest extends BQRunnerTest {
   void groupByValueDisplayAttribute() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField groupByAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("gender"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("gender"), false);
     CountQueryResult countQueryResult =
         bqQueryRunner.run(
             new CountQueryRequest(

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFieldTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFieldTest.java
@@ -27,15 +27,15 @@ public class BQFieldTest extends BQRunnerTest {
   void attributeField() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     AttributeField valueDisplayAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("gender"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("gender"), false);
     AttributeField valueDisplayAttributeWithoutDisplay =
-        new AttributeField(underlay, entity, entity.getAttribute("race"), true, false);
+        new AttributeField(underlay, entity, entity.getAttribute("race"), true);
     AttributeField runtimeCalculatedAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("age"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("age"), false);
     AttributeField idAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
 
     List<ValueDisplayField> selectAttributes =
         List.of(
@@ -52,8 +52,8 @@ public class BQFieldTest extends BQRunnerTest {
     int limit = 35;
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, selectAttributes, null, orderBys, limit, null, null, true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, selectAttributes, null, orderBys, limit));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("attributeField", listQueryResult.getSql(), table);
@@ -68,8 +68,8 @@ public class BQFieldTest extends BQRunnerTest {
     List<OrderBy> orderBys = List.of(new OrderBy(entityIdCountField, OrderByDirection.DESCENDING));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, selectAttributes, null, orderBys, null, null, null, true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, selectAttributes, null, orderBys, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("entityIdCountField", listQueryResult.getSql(), table);
@@ -97,8 +97,8 @@ public class BQFieldTest extends BQRunnerTest {
         List.of(new OrderBy(hierarchyNumChildrenField, OrderByDirection.DESCENDING));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, selectAttributes, null, orderBys, null, null, null, true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, selectAttributes, null, orderBys, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("hierarchyFields", listQueryResult.getSql(), table);
@@ -124,16 +124,8 @@ public class BQFieldTest extends BQRunnerTest {
             new OrderBy(relatedEntityIdCountFieldWithHier, OrderByDirection.ASCENDING));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                countForEntity,
-                selectAttributes,
-                null,
-                orderBys,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, countForEntity, selectAttributes, null, orderBys, null));
 
     BQTable table =
         underlay.getIndexSchema().getEntityMain(countForEntity.getName()).getTablePointer();

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -524,7 +524,7 @@ public class BQFilterTest extends BQRunnerTest {
             pulsePerson.getGroupEntity().getIdAttribute(),
             false);
     SqlQueryRequest sqlQueryRequest =
-        bqQueryRunner.buildListQuerySql(
+        bqQueryRunner.buildListQuerySqlAgainstIndexData(
             ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 pulsePerson.getGroupEntity(),
@@ -1102,7 +1102,7 @@ public class BQFilterTest extends BQRunnerTest {
         new AttributeField(
             underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false);
     SqlQueryRequest sqlQueryRequest =
-        bqQueryRunner.buildListQuerySql(
+        bqQueryRunner.buildListQuerySqlAgainstIndexData(
             ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
@@ -2069,7 +2069,7 @@ public class BQFilterTest extends BQRunnerTest {
             groupItems.getGroupEntity().getIdAttribute(),
             false);
     SqlQueryRequest sqlQueryRequest =
-        bqQueryRunner.buildListQuerySql(
+        bqQueryRunner.buildListQuerySqlAgainstIndexData(
             ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getGroupEntity(),

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFilterTest.java
@@ -53,19 +53,11 @@ public class BQFilterTest extends BQRunnerTest {
     AttributeFilter attributeFilter =
         new AttributeFilter(underlay, entity, attribute, UnaryOperator.IS_NOT_NULL);
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("attributeFilterUnary", listQueryResult.getSql(), table);
 
@@ -76,16 +68,8 @@ public class BQFilterTest extends BQRunnerTest {
             underlay, entity, attribute, BinaryOperator.NOT_EQUALS, Literal.forInt64(1_956L));
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
     assertSqlMatchesWithTableNameOnly("attributeFilterBinary", listQueryResult.getSql(), table);
 
     // Filter with n-ary operator IN.
@@ -99,16 +83,8 @@ public class BQFilterTest extends BQRunnerTest {
             List.of(Literal.forInt64(18L), Literal.forInt64(19L), Literal.forInt64(20L)));
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
     assertSqlMatchesWithTableNameOnly("attributeFilterNaryIn", listQueryResult.getSql(), table);
 
     // Filter with n-ary operator BETWEEN.
@@ -122,16 +98,8 @@ public class BQFilterTest extends BQRunnerTest {
             List.of(Literal.forInt64(45L), Literal.forInt64(65L)));
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
     assertSqlMatchesWithTableNameOnly(
         "attributeFilterNaryBetween", listQueryResult.getSql(), table);
   }
@@ -150,19 +118,11 @@ public class BQFilterTest extends BQRunnerTest {
         new BooleanAndOrFilter(
             BooleanAndOrFilter.LogicalOperator.AND, List.of(attributeFilter, textSearchFilter));
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("name"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("name"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                booleanAndOrFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), booleanAndOrFilter, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("booleanAndOrFilter", listQueryResult.getSql(), table);
   }
@@ -176,19 +136,11 @@ public class BQFilterTest extends BQRunnerTest {
             underlay, entity, attribute, BinaryOperator.NOT_EQUALS, Literal.forInt64(1_956L));
     BooleanNotFilter booleanNotFilter = new BooleanNotFilter(attributeFilter);
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                booleanNotFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), booleanNotFilter, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("booleanNotFilter", listQueryResult.getSql(), table);
   }
@@ -203,19 +155,16 @@ public class BQFilterTest extends BQRunnerTest {
             entity.getHierarchy(Hierarchy.DEFAULT_NAME),
             Literal.forInt64(201_826L));
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("name"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("name"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 entity,
                 List.of(simpleAttribute),
                 hierarchyHasAncestorFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable entityMainTable =
         underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     BQTable ancestorDescendantTable =
@@ -237,16 +186,13 @@ public class BQFilterTest extends BQRunnerTest {
             List.of(Literal.forInt64(201_826L), Literal.forInt64(201_254L)));
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 entity,
                 List.of(simpleAttribute),
                 hierarchyHasAncestorFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "hierarchyHasAncestorFilterIn",
         listQueryResult.getSql(),
@@ -264,19 +210,11 @@ public class BQFilterTest extends BQRunnerTest {
             entity.getHierarchy(Hierarchy.DEFAULT_NAME),
             Literal.forInt64(201_826L));
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("name"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("name"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                hierarchyHasParentFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), hierarchyHasParentFilter, null, null));
     BQTable entityMainTable =
         underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     BQTable childParentTable =
@@ -298,16 +236,8 @@ public class BQFilterTest extends BQRunnerTest {
             List.of(Literal.forInt64(201_826L), Literal.forInt64(201_254L)));
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                hierarchyHasParentFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), hierarchyHasParentFilter, null, null));
     assertSqlMatchesWithTableNameOnly(
         "hierarchyHasParentFilterIn", listQueryResult.getSql(), entityMainTable, childParentTable);
   }
@@ -318,19 +248,11 @@ public class BQFilterTest extends BQRunnerTest {
     HierarchyIsMemberFilter hierarchyIsMemberFilter =
         new HierarchyIsMemberFilter(underlay, entity, entity.getHierarchy(Hierarchy.DEFAULT_NAME));
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("name"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("name"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                hierarchyIsMemberFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), hierarchyIsMemberFilter, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("hierarchyIsMemberFilter", listQueryResult.getSql(), table);
   }
@@ -341,19 +263,11 @@ public class BQFilterTest extends BQRunnerTest {
     HierarchyIsRootFilter hierarchyIsRootFilter =
         new HierarchyIsRootFilter(underlay, entity, entity.getHierarchy(Hierarchy.DEFAULT_NAME));
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("name"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("name"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                hierarchyIsRootFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), hierarchyIsRootFilter, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("hierarchyIsRootFilter", listQueryResult.getSql(), table);
   }
@@ -385,19 +299,16 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false, false);
+            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable primaryTable =
@@ -431,16 +342,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterFKSelectNotIdFilter",
         listQueryResult.getSql(),
@@ -460,16 +368,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterFKSelectNullFilter",
         listQueryResult.getSql(),
@@ -507,20 +412,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getAttribute("year_of_birth"),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable primaryTable =
@@ -553,16 +454,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterFKFilterNotIdFilter",
         listQueryResult.getSql(),
@@ -582,16 +480,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterFKFilterNullFilterWithoutRollupCount",
         listQueryResult.getSql(),
@@ -627,20 +522,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             pulsePerson.getGroupEntity(),
             pulsePerson.getGroupEntity().getIdAttribute(),
-            false,
             false);
     SqlQueryRequest sqlQueryRequest =
         bqQueryRunner.buildListQuerySql(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 pulsePerson.getGroupEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     primaryTable =
         underlay
             .getIndexSchema()
@@ -679,20 +570,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems.getItemsEntity(),
             groupItems.getItemsEntity().getAttribute("name"),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable groupTable =
         underlay
             .getIndexSchema()
@@ -738,16 +625,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterIntTableNotIdFilter",
         listQueryResult.getSql(),
@@ -768,16 +652,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterIntTableNullFilterWithoutRollupCount",
         listQueryResult.getSql(),
@@ -791,7 +672,6 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems.getGroupEntity(),
             groupItems.getItemsEntity().getAttribute("name"),
-            false,
             false);
     relationshipFilter =
         new RelationshipFilter(
@@ -805,16 +685,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getGroupEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterIntTableNullFilterWithRollupCount",
         listQueryResult.getSql(),
@@ -854,20 +731,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getAttribute("year_of_birth"),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable primaryTable =
@@ -902,16 +775,13 @@ public class BQFilterTest extends BQRunnerTest {
             1);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterFKFilterNotIdFilterWithGroupBy",
         listQueryResult.getSql(),
@@ -933,16 +803,13 @@ public class BQFilterTest extends BQRunnerTest {
             14);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterFKFilterNullFilterWithGroupBy",
         listQueryResult.getSql(),
@@ -977,20 +844,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems.getItemsEntity(),
             groupItems.getItemsEntity().getAttribute("name"),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable groupTable =
         underlay
             .getIndexSchema()
@@ -1036,16 +899,13 @@ public class BQFilterTest extends BQRunnerTest {
             1);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterIntTableNotIdFilterWithGroupBy",
         listQueryResult.getSql(),
@@ -1066,16 +926,13 @@ public class BQFilterTest extends BQRunnerTest {
             1);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "relationshipFilterIntTableNullFilterWithGroupBy",
         listQueryResult.getSql(),
@@ -1120,19 +977,16 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false, false);
+            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 occurrenceFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly(
@@ -1176,19 +1030,16 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false, false);
+            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 occurrenceFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable intermediateTable =
@@ -1249,19 +1100,16 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false, false);
+            underlay, occurrenceEntity, occurrenceEntity.getAttribute("start_date"), false);
     SqlQueryRequest sqlQueryRequest =
         bqQueryRunner.buildListQuerySql(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 occurrenceFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable itemsTable =
@@ -1311,19 +1159,16 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, occurrenceEntity, occurrenceEntity.getAttribute("person_id"), false, false);
+            underlay, occurrenceEntity, occurrenceEntity.getAttribute("person_id"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable criteriaTable =
@@ -1376,19 +1221,16 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, occurrenceEntity, occurrenceEntity.getAttribute("person_id"), false, false);
+            underlay, occurrenceEntity, occurrenceEntity.getAttribute("person_id"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 occurrenceEntity,
                 List.of(simpleAttribute),
                 relationshipFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable occurrenceTable =
         underlay.getIndexSchema().getEntityMain(occurrenceEntity.getName()).getTablePointer();
     BQTable criteriaTable =
@@ -1421,19 +1263,11 @@ public class BQFilterTest extends BQRunnerTest {
         new TextSearchFilter(
             underlay, entity, TextSearchFilter.TextSearchOperator.EXACT_MATCH, "diabetes", null);
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("name"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("name"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                textSearchFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), textSearchFilter, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("textSearchFilterIndex", listQueryResult.getSql(), table);
 
@@ -1446,16 +1280,8 @@ public class BQFilterTest extends BQRunnerTest {
             entity.getAttribute("name"));
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                textSearchFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), textSearchFilter, null, null));
     assertSqlMatchesWithTableNameOnly("textSearchFilterAttribute", listQueryResult.getSql(), table);
   }
 
@@ -1479,20 +1305,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getIdAttribute(),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     List<BQTable> tableNamesToSubstitute = new ArrayList<>();
     criteriaOccurrence.getOccurrenceEntities().stream()
@@ -1554,16 +1376,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "primaryWithCriteriaFilterSingleOccAttributeSubfilter",
         listQueryResult.getSql(),
@@ -1591,20 +1410,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getIdAttribute(),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     List<BQTable> tableNamesToSubstitute = new ArrayList<>();
     criteriaOccurrence.getOccurrenceEntities().stream()
@@ -1670,16 +1485,13 @@ public class BQFilterTest extends BQRunnerTest {
             null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "primaryWithCriteriaFilterMultipleOccAttributeSubfilter",
         listQueryResult.getSql(),
@@ -1713,20 +1525,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getIdAttribute(),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     List<BQTable> tableNamesToSubstitute = new ArrayList<>();
     criteriaOccurrence.getOccurrenceEntities().stream()
@@ -1791,16 +1599,13 @@ public class BQFilterTest extends BQRunnerTest {
             4);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "primaryWithCriteriaFilterGroupBySingleOccAttributeSubfilter",
         listQueryResult.getSql(),
@@ -1850,20 +1655,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             underlay.getPrimaryEntity(),
             underlay.getPrimaryEntity().getIdAttribute(),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     List<BQTable> tableNamesToSubstitute = new ArrayList<>();
     criteriaOccurrence.getOccurrenceEntities().stream()
@@ -1930,16 +1731,13 @@ public class BQFilterTest extends BQRunnerTest {
             14);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 underlay.getPrimaryEntity(),
                 List.of(simpleAttribute),
                 primaryWithCriteriaFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "primaryWithCriteriaFilterGroupByMultipleOccAttributeSubfilter",
         listQueryResult.getSql(),
@@ -1978,19 +1776,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay, criteriaOccurrence, conditionOccurrence, personFilter, null);
     AttributeField simpleAttribute =
         new AttributeField(
-            underlay, conditionOccurrence, conditionOccurrence.getIdAttribute(), false, false);
+            underlay, conditionOccurrence, conditionOccurrence.getIdAttribute(), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 conditionOccurrence,
                 List.of(simpleAttribute),
                 occurrenceForPrimaryFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     List<BQTable> tableNamesToSubstitute = new ArrayList<>();
     criteriaOccurrence.getOccurrenceEntities().stream()
@@ -2031,16 +1826,13 @@ public class BQFilterTest extends BQRunnerTest {
             underlay, criteriaOccurrence, conditionOccurrence, null, conditionFilter);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 conditionOccurrence,
                 List.of(simpleAttribute),
                 occurrenceForPrimaryFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "occurrenceForPrimaryFilterWithCriteriaSubFilterOnly",
         listQueryResult.getSql(),
@@ -2052,16 +1844,13 @@ public class BQFilterTest extends BQRunnerTest {
             underlay, criteriaOccurrence, conditionOccurrence, personFilter, conditionFilter);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 conditionOccurrence,
                 List.of(simpleAttribute),
                 occurrenceForPrimaryFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "occurrenceForPrimaryFilterWithBothSubFilters",
         listQueryResult.getSql(),
@@ -2075,16 +1864,13 @@ public class BQFilterTest extends BQRunnerTest {
         InvalidQueryException.class,
         () ->
             bqQueryRunner.run(
-                new ListQueryRequest(
+                ListQueryRequest.dryRunAgainstIndexData(
                     underlay,
                     conditionOccurrence,
                     List.of(simpleAttribute),
                     invalidOccurrenceForPrimaryFilter,
                     null,
-                    null,
-                    null,
-                    null,
-                    true)));
+                    null)));
   }
 
   @Test
@@ -2099,20 +1885,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems.getItemsEntity(),
             groupItems.getItemsEntity().getAttribute("name"),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 itemInGroupFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     BQTable groupEntityTable =
         underlay
@@ -2151,16 +1933,13 @@ public class BQFilterTest extends BQRunnerTest {
         new ItemInGroupFilter(underlay, groupItems, groupSubFilter, null, null, null);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 itemInGroupFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "itemInGroupWithSubFilterIntTable",
         listQueryResult.getSql(),
@@ -2173,16 +1952,13 @@ public class BQFilterTest extends BQRunnerTest {
         new ItemInGroupFilter(underlay, groupItems, null, null, BinaryOperator.GREATER_THAN, 2);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 itemInGroupFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "itemInGroupWithGroupByNoSubFilterIntTable",
         listQueryResult.getSql(),
@@ -2208,16 +1984,13 @@ public class BQFilterTest extends BQRunnerTest {
             2);
     listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getItemsEntity(),
                 List.of(simpleAttribute),
                 itemInGroupFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
     assertSqlMatchesWithTableNameOnly(
         "itemInGroupWithGroupByAttributeWithSubFilterIntTable",
         listQueryResult.getSql(),
@@ -2237,20 +2010,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems.getGroupEntity(),
             groupItems.getGroupEntity().getAttribute("name"),
-            false,
             false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getGroupEntity(),
                 List.of(simpleAttribute),
                 groupHasItemsFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     BQTable groupEntityTable =
         underlay
@@ -2298,20 +2067,16 @@ public class BQFilterTest extends BQRunnerTest {
             underlay,
             groupItems.getGroupEntity(),
             groupItems.getGroupEntity().getIdAttribute(),
-            false,
             false);
     SqlQueryRequest sqlQueryRequest =
         bqQueryRunner.buildListQuerySql(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 groupItems.getGroupEntity(),
                 List.of(simpleAttribute),
                 groupHasItemsFilter,
                 null,
-                null,
-                null,
-                null,
-                true));
+                null));
 
     groupEntityTable =
         underlay

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQListQueryTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQListQueryTest.java
@@ -22,19 +22,19 @@ public class BQListQueryTest extends BQRunnerTest {
         InvalidQueryException.class,
         () ->
             bqQueryRunner.run(
-                new ListQueryRequest(
-                    underlay, entity, List.of(), null, null, null, null, null, true)));
+                ListQueryRequest.dryRunAgainstIndexData(
+                    underlay, entity, List.of(), null, null, null)));
   }
 
   @Test
   void noFilter() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, List.of(simpleAttribute), null, null, null, null, null, true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), null, null, null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("noFilter", listQueryResult.getSql(), table);
   }
@@ -43,19 +43,16 @@ public class BQListQueryTest extends BQRunnerTest {
   void withOrderByInSelect() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField selectAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("age"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("age"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 entity,
                 List.of(selectAttribute),
                 null,
                 List.of(new ListQueryRequest.OrderBy(selectAttribute, OrderByDirection.DESCENDING)),
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("withOrderByInSelect", listQueryResult.getSql(), table);
   }
@@ -64,21 +61,18 @@ public class BQListQueryTest extends BQRunnerTest {
   void withOrderByNotInSelect() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField selectAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     AttributeField orderByAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("age"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("age"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 entity,
                 List.of(selectAttribute),
                 null,
                 List.of(new ListQueryRequest.OrderBy(orderByAttribute, OrderByDirection.ASCENDING)),
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("withOrderByNotInSelect", listQueryResult.getSql(), table);
   }
@@ -87,21 +81,18 @@ public class BQListQueryTest extends BQRunnerTest {
   void withOrderByValueDisplayAttribute() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField selectAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     AttributeField orderByAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("gender"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("gender"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 entity,
                 List.of(selectAttribute),
                 null,
                 List.of(new ListQueryRequest.OrderBy(orderByAttribute, OrderByDirection.ASCENDING)),
-                null,
-                null,
-                null,
-                true));
+                null));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly(
         "withOrderByValueDisplayAttribute", listQueryResult.getSql(), table);
@@ -111,19 +102,16 @@ public class BQListQueryTest extends BQRunnerTest {
   void withOrderByRandom() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField selectAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
+            ListQueryRequest.dryRunAgainstIndexData(
                 underlay,
                 entity,
                 List.of(selectAttribute),
                 null,
                 List.of(ListQueryRequest.OrderBy.random()),
-                45,
-                null,
-                null,
-                true));
+                45));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("withOrderByRandom", listQueryResult.getSql(), table);
   }
@@ -132,11 +120,11 @@ public class BQListQueryTest extends BQRunnerTest {
   void withLimit() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField selectAttribute =
-        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false, false);
+        new AttributeField(underlay, entity, entity.getAttribute("year_of_birth"), false);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay, entity, List.of(selectAttribute), null, List.of(), 45, null, null, true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(selectAttribute), null, List.of(), 45));
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("withLimit", listQueryResult.getSql(), table);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
@@ -35,7 +35,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
   void int64RemoveParam() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
     AttributeFilter attributeFilter =
         new AttributeFilter(
             underlay,
@@ -45,16 +45,8 @@ public class BQRemoveParamsTest extends BQRunnerTest {
             Literal.forInt64(25L));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("int64", listQueryResult.getSqlNoParams(), table);
@@ -64,7 +56,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
   void float64RemoveParam() throws IOException {
     Entity entity = underlay.getEntity("measurementOccurrence");
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
     AttributeFilter attributeFilter =
         new AttributeFilter(
             underlay,
@@ -74,16 +66,8 @@ public class BQRemoveParamsTest extends BQRunnerTest {
             Literal.forDouble(26.54));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("float64", listQueryResult.getSqlNoParams(), table);
@@ -93,7 +77,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
   void stringRemoveParam() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
     AttributeFilter attributeFilter =
         new AttributeFilter(
             underlay,
@@ -103,16 +87,8 @@ public class BQRemoveParamsTest extends BQRunnerTest {
             Literal.forString("id12345"));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("string", listQueryResult.getSqlNoParams(), table);
@@ -131,7 +107,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
 
     Entity entity = underlay.getEntity("conditionOccurrence");
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
     AttributeFilter attributeFilter =
         new AttributeFilter(
             underlay,
@@ -141,16 +117,8 @@ public class BQRemoveParamsTest extends BQRunnerTest {
             Literal.forDate(Date.valueOf("2024-01-24")));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("date", listQueryResult.getSqlNoParams(), table);
@@ -160,7 +128,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
   void timestampRemoveParam() throws IOException {
     Entity entity = underlay.getEntity("conditionOccurrence");
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
     AttributeFilter attributeFilter =
         new AttributeFilter(
             underlay,
@@ -170,16 +138,8 @@ public class BQRemoveParamsTest extends BQRunnerTest {
             Literal.forTimestamp(Timestamp.valueOf("2024-01-24 11:54:32")));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                attributeFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), attributeFilter, null, null));
 
     BQTable table = underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly("timestamp", listQueryResult.getSqlNoParams(), table);
@@ -189,7 +149,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
   void overlappingParams() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
     AttributeField simpleAttribute =
-        new AttributeField(underlay, entity, entity.getIdAttribute(), false, false);
+        new AttributeField(underlay, entity, entity.getIdAttribute(), false);
     List<EntityFilter> attributeFilters = new ArrayList<>();
     for (int i = 0; i < 11; i++) {
       attributeFilters.add(
@@ -204,16 +164,8 @@ public class BQRemoveParamsTest extends BQRunnerTest {
         new BooleanAndOrFilter(BooleanAndOrFilter.LogicalOperator.OR, attributeFilters);
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
-            new ListQueryRequest(
-                underlay,
-                entity,
-                List.of(simpleAttribute),
-                booleanAndOrFilter,
-                null,
-                null,
-                null,
-                null,
-                true));
+            ListQueryRequest.dryRunAgainstIndexData(
+                underlay, entity, List.of(simpleAttribute), booleanAndOrFilter, null, null));
 
     assertTrue(listQueryResult.getSql().contains("val1"));
     assertTrue(listQueryResult.getSql().contains("val10"));

--- a/underlay/src/test/java/bio/terra/tanagra/underlay/ConfigReaderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/underlay/ConfigReaderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.serialization.SZCriteriaSelector;
 import bio.terra.tanagra.underlay.serialization.SZEntity;
@@ -89,5 +90,16 @@ public class ConfigReaderTest {
         Underlay.fromConfig(verilyCmssynpuf.bigQuery, szCmssynpuf, ConfigReader.fromJarResources());
     assertNotNull(cmssynpuf);
     assertEquals("cmssynpuf", cmssynpuf.getName());
+
+    Entity person = cmssynpuf.getPrimaryEntity();
+    assertEquals(
+        "bigquery-public-data.cms_synthetic_patient_data_omop.person",
+        person.getSourceQueryTableName());
+    Attribute gender = person.getAttribute("gender");
+    assertNotNull(gender.getSourceQuery());
+    assertEquals(
+        "bigquery-public-data.cms_synthetic_patient_data_omop.concept",
+        gender.getSourceQuery().getDisplayFieldTable());
+    assertEquals("concept_id", gender.getSourceQuery().getDisplayFieldTableJoinFieldName());
   }
 }

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -1,0 +1,20 @@
+
+    SELECT
+        st.year_of_birth,
+        st.gender_concept_id,
+        dt0.concept_name AS T_DISP_gender,
+        st.race_concept_id,
+        st.birth_datetime,
+        st.person_id      
+    FROM
+        ${person} AS st      
+    JOIN
+        ${concept} AS dt0              
+            ON dt0.concept_id = st.gender_concept_id      
+    WHERE
+        st.person_id IN (
+            SELECT
+                id              
+            FROM
+                ${ENT_person}         
+        )

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -5,7 +5,9 @@
         dt0.concept_name AS T_DISP_gender,
         st.race_concept_id,
         st.birth_datetime,
-        st.person_id      
+        st.person_id,
+        st.person_source_value,
+        st.ethnicity_concept_id AS T_DISP_ethnicityNoDisplayJoin      
     FROM
         ${person} AS st      
     JOIN
@@ -16,5 +18,7 @@
             SELECT
                 id              
             FROM
-                ${ENT_person}         
+                ${ENT_person}              
+            WHERE
+                person_source_value IS NOT NULL         
         )

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -10,7 +10,7 @@
         st.ethnicity_concept_id AS T_DISP_ethnicityNoDisplayJoin      
     FROM
         ${person} AS st      
-    JOIN
+    LEFT JOIN
         ${concept} AS dt0              
             ON dt0.concept_id = st.gender_concept_id      
     WHERE


### PR DESCRIPTION
- Added new configuration properties for entities and attributes to define the mapping to the source dataset.
  - You have to define the new `sourceQueryTableName` property for each entity that you want to generate source queries for. I've done this for the `cmssynpuf.person` entity.
  - For each attribute, you can override the default behavior (i.e. same column name as the index data mapping) with additional config properties, or suppress it entirely for source queries. You can also specify a table to `LEFT JOIN` to to include a display field.
- Implemented the SQL generation for a `ListQueryRequest` against the source data.
- Updated the `ipynb` file download export option to generate a query against the source data.
- Handled the case for frontend filterbuilding, when the primary entity filter is passed as one of the list instances queries instead of in the separate property.
- Some refactoring for better readability:
  - Pulled the serialization classes nested in `SZEntity` out into separate files.
  - Changed the `ListQueryRequest` constructor calls to use static factory methods instead.
  - Changed the `AttributeField` constructor calls to never allow the `isAgainstSourceDataset` flag to be set to true. Since we can't have a mix of source/index fields, this field can only be set if the `isAgainstSourceDataset` flag is set on the whole query request. During SQL generation, it's still helpful to have the flag also on the `AttributeField`, so I added a separate factory method specifically for that case.
