### PR TITLE
Include BioVU DNA selections in criteria title

### DIFF
--- a/ui/src/plugins/vumc/biovu.tsx
+++ b/ui/src/plugins/vumc/biovu.tsx
@@ -121,20 +121,19 @@ class _ implements CriteriaPlugin<string> {
 
   displayDetails() {
     const decodedData = decodeData(this.data);
+    let title = this.config.plasmaFilter
+      ? PLASMA
+      : sampleFilterDescriptions[decodedData.sampleFilter];
 
-    const additionalText: string[] = [];
     if (decodedData.excludeCompromised) {
-      additionalText.push(EXCLUDE_COMPROMISED);
+      title += `, ${EXCLUDE_COMPROMISED}`;
     }
     if (decodedData.excludeInternal) {
-      additionalText.push(EXCLUDE_INTERNAL);
+      title += `, ${EXCLUDE_INTERNAL}`;
     }
 
     return {
-      title: this.config.plasmaFilter
-        ? PLASMA
-        : sampleFilterDescriptions[decodedData.sampleFilter],
-      additionalText: additionalText,
+      title: title,
     };
   }
 


### PR DESCRIPTION
Update to the display of the biovu plugin, adding 'Exclude Compromised DNA' and 'Include only samples available for external processing' to the `title` string when selected instead of the `additionalText` array (they are only visible in cohort review when located in `additionalText`)