### PR TITLE
Initial regression test suite for cmssynpuf underlay.

### DIFF
--- a/service/src/test/resources/regression/cmssynpuf/cohortAge4045_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortAge4045_datafeaturesetDemographics.json
@@ -1,23 +1,12 @@
 {
   "underlay": "cmssynpuf",
   "cohorts": [{
-    "displayName": "men 50-65",
+    "displayName": "Age: 40 - 45",
     "criteriaGroupSections": [{
       "criteriaGroups": [{
         "criteria": [{
-          "selectorOrModifierName": "tanagra-gender",
-          "selectionData": "CgsKAxC7QhIETUFMRQ\u003d\u003d",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }, {
-      "criteriaGroups": [{
-        "criteria": [{
           "selectorOrModifierName": "tanagra-age",
-          "selectionData": "EhwKCDdNVFkwaDdaEQAAAAAAAElAGQAAAAAAQFBA",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"GD8p3XkP\",\"min\":40,\"max\":45}]}",
           "pluginVersion": 0,
           "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
           "pluginName": "attribute"
@@ -27,7 +16,7 @@
     }]
   }],
   "dataFeatureSets": [{
-    "displayName": "demographics",
+    "displayName": "Demographics",
     "criteria": [{
       "predefinedId": "_demographics",
       "selectionData": ""
@@ -35,6 +24,6 @@
   }],
   "entityOutputCounts": [{
     "entity": "person",
-    "numRows": "66396"
+    "numRows": "18140"
   }]
 }

--- a/service/src/test/resources/regression/cmssynpuf/cohortConditionDiabetesmellitusAgeatoccurrence2430Occurrencecount2_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortConditionDiabetesmellitusAgeatoccurrence2430Occurrencecount2_datafeaturesetDemographics.json
@@ -1,0 +1,41 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Condition: Diabetes mellitus, Age at occurrence 24-30, Occurrence count \u003e\u003d2",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-conditions",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":201820},\"name\":\"Diabetes mellitus\",\"entityGroup\":\"conditionPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"conditionPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"xNx2brW6\",\"min\":24,\"max\":30}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":2,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"conditionOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"condition\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "10579"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortConditionDiabetesmellitus_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortConditionDiabetesmellitus_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Condition: Diabetes mellitus",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-conditions",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":201820},\"name\":\"Diabetes mellitus\",\"entityGroup\":\"conditionPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"conditionPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "1593269"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortDrugIbuprofenAgeatoccurrence2529Occurrencecount4_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortDrugIbuprofenAgeatoccurrence2529Occurrencecount4_datafeaturesetDemographics.json
@@ -1,22 +1,34 @@
 {
   "underlay": "cmssynpuf",
   "cohorts": [{
-    "displayName": "acetaminophen",
+    "displayName": "Drug: Ibuprofen, Age at occurrence 25-29, Occurrence count \u003e\u003d4",
     "criteriaGroupSections": [{
       "criteriaGroups": [{
         "criteria": [{
           "selectorOrModifierName": "tanagra-drugs",
-          "selectionData": "CicKBBDD10QSDUFjZXRhbWlub3BoZW4aEGluZ3JlZGllbnRQZXJzb24SCQoFdF9hbnkiAA\u003d\u003d",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1177480},\"name\":\"Ibuprofen\",\"entityGroup\":\"ingredientPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
           "pluginVersion": 0,
           "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"ingredientPerson\"\n    }\n  ],\n  \"groupingEntityGroups\": [\n    {\n      \"id\": \"brandIngredient\",\n      \"sortOrder\": {\n        \"attribute\": \"name\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ]\n}",
           "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"cXIVDXDh\",\"min\":25,\"max\":29}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":4,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"ingredientOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"ingredient\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
         }]
       }],
       "operator": "OR"
     }]
   }],
   "dataFeatureSets": [{
-    "displayName": "demographics",
+    "displayName": "Demographics",
     "criteria": [{
       "predefinedId": "_demographics",
       "selectionData": ""
@@ -24,6 +36,6 @@
   }],
   "entityOutputCounts": [{
     "entity": "person",
-    "numRows": "1100649"
+    "numRows": "33"
   }]
 }

--- a/service/src/test/resources/regression/cmssynpuf/cohortDrugIbuprofen_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortDrugIbuprofen_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Drug: Ibuprofen",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-drugs",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1177480},\"name\":\"Ibuprofen\",\"entityGroup\":\"ingredientPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"ingredientPerson\"\n    }\n  ],\n  \"groupingEntityGroups\": [\n    {\n      \"id\": \"brandIngredient\",\n      \"sortOrder\": {\n        \"attribute\": \"name\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "419951"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortEthnicityHispanicorLatino_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortEthnicityHispanicorLatino_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Ethnicity: Hispanic or Latino",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-ethnicity",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":38003563},\"name\":\"Hispanic or Latino\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"ethnicity\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "54453"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetConditionDiabetesmellitus.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetConditionDiabetesmellitus.json
@@ -1,50 +1,14 @@
 {
   "underlay": "cmssynpuf",
   "cohorts": [{
-    "displayName": "men 50-65",
+    "displayName": "Gender identity: FEMALE",
     "criteriaGroupSections": [{
       "criteriaGroups": [{
         "criteria": [{
           "selectorOrModifierName": "tanagra-gender",
-          "selectionData": "CgsKAxC7QhIETUFMRQ\u003d\u003d",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
           "pluginVersion": 0,
           "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }, {
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-age",
-          "selectionData": "EhwKCDdNVFkwaDdaEQAAAAAAAElAGQAAAAAAQFBA",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }]
-  }, {
-    "displayName": "women 40-65",
-    "criteriaGroupSections": [{
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-gender",
-          "selectionData": "Cg0KAxDUQhIGRkVNQUxF",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }, {
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-age",
-          "selectionData": "EhwKCG5EWTVJNWpREQAAAAAAAERAGQAAAAAAQFBA",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
           "pluginName": "attribute"
         }]
       }],
@@ -52,10 +16,10 @@
     }]
   }],
   "dataFeatureSets": [{
-    "displayName": "type 2 diabetes",
+    "displayName": "Condition: Diabetes mellitus",
     "criteria": [{
       "selectorOrModifierName": "tanagra-conditions",
-      "selectionData": "CjEKBBDiqAwSGFR5cGUgMiBkaWFiZXRlcyBtZWxsaXR1cxoPY29uZGl0aW9uUGVyc29uEgkKBXRfYW55IgA\u003d",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":201820},\"name\":\"Diabetes mellitus\",\"entityGroup\":\"conditionPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
       "pluginVersion": 0,
       "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"conditionPerson\"\n    }\n  ]\n}",
       "pluginName": "entityGroup"
@@ -63,6 +27,6 @@
   }],
   "entityOutputCounts": [{
     "entity": "conditionOccurrence",
-    "numRows": "728024"
+    "numRows": "8142962"
   }]
 }

--- a/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetDemographics.json
@@ -1,25 +1,14 @@
 {
   "underlay": "cmssynpuf",
   "cohorts": [{
-    "displayName": "women 40-65",
+    "displayName": "Gender identity: FEMALE",
     "criteriaGroupSections": [{
       "criteriaGroups": [{
         "criteria": [{
           "selectorOrModifierName": "tanagra-gender",
-          "selectionData": "Cg0KAxDUQhIGRkVNQUxF",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
           "pluginVersion": 0,
           "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }, {
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-age",
-          "selectionData": "EhwKCG5EWTVJNWpREQAAAAAAAERAGQAAAAAAQFBA",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
           "pluginName": "attribute"
         }]
       }],
@@ -27,7 +16,7 @@
     }]
   }],
   "dataFeatureSets": [{
-    "displayName": "demographics",
+    "displayName": "Demographics",
     "criteria": [{
       "predefinedId": "_demographics",
       "selectionData": ""
@@ -35,6 +24,6 @@
   }],
   "entityOutputCounts": [{
     "entity": "person",
-    "numRows": "73519"
+    "numRows": "1292861"
   }]
 }

--- a/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetDrugIbuprofen.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetDrugIbuprofen.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Gender identity: FEMALE",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-gender",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Drug: Ibuprofen",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-drugs",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1177480},\"name\":\"Ibuprofen\",\"entityGroup\":\"ingredientPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"ingredientPerson\"\n    }\n  ],\n  \"groupingEntityGroups\": [\n    {\n      \"id\": \"brandIngredient\",\n      \"sortOrder\": {\n        \"attribute\": \"name\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ]\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "ingredientOccurrence",
+    "numRows": "344886"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetICD9CMEssentialhypertension.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetICD9CMEssentialhypertension.json
@@ -1,0 +1,36 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Gender identity: FEMALE",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-gender",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "ICD-9-CM: Essential hypertension",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-icd9cm",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":44833556},\"name\":\"Essential hypertension\",\"entityGroup\":\"icd9cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "observationOccurrence"
+  }, {
+    "entity": "conditionOccurrence",
+    "numRows": "263206"
+  }, {
+    "entity": "procedureOccurrence"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetObservationHOartificialjoint.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetObservationHOartificialjoint.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Gender identity: FEMALE",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-gender",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Observation: H/O: artificial joint",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-observations",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4058431},\"name\":\"H/O: artificial joint\",\"entityGroup\":\"observationPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"observationPerson\"\n    }\n  ]\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "observationOccurrence",
+    "numRows": "486254"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetProcedureYellowfeverscreening.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortGenderidentityFEMALE_datafeaturesetProcedureYellowfeverscreening.json
@@ -1,50 +1,14 @@
 {
   "underlay": "cmssynpuf",
   "cohorts": [{
-    "displayName": "men 50-65",
+    "displayName": "Gender identity: FEMALE",
     "criteriaGroupSections": [{
       "criteriaGroups": [{
         "criteria": [{
           "selectorOrModifierName": "tanagra-gender",
-          "selectionData": "CgsKAxC7QhIETUFMRQ\u003d\u003d",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
           "pluginVersion": 0,
           "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }, {
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-age",
-          "selectionData": "EhwKCDdNVFkwaDdaEQAAAAAAAElAGQAAAAAAQFBA",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }]
-  }, {
-    "displayName": "women 40-65",
-    "criteriaGroupSections": [{
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-gender",
-          "selectionData": "Cg0KAxDUQhIGRkVNQUxF",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
-          "pluginName": "attribute"
-        }]
-      }],
-      "operator": "OR"
-    }, {
-      "criteriaGroups": [{
-        "criteria": [{
-          "selectorOrModifierName": "tanagra-age",
-          "selectionData": "EhwKCG5EWTVJNWpREQAAAAAAAERAGQAAAAAAQFBA",
-          "pluginVersion": 0,
-          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
           "pluginName": "attribute"
         }]
       }],
@@ -52,10 +16,10 @@
     }]
   }],
   "dataFeatureSets": [{
-    "displayName": "optional surgery",
+    "displayName": "Procedure: Yellow fever screening",
     "criteria": [{
       "selectorOrModifierName": "tanagra-procedures",
-      "selectionData": "CioKBRDvqP4BEhBPcHRpb25hbCBzdXJnZXJ5Gg9wcm9jZWR1cmVQZXJzb24SCQoFdF9hbnkiAA\u003d\u003d",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4064902},\"name\":\"Yellow fever screening\",\"entityGroup\":\"procedurePerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
       "pluginVersion": 0,
       "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"procedurePerson\"\n    }\n  ]\n}",
       "pluginName": "entityGroup"
@@ -63,6 +27,6 @@
   }],
   "entityOutputCounts": [{
     "entity": "procedureOccurrence",
-    "numRows": "931"
+    "numRows": "8276"
   }]
 }

--- a/service/src/test/resources/regression/cmssynpuf/cohortICD9CMEssentialhypertension_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortICD9CMEssentialhypertension_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "ICD-9-CM: Essential hypertension",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd9cm",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":44833556},\"name\":\"Essential hypertension\",\"entityGroup\":\"icd9cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "306651"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortObservationHOartificialjointAgeatoccurrence2432Occurrencecount3_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortObservationHOartificialjointAgeatoccurrence2432Occurrencecount3_datafeaturesetDemographics.json
@@ -1,0 +1,41 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Observation: H/O: artificial joint, Age at occurrence 24-32, Occurrence count \u003e\u003d3",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-observations",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4058431},\"name\":\"H/O: artificial joint\",\"entityGroup\":\"observationPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"observationPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"O5T7LBXT\",\"min\":24,\"max\":32}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "dateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":3,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"observationOccurrence\": {\n      \"values\": [\n        \"date\",\n        \"observation\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "268"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortObservationHOartificialjoint_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortObservationHOartificialjoint_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Observation: H/O: artificial joint",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-observations",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4058431},\"name\":\"H/O: artificial joint\",\"entityGroup\":\"observationPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"observationPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "480208"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortProcedureYellowfeverscreeningAgeatoccurrence3034Occurrencecount1_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortProcedureYellowfeverscreeningAgeatoccurrence3034Occurrencecount1_datafeaturesetDemographics.json
@@ -1,0 +1,41 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Procedure: Yellow fever screening, Age at occurrence 30-34, Occurrence count \u003e\u003d1",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-procedures",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4064902},\"name\":\"Yellow fever screening\",\"entityGroup\":\"procedurePerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"procedurePerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"7DkG9rwj\",\"min\":30,\"max\":34}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "dateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"date\",\n        \"procedure\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "77"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortProcedureYellowfeverscreening_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortProcedureYellowfeverscreening_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Procedure: Yellow fever screening",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-procedures",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4064902},\"name\":\"Yellow fever screening\",\"entityGroup\":\"procedurePerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Concept name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 120,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"procedurePerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "14352"
+  }]
+}

--- a/service/src/test/resources/regression/cmssynpuf/cohortRaceBlackorAfricanAmerican_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/cmssynpuf/cohortRaceBlackorAfricanAmerican_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "cmssynpuf",
+  "cohorts": [{
+    "displayName": "Race: Black or African American",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-race",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8516},\"name\":\"Black or African American\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"race\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "247723"
+  }]
+}


### PR DESCRIPTION
Built initial regression test suite for the `cmssynpuf` underlay, following the [guidelines](https://github.com/DataBiosphere/tanagra/blob/main/docs/REGRESSION_TESTING.md#build-a-test-suite) in the documentation.

- One test per cohort criteria type: age, ethnicity, gender, race, condition, drug, icd9-cm, observation, procedure. All use the the demographics data feature set.
- One test per cohort criteria type with modifiers: condition, drug, observation, procedure. All use the demographics data feature set.
- One test per data feature criteria type: condition, drug, icd9-cm, observation, procedure. All use the gender cohort.
