### PR TITLE
Add numeric value answer to AoU Basics survey.

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/surveyOccurrence/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/surveyOccurrence/all.sql
@@ -2,6 +2,7 @@ SELECT
   o.observation_id,
   o.person_id,
   o.observation_datetime,
+  o.value_as_number,
   ps.id AS survey_item_id,
 
   ps_survey.concept_id AS survey_concept_id,
@@ -12,9 +13,15 @@ SELECT
   ac.concept_name AS answer_concept_name
 
 FROM `${omopDataset}.observation` AS o
+
 JOIN `${omopDataset}.prep_survey` AS ps
     ON ps.concept_id = o.observation_source_concept_id
-    AND CAST(ps.value AS INT64) = o.value_source_concept_id
+    AND (
+      (CAST(ps.value AS INT64) = o.value_source_concept_id)
+      OR
+      (ps.value IS NULL AND o.value_source_concept_id IS NULL)
+    )
+    AND ps.subtype = 'ANSWER'
 
 JOIN `${omopDataset}.prep_survey` AS ps_survey
     ON ps_survey.survey = ps.survey

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/surveyOccurrence/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/surveyOccurrence/all.sql
@@ -32,3 +32,5 @@ LEFT JOIN `${omopDataset}.concept` AS qc
     ON qc.concept_id = o.observation_source_concept_id
 LEFT JOIN `${omopDataset}.concept` AS ac
     ON ac.concept_id = o.value_source_concept_id
+
+WHERE ps.survey = 'Basics'

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/surveyOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/surveyOccurrence/entity.json
@@ -5,6 +5,7 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "observation_id" },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "survey_datetime", "dataType": "TIMESTAMP", "valueFieldName": "observation_datetime" },
+    { "name": "value_numeric", "dataType": "DOUBLE", "valueFieldName": "value_as_number" },
     { "name": "survey_item_id", "dataType": "INT64" },
     { "name": "survey", "dataType": "INT64", "valueFieldName": "survey_concept_id", "displayFieldName": "survey_concept_name" },
     { "name": "question", "dataType": "INT64", "valueFieldName": "question_concept_id", "displayFieldName": "question_concept_name" },

--- a/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/surveyBasicsPerson/entityGroup.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/surveyBasicsPerson/entityGroup.json
@@ -9,7 +9,8 @@
       },
       "primaryRelationship": {
         "foreignKeyAttributeOccurrenceEntity": "person_id"
-      }
+      },
+      "attributesWithInstanceLevelHints": [ "value_numeric" ]
     }
   ],
   "primaryCriteriaRelationship": {

--- a/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/surveyBasicsPerson/primaryCriteria.sql
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entitygroup/surveyBasicsPerson/primaryCriteria.sql
@@ -5,6 +5,11 @@ SELECT
 FROM `${omopDataset}.observation` AS o
 JOIN `${omopDataset}.prep_survey` AS ps
     ON ps.concept_id = o.observation_source_concept_id
-    AND CAST(ps.value AS INT64) = o.value_source_concept_id
+    AND (
+      (CAST(ps.value AS INT64) = o.value_source_concept_id)
+      OR
+      (ps.value IS NULL AND o.value_source_concept_id IS NULL)
+    )
+    AND ps.subtype = 'ANSWER'
 
 WHERE ps.survey = 'Basics'

--- a/underlay/src/main/resources/config/display/aouSR2023Q3R2/criteriaselector/surveyBasics/surveyBasics.json
+++ b/underlay/src/main/resources/config/display/aouSR2023Q3R2/criteriaselector/surveyBasics/surveyBasics.json
@@ -57,5 +57,11 @@
       }
     }
   ],
-  "multiSelect": true
+  "multiSelect": false,
+  "valueConfigs": [
+    {
+      "attribute": "value_numeric",
+      "title": "Numeric value"
+    }
+  ]
 }


### PR DESCRIPTION
- Included the "Select a value" answer in the `surveyBasics` entity hierarchy.
- Added the `value_numeric` attribute to the `surveyOccurrence` entity for the numeric value answers.
- Added an instance-level modifier for the `surveyOccurrence.value_numeric` attribute in the `surveyBasicsPerson` entity group.
- Filtered the `surveyOccurrence` instances to only include those rows for the Basics survey. We can add other surveys as we add support for them, and can validate that their counts are correct.
- Enabled instance-level modifiers in the `surveyBasics` criteria selector and disabled multi-select. The UI does not support multi-select and instance-level modifiers (e.g. Labs & Measurements).