### PR TITLE
Add visualization plugin framework

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -4,6 +4,7 @@ import { enableMapSet } from "immer";
 import "plugins";
 import { RouterProvider } from "react-router-dom";
 import { createAppRouter } from "router";
+import "viz/plugins";
 import theme from "./theme";
 
 enableMapSet();

--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -110,15 +110,25 @@ export function sectionName(section: GroupSection, index: number) {
   return section.name || "group " + String(index + 1);
 }
 
-export function defaultSection(criteria?: Criteria): GroupSection {
+const DEFAULT_SECTION_ID = "_default";
+
+function newSectionInternal(id: string, criteria?: Criteria): GroupSection {
   return {
-    id: generateId(),
+    id,
     filter: {
       kind: GroupSectionFilterKind.Any,
       excluded: false,
     },
     groups: !!criteria ? [defaultGroup(criteria)] : [],
   };
+}
+
+export function newSection(criteria?: Criteria): GroupSection {
+  return newSectionInternal(generateId(), criteria);
+}
+
+export function defaultSection(): GroupSection {
+  return newSectionInternal(DEFAULT_SECTION_ID);
 }
 
 export function defaultGroup(criteria: Criteria): Group {

--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -1,7 +1,8 @@
-import { defaultGroup, defaultSection } from "cohort";
+import { defaultGroup, newSection } from "cohort";
 import { Cohort, Criteria, GroupSectionFilter } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useUnderlaySource } from "data/underlaySourceContext";
+import deepEqual from "deep-equal";
 import produce from "immer";
 import { createContext, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
@@ -59,22 +60,24 @@ export function useNewCohortContext(showSnackbar: (message: string) => void) {
     return await studySource.getCohort(studyId, underlaySource, cohortId);
   });
 
-  useEffect(
-    () =>
-      setState(
-        status.data
-          ? {
-              past: state?.past ?? [],
-              present: status.data,
-              future: state?.future ?? [],
+  useEffect(() => {
+    if (state?.present && deepEqual(status.data, state.present)) {
+      return;
+    }
 
-              saving: false,
-              showSnackbar,
-            }
-          : null
-      ),
-    [status.data]
-  );
+    setState(
+      status.data
+        ? {
+            past: state?.past ?? [],
+            present: status.data,
+            future: state?.future ?? [],
+
+            saving: false,
+            showSnackbar,
+          }
+        : null
+    );
+  }, [status.data]);
 
   const updateCohort = async (newState: CohortState | null) => {
     if (!newState) {
@@ -336,7 +339,7 @@ export function insertCohortGroupSection(
   criteria?: Criteria
 ) {
   context.updatePresent((present) => {
-    present.groupSections.push(defaultSection(criteria));
+    present.groupSections.push(newSection(criteria));
   });
 }
 
@@ -346,7 +349,7 @@ export function deleteCohortGroupSection(
 ) {
   context.updatePresent((present) => {
     if (present.groupSections.length === 1) {
-      present.groupSections = [defaultSection()];
+      present.groupSections = [newSection()];
       return;
     }
 

--- a/ui/src/viz/plugins.ts
+++ b/ui/src/viz/plugins.ts
@@ -1,0 +1,1 @@
+import "viz/plugins/core/bar.tsx";

--- a/ui/src/viz/plugins/core/bar.tsx
+++ b/ui/src/viz/plugins/core/bar.tsx
@@ -1,0 +1,187 @@
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import { useTheme } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { isValid } from "util/valid";
+import {
+  registerVizPlugin,
+  VizData,
+  VizKeyType,
+  VizPlugin,
+  VizValueType,
+} from "viz/viz";
+
+interface Config {
+  colors?: string[];
+}
+
+const defaultColors = [
+  "#4450C0",
+  "#F7963F",
+  "#4393C3",
+  "#FBCD50",
+  "#53978B",
+  "#D14545",
+  "#538B61",
+  "#D77CA8",
+  "#B6D07E",
+  "#91C3C7",
+  "#1F255C",
+  "#9D4D07",
+  "#1D455D",
+  "#B48504",
+  "#335C55",
+  "#832121",
+  "#538B61",
+  "#AC356E",
+  "#448388",
+];
+
+@registerVizPlugin("bar", [
+  {
+    keyTypes: [[VizKeyType.NumericId, VizKeyType.StringId]],
+    valueTypes: [VizValueType.Numeric],
+  },
+  {
+    keyTypes: [
+      [VizKeyType.NumericId, VizKeyType.StringId],
+      [VizKeyType.NumericId, VizKeyType.StringId],
+    ],
+    valueTypes: [VizValueType.Numeric],
+  },
+])
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class _ implements VizPlugin {
+  config: Config;
+
+  constructor(config: object) {
+    this.config = config as Config;
+  }
+
+  render(data: VizData[]) {
+    return <BarViz config={this.config} data={data} />;
+  }
+}
+
+type BarVizProps = {
+  config: Config;
+  data: VizData[];
+};
+
+function BarViz(props: BarVizProps) {
+  const theme = useTheme();
+
+  const stackedProperties = useMemo(
+    () =>
+      Array.from(new Set(props.data.map((d) => d.keys[1]?.name)))
+        .filter(isValid)
+        .sort(),
+    [props.data]
+  );
+
+  const barData = useMemo(() => {
+    const barData: Record<string, Record<string, string | number>> = {};
+    props.data.forEach((d) => {
+      if (!barData[d.keys[0].name]) {
+        barData[d.keys[0].name] = { name: d.keys[0].name };
+      }
+
+      const bd = barData[d.keys[0].name];
+      const n = d.values[0].numeric ?? 0;
+      if (d.keys.length > 1) {
+        bd[d.keys[1].name] = n;
+      } else {
+        bd.count = n;
+      }
+    });
+
+    const arr: Record<string, string | number>[] = [];
+    for (const k in barData) {
+      arr.push({
+        name: k,
+        ...barData[k],
+      });
+    }
+    return arr;
+  }, [props.data]);
+
+  const barColors = props.config.colors ?? defaultColors;
+
+  return (
+    <>
+      <ResponsiveContainer width="100%" height={40 + barData.length * 30}>
+        <BarChart data={barData} layout="vertical">
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            type="number"
+            style={{
+              ...theme.typography.body2,
+            }}
+          />
+          <YAxis
+            dataKey="name"
+            type="category"
+            width={150}
+            tickMargin={10}
+            style={{
+              ...theme.typography.body2,
+            }}
+          />
+          <Tooltip
+            content={(props: TooltipProps<number, string>) => {
+              return (
+                <Paper elevation={1} sx={{ p: 1 }}>
+                  <Stack>
+                    <Typography variant="body2em">{props.label}</Typography>
+                    {props.payload?.map((row) => (
+                      <Stack key={row.name} direction="row" sx={{ mt: 1 }}>
+                        <Box
+                          sx={{
+                            width: "20px",
+                            height: "20px",
+                            backgroundColor: row.color,
+                            mr: 1,
+                          }}
+                        />
+                        <Typography variant="body2">
+                          {(stackedProperties.length > 0
+                            ? row.name + ": "
+                            : "") + row.value}
+                        </Typography>
+                      </Stack>
+                    ))}
+                  </Stack>
+                </Paper>
+              );
+            }}
+          />
+          {stackedProperties.length > 0 ? (
+            stackedProperties.map((property, index) => (
+              <Bar
+                key={index}
+                dataKey={property as string}
+                stackId="a"
+                fill={barColors[index % barColors.length]}
+                maxBarSize={100}
+              />
+            ))
+          ) : (
+            <Bar dataKey="count" fill={barColors[0]} maxBarSize={60} />
+          )}
+        </BarChart>
+      </ResponsiveContainer>
+    </>
+  );
+}

--- a/ui/src/viz/viz.ts
+++ b/ui/src/viz/viz.ts
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+
+// The data format shared across all visualizations is 1+ keys and 1+ values.
+// The keys have both names and values in preparation to support interactive
+// charts. Multiple keys support cases like stacked bar charts, while multiple
+// values support cases like scatterplots. Each plugin returns a list of
+// supported data formats so they will be able to know what input data they can
+// be used with.
+export type VizKey = {
+  name: string;
+
+  numericId?: number;
+  stringId?: string;
+};
+
+export type VizValue = {
+  numeric?: number;
+  quartiles?: number[];
+};
+
+export type VizData = {
+  keys: VizKey[];
+  values: VizValue[];
+};
+
+export type VizPlugin = {
+  render: (data: VizData[]) => JSX.Element;
+};
+
+export enum VizKeyType {
+  NumericId = "numeric",
+  StringId = "stringId",
+}
+
+export enum VizValueType {
+  Numeric = "numeric",
+  Quartiles = "quartiles",
+}
+
+export type VizDataFormat = {
+  keyTypes: VizKeyType[][];
+  valueTypes: VizValueType[];
+};
+
+// registerVizPlugin is a decorator that allows visualizations to automatically
+// register with the app simply by importing them.
+export function registerVizPlugin(type: string, dataFormats: VizDataFormat[]) {
+  return <T extends VizPluginConstructor>(constructor: T): void => {
+    vizRegistry.set(type, {
+      dataFormats,
+      constructor,
+    });
+  };
+}
+
+export function getVizPlugin(type: string, config: object): VizPlugin {
+  return new (getVizEntry(type).constructor)(config);
+}
+
+export function useVizPlugin(type: string, config: object): VizPlugin {
+  return useMemo(() => getVizPlugin(type, config), [type, config]);
+}
+
+function getVizEntry(type: string): RegistryEntry {
+  const entry = vizRegistry.get(type);
+  if (!entry) {
+    throw `Unknown viz plugin type '${type}'`;
+  }
+  return entry;
+}
+
+interface VizPluginConstructor {
+  new (config: object): VizPlugin;
+}
+
+type RegistryEntry = {
+  dataFormats: VizDataFormat[];
+  constructor: VizPluginConstructor;
+};
+
+const vizRegistry = new Map<string, RegistryEntry>();


### PR DESCRIPTION
This is pluggable framework for visualizations that currently just replaces the demographics charts. This gives us something to hook up the new queries and configuration to as we build it out.

Also fixes an issue that was causing empty cohorts to unnecessarily refresh the demographic charts. A new random id was being generated every time an empty cohort was fetched causing the UI to constantly think it had changed.

After experiments with other charting libraries didn't pan out, this largely leaves the existing demographic chart code intact but moved into a plugin that's instantiated for each chart.