### PR TITLE
Fix date for documents in review underlay config

### DIFF
--- a/underlay/src/main/resources/config/underlay/sd/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd/ui.json
@@ -210,7 +210,7 @@
         "plugin": {
           "entity": "noteOccurrence",
           "title": "title",
-          "subtitles": ["note", "date"],
+          "subtitles": ["note", "start_date"],
           "text": "note_text",
           "categoryAttribute": "note",
           "sortOrder": {


### PR DESCRIPTION
In the UI underlay config, the date for the `textSearch` plugin in cohort review (used for Documents) was using `date` when it should be `start_date`, resulting in 'undefined' displayed in the app.
![documents_undefined](https://github.com/DataBiosphere/tanagra/assets/40036095/ce5547ca-6893-4e6d-8cce-b4377b5de21f)
