### PR TITLE
Stop populating output parameters for export models.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/export/ExportResult.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/ExportResult.java
@@ -29,6 +29,10 @@ public final class ExportResult {
     return new ExportResult(outputs, null, null, fileResults);
   }
 
+  public static ExportResult forFileResults(List<ExportFileResult> fileResults) {
+    return new ExportResult(Map.of(), null, null, fileResults);
+  }
+
   public static ExportResult forRedirectUrl(
       String redirectAwayUrl, List<ExportFileResult> fileResults) {
     return new ExportResult(Map.of(), redirectAwayUrl, null, fileResults);

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IndividualFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IndividualFileDownload.java
@@ -9,14 +9,9 @@ import bio.terra.tanagra.service.export.ExportFileResult;
 import bio.terra.tanagra.service.export.ExportRequest;
 import bio.terra.tanagra.service.export.ExportResult;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class IndividualFileDownload implements DataExport {
-
-  private static final String ENTITY_OUTPUT_KEY_PREFIX = "Data:";
-  private static final String COHORT_OUTPUT_KEY_PREFIX = "Annotations:";
 
   @Override
   public Type getType() {
@@ -31,13 +26,6 @@ public class IndividualFileDownload implements DataExport {
   @Override
   public String getDescription() {
     return "List of file URLs. Each URL points to a single file with either query results or annotation data.";
-  }
-
-  @Override
-  public Map<String, String> describeOutputs() {
-    return Map.of(
-        ENTITY_OUTPUT_KEY_PREFIX + "*", "URL to query results",
-        COHORT_OUTPUT_KEY_PREFIX + "*", "URL to annotation data for a cohort");
   }
 
   @Override
@@ -87,32 +75,6 @@ public class IndividualFileDownload implements DataExport {
               allExportFileResults.add(exportFileResult);
             });
 
-    // TODO: Skip populating these output parameters once the UI is processing the file results
-    // directly.
-    Map<String, String> outputParams = new HashMap<>();
-    entityExportFileResults.stream()
-        .filter(
-            exportFileResult -> exportFileResult.isSuccessful() && exportFileResult.hasFileUrl())
-        .forEach(
-            exportFileResult ->
-                outputParams.put(
-                    ENTITY_OUTPUT_KEY_PREFIX + exportFileResult.getEntity().getName(),
-                    exportFileResult.getFileUrl()));
-    annotationExportFileResults.stream()
-        .filter(
-            annotationExportFileResult ->
-                annotationExportFileResult.isSuccessful()
-                    && annotationExportFileResult.hasFileUrl())
-        .forEach(
-            exportFileResult -> {
-              String cohortName = exportFileResult.getCohort().getDisplayName();
-              if (cohortName == null || cohortName.isEmpty()) {
-                cohortName = exportFileResult.getCohort().getId();
-              }
-              outputParams.put(
-                  COHORT_OUTPUT_KEY_PREFIX + cohortName, exportFileResult.getFileUrl());
-            });
-
-    return ExportResult.forOutputParams(outputParams, allExportFileResults);
+    return ExportResult.forFileResults(allExportFileResults);
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/IpynbFileDownload.java
@@ -43,11 +43,6 @@ public class IpynbFileDownload implements DataExport {
   }
 
   @Override
-  public Map<String, String> describeOutputs() {
-    return Map.of(IPYNB_FILE_KEY, "URL to ipynb file");
-  }
-
-  @Override
   public void initialize(DeploymentConfig deploymentConfig) {
     gcsBucketNames = deploymentConfig.getShared().getGcsBucketNames();
   }
@@ -104,13 +99,9 @@ public class IpynbFileDownload implements DataExport {
     // Generate a signed URL for the ipynb file.
     String ipynbSignedUrl = helper.getStorageService().createSignedUrl(blobId.toGsUtilUri());
 
-    // TODO: Skip populating this output parameter once the UI is processing the file result
-    // directly.
-    Map<String, String> outputParams = Map.of(IPYNB_FILE_KEY, ipynbSignedUrl);
-
     ExportFileResult exportFileResult =
         ExportFileResult.forFile(fileName, ipynbSignedUrl, null, null);
     exportFileResult.addTags(List.of("Notebook File"));
-    return ExportResult.forOutputParams(outputParams, List.of(exportFileResult));
+    return ExportResult.forFileResults(List.of(exportFileResult));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/export/impl/RegressionTest.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/impl/RegressionTest.java
@@ -90,14 +90,10 @@ public class RegressionTest implements DataExport {
     // Generate a signed URL for the JSON file.
     String jsonSignedUrl = helper.getStorageService().createSignedUrl(blobId.toGsUtilUri());
 
-    // TODO: Skip populating this output parameter once the UI is processing the file result
-    // directly.
-    Map<String, String> outputParams = Map.of("Regression Test File:" + fileName, jsonSignedUrl);
-
     ExportFileResult exportFileResult =
         ExportFileResult.forFile(fileName, jsonSignedUrl, null, null);
     exportFileResult.addTags(List.of("Regression Test File"));
-    return ExportResult.forOutputParams(outputParams, List.of(exportFileResult));
+    return ExportResult.forFileResults(List.of(exportFileResult));
   }
 
   private static RTExportCounts.EntityOutputCount toRegressionTestObj(


### PR DESCRIPTION
Now that the UI is displaying the file results directly, we don't need to populate the output parameters any more. I left the output parameters in as an optional part of the export models though, in case we have a use for them in the future.