### PR TITLE
Add isSuppressedForExport flag to attribute.

### DIFF
--- a/docs/DEVELOPER_INFO.md
+++ b/docs/DEVELOPER_INFO.md
@@ -159,3 +159,14 @@ Modify the logging level for the service directly in the [`application.yml` file
 ```
 logging.level.org.springframework.jdbc.core: trace
 ```
+
+## Generated documentation
+We generate documentation for the underlay and service application configuration properties, directly from the code.
+Run the `checkGeneratedFiles.sh` script to regenerate the documentation or confirm that no changes are needed.
+
+```
+.github/tools/checkGeneratedFiles.sh
+```
+
+If any changes are generated, check them in. This script is also run in a GitHub action that will prevent you from
+merging code that has code inconsistent documentation.

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -71,6 +71,13 @@ When set to true, an indexing job will try to compute a display hint for this at
 
 *Default value:* `false`
 
+### SZAttribute.isSuppressedForExport
+**optional** boolean
+
+True if this attribute is suppressed for export (i.e. not available for selection in data feature sets).
+
+*Default value:* `false`
+
 ### SZAttribute.name
 **required** String
 
@@ -976,13 +983,6 @@ Name of the field in the display table (#szsourcequerydisplayfieldtable) that is
 This is required if the #szsourcequerydisplayfieldtable is specified.
 
 *Example value:* `concept_id`
-
-### SZSourceQuery.isSuppressed
-**optional** boolean
-
-True if this attribute doesn't map to a specific field in the source table.
-
-*Default value:* `false`
 
 ### SZSourceQuery.valueFieldName
 **optional** String

--- a/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
@@ -288,7 +288,9 @@ public class FilterBuilderService {
               List<EntityFilter> filters = entry.getValue().getLeft();
               List<Attribute> includeAttributes =
                   includeAllAttributes
-                      ? outputEntity.getAttributes()
+                      ? outputEntity.getAttributes().stream()
+                          .filter(attribute -> !attribute.isSuppressedForExport())
+                          .collect(Collectors.toList())
                       : new ArrayList<>(entry.getValue().getRight());
               EntityOutput entityOutput;
               if (filters.isEmpty()) {

--- a/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
@@ -244,6 +244,30 @@ public class FilterBuilderServiceTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.UnnecessaryFullyQualifiedName")
+  void suppressedAttribute() {
+    Underlay cmssynpuf = underlayService.getUnderlay("cmssynpuf");
+
+    // One suppressed attribute.
+    List<EntityOutputPreview> entityOutputs =
+        filterBuilderService.buildOutputPreviewsForConceptSets(
+            List.of(
+                bio.terra.tanagra.service.criteriaconstants.cmssynpuf.ConceptSet.CS_DEMOGRAPHICS),
+            true);
+    assertEquals(1, entityOutputs.size());
+    assertEquals(
+        cmssynpuf.getPrimaryEntity().getAttributes().size() - 1,
+        entityOutputs.get(0).getEntityOutput().getAttributes().size());
+    EntityOutput expectedOutput =
+        EntityOutput.unfiltered(
+            cmssynpuf.getPrimaryEntity(),
+            cmssynpuf.getPrimaryEntity().getAttributes().stream()
+                .filter(attribute -> !attribute.isSuppressedForExport())
+                .collect(Collectors.toList()));
+    assertEquals(expectedOutput, entityOutputs.get(0).getEntityOutput());
+  }
+
+  @Test
   void export() {
     // No cohorts or concept sets = no entity outputs.
     List<EntityOutput> entityOutputs =

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/ConceptSet.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/ConceptSet.java
@@ -1,0 +1,26 @@
+package bio.terra.tanagra.service.criteriaconstants.cmssynpuf;
+
+import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.Criteria.DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE;
+
+import java.util.List;
+import java.util.Map;
+
+public final class ConceptSet {
+  private static final String UNDERLAY_NAME = "cmssynpuf";
+
+  private ConceptSet() {}
+
+  public static final bio.terra.tanagra.service.artifact.model.ConceptSet CS_DEMOGRAPHICS =
+      bio.terra.tanagra.service.artifact.model.ConceptSet.builder()
+          .underlay(UNDERLAY_NAME)
+          .criteria(List.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getRight()))
+          .build();
+
+  public static final bio.terra.tanagra.service.artifact.model.ConceptSet
+      CS_DEMOGRAPHICS_EXCLUDE_ID_GENDER =
+          bio.terra.tanagra.service.artifact.model.ConceptSet.builder()
+              .underlay(UNDERLAY_NAME)
+              .criteria(List.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getRight()))
+              .excludeOutputAttributesPerEntity(Map.of("person", List.of("id", "gender")))
+              .build();
+}

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -4,6 +4,7 @@ export type SZAttribute = {
   displayHintRangeMax?: number;
   displayHintRangeMin?: number;
   isComputeDisplayHint?: boolean;
+  isSuppressedForExport?: boolean;
   name: string;
   runtimeDataType?: SZDataType;
   runtimeSqlFunctionWrapper?: string;
@@ -182,7 +183,6 @@ export type SZSourceQuery = {
   displayFieldName?: string;
   displayFieldTable?: string;
   displayFieldTableJoinFieldName?: string;
-  isSuppressed?: boolean;
   valueFieldName?: string;
 };
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -234,9 +234,6 @@ public class BQQueryRunner implements QueryRunner {
                   AttributeField.againstSourceDataset((AttributeField) valueDisplayField);
               Attribute.SourceQuery attrSourcePointer =
                   attrFieldAgainstSourceData.getAttribute().getSourceQuery();
-              if (attrSourcePointer.isSuppressed()) {
-                return;
-              }
 
               List<SqlQueryField> valueAndDisplayFields =
                   bqTranslator.translator(attrFieldAgainstSourceData).buildSqlFieldsForListSelect();

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -334,7 +334,6 @@ public final class Underlay {
                   Attribute.SourceQuery sourceQuery =
                       szAttribute.sourceQuery == null
                           ? new Attribute.SourceQuery(
-                              false,
                               szAttribute.valueFieldName == null
                                   ? szAttribute.name
                                   : szAttribute.valueFieldName,
@@ -342,7 +341,6 @@ public final class Underlay {
                               null,
                               null)
                           : new Attribute.SourceQuery(
-                              szAttribute.sourceQuery.isSuppressed,
                               szAttribute.sourceQuery.valueFieldName == null
                                   ? (szAttribute.valueFieldName == null
                                       ? szAttribute.name
@@ -359,6 +357,7 @@ public final class Underlay {
                       szAttribute.runtimeSqlFunctionWrapper,
                       ConfigReader.deserializeDataType(szAttribute.runtimeDataType),
                       szAttribute.isComputeDisplayHint,
+                      szAttribute.isSuppressedForExport,
                       sourceQuery);
                 })
             .collect(Collectors.toList());

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Attribute.java
@@ -11,6 +11,7 @@ public final class Attribute {
   private final String runtimeSqlFunctionWrapper;
   private final DataType runtimeDataType;
   private final boolean isComputeDisplayHint;
+  private final boolean isSuppressedForExport;
   private final SourceQuery sourceQuery;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -22,6 +23,7 @@ public final class Attribute {
       String runtimeSqlFunctionWrapper,
       DataType runtimeDataType,
       boolean isComputeDisplayHint,
+      boolean isSuppressedForExport,
       SourceQuery sourceQuery) {
     this.name = name;
     this.dataType = dataType;
@@ -30,6 +32,7 @@ public final class Attribute {
     this.runtimeSqlFunctionWrapper = runtimeSqlFunctionWrapper;
     this.runtimeDataType = runtimeDataType;
     this.isComputeDisplayHint = isComputeDisplayHint && !isId;
+    this.isSuppressedForExport = isSuppressedForExport;
     this.sourceQuery = sourceQuery;
   }
 
@@ -69,6 +72,10 @@ public final class Attribute {
     return isComputeDisplayHint;
   }
 
+  public boolean isSuppressedForExport() {
+    return isSuppressedForExport;
+  }
+
   public SourceQuery getSourceQuery() {
     return sourceQuery;
   }
@@ -85,6 +92,7 @@ public final class Attribute {
     return isValueDisplay == attribute.isValueDisplay
         && isId == attribute.isId
         && isComputeDisplayHint == attribute.isComputeDisplayHint
+        && isSuppressedForExport == attribute.isSuppressedForExport
         && name.equals(attribute.name)
         && dataType == attribute.dataType
         && Objects.equals(runtimeSqlFunctionWrapper, attribute.runtimeSqlFunctionWrapper)
@@ -102,12 +110,11 @@ public final class Attribute {
         runtimeSqlFunctionWrapper,
         runtimeDataType,
         isComputeDisplayHint,
+        isSuppressedForExport,
         sourceQuery);
   }
 
   public static class SourceQuery {
-    private final boolean isSuppressed;
-
     private final String valueFieldName;
 
     private final String displayFieldTable;
@@ -117,20 +124,14 @@ public final class Attribute {
     private final String displayFieldTableJoinFieldName;
 
     public SourceQuery(
-        boolean isSuppressed,
         String valueFieldName,
         String displayFieldTable,
         String displayFieldName,
         String displayFieldTableJoinFieldName) {
-      this.isSuppressed = isSuppressed;
       this.valueFieldName = valueFieldName;
       this.displayFieldTable = displayFieldTable;
       this.displayFieldName = displayFieldName;
       this.displayFieldTableJoinFieldName = displayFieldTableJoinFieldName;
-    }
-
-    public boolean isSuppressed() {
-      return isSuppressed;
     }
 
     public String getValueFieldName() {
@@ -166,8 +167,7 @@ public final class Attribute {
         return false;
       }
       SourceQuery that = (SourceQuery) o;
-      return isSuppressed == that.isSuppressed
-          && valueFieldName.equals(that.valueFieldName)
+      return valueFieldName.equals(that.valueFieldName)
           && Objects.equals(displayFieldTable, that.displayFieldTable)
           && Objects.equals(displayFieldName, that.displayFieldName)
           && Objects.equals(displayFieldTableJoinFieldName, that.displayFieldTableJoinFieldName);
@@ -176,11 +176,7 @@ public final class Attribute {
     @Override
     public int hashCode() {
       return Objects.hash(
-          isSuppressed,
-          valueFieldName,
-          displayFieldTable,
-          displayFieldName,
-          displayFieldTableJoinFieldName);
+          valueFieldName, displayFieldTable, displayFieldName, displayFieldTableJoinFieldName);
     }
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttribute.java
@@ -116,6 +116,15 @@ public class SZAttribute {
   public Double displayHintRangeMax;
 
   @AnnotatedField(
+      name = "SZAttribute.isSuppressedForExport",
+      markdown =
+          "True if this attribute is suppressed for export "
+              + "(i.e. not available for selection in data feature sets).",
+      optional = true,
+      defaultValue = "false")
+  public boolean isSuppressedForExport;
+
+  @AnnotatedField(
       name = "SZAttribute.sourceQuery",
       markdown =
           "How to generate a query against the source data that includes this attribute.\n\n"
@@ -133,13 +142,6 @@ public class SZAttribute {
               + "This query isn't actually run by the service, only generated as an export option "
               + "(e.g. as part of a notebook file).")
   public static class SourceQuery {
-    @AnnotatedField(
-        name = "SZSourceQuery.isSuppressed",
-        markdown = "True if this attribute doesn't map to a specific field in the source table.",
-        optional = true,
-        defaultValue = "false")
-    public boolean isSuppressed;
-
     @AnnotatedField(
         name = "SZSourceQuery.valueFieldName",
         markdown =

--- a/underlay/src/main/resources/config/datamapping/cmssynpuf/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/cmssynpuf/entity/person/entity.json
@@ -4,7 +4,7 @@
   "attributes": [
     { "name": "id", "dataType": "INT64", "valueFieldName": "person_id" },
     { "name": "year_of_birth", "dataType": "INT64", "isComputeDisplayHint": true },
-    { "name": "age", "dataType": "TIMESTAMP", "valueFieldName": "birth_datetime", "runtimeSqlFunctionWrapper": "CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)", "runtimeDataType": "INT64", "isComputeDisplayHint": true },
+    { "name": "age", "dataType": "TIMESTAMP", "valueFieldName": "birth_datetime", "runtimeSqlFunctionWrapper": "CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), ${fieldSql}, DAY) / 365.25) AS INT64)", "runtimeDataType": "INT64", "isComputeDisplayHint": true, "isSuppressedForExport": true },
     { "name": "person_source_value", "dataType": "STRING" },
     { "name": "gender", "dataType": "INT64", "valueFieldName": "gender_concept_id", "displayFieldName": "gender_concept_name", "isComputeDisplayHint": true,
       "sourceQuery": {

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFieldTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFieldTest.java
@@ -93,12 +93,9 @@ public class BQFieldTest extends BQRunnerTest {
                 ethnicityAttribute.getRuntimeSqlFunctionWrapper(),
                 ethnicityAttribute.getRuntimeDataType(),
                 ethnicityAttribute.isComputeDisplayHint(),
+                ethnicityAttribute.isSuppressedForExport(),
                 new Attribute.SourceQuery(
-                    ethnicityAttribute.getSourceQuery().isSuppressed(),
-                    "person_source_value",
-                    null,
-                    "ethnicity_concept_id",
-                    null)),
+                    "person_source_value", null, "ethnicity_concept_id", null)),
             false);
 
     // We don't have an example of a suppressed attribute, yet.
@@ -116,8 +113,8 @@ public class BQFieldTest extends BQRunnerTest {
                 genderAttribute.getRuntimeSqlFunctionWrapper(),
                 genderAttribute.getRuntimeDataType(),
                 genderAttribute.isComputeDisplayHint(),
+                true,
                 new Attribute.SourceQuery(
-                    true,
                     genderAttribute.getSourceQuery().getValueFieldName(),
                     genderAttribute.getSourceQuery().getDisplayFieldTable(),
                     genderAttribute.getSourceQuery().getDisplayFieldName(),

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -6,6 +6,8 @@
         st.race_concept_id,
         st.birth_datetime,
         st.person_id,
+        st.gender_concept_id,
+        dt1.concept_name AS T_DISP_genderSuppressed,
         st.person_source_value,
         st.ethnicity_concept_id AS T_DISP_ethnicityNoDisplayJoin      
     FROM
@@ -13,6 +15,9 @@
     LEFT JOIN
         ${concept} AS dt0              
             ON dt0.concept_id = st.gender_concept_id      
+    LEFT JOIN
+        ${concept} AS dt1              
+            ON dt1.concept_id = st.gender_concept_id      
     WHERE
         st.person_id IN (
             SELECT


### PR DESCRIPTION
Suppressing an attribute for export means that it is not available for selection in data feature set definitions. This replaces the `isSuppressed` flag that was previously on the attribute's `sourceQuery` definition. This change allows suppressing attributes even if source queries are not configured for an entity.

Flag is `false` by default, so all attributes are available for export. Set the flag to `true` for the `person.age` attribute in the `cmssynpuf` underlay, as an example.