### PR TITLE
Initial regression test suite for sd20230831 underlay.

### DIFF
--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetBMIany.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetBMIany.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "BMI: (any)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-bmi",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"bmi\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"is_clean\",\n      \"title\": \"Cleanliness\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"kg/m^2\"\n    }\n  ]\n}",
+      "pluginName": "multiAttribute"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "bmi",
+    "numRows": "3201097"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetBloodpressureany.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetBloodpressureany.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Blood pressure: (any)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-blood-pressure",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"bloodPressure\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"status_code\",\n      \"title\": \"Category\"\n    },\n    {\n      \"attribute\": \"systolic\",\n      \"title\": \"Systolic\"\n    },\n    {\n      \"attribute\": \"diastolic\",\n      \"title\": \"Diastolic\"\n    }\n  ]\n}",
+      "pluginName": "multiAttribute"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "bloodPressure",
+    "numRows": "4048846"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetCPT4CesareanDeliveryProcedures.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetCPT4CesareanDeliveryProcedures.json
@@ -1,0 +1,38 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "CPT-4: Cesarean Delivery Procedures",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-cpt4",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1636},\"name\":\"Cesarean Delivery Procedures\",\"entityGroup\":\"cpt4Person\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"is_standard\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/Standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"is_standard\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/Standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"cpt4Person\",\n      \"sortOrder\": {\n        \"attribute\": \"label\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "measurementOccurrence"
+  }, {
+    "entity": "observationOccurrence"
+  }, {
+    "entity": "ingredientOccurrence"
+  }, {
+    "entity": "procedureOccurrence",
+    "numRows": "1509"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetConditionType2diabetesmellitus.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetConditionType2diabetesmellitus.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Condition: Type 2 diabetes mellitus",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-conditions",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":201826},\"name\":\"Type 2 diabetes mellitus\",\"entityGroup\":\"conditionPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"conditionPerson\"\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "conditionOccurrence",
+    "numRows": "21309"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "231347"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetDocumentsAny.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetDocumentsAny.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Documents: Any",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-documents",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"noteOccurrence\",\n  \"categoryAttribute\": \"note\"\n}",
+      "pluginName": "search"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "noteOccurrence",
+    "numRows": "26099417"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetDrugOPIOIDS.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetDrugOPIOIDS.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Drug: OPIOIDS",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-drugs",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":21604254},\"name\":\"OPIOIDS\",\"entityGroup\":\"ingredientPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"ingredientPerson\"\n    }\n  ],\n  \"groupingEntityGroups\": [\n    {\n      \"id\": \"brandIngredient\",\n      \"sortOrder\": {\n        \"attribute\": \"name\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "ingredientOccurrence",
+    "numRows": "1899935"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetHeightany.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetHeightany.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Height: (any)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-height",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"height\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"is_clean\",\n      \"title\": \"Cleanliness\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"cm\"\n    }\n  ]\n}",
+      "pluginName": "multiAttribute"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "height",
+    "numRows": "885735"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD10CMAcutebronchitis.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD10CMAcutebronchitis.json
@@ -1,0 +1,39 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "ICD-10-CM: Acute bronchitis",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-icd10cm",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1569470},\"name\":\"Acute bronchitis\",\"entityGroup\":\"icd10cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd10cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "measurementOccurrence"
+  }, {
+    "entity": "observationOccurrence",
+    "numRows": "6"
+  }, {
+    "entity": "conditionOccurrence",
+    "numRows": "3113"
+  }, {
+    "entity": "procedureOccurrence"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD10PCSImagingEyeProcedure.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD10PCSImagingEyeProcedure.json
@@ -1,0 +1,33 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "ICD-10-PCS: Imaging @ Eye (Procedure)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-icd10pcs",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":2873468},\"name\":\"Imaging @ Eye (Procedure)\",\"entityGroup\":\"icd10pcsPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd10pcsPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "ingredientOccurrence"
+  }, {
+    "entity": "procedureOccurrence"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD9CMEpilepsyandrecurrentseizures.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD9CMEpilepsyandrecurrentseizures.json
@@ -1,0 +1,38 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "ICD-9-CM: Epilepsy and recurrent seizures",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-icd9cm",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":44834634},\"name\":\"Epilepsy and recurrent seizures\",\"entityGroup\":\"icd9cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "measurementOccurrence"
+  }, {
+    "entity": "observationOccurrence"
+  }, {
+    "entity": "conditionOccurrence",
+    "numRows": "42186"
+  }, {
+    "entity": "procedureOccurrence"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD9ProcCardiacstresstestsandpacemakeranddefibrillatorchecks.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetICD9ProcCardiacstresstestsandpacemakeranddefibrillatorchecks.json
@@ -1,0 +1,34 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "ICD-9-Proc: Cardiac stress tests and pacemaker and defibrillator checks",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-icd9proc",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":2007054},\"name\":\"Cardiac stress tests and pacemaker and defibrillator checks\",\"entityGroup\":\"icd9procPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9procPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "ingredientOccurrence"
+  }, {
+    "entity": "procedureOccurrence",
+    "numRows": "87"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetLabsandmeasurementsGlucoseMassvolumeinBlood.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetLabsandmeasurementsGlucoseMassvolumeinBlood.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Labs and measurements: Glucose [Mass/volume] in Blood",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-measurement",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":3000483},\"name\":\"Glucose [Mass/volume] in Blood\",\"entityGroup\":\"measurementLoincPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"measurementLoincPerson\"\n    },\n    {\n      \"id\": \"measurementSnomedPerson\"\n    }\n  ],\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_enum\",\n      \"title\": \"Categorical value\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"title\": \"Numeric value\"\n    }\n  ],\n  \"defaultSort\": {\n    \"attribute\": \"t_item_count\",\n    \"direction\": \"SORT_ORDER_DIRECTION_DESCENDING\"\n  }\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "measurementOccurrence",
+    "numRows": "84709"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetObservationCigarettesmoker.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetObservationCigarettesmoker.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Observation: Cigarette smoker",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-observations",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4276526},\"name\":\"Cigarette smoker\",\"entityGroup\":\"observationPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"observationPerson\"\n    }\n  ]\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "observationOccurrence",
+    "numRows": "2769"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetPheWASPaininjoint.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetPheWASPaininjoint.json
@@ -1,0 +1,38 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "PheWAS: Pain in joint",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-phewas",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":536},\"name\":\"Pain in joint\",\"entityGroup\":\"phewasPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"phewasPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"numeric_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true,\n  \"limit\": 1000\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "measurementOccurrence"
+  }, {
+    "entity": "observationOccurrence"
+  }, {
+    "entity": "conditionOccurrence",
+    "numRows": "46746"
+  }, {
+    "entity": "procedureOccurrence"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetProcedureMammography.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetProcedureMammography.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Procedure: Mammography",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-procedures",
+      "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4324693},\"name\":\"Mammography\",\"entityGroup\":\"procedurePerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"procedurePerson\"\n    }\n  ],\n  \"multiSelect\": true\n}",
+      "pluginName": "entityGroup"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "procedureOccurrence",
+    "numRows": "37"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetPulseany.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetPulseany.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Pulse: (any)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-pulse",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"pulse\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"bpm\"\n    }\n  ]\n}",
+      "pluginName": "multiAttribute"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "pulse",
+    "numRows": "1111709"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetRespRateany.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetRespRateany.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Resp Rate: (any)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-resp-rate",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"respiratoryRate\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_numeric\",\n      \"title\": \"Resp rate in br/min\",\n      \"unit\": \"br/min\"\n    }\n  ]\n}",
+      "pluginName": "multiAttribute"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "respiratoryRate",
+    "numRows": "657492"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetWeightany.json
+++ b/service/src/test/resources/regression/sd/cohortAge2024_datafeaturesetWeightany.json
@@ -1,0 +1,32 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Age: 20-24",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-age",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"DClglggx\",\"min\":20,\"max\":24}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Weight: (any)",
+    "criteria": [{
+      "selectorOrModifierName": "tanagra-weight",
+      "selectionData": "{}",
+      "pluginVersion": 0,
+      "pluginConfig": "{\n  \"entity\": \"weight\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"is_clean\",\n      \"title\": \"Cleanliness\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"kg\"\n    }\n  ]\n}",
+      "pluginName": "multiAttribute"
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "weight",
+    "numRows": "1849963"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortBMIRaw1825_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortBMIRaw1825_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "BMI: Raw, 18-25",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-bmi",
+          "selectionData": "{\"valueData\":[{\"attribute\":\"is_clean\",\"selected\":[{\"value\":{\"int64Value\":0},\"name\":\"Raw\"}],\"range\":{\"min\":-9007199254740991,\"max\":9007199254740991}},{\"attribute\":\"value_numeric\",\"numeric\":true,\"range\":{\"min\":18,\"max\":25}}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"entity\": \"bmi\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"is_clean\",\n      \"title\": \"Cleanliness\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"kg/m^2\"\n    }\n  ]\n}",
+          "pluginName": "multiAttribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "986060"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortBioVUDNAAtleast100ngwithatleast2ngLBioVUDNAExcludeCompromisedDNAIncludeonlysamplesavailableforexternalprocessing_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortBioVUDNAAtleast100ngwithatleast2ngLBioVUDNAExcludeCompromisedDNAIncludeonlysamplesavailableforexternalprocessing_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "BioVU DNA: At least 100ng with at least 2 ng/µL BioVU DNA, Exclude Compromised DNA, Include only samples available for external processing",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "biovu",
+          "selectionData": "CAIQARgB",
+          "pluginVersion": 0,
+          "pluginConfig": "{}",
+          "pluginName": "biovu"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "305380"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortBioVUGeneticDataIlluminaMEGAexArray_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortBioVUGeneticDataIlluminaMEGAexArray_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "BioVU Genetic Data: Illumina MEGA-ex Array",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-genotyping",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":30},\"name\":\"Illumina MEGA-ex Array\",\"entityGroup\":\"genotypingPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Genotyping platform\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Id\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Genotyping platform\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 100,\n      \"title\": \"Id\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"genotypingPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "91092"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortBioVUPlasmaAnybankedBioVUPlasma_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortBioVUPlasmaAnybankedBioVUPlasma_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "BioVU Plasma: Any banked BioVU Plasma",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "biovu-plasma",
+          "selectionData": "CAE\u003d",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"plasmaFilter\": true\n}",
+          "pluginName": "biovu"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "2576"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortBloodpressureNormalSystolic120129Diastolic8084_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortBloodpressureNormalSystolic120129Diastolic8084_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Blood pressure: Normal, Systolic 120-129, Diastolic 80-84",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-blood-pressure",
+          "selectionData": "{\"valueData\":[{\"attribute\":\"status_code\",\"selected\":[{\"value\":{\"int64Value\":4},\"name\":\"Normal\"}],\"range\":{\"min\":-9007199254740991,\"max\":9007199254740991}},{\"attribute\":\"systolic\",\"numeric\":true,\"range\":{\"min\":120,\"max\":129}},{\"attribute\":\"diastolic\",\"numeric\":true,\"range\":{\"min\":80,\"max\":84}}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"entity\": \"bloodPressure\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"status_code\",\n      \"title\": \"Category\"\n    },\n    {\n      \"attribute\": \"systolic\",\n      \"title\": \"Systolic\"\n    },\n    {\n      \"attribute\": \"diastolic\",\n      \"title\": \"Diastolic\"\n    }\n  ]\n}",
+          "pluginName": "multiAttribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "145503"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortCPT4AppendectomyEndoscopyProceduresontheEsophagus_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortCPT4AppendectomyEndoscopyProceduresontheEsophagus_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "CPT-4: Appendectomy, Endoscopy Procedures on the Esophagus",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-cpt4",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":12933},\"name\":\"Appendectomy\",\"entityGroup\":\"cpt4Person\"},{\"key\":{\"int64Key\":3596},\"name\":\"Endoscopy Procedures on the Esophagus\",\"entityGroup\":\"cpt4Person\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"is_standard\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/Standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"is_standard\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/Standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"cpt4Person\",\n      \"sortOrder\": {\n        \"attribute\": \"label\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "154512"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortCPT4SurgeryAgeatoccurrence5565VisittypeInpatientOccurrencecount2_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortCPT4SurgeryAgeatoccurrence5565VisittypeInpatientOccurrencecount2_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "CPT-4: Surgery, Age at occurrence 55-65, Visit type Inpatient, Occurrence count \u003e\u003d2",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-cpt4",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1213},\"name\":\"Surgery\",\"entityGroup\":\"cpt4Person\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"is_standard\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/Standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"is_standard\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/Standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"cpt4Person\",\n      \"sortOrder\": {\n        \"attribute\": \"label\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"yEU6Pois\",\"min\":55,\"max\":89}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9201},\"name\":\"Inpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"observationOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"measurementOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"ingredientOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "206095"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortConditionType2diabetesmellitusAgeatoccurrence6080VisittypeOutpatientOccurrencecount2_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortConditionType2diabetesmellitusAgeatoccurrence6080VisittypeOutpatientOccurrencecount2_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Condition: Type 2 diabetes mellitus, Age at occurrence 60-80, Visit type Outpatient, Occurrence count \u003e\u003d2",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-conditions",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":201826},\"name\":\"Type 2 diabetes mellitus\",\"entityGroup\":\"conditionPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"conditionPerson\"\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"7NWupKYL\",\"min\":60,\"max\":80}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9202},\"name\":\"Outpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":2,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"conditionOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"condition\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "50574"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortConditionType2diabetesmellitusType1diabetesmellitus_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortConditionType2diabetesmellitusType1diabetesmellitus_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Condition: Type 2 diabetes mellitus, Type 1 diabetes mellitus",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-conditions",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":201826},\"name\":\"Type 2 diabetes mellitus\",\"entityGroup\":\"conditionPerson\"},{\"key\":{\"int64Key\":201254},\"name\":\"Type 1 diabetes mellitus\",\"entityGroup\":\"conditionPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"conditionPerson\"\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "244972"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortDrugcetirizineAgeatoccurrence6065VisittypeOutpatientOccurrencecount3_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortDrugcetirizineAgeatoccurrence6065VisittypeOutpatientOccurrencecount3_datafeaturesetDemographics.json
@@ -1,22 +1,40 @@
 {
   "underlay": "sd",
   "cohorts": [{
-    "displayName": "acetaminophen",
+    "displayName": "Drug: cetirizine, Age at occurrence 60-65, Visit type Outpatient, Occurrence count \u003c\u003d3",
     "criteriaGroupSections": [{
       "criteriaGroups": [{
         "criteria": [{
           "selectorOrModifierName": "tanagra-drugs",
-          "selectionData": "CicKBBDD10QSDWFjZXRhbWlub3BoZW4aEGluZ3JlZGllbnRQZXJzb24SCQoFdF9hbnkiAA\u003d\u003d",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1149196},\"name\":\"cetirizine\",\"entityGroup\":\"ingredientPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
           "pluginVersion": 0,
           "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"ingredientPerson\"\n    }\n  ],\n  \"groupingEntityGroups\": [\n    {\n      \"id\": \"brandIngredient\",\n      \"sortOrder\": {\n        \"attribute\": \"name\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
           "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"ZfmTkiTZ\",\"min\":60,\"max\":65}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9202},\"name\":\"Outpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_LESS_THAN_EQUAL\",\"min\":3,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"ingredientOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"ingredient\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
         }]
       }],
       "operator": "OR"
     }]
   }],
   "dataFeatureSets": [{
-    "displayName": "demographics",
+    "displayName": "Demographics",
     "criteria": [{
       "predefinedId": "_demographics",
       "selectionData": ""
@@ -24,6 +42,6 @@
   }],
   "entityOutputCounts": [{
     "entity": "person",
-    "numRows": "1118027"
+    "numRows": "4383"
   }]
 }

--- a/service/src/test/resources/regression/sd/cohortDrugibuprofenacetaminophen_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortDrugibuprofenacetaminophen_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Drug: ibuprofen, acetaminophen",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-drugs",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1177480},\"name\":\"ibuprofen\",\"entityGroup\":\"ingredientPerson\"},{\"key\":{\"int64Key\":1125315},\"name\":\"acetaminophen\",\"entityGroup\":\"ingredientPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"ingredientPerson\"\n    }\n  ],\n  \"groupingEntityGroups\": [\n    {\n      \"id\": \"brandIngredient\",\n      \"sortOrder\": {\n        \"attribute\": \"name\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "1334434"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortEthnicityHispanicorLatino_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortEthnicityHispanicorLatino_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Ethnicity: Hispanic or Latino",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-ethnicity",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":38003563},\"name\":\"Hispanic or Latino\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"ethnicity\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "154473"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortGenderidentityFEMALE_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortGenderidentityFEMALE_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Gender identity: FEMALE",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-gender",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":8532},\"name\":\"FEMALE\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"gender\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "2028135"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortHeightRaw145170_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortHeightRaw145170_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Height: Raw, 145-170",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-height",
+          "selectionData": "{\"valueData\":[{\"attribute\":\"is_clean\",\"selected\":[{\"value\":{\"int64Value\":0},\"name\":\"Raw\"}],\"range\":{\"min\":-9007199254740991,\"max\":9007199254740991}},{\"attribute\":\"value_numeric\",\"numeric\":true,\"range\":{\"min\":145,\"max\":170}}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"entity\": \"height\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"is_clean\",\n      \"title\": \"Cleanliness\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"cm\"\n    }\n  ]\n}",
+          "pluginName": "multiAttribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "60300"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD10CMGlaucomaAgeatoccurrence5585VisittypeInpatientOccurrencecount1_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD10CMGlaucomaAgeatoccurrence5585VisittypeInpatientOccurrencecount1_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD10-CM: Glaucoma, Age at occurrence 55-85, Visit type Inpatient, Occurrence count \u003e\u003d1",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd10cm",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1568761},\"name\":\"Glaucoma\",\"entityGroup\":\"icd10cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd10cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"KJJOBozB\",\"min\":55,\"max\":85}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9201},\"name\":\"Inpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"conditionOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"measurementOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"observationOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "4566"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD10CMGlaucoma_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD10CMGlaucoma_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD10-CM: Glaucoma",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd10cm",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1568761},\"name\":\"Glaucoma\",\"entityGroup\":\"icd10cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd10cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "37656"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD10PCSRadiationTherapyCentralandPeripheralNervousSystemStereotacticRadiosurgeryAgeatoccurrence035VisittypeInpatientOccurrencecount1_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD10PCSRadiationTherapyCentralandPeripheralNervousSystemStereotacticRadiosurgeryAgeatoccurrence035VisittypeInpatientOccurrencecount1_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD10-PCS: Radiation Therapy, Central and Peripheral Nervous System, Stereotactic Radiosurgery, Age at occurrence 0-35, Visit type Inpatient, Occurrence count \u003e\u003d1",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd10pcs",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":2791306},\"name\":\"Radiation Therapy, Central and Peripheral Nervous System, Stereotactic Radiosurgery\",\"entityGroup\":\"icd10pcsPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd10pcsPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"yLaWUuQv\",\"max\":35}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9201},\"name\":\"Inpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"ingredientOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "22"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD10PCSReplacementofRightHipJointwithSyntheticSubstituteUncementedOpenApproach_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD10PCSReplacementofRightHipJointwithSyntheticSubstituteUncementedOpenApproach_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD10-PCS: Replacement of Right Hip Joint with Synthetic Substitute, Uncemented, Open Approach",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd10pcs",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":2774063},\"name\":\"Replacement of Right Hip Joint with Synthetic Substitute, Uncemented, Open Approach\",\"entityGroup\":\"icd10pcsPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd10pcsPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "118"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD9CMEssentialhypertensionSecondaryhypertension_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD9CMEssentialhypertensionSecondaryhypertension_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD9-CM: Essential hypertension, Secondary hypertension",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd9cm",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":44833556},\"name\":\"Essential hypertension\",\"entityGroup\":\"icd9cmPerson\"},{\"key\":{\"int64Key\":44832370},\"name\":\"Secondary hypertension\",\"entityGroup\":\"icd9cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "305647"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD9CMPaininjointAgeatoccurrence6585VisittypeOutpatientOccurrencecount2_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD9CMPaininjointAgeatoccurrence6585VisittypeOutpatientOccurrencecount2_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD9-CM: Pain in joint, Age at occurrence 65-85, Visit type Outpatient, Occurrence count \u003e\u003d2",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd9cm",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":44831506},\"name\":\"Pain in joint\",\"entityGroup\":\"icd9cmPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 180,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9cmPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"AXgBonKj\",\"min\":65,\"max\":85}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9202},\"name\":\"Outpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":2,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"conditionOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"measurementOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"observationOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "22573"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD9ProcColonoscopy_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD9ProcColonoscopy_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD9-Proc: Colonoscopy",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd9proc",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":2002703},\"name\":\"Colonoscopy\",\"entityGroup\":\"icd9procPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9procPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "15124"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortICD9ProcStereotacticradiosurgeryAgeatoccurrence1865VisittypeOutpatientOccurrencecount1_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortICD9ProcStereotacticradiosurgeryAgeatoccurrence1865VisittypeOutpatientOccurrencecount1_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "ICD9-Proc: Stereotactic radiosurgery, Age at occurrence 18-65, Visit type Outpatient, Occurrence count \u003e\u003d1",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-icd9proc",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":2007489},\"name\":\"Stereotactic radiosurgery\",\"entityGroup\":\"icd9procPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"icd9procPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"concept_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"ssoDpdo9\",\"min\":18,\"max\":65}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9202},\"name\":\"Outpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"ingredientOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "314"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortLabsandmeasurementsGlucoseMassvolumeinSerumorPlasma_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortLabsandmeasurementsGlucoseMassvolumeinSerumorPlasma_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Labs and measurements: Glucose [Mass/volume] in Serum or Plasma",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-measurement",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":3004501},\"name\":\"Glucose [Mass/volume] in Serum or Plasma\",\"entityGroup\":\"measurementLoincPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"measurementLoincPerson\"\n    },\n    {\n      \"id\": \"measurementSnomedPerson\"\n    }\n  ],\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_enum\",\n      \"title\": \"Categorical value\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"title\": \"Numeric value\"\n    }\n  ],\n  \"defaultSort\": {\n    \"attribute\": \"t_item_count\",\n    \"direction\": \"SORT_ORDER_DIRECTION_DESCENDING\"\n  }\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "1440880"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortLabsandmeasurementsGlucoseMassvolumeinUrineNormalAgeatoccurrence2080Occurrencecount2_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortLabsandmeasurementsGlucoseMassvolumeinUrineNormalAgeatoccurrence2080Occurrencecount2_datafeaturesetDemographics.json
@@ -1,0 +1,41 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Labs and measurements: Glucose [Mass/volume] in Urine, Normal, Age at occurrence 20-80, Occurrence count \u003e\u003d2",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-measurement",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":3020399},\"name\":\"Glucose [Mass/volume] in Urine\",\"entityGroup\":\"measurementLoincPerson\"}],\"valueData\":{\"attribute\":\"value_enum\",\"selected\":[{\"value\":{\"int64Value\":45884153},\"name\":\"Normal\"}],\"range\":{\"min\":-9007199254740991,\"max\":9007199254740991}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"measurementLoincPerson\"\n    },\n    {\n      \"id\": \"measurementSnomedPerson\"\n    }\n  ],\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_enum\",\n      \"title\": \"Categorical value\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"title\": \"Numeric value\"\n    }\n  ],\n  \"defaultSort\": {\n    \"attribute\": \"t_item_count\",\n    \"direction\": \"SORT_ORDER_DIRECTION_DESCENDING\"\n  }\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"smcoaWyu\",\"min\":20,\"max\":80}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":2,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"measurementOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"measurement\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "1"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortObservationPainscoreAgeatoccurrence3575Occurrencecount3_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortObservationPainscoreAgeatoccurrence3575Occurrencecount3_datafeaturesetDemographics.json
@@ -1,0 +1,41 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Observation: Pain score, Age at occurrence 35-75, Occurrence count \u003e\u003d3",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-observations",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4022240},\"name\":\"Pain score\",\"entityGroup\":\"observationPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"observationPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"4616JNWq\",\"min\":35,\"max\":75}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":3,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"observationOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"observation\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "192836"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortObservationRequiresinfluenzavirusvaccination_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortObservationRequiresinfluenzavirusvaccination_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Observation: Requires influenza virus vaccination",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-observations",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":44784283},\"name\":\"Requires influenza virus vaccination\",\"entityGroup\":\"observationPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_item_count\",\n      \"widthDouble\": 120,\n      \"title\": \"Count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"observationPerson\"\n    }\n  ]\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "144086"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortPheWASCoughAgeatoccurrence4555VisittypeOutpatientOccurrencecount2_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortPheWASCoughAgeatoccurrence4555VisittypeOutpatientOccurrencecount2_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "PheWAS: Cough, Age at occurrence 45-55, Visit type Outpatient, Occurrence count \u003d2",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-phewas",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":1191},\"name\":\"Cough\",\"entityGroup\":\"phewasPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"phewasPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"numeric_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true,\n  \"limit\": 1000\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"Qq6EwGDI\",\"min\":45,\"max\":55}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9202},\"name\":\"Outpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"conditionOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"measurementOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"observationOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    },\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"source_criteria_id\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "14631"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortPheWASHypertensionCardiacdysrhythmias_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortPheWASHypertensionCardiacdysrhythmias_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "PheWAS: Hypertension, Cardiac dysrhythmias",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-phewas",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":257},\"name\":\"Hypertension\",\"entityGroup\":\"phewasPerson\"},{\"key\":{\"int64Key\":268},\"name\":\"Cardiac dysrhythmias\",\"entityGroup\":\"phewasPerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept Id\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"phewasPerson\",\n      \"sortOrder\": {\n        \"attribute\": \"numeric_code\",\n        \"direction\": \"SORT_ORDER_DIRECTION_ASCENDING\"\n      }\n    }\n  ],\n  \"multiSelect\": true,\n  \"limit\": 1000\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "428580"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortProcedureReconstructionofthumbAgeatoccurrence5089VisittypeOutpatientOccurrencecount1_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortProcedureReconstructionofthumbAgeatoccurrence5089VisittypeOutpatientOccurrencecount1_datafeaturesetDemographics.json
@@ -1,0 +1,47 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Procedure: Reconstruction of thumb, Age at occurrence 50-89, Visit type Outpatient, Occurrence count \u003e\u003d1",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-procedures",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":4042515},\"name\":\"Reconstruction of thumb\",\"entityGroup\":\"procedurePerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"procedurePerson\"\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }, {
+          "selectorOrModifierName": "ageAtOccurrence",
+          "selectionData": "{\"dataRanges\":[{\"id\":\"QNhjN4xE\",\"min\":50,\"max\":89}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"age_at_occurrence\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "visitType",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":9202},\"name\":\"Outpatient Visit\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"visit_type\"\n}",
+          "pluginName": "attribute"
+        }, {
+          "selectorOrModifierName": "startDateGroupByCount",
+          "selectionData": "{\"operator\":\"COMPARISON_OPERATOR_GREATER_THAN_EQUAL\",\"min\":1,\"max\":10}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"groupByCount\": true,\n  \"attributes\": {\n    \"procedureOccurrence\": {\n      \"values\": [\n        \"start_date\",\n        \"procedure\"\n      ]\n    }\n  }\n}\n",
+          "pluginName": "unhinted-value"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "3"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortProcedureThumbsurgeryCryosurgery_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortProcedureThumbsurgeryCryosurgery_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Procedure: Thumb surgery, Cryosurgery",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-procedures",
+          "selectionData": "{\"selected\":[{\"key\":{\"int64Key\":46274029},\"name\":\"Thumb surgery\",\"entityGroup\":\"procedurePerson\"},{\"key\":{\"int64Key\":4146273},\"name\":\"Cryosurgery\",\"entityGroup\":\"procedurePerson\"}],\"valueData\":{\"attribute\":\"t_any\",\"range\":{}}}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"columns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"hierarchyColumns\": [\n    {\n      \"key\": \"name\",\n      \"widthString\": \"100%\",\n      \"title\": \"Name\"\n    },\n    {\n      \"key\": \"id\",\n      \"widthDouble\": 120,\n      \"title\": \"Concept ID\"\n    },\n    {\n      \"key\": \"standard_concept\",\n      \"widthDouble\": 180,\n      \"title\": \"Source/standard\"\n    },\n    {\n      \"key\": \"vocabulary_t_value\",\n      \"widthDouble\": 120,\n      \"title\": \"Vocab\"\n    },\n    {\n      \"key\": \"concept_code\",\n      \"widthDouble\": 120,\n      \"title\": \"Code\"\n    },\n    {\n      \"key\": \"t_rollup_count\",\n      \"widthDouble\": 150,\n      \"title\": \"Roll-up count\"\n    }\n  ],\n  \"classificationEntityGroups\": [\n    {\n      \"id\": \"procedurePerson\"\n    }\n  ],\n  \"multiSelect\": true\n}",
+          "pluginName": "entityGroup"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "573"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortPulse40160_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortPulse40160_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Pulse: 40-160",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-pulse",
+          "selectionData": "{\"valueData\":[{\"attribute\":\"value_numeric\",\"numeric\":true,\"range\":{\"min\":40,\"max\":160}}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"entity\": \"pulse\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"bpm\"\n    }\n  ]\n}",
+          "pluginName": "multiAttribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "1555900"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortRacePACIFICISLAND_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortRacePACIFICISLAND_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Race: PACIFIC ISLAND",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-race",
+          "selectionData": "{\"selected\":[{\"value\":{\"int64Value\":2001173109},\"name\":\"PACIFIC ISLAND\"}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"attribute\": \"race\"\n}",
+          "pluginName": "attribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "557"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortRespiratoryRate315_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortRespiratoryRate315_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Respiratory Rate: 3-15",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-resp-rate",
+          "selectionData": "{\"valueData\":[{\"attribute\":\"value_numeric\",\"numeric\":true,\"range\":{\"min\":3,\"max\":15}}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"entity\": \"respiratoryRate\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"value_numeric\",\n      \"title\": \"Resp rate in br/min\",\n      \"unit\": \"br/min\"\n    }\n  ]\n}",
+          "pluginName": "multiAttribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "385754"
+  }]
+}

--- a/service/src/test/resources/regression/sd/cohortWeightClean0100_datafeaturesetDemographics.json
+++ b/service/src/test/resources/regression/sd/cohortWeightClean0100_datafeaturesetDemographics.json
@@ -1,0 +1,29 @@
+{
+  "underlay": "sd",
+  "cohorts": [{
+    "displayName": "Weight: Clean, 0-100",
+    "criteriaGroupSections": [{
+      "criteriaGroups": [{
+        "criteria": [{
+          "selectorOrModifierName": "tanagra-weight",
+          "selectionData": "{\"valueData\":[{\"attribute\":\"is_clean\",\"selected\":[{\"value\":{\"int64Value\":1},\"name\":\"Clean\"}],\"range\":{\"min\":-9007199254740991,\"max\":9007199254740991}},{\"attribute\":\"value_numeric\",\"numeric\":true,\"range\":{\"max\":100}}]}",
+          "pluginVersion": 0,
+          "pluginConfig": "{\n  \"entity\": \"weight\",\n  \"valueConfigs\": [\n    {\n      \"attribute\": \"is_clean\",\n      \"title\": \"Cleanliness\"\n    },\n    {\n      \"attribute\": \"value_numeric\",\n      \"unit\": \"kg\"\n    }\n  ]\n}",
+          "pluginName": "multiAttribute"
+        }]
+      }],
+      "operator": "OR"
+    }]
+  }],
+  "dataFeatureSets": [{
+    "displayName": "Demographics",
+    "criteria": [{
+      "predefinedId": "_demographics",
+      "selectionData": ""
+    }]
+  }],
+  "entityOutputCounts": [{
+    "entity": "person",
+    "numRows": "2304146"
+  }]
+}


### PR DESCRIPTION
Built initial regression test suite for the sd underlay (0831 refresh), following the [guidelines](https://github.com/DataBiosphere/tanagra/blob/main/docs/REGRESSION_TESTING.md#build-a-test-suite) in the documentation.

- One test per cohort criteria type: ethnicity, gender, race, age, biovu genetic data, biovu dna, biovu plasma, labs and measurements, condition, procedure, observation, drug, phewas, cpt-4, icd9-cm, icd9-proc, icd10-cm, icd10-pcs, bmi, blood pressure, height, weight, pulse, respiratory rate. All use the the demographics data feature set.
- One test per cohort criteria type with modifiers: labs and measurements, condition, drug, observation, procedure. All use the demographics data feature set.
- One test per data feature criteria type: labs and measurements, condition, procedure, observation, drug, documents, phewas, cpt-4, icd9-cm, icd9-proc, icd10-cm, icd10-pcs, bmi, blood pressure, height, weight, pulse, respiratory rate. All use the age cohort.

The only thing missing from this initial test suite is a test for the documents cohort critiera. Once I re-index the dataset on the Verily side, I'll add these tests in a follow-on PR.