### PR TITLE
Tolerate null counts in API translation.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -166,7 +166,10 @@ public final class ToApiUtils {
             listQueryResult.getPageMarker() == null
                 ? null
                 : listQueryResult.getPageMarker().serialize())
-        .numRowsAcrossAllPages(Math.toIntExact(listQueryResult.getNumRowsAcrossAllPages()));
+        .numRowsAcrossAllPages(
+            listQueryResult.getNumRowsAcrossAllPages() == null
+                ? null
+                : Math.toIntExact(listQueryResult.getNumRowsAcrossAllPages()));
   }
 
   private static ApiInstance toApiObject(ListInstance listInstance) {
@@ -191,7 +194,10 @@ public final class ToApiUtils {
                 getHierarchyFieldSet(
                         hierarchyFieldSets,
                         ((HierarchyNumChildrenField) field).getHierarchy().getName())
-                    .setNumChildren(Math.toIntExact(value.getValue().getInt64Val()));
+                    .setNumChildren(
+                        value.getValue().getInt64Val() == null
+                            ? null
+                            : Math.toIntExact(value.getValue().getInt64Val()));
               } else if (field instanceof HierarchyIsRootField) {
                 getHierarchyFieldSet(
                         hierarchyFieldSets, ((HierarchyIsRootField) field).getHierarchy().getName())
@@ -210,7 +216,10 @@ public final class ToApiUtils {
                             countField.getHierarchy() == null
                                 ? null
                                 : countField.getHierarchy().getName())
-                        .count(Math.toIntExact(value.getValue().getInt64Val())));
+                        .count(
+                            value.getValue().getInt64Val() == null
+                                ? null
+                                : Math.toIntExact(value.getValue().getInt64Val())));
               }
             });
     return new ApiInstance()
@@ -238,7 +247,10 @@ public final class ToApiUtils {
             countQueryResult.getPageMarker() == null
                 ? null
                 : countQueryResult.getPageMarker().serialize())
-        .numRowsAcrossAllPages(Math.toIntExact(countQueryResult.getNumRowsAcrossAllPages()));
+        .numRowsAcrossAllPages(
+            countQueryResult.getNumRowsAcrossAllPages() == null
+                ? null
+                : Math.toIntExact(countQueryResult.getNumRowsAcrossAllPages()));
   }
 
   public static ApiInstanceCount toApiObject(CountInstance countInstance) {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -515,9 +515,11 @@ public class BQQueryRunner implements QueryRunner {
                 enumValues.put(attribute, enumValuesForAttr);
               } else {
                 // This is a range hint.
-                double min = sqlRowResult.get(minColName, DataType.DOUBLE).getDoubleVal();
-                double max = sqlRowResult.get(maxColName, DataType.DOUBLE).getDoubleVal();
-                hintInstances.add(new HintInstance(attribute, min, max));
+                Double min = sqlRowResult.get(minColName, DataType.DOUBLE).getDoubleVal();
+                Double max = sqlRowResult.get(maxColName, DataType.DOUBLE).getDoubleVal();
+                if (min != null && max != null) {
+                  hintInstances.add(new HintInstance(attribute, min, max));
+                }
               }
             });
     // Assemble the value/count pairs into a single enum values hint for each attribute.


### PR DESCRIPTION
Came across this while testing hierarchy counts for the AoU underlay. The counts were incorrect, so we shouldn't be getting nulls in that case, but in case this does come up in the future (i.e. missing counts), this change means we won't mask the error in a null pointer exception on the backend.