### PR TITLE
Update AoU drug hierarchy configuration.

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/all.sql
@@ -1,26 +1,33 @@
-SELECT
-    concept_id,
+SELECT DISTINCT(concept_id) concept_id,
     concept_name,
     vocabulary_id,
     concept_code,
-    'Standard' AS standard_concept
-FROM `${omopDataset}.concept`
-WHERE
-    (vocabulary_id = 'ATC' AND standard_concept = 'C')
-    OR (vocabulary_id = 'RxNorm' AND standard_concept = 'S')
+    standard_concept
+FROM (
+    SELECT
+        concept_id,
+        concept_name,
+        vocabulary_id,
+        concept_code,
+        'Standard' AS standard_concept
+    FROM `${omopDataset}.concept`
+    WHERE
+        (vocabulary_id = 'ATC' AND standard_concept = 'C')
+        OR (vocabulary_id = 'RxNorm' AND standard_concept = 'S')
 
-UNION ALL
+    UNION ALL
 
-SELECT
-    c2.concept_id,
-    c2.concept_name,
-    c2.vocabulary_id,
-    c2.concept_code,
-    'Standard' AS standard_concept
-FROM `${omopDataset}.concept_ancestor` ca
-JOIN `${omopDataset}.concept` c1
-    ON c1.concept_id = ca.ancestor_concept_id
-    AND c1.vocabulary_id = 'RxNorm'
-    AND c1.concept_class_id = 'Ingredient'
-JOIN `${omopDataset}.concept` c2
-    ON c2.concept_id = ca.descendant_concept_id
+    SELECT
+        c2.concept_id,
+        c2.concept_name,
+        c2.vocabulary_id,
+        c2.concept_code,
+        'Standard' AS standard_concept
+    FROM `${omopDataset}.concept_ancestor` ca
+    JOIN `${omopDataset}.concept` c1
+        ON c1.concept_id = ca.ancestor_concept_id
+        AND c1.vocabulary_id = 'RxNorm'
+        AND c1.concept_class_id = 'Ingredient'
+    JOIN `${omopDataset}.concept` c2
+        ON c2.concept_id = ca.descendant_concept_id
+)

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/all.sql
@@ -7,4 +7,20 @@ SELECT
 FROM `${omopDataset}.concept`
 WHERE
     (vocabulary_id = 'ATC' AND standard_concept = 'C')
-    OR (vocabulary_id IN ('RxNorm', 'RxNorm Extension') AND standard_concept = 'S')
+    OR (vocabulary_id = 'RxNorm' AND standard_concept = 'S')
+
+UNION ALL
+
+SELECT
+    c2.concept_id,
+    c2.concept_name,
+    c2.vocabulary_id,
+    c2.concept_code,
+    'Standard' AS standard_concept
+FROM `${omopDataset}.concept_ancestor` ca
+JOIN `${omopDataset}.concept` c1
+    ON c1.concept_id = ca.ancestor_concept_id
+    AND c1.vocabulary_id = 'RxNorm'
+    AND c1.concept_class_id = 'Ingredient'
+JOIN `${omopDataset}.concept` c2
+    ON c2.concept_id = ca.descendant_concept_id

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/all.sql
@@ -5,8 +5,6 @@ SELECT
     concept_code,
     'Standard' AS standard_concept
 FROM `${omopDataset}.concept`
-WHERE domain_id = 'Drug'
-AND (
+WHERE
     (vocabulary_id = 'ATC' AND standard_concept = 'C')
     OR (vocabulary_id IN ('RxNorm', 'RxNorm Extension') AND standard_concept = 'S')
-)

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
@@ -1,37 +1,88 @@
-SELECT
-    cr.concept_id_1 AS parent,
-    cr.concept_id_2 AS child
+/* ATC1 (roots) to ATC2 */
+SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
 FROM `${omopDataset}.concept_relationship` cr
-JOIN `${omopDataset}.concept` c1 ON c1.concept_id = cr.concept_id_1
-JOIN `${omopDataset}.concept` c2 ON c2.concept_id = cr.concept_id_2
+JOIN `${omopDataset}.concept` c1
+    ON c1.concept_id = cr.concept_id_1
+    AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 1st' AND c1.STANDARD_CONCEPT = 'C'
+JOIN `${omopDataset}.concept` c2
+    ON c2.concept_id = cr.concept_id_2
+    AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 2nd' AND c2.STANDARD_CONCEPT = 'C'
 WHERE
-    c1.concept_id != c2.concept_id
-    AND c1.domain_id = 'Drug' AND c2.domain_id = 'Drug'
-    AND (
+    cr.relationship_id = 'Subsumes'
 
-        /*
-           Populate Ingredients' ancestors', which are ATCs. See
-           https://www.ohdsi.org/web/wiki/doku.php?id=documentation:vocabulary:atc#:~:text=the%20original%20ATC%20hierarchy%20is%20extended%20by%20Standard%20Drug%20Products%20of%20RxNorm%20and%20RxNorm%20Extension%20vocabularies%2C%20which%20are%20assigned%20to%20be%20descendants%20of%20the%205th%20ATC%20Classes.
-           Eg:
-             ATC 1st (highest ancestor) Subsumes ATC 2nd
-             ATC 5th (direct parent of RxNorm) Maps to RxNorm
-         */
-        (c1.vocabulary_id IN ('ATC') AND cr.relationship_id IN ('Subsumes', 'Maps to'))
+UNION ALL
 
-        OR
+/* ATC2 to ATC3 */
+SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
+FROM `${omopDataset}.concept_relationship` cr
+JOIN `${omopDataset}.concept` c1
+    ON c1.concept_id = cr.concept_id_1
+    AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 2nd' AND c1.STANDARD_CONCEPT = 'C'
+JOIN `${omopDataset}.concept` c2
+    ON c2.concept_id = cr.concept_id_2
+    AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 3rd' AND c2.STANDARD_CONCEPT = 'C'
+WHERE
+    cr.relationship_id = 'Subsumes'
 
-        /*
-           Populate Ingredients and their descendants: Branded Drug, Clinical Drug, etc. Ingredients and their
-           descendants are RxNorm. drug_exposure contains Ingredients or their descendants.
-           Use [1] and [2] to define hierarchy. Eg "Marketed Product" is most specific and is bottom of hierarchy.
-           [1] https://www.ohdsi.org/web/wiki/doku.php?id=documentation:cdm:drug_exposure#:~:text=These%20are%20indicated,is%20available%20%E2%80%9CIngredient%E2%80%9D
-           [2] https://www.ohdsi.org/web/wiki/doku.php?id=documentation:vocabulary:drug#:~:text=are%20not%20implemented.-,Relationships,-As%20usual%2C%20all
-         */
-        (
-            c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
-            AND c2.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
-            /* Only keep relationships where c1 is "parent" of c2 */
-            AND cr.relationship_id IN ('Constitutes', 'Contained in' , 'Has form', 'Has quantified form', 'RxNorm ing of', 'RxNorm inverse is a', 'Precise ing of')
-        )
+UNION ALL
 
-    )
+/* ATC3 to ATC4 */
+SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
+FROM `${omopDataset}.concept_relationship` cr
+JOIN `${omopDataset}.concept` c1
+    ON c1.concept_id = cr.concept_id_1
+    AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 3rd' AND c1.STANDARD_CONCEPT = 'C'
+JOIN `${omopDataset}.concept` c2
+    ON c2.concept_id = cr.concept_id_2
+    AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 4th' AND c2.STANDARD_CONCEPT = 'C'
+WHERE
+    cr.relationship_id = 'Subsumes'
+
+UNION ALL
+
+/* ATC4 to RxNorm/Extension ingredient via shared ATC5 child */
+SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
+FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
+JOIN `${omopDataset}.concept` c_atc4
+    ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
+    AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
+JOIN `${omopDataset}.concept` c_atc5
+    ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
+    AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
+
+LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_atc5
+    ON cr_rxing_atc5.concept_id_2 = c_atc5.concept_id
+    AND cr_rxing_atc5.relationship_id IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
+JOIN `${omopDataset}.concept` c_rxing
+    ON c_rxing.concept_id = cr_rxing_atc5.concept_id_1
+    AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' AND c_rxing.STANDARD_CONCEPT = 'S'
+
+WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
+
+UNION ALL
+
+/* ATC4 to RxNorm/Extension ingredient via RxNorm precise ingredient to shared ATC5 child */
+SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
+FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
+JOIN `${omopDataset}.concept` c_atc4
+    ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
+    AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
+JOIN `${omopDataset}.concept` c_atc5
+    ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
+    AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
+
+LEFT JOIN `${omopDataset}.concept_relationship` cr_rxprecing_atc5
+    ON cr_rxprecing_atc5.concept_id_2 = c_atc5.concept_id
+    AND cr_rxprecing_atc5.relationship_id = 'RxNorm - ATC'
+JOIN `${omopDataset}.concept` cr_rxprecing
+    ON cr_rxprecing.concept_id = cr_rxprecing_atc5.concept_id_1
+    AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
+
+LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_rxprecing
+    ON cr_rxing_rxprecing.concept_id_2 = cr_rxprecing.concept_id
+    AND cr_rxprecing_atc5.relationship_id = 'Has form'
+JOIN `${omopDataset}.concept` c_rxing
+    ON c_rxing.concept_id = cr_rxing_rxprecing.concept_id_1
+    AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' and c_rxing.STANDARD_CONCEPT = 'S'
+
+WHERE cr_atc4_atc5.relationship_id = 'Subsumes'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
@@ -37,7 +37,7 @@ WHERE cr.relationship_id = 'Subsumes'
 
 UNION ALL
 
-/* ATC4 to RxNorm/Extension ingredient (via shared ATC5 child) */
+/* ATC4 to RxNorm ingredient (via shared ATC5 child) */
 SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
 FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
 JOIN `${omopDataset}.concept` c_atc4
@@ -58,7 +58,7 @@ WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
 
 UNION ALL
 
-/* ATC4 to RxNorm/Extension ingredient (via RxNorm/Extension precise ingredient to shared ATC5 grandchild) */
+/* ATC4 to RxNorm ingredient (via RxNorm precise ingredient to shared ATC5 grandchild) */
 SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
 FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
 JOIN `${omopDataset}.concept` c_atc4
@@ -85,58 +85,10 @@ WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
 
 UNION ALL
 
-/* RxNorm/Extension ingredient to all descendants */
+/* RxNorm ingredient to all descendants */
 SELECT ca.ancestor_concept_id AS parent, ca.descendant_concept_id AS child
 FROM `${omopDataset}.concept_ancestor` ca
 JOIN `${omopDataset}.concept` c1
     ON c1.concept_id = ca.ancestor_concept_id
-WHERE c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+WHERE c1.vocabulary_id = 'RxNorm'
     AND c1.concept_class_id = 'Ingredient'
-
-AND c1.concept_id IN (
-    /* ATC4 to RxNorm/Extension ingredient (via shared ATC5 child) */
-    SELECT c_rxing.concept_id AS child
-    FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
-    JOIN `${omopDataset}.concept` c_atc4
-        ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
-        AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
-    JOIN `${omopDataset}.concept` c_atc5
-        ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
-        AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
-    
-    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_atc5
-        ON cr_rxing_atc5.concept_id_2 = c_atc5.concept_id
-        AND cr_rxing_atc5.relationship_id IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
-    JOIN `${omopDataset}.concept` c_rxing
-        ON c_rxing.concept_id = cr_rxing_atc5.concept_id_1
-        AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' AND c_rxing.STANDARD_CONCEPT = 'S'
-    
-    WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
-    
-    UNION ALL
-    
-    /* ATC4 to RxNorm/Extension ingredient (via RxNorm/Extension precise ingredient to shared ATC5 grandchild) */
-    SELECT c_rxing.concept_id AS child
-    FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
-    JOIN `${omopDataset}.concept` c_atc4
-        ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
-        AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
-    JOIN `${omopDataset}.concept` c_atc5
-        ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
-        AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
-    
-    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxprecing_atc5
-        ON cr_rxprecing_atc5.concept_id_2 = c_atc5.concept_id
-        AND cr_rxprecing_atc5.relationship_id = 'RxNorm - ATC'
-    JOIN `${omopDataset}.concept` cr_rxprecing
-        ON cr_rxprecing.concept_id = cr_rxprecing_atc5.concept_id_1
-        AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
-    
-    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_rxprecing
-        ON cr_rxing_rxprecing.concept_id_2 = cr_rxprecing.concept_id
-        AND cr_rxing_rxprecing.relationship_id = 'Has form'
-    JOIN `${omopDataset}.concept` c_rxing
-        ON c_rxing.concept_id = cr_rxing_rxprecing.concept_id_1
-        AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' and c_rxing.STANDARD_CONCEPT = 'S'
-    WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
-)

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
@@ -1,94 +1,99 @@
-/* ATC1 (roots) to ATC2 */
-SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
-FROM `${omopDataset}.concept_relationship` cr
-JOIN `${omopDataset}.concept` c1
-    ON c1.concept_id = cr.concept_id_1
-    AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 1st' AND c1.STANDARD_CONCEPT = 'C'
-JOIN `${omopDataset}.concept` c2
-    ON c2.concept_id = cr.concept_id_2
-    AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 2nd' AND c2.STANDARD_CONCEPT = 'C'
-WHERE cr.relationship_id = 'Subsumes'
+SELECT cp.child, cp.parent
+FROM (
+    /* ATC1 (roots) to ATC2 */
+    SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
+    FROM `${omopDataset}.concept_relationship` cr
+    JOIN `${omopDataset}.concept` c1
+        ON c1.concept_id = cr.concept_id_1
+        AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 1st' AND c1.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c2
+        ON c2.concept_id = cr.concept_id_2
+        AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 2nd' AND c2.STANDARD_CONCEPT = 'C'
+    WHERE cr.relationship_id = 'Subsumes'
 
-UNION ALL
+    UNION ALL
 
-/* ATC2 to ATC3 */
-SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
-FROM `${omopDataset}.concept_relationship` cr
-JOIN `${omopDataset}.concept` c1
-    ON c1.concept_id = cr.concept_id_1
-    AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 2nd' AND c1.STANDARD_CONCEPT = 'C'
-JOIN `${omopDataset}.concept` c2
-    ON c2.concept_id = cr.concept_id_2
-    AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 3rd' AND c2.STANDARD_CONCEPT = 'C'
-WHERE cr.relationship_id = 'Subsumes'
+    /* ATC2 to ATC3 */
+    SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
+    FROM `${omopDataset}.concept_relationship` cr
+    JOIN `${omopDataset}.concept` c1
+        ON c1.concept_id = cr.concept_id_1
+        AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 2nd' AND c1.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c2
+        ON c2.concept_id = cr.concept_id_2
+        AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 3rd' AND c2.STANDARD_CONCEPT = 'C'
+    WHERE cr.relationship_id = 'Subsumes'
 
-UNION ALL
+    UNION ALL
 
-/* ATC3 to ATC4 */
-SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
-FROM `${omopDataset}.concept_relationship` cr
-JOIN `${omopDataset}.concept` c1
-    ON c1.concept_id = cr.concept_id_1
-    AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 3rd' AND c1.STANDARD_CONCEPT = 'C'
-JOIN `${omopDataset}.concept` c2
-    ON c2.concept_id = cr.concept_id_2
-    AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 4th' AND c2.STANDARD_CONCEPT = 'C'
-WHERE cr.relationship_id = 'Subsumes'
+    /* ATC3 to ATC4 */
+    SELECT cr.concept_id_1 AS parent, cr.concept_id_2 AS child
+    FROM `${omopDataset}.concept_relationship` cr
+    JOIN `${omopDataset}.concept` c1
+        ON c1.concept_id = cr.concept_id_1
+        AND c1.VOCABULARY_ID = 'ATC' AND c1.CONCEPT_CLASS_ID = 'ATC 3rd' AND c1.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c2
+        ON c2.concept_id = cr.concept_id_2
+        AND c2.VOCABULARY_ID = 'ATC' AND c2.CONCEPT_CLASS_ID = 'ATC 4th' AND c2.STANDARD_CONCEPT = 'C'
+    WHERE cr.relationship_id = 'Subsumes'
 
-UNION ALL
+    UNION ALL
 
-/* ATC4 to RxNorm ingredient (via shared ATC5 child) */
-SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
-FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
-JOIN `${omopDataset}.concept` c_atc4
-    ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
-    AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
-JOIN `${omopDataset}.concept` c_atc5
-    ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
-    AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
+    /* ATC4 to RxNorm ingredient (via shared ATC5 child) */
+    SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
+    FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
+    JOIN `${omopDataset}.concept` c_atc4
+        ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
+        AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c_atc5
+        ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
+        AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
 
-LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_atc5
-    ON cr_rxing_atc5.concept_id_2 = c_atc5.concept_id
-    AND cr_rxing_atc5.relationship_id IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
-JOIN `${omopDataset}.concept` c_rxing
-    ON c_rxing.concept_id = cr_rxing_atc5.concept_id_1
-    AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' AND c_rxing.STANDARD_CONCEPT = 'S'
+    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_atc5
+        ON cr_rxing_atc5.concept_id_2 = c_atc5.concept_id
+        AND cr_rxing_atc5.relationship_id IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
+    JOIN `${omopDataset}.concept` c_rxing
+        ON c_rxing.concept_id = cr_rxing_atc5.concept_id_1
+        AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' AND c_rxing.STANDARD_CONCEPT = 'S'
 
-WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
+    WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
 
-UNION ALL
+    UNION ALL
 
-/* ATC4 to RxNorm ingredient (via RxNorm precise ingredient to shared ATC5 grandchild) */
-SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
-FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
-JOIN `${omopDataset}.concept` c_atc4
-    ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
-    AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
-JOIN `${omopDataset}.concept` c_atc5
-    ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
-    AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
+    /* ATC4 to RxNorm ingredient (via RxNorm precise ingredient to shared ATC5 grandchild) */
+    SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
+    FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
+    JOIN `${omopDataset}.concept` c_atc4
+        ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
+        AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c_atc5
+        ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
+        AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
 
-LEFT JOIN `${omopDataset}.concept_relationship` cr_rxprecing_atc5
-    ON cr_rxprecing_atc5.concept_id_2 = c_atc5.concept_id
-    AND cr_rxprecing_atc5.relationship_id = 'RxNorm - ATC'
-JOIN `${omopDataset}.concept` cr_rxprecing
-    ON cr_rxprecing.concept_id = cr_rxprecing_atc5.concept_id_1
-    AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
+    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxprecing_atc5
+        ON cr_rxprecing_atc5.concept_id_2 = c_atc5.concept_id
+        AND cr_rxprecing_atc5.relationship_id = 'RxNorm - ATC'
+    JOIN `${omopDataset}.concept` cr_rxprecing
+        ON cr_rxprecing.concept_id = cr_rxprecing_atc5.concept_id_1
+        AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
 
-LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_rxprecing
-    ON cr_rxing_rxprecing.concept_id_2 = cr_rxprecing.concept_id
-    AND cr_rxing_rxprecing.relationship_id = 'Has form'
-JOIN `${omopDataset}.concept` c_rxing
-    ON c_rxing.concept_id = cr_rxing_rxprecing.concept_id_1
-    AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' and c_rxing.STANDARD_CONCEPT = 'S'
-WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
+    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_rxprecing
+        ON cr_rxing_rxprecing.concept_id_2 = cr_rxprecing.concept_id
+        AND cr_rxing_rxprecing.relationship_id = 'Has form'
+    JOIN `${omopDataset}.concept` c_rxing
+        ON c_rxing.concept_id = cr_rxing_rxprecing.concept_id_1
+        AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' and c_rxing.STANDARD_CONCEPT = 'S'
+    WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
 
-UNION ALL
+    UNION ALL
 
-/* RxNorm ingredient to all descendants */
-SELECT ca.ancestor_concept_id AS parent, ca.descendant_concept_id AS child
-FROM `${omopDataset}.concept_ancestor` ca
-JOIN `${omopDataset}.concept` c1
-    ON c1.concept_id = ca.ancestor_concept_id
-WHERE c1.vocabulary_id = 'RxNorm'
-    AND c1.concept_class_id = 'Ingredient'
+    /* RxNorm ingredient to all descendants */
+    SELECT ca.ancestor_concept_id AS parent, ca.descendant_concept_id AS child
+    FROM `${omopDataset}.concept_ancestor` ca
+    JOIN `${omopDataset}.concept` c1
+        ON c1.concept_id = ca.ancestor_concept_id
+    WHERE c1.vocabulary_id = 'RxNorm'
+        AND c1.concept_class_id = 'Ingredient'
+) cp
+WHERE cp.child != cp.parent
+GROUP BY cp.child, cp.parent

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/childParent.sql
@@ -58,19 +58,6 @@ WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
 
 UNION ALL
 
-/* RxNorm/Extension ingredient to ATC5 */
-SELECT cr_rxing_atc5.concept_id_1 AS parent, cr_rxing_atc5.concept_id_2 AS child
-FROM `${omopDataset}.concept_relationship` cr_rxing_atc5
-JOIN `${omopDataset}.concept` c_rxing
-    ON c_rxing.concept_id = cr_rxing_atc5.concept_id_1
-    AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' AND c_rxing.STANDARD_CONCEPT = 'S'
-JOIN `${omopDataset}.concept` c_atc5
-    ON c_atc5.concept_id = cr_rxing_atc5.concept_id_2
-    AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
-WHERE cr_rxing_atc5.relationship_id IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
-
-UNION ALL
-
 /* ATC4 to RxNorm/Extension ingredient (via RxNorm/Extension precise ingredient to shared ATC5 grandchild) */
 SELECT c_atc4.concept_id AS parent, c_rxing.concept_id AS child
 FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
@@ -98,26 +85,58 @@ WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
 
 UNION ALL
 
-/* RxNorm/Extension ingredient to RxNorm/Extension precise ingredient */
-SELECT cr_rxing_rxprecing.concept_id_1 AS parent, cr_rxing_rxprecing.concept_id_2 AS child
-FROM `${omopDataset}.concept_relationship` cr_rxing_rxprecing
-JOIN `${omopDataset}.concept` c_rxing
-    ON c_rxing.concept_id = cr_rxing_rxprecing.concept_id_1
-    AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' and c_rxing.STANDARD_CONCEPT = 'S'
-JOIN `${omopDataset}.concept` cr_rxprecing
-    ON cr_rxprecing.concept_id = cr_rxing_rxprecing.concept_id_2
-    AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
-WHERE cr_rxing_rxprecing.relationship_id = 'Has form'
+/* RxNorm/Extension ingredient to all descendants */
+SELECT ca.ancestor_concept_id AS parent, ca.descendant_concept_id AS child
+FROM `${omopDataset}.concept_ancestor` ca
+JOIN `${omopDataset}.concept` c1
+    ON c1.concept_id = ca.ancestor_concept_id
+WHERE c1.vocabulary_id IN ('RxNorm', 'RxNorm Extension')
+    AND c1.concept_class_id = 'Ingredient'
 
-UNION ALL
-
-/* RxNorm/Extension precise ingredient to ATC5 */
-SELECT cr_rxprecing_atc5.concept_id_1 AS parent, cr_rxprecing_atc5.concept_id_2 AS child
-FROM `${omopDataset}.concept_relationship` cr_rxprecing_atc5
-JOIN `${omopDataset}.concept` cr_rxprecing
-    ON cr_rxprecing.concept_id = cr_rxprecing_atc5.concept_id_1
-    AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
-JOIN `${omopDataset}.concept` c_atc5
-    ON c_atc5.concept_id = cr_rxprecing_atc5.concept_id_2
-    AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
-WHERE cr_rxprecing_atc5.relationship_id = 'RxNorm - ATC'
+AND c1.concept_id IN (
+    /* ATC4 to RxNorm/Extension ingredient (via shared ATC5 child) */
+    SELECT c_rxing.concept_id AS child
+    FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
+    JOIN `${omopDataset}.concept` c_atc4
+        ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
+        AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c_atc5
+        ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
+        AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
+    
+    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_atc5
+        ON cr_rxing_atc5.concept_id_2 = c_atc5.concept_id
+        AND cr_rxing_atc5.relationship_id IN ('RxNorm - ATC name','Mapped from', 'RxNorm - ATC')
+    JOIN `${omopDataset}.concept` c_rxing
+        ON c_rxing.concept_id = cr_rxing_atc5.concept_id_1
+        AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' AND c_rxing.STANDARD_CONCEPT = 'S'
+    
+    WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
+    
+    UNION ALL
+    
+    /* ATC4 to RxNorm/Extension ingredient (via RxNorm/Extension precise ingredient to shared ATC5 grandchild) */
+    SELECT c_rxing.concept_id AS child
+    FROM `${omopDataset}.concept_relationship` cr_atc4_atc5
+    JOIN `${omopDataset}.concept` c_atc4
+        ON c_atc4.concept_id = cr_atc4_atc5.concept_id_1
+        AND c_atc4.VOCABULARY_ID = 'ATC' AND c_atc4.CONCEPT_CLASS_ID = 'ATC 4th' AND c_atc4.STANDARD_CONCEPT = 'C'
+    JOIN `${omopDataset}.concept` c_atc5
+        ON c_atc5.concept_id = cr_atc4_atc5.concept_id_2
+        AND c_atc5.VOCABULARY_ID = 'ATC' AND c_atc5.CONCEPT_CLASS_ID = 'ATC 5th' AND c_atc5.STANDARD_CONCEPT = 'C'
+    
+    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxprecing_atc5
+        ON cr_rxprecing_atc5.concept_id_2 = c_atc5.concept_id
+        AND cr_rxprecing_atc5.relationship_id = 'RxNorm - ATC'
+    JOIN `${omopDataset}.concept` cr_rxprecing
+        ON cr_rxprecing.concept_id = cr_rxprecing_atc5.concept_id_1
+        AND cr_rxprecing.VOCABULARY_ID = 'RxNorm' AND cr_rxprecing.CONCEPT_CLASS_ID = 'Precise Ingredient'
+    
+    LEFT JOIN `${omopDataset}.concept_relationship` cr_rxing_rxprecing
+        ON cr_rxing_rxprecing.concept_id_2 = cr_rxprecing.concept_id
+        AND cr_rxing_rxprecing.relationship_id = 'Has form'
+    JOIN `${omopDataset}.concept` c_rxing
+        ON c_rxing.concept_id = cr_rxing_rxprecing.concept_id_1
+        AND c_rxing.VOCABULARY_ID = 'RxNorm' AND c_rxing.CONCEPT_CLASS_ID = 'Ingredient' and c_rxing.STANDARD_CONCEPT = 'S'
+    WHERE cr_atc4_atc5.relationship_id = 'Subsumes'
+)

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientConcept/entity.json
@@ -22,7 +22,7 @@
       "parentIdFieldName": "parent",
       "rootNodeIdsSqlFile": "rootNode.sql",
       "rootIdFieldName": "concept_id",
-      "maxDepth": 15,
+      "maxDepth": 8,
       "keepOrphanNodes": false,
       "cleanHierarchyNodesWithZeroCounts": true
     }


### PR DESCRIPTION
Updated the AoU `ingredient` entity definition (`all.sql`, `childParent.sql`) to match the hierarchy built for AoU-CB.
- Built the relationship between the root `ATC-1st` nodes and the ingredient `RxNorm` nodes using the `concept_relationship` table, as diagrammed below.
- Built the relationship between the ingredient `RxNorm` nodes and the dosage nodes using the `concept_ancestor` table (see `childParent.sql` last `SELECT` statement in the `UNION`).

![Screenshot 2024-04-25 at 11 29 54 AM](https://github.com/DataBiosphere/tanagra/assets/12446128/4de97de5-b39d-4f76-a9f1-3475c8a5483f)

This PR was a joint effort with @freemabd.