### PR TITLE
Suppress only empty files, not errors in individual file download.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IndividualFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IndividualFileDownload.java
@@ -70,14 +70,16 @@ public class IndividualFileDownload implements DataExport {
     List<ExportFileResult> allExportFileResults = new ArrayList<>();
     // Set the tags for each file result, and suppress empty files.
     entityExportFileResults.stream()
-        .filter(ExportFileResult::hasFileUrl)
+        .filter(
+            exportFileResult -> exportFileResult.hasFileUrl() || !exportFileResult.isSuccessful())
         .forEach(
             exportFileResult -> {
               exportFileResult.addTags(List.of("Data", exportFileResult.getEntity().getName()));
               allExportFileResults.add(exportFileResult);
             });
     annotationExportFileResults.stream()
-        .filter(ExportFileResult::hasFileUrl)
+        .filter(
+            exportFileResult -> exportFileResult.hasFileUrl() || !exportFileResult.isSuccessful())
         .forEach(
             exportFileResult -> {
               exportFileResult.addTags(

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/VwbFileImport.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/VwbFileImport.java
@@ -67,14 +67,16 @@ public class VwbFileImport implements DataExport {
     List<ExportFileResult> allExportFileResults = new ArrayList<>();
     // Set the tags for each file result, and suppress empty files.
     entityExportFileResults.stream()
-        .filter(ExportFileResult::hasFileUrl)
+        .filter(
+            exportFileResult -> exportFileResult.hasFileUrl() || !exportFileResult.isSuccessful())
         .forEach(
             exportFileResult -> {
               exportFileResult.addTags(List.of("Data", exportFileResult.getEntity().getName()));
               allExportFileResults.add(exportFileResult);
             });
     annotationExportFileResults.stream()
-        .filter(ExportFileResult::hasFileUrl)
+        .filter(
+            exportFileResult -> exportFileResult.hasFileUrl() || !exportFileResult.isSuccessful())
         .forEach(
             exportFileResult -> {
               exportFileResult.addTags(

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -148,7 +148,7 @@ public class BQExecutor {
           exportProjectId,
           exportDatasetId,
           tempTableName);
-      return null;
+      return Pair.of(null, null);
     }
 
     // Export the temporary table to a compressed file.


### PR DESCRIPTION
Fixed the individual file download and vwb import export models to not suppress individual file errors. I introduced this bug when I changed these same export models to suppress empty (i.e. no data) files -- I accidentally also suppressed file errors.