### PR TITLE
Add flag to override data feature set definition and include all attributes.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -125,7 +125,8 @@ public class ExportApiController implements ExportApi {
             .map(conceptSetId -> conceptSetService.getConceptSet(body.getStudy(), conceptSetId))
             .collect(Collectors.toList());
     List<EntityOutputPreview> entityOutputPreviews =
-        filterBuilderService.buildOutputPreviewsForExport(cohorts, conceptSets);
+        filterBuilderService.buildOutputPreviewsForExport(
+            cohorts, conceptSets, body.isIncludeAllAttributes());
     EntityOutputPreview entityOutputPreview =
         entityOutputPreviews.stream()
             .filter(eop -> entityName.equals(eop.getEntityOutput().getEntity().getName()))
@@ -175,7 +176,8 @@ public class ExportApiController implements ExportApi {
             .map(conceptSetId -> conceptSetService.getConceptSet(body.getStudy(), conceptSetId))
             .collect(Collectors.toList());
     List<EntityOutputPreview> entityOutputPreviews =
-        filterBuilderService.buildOutputPreviewsForExport(cohorts, conceptSets);
+        filterBuilderService.buildOutputPreviewsForExport(
+            cohorts, conceptSets, body.isIncludeAllAttributes());
 
     // Build the index and source sql for each entity output.
     Underlay underlay = underlayService.getUnderlay(underlayName);

--- a/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
@@ -142,7 +142,8 @@ public class FilterBuilderService {
     }
   }
 
-  public List<EntityOutputPreview> buildOutputPreviewsForConceptSets(List<ConceptSet> conceptSets) {
+  public List<EntityOutputPreview> buildOutputPreviewsForConceptSets(
+      List<ConceptSet> conceptSets, boolean includeAllAttributes) {
     // No concept sets = no entity outputs.
     if (conceptSets.isEmpty()) {
       return List.of();
@@ -285,7 +286,10 @@ public class FilterBuilderService {
             entry -> {
               Entity outputEntity = entry.getKey();
               List<EntityFilter> filters = entry.getValue().getLeft();
-              List<Attribute> includeAttributes = new ArrayList<>(entry.getValue().getRight());
+              List<Attribute> includeAttributes =
+                  includeAllAttributes
+                      ? outputEntity.getAttributes()
+                      : new ArrayList<>(entry.getValue().getRight());
               EntityOutput entityOutput;
               if (filters.isEmpty()) {
                 entityOutput = EntityOutput.unfiltered(outputEntity, includeAttributes);
@@ -317,7 +321,7 @@ public class FilterBuilderService {
   }
 
   public List<EntityOutputPreview> buildOutputPreviewsForExport(
-      List<Cohort> cohorts, List<ConceptSet> conceptSets) {
+      List<Cohort> cohorts, List<ConceptSet> conceptSets, boolean includeAllAttributes) {
     // No cohorts and no concept sets = no entity outputs.
     if (cohorts.isEmpty() && conceptSets.isEmpty()) {
       return List.of();
@@ -347,7 +351,7 @@ public class FilterBuilderService {
 
     // Build a combined filter per output entity from all the data feature sets.
     List<EntityOutputPreview> dataFeatureOutputPreviews =
-        buildOutputPreviewsForConceptSets(conceptSets);
+        buildOutputPreviewsForConceptSets(conceptSets, includeAllAttributes);
 
     // If there's no cohort filter, just return the entity output from the concept sets.
     if (combinedCohortFilter == null) {
@@ -435,7 +439,7 @@ public class FilterBuilderService {
 
   public List<EntityOutput> buildOutputsForExport(
       List<Cohort> cohorts, List<ConceptSet> conceptSets) {
-    return buildOutputPreviewsForExport(cohorts, conceptSets).stream()
+    return buildOutputPreviewsForExport(cohorts, conceptSets, false).stream()
         .map(EntityOutputPreview::getEntityOutput)
         .collect(Collectors.toList());
   }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2575,8 +2575,16 @@ components:
         limit:
           type: integer
           default: 50
+        includeAllAttributes:
+          type: boolean
+          description: |
+            When true, ignore the selected attributes in the data feature set definitions and include all
+            attributes for each output entity.
       required:
         - study
+        - cohorts
+        - conceptSets
+        - includeAllAttributes
 
     EntityOutputPreview:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2580,11 +2580,11 @@ components:
           description: |
             When true, ignore the selected attributes in the data feature set definitions and include all
             attributes for each output entity.
+          default: false
       required:
         - study
         - cohorts
         - conceptSets
-        - includeAllAttributes
 
     EntityOutputPreview:
       type: object

--- a/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
@@ -145,16 +145,17 @@ public class FilterBuilderServiceTest {
   void conceptSet() {
     // No concept sets = no entity outputs.
     List<EntityOutputPreview> entityOutputs =
-        filterBuilderService.buildOutputPreviewsForConceptSets(List.of());
+        filterBuilderService.buildOutputPreviewsForConceptSets(List.of(), false);
     assertTrue(entityOutputs.isEmpty());
 
     // Single empty concept set, no excluded attributes.
-    entityOutputs = filterBuilderService.buildOutputPreviewsForConceptSets(List.of(CS_EMPTY));
+    entityOutputs =
+        filterBuilderService.buildOutputPreviewsForConceptSets(List.of(CS_EMPTY), false);
     assertTrue(entityOutputs.isEmpty());
 
     // Single concept set, no excluded attributes.
     entityOutputs =
-        filterBuilderService.buildOutputPreviewsForConceptSets(List.of(CS_DEMOGRAPHICS));
+        filterBuilderService.buildOutputPreviewsForConceptSets(List.of(CS_DEMOGRAPHICS), false);
     assertEquals(1, entityOutputs.size());
     EntityOutput expectedOutput = EntityOutput.unfiltered(underlay.getPrimaryEntity());
     assertEquals(expectedOutput, entityOutputs.get(0).getEntityOutput());
@@ -163,6 +164,14 @@ public class FilterBuilderServiceTest {
         .forEach(criteria -> expectedAttributedCriteria.add(Pair.of(CS_DEMOGRAPHICS, criteria)));
     assertEquals(expectedAttributedCriteria, entityOutputs.get(0).getAttributedCriteria());
 
+    // Single concept set, excluded attributes but with override flag to include all attributes.
+    entityOutputs =
+        filterBuilderService.buildOutputPreviewsForConceptSets(
+            List.of(CS_DEMOGRAPHICS_EXCLUDE_ID_AGE), true);
+    assertEquals(1, entityOutputs.size());
+    expectedOutput = EntityOutput.unfiltered(underlay.getPrimaryEntity());
+    assertEquals(expectedOutput, entityOutputs.get(0).getEntityOutput());
+
     // Multiple concept sets, with overlapping excluded attributes.
     entityOutputs =
         filterBuilderService.buildOutputPreviewsForConceptSets(
@@ -170,7 +179,8 @@ public class FilterBuilderServiceTest {
                 CS_EMPTY,
                 CS_DEMOGRAPHICS_EXCLUDE_ID_AGE,
                 CS_DEMOGRAPHICS_EXCLUDE_ID_GENDER,
-                CS_CONDITION_AND_PROCEDURE));
+                CS_CONDITION_AND_PROCEDURE),
+            false);
     assertEquals(3, entityOutputs.size());
 
     EntityOutput expectedOutput1 =


### PR DESCRIPTION
This is to support the data feature set preview page, where we need to return all columns, even the unselected ones. The flag is `false` by default, so we only return the columns that are included by one or more of the selected data feature sets.

This flag applies to both the `/v2/underlays/{underlayName}/entityOutputsPreview` and `/v2/underlays/{underlayName}/entities/{entityName}/exportPreview` endpoints.