### PR TITLE
[BENCH-2899], [BENCH-2973] Remove v2 prefix from version endpoint, add test

### DIFF
--- a/service/gradle/task-dependencies.gradle
+++ b/service/gradle/task-dependencies.gradle
@@ -18,3 +18,6 @@ for (task in TASKS_ONLY_IF_COMPILE_JAVA) {
 
 // Explicit dep to avoid accidental dep deprecation warning.
 tasks.processResources.dependsOn(generateVersionProperties)
+
+// Status and version endpoint tests added to regression test
+tasks.regressionTests.dependsOn(generateVersionProperties)

--- a/service/gradle/task-dependencies.gradle
+++ b/service/gradle/task-dependencies.gradle
@@ -19,5 +19,5 @@ for (task in TASKS_ONLY_IF_COMPILE_JAVA) {
 // Explicit dep to avoid accidental dep deprecation warning.
 tasks.processResources.dependsOn(generateVersionProperties)
 
-// Status and version endpoint tests added to regression test
-tasks.regressionTests.dependsOn(generateVersionProperties)
+// Status and version endpoint tests added to test
+tasks.test.dependsOn(generateVersionProperties)

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -12,8 +12,11 @@ security:
   - authorization: [openid, email, profile]
 
 paths:
+  # --------------- Unauthenticated Paths ---------------
+
   "/status":
     get:
+      security: [ ]
       summary: Returns the operational status of the service
       operationId: serviceStatus
       tags: [Unauthenticated]
@@ -21,10 +24,13 @@ paths:
         200:
           description: Service can process requests
         500:
-          description: Service is broken
+          description: |
+            Service cannot process requests. That might be because dependent services are
+            unavailable, or because there is a problem with the service itself.
 
-  "/v2/version":
+  "/version":
     get:
+      security: [ ]
       summary: Returns the deployed version of the service
       operationId: serviceVersion
       tags: [Unauthenticated]
@@ -38,11 +44,13 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- Users ---------------
+
   "/v2/profile":
     get:
-      tags: [Users]
       description: Returns the current user's profile information
       operationId: getMe
+      tags: [Users]
       responses:
         200:
           description: OK
@@ -52,6 +60,8 @@ paths:
                 $ref: "#/components/schemas/UserProfile"
         500:
           $ref: "#/components/responses/ServerError"
+
+  # --------------- Underlays ---------------
 
   "/v2/underlays":
     get:
@@ -230,6 +240,8 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- Studies ---------------
+
   "/v2/studies":
     get:
       parameters:
@@ -405,6 +417,8 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- Studies: Cohorts ---------------
+
   "/v2/studies/{studyId}/cohorts/{cohortId}":
     parameters:
       - $ref: "#/components/parameters/StudyId"
@@ -483,6 +497,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         500:
           $ref: "#/components/responses/ServerError"
+
+  # --------------- Studies: Reviews ---------------
 
   "/v2/studies/{studyId}/cohorts/{cohortId}/reviews":
     parameters:
@@ -627,6 +643,8 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- Studies: Annotations ---------------
+
   "/v2/studies/{studyId}/cohorts/{cohortId}/annotations":
     parameters:
       - $ref: "#/components/parameters/StudyId"
@@ -756,6 +774,8 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- Studies: ConceptSets ---------------
+
   "/v2/studies/{studyId}/conceptSets":
     parameters:
       - $ref: "#/components/parameters/StudyId"
@@ -846,6 +866,8 @@ paths:
           $ref: "#/components/responses/NotFound"
         500:
           $ref: "#/components/responses/ServerError"
+
+  # --------------- Underlays: Export ---------------
 
   "/v2/underlays/{underlayName}/exportModels":
     parameters:
@@ -942,6 +964,8 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- Activity log ---------------
+
   "/v2/activityLogEntries":
     parameters:
       - $ref: "#/components/parameters/ActivityLogFilterUserEmail"
@@ -981,11 +1005,13 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  # --------------- (Misc) Test ---------------
+
   /v2/vumc-admin-service-test:
     get:
-      tags: [Test]
       description: Temporary endpoint to test service-to-service communication with the VUMC admin service.
       operationId: vumcAdminServiceTest
+      tags: [Test]
       responses:
         200:
           description: OK

--- a/service/src/test/java/bio/terra/tanagra/app/controller/QueryCountRegressionTest.java
+++ b/service/src/test/java/bio/terra/tanagra/app/controller/QueryCountRegressionTest.java
@@ -1,11 +1,10 @@
-package bio.terra.tanagra.regression;
+package bio.terra.tanagra.app.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
-import bio.terra.tanagra.app.Main;
 import bio.terra.tanagra.app.configuration.FeatureConfiguration;
 import bio.terra.tanagra.proto.regressiontest.RTCriteria;
 import bio.terra.tanagra.proto.regressiontest.RTDataFeatureSet;
@@ -41,21 +40,12 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = Main.class)
-@SpringBootTest
-@ActiveProfiles("test")
 @Tag("requires-cloud-access")
 @Tag("regression-test")
 public class QueryCountRegressionTest extends BaseSpringUnitTest {

--- a/service/src/test/java/bio/terra/tanagra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/service/src/test/java/bio/terra/tanagra/app/controller/UnauthenticatedApiControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.tanagra.generated.model.ApiSystemVersion;
 import bio.terra.tanagra.testing.BaseSpringUnitTest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/service/src/test/java/bio/terra/tanagra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/service/src/test/java/bio/terra/tanagra/app/controller/UnauthenticatedApiControllerTest.java
@@ -1,0 +1,42 @@
+package bio.terra.tanagra.app.controller;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.tanagra.generated.model.ApiSystemVersion;
+import bio.terra.tanagra.testing.BaseSpringUnitTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Tag("regression-test")
+@AutoConfigureMockMvc
+public class UnauthenticatedApiControllerTest extends BaseSpringUnitTest {
+  @Autowired private MockMvc mvc;
+
+  @Test
+  public void serviceStatusTest() {
+    assertDoesNotThrow(
+        () -> this.mvc.perform(get("/status")).andExpect(status().isOk()).andReturn());
+  }
+
+  @Test
+  public void serviceVersionTest() throws Exception {
+    MockHttpServletResponse response =
+        this.mvc.perform(get("/version")).andExpect(status().isOk()).andReturn().getResponse();
+
+    ApiSystemVersion version =
+        new ObjectMapper().readValue(response.getContentAsString(), ApiSystemVersion.class);
+    assertNotNull(version);
+    assertNotNull(version.getGitTag());
+    assertNotNull(version.getGitHash());
+    assertNotNull(version.getGithub());
+    assertNotNull(version.getBuild());
+  }
+}

--- a/service/src/test/java/bio/terra/tanagra/app/controller/UnauthenticatedApiControllerTest.java
+++ b/service/src/test/java/bio/terra/tanagra/app/controller/UnauthenticatedApiControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 
-@Tag("regression-test")
 @AutoConfigureMockMvc
 public class UnauthenticatedApiControllerTest extends BaseSpringUnitTest {
   @Autowired private MockMvc mvc;

--- a/service/src/test/java/bio/terra/tanagra/regression/QueryCountRegressionTest.java
+++ b/service/src/test/java/bio/terra/tanagra/regression/QueryCountRegressionTest.java
@@ -1,4 +1,4 @@
-package bio.terra.tanagra.app.controller;
+package bio.terra.tanagra.regression;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/service/src/test/java/bio/terra/tanagra/testing/BaseSpringUnitTest.java
+++ b/service/src/test/java/bio/terra/tanagra/testing/BaseSpringUnitTest.java
@@ -1,13 +1,8 @@
 package bio.terra.tanagra.testing;
 
 import bio.terra.tanagra.app.Main;
-import bio.terra.tanagra.utils.RandomNumberGenerator;
-import java.util.Random;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -18,16 +13,4 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(classes = Main.class)
 @SpringBootTest
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
-public class BaseSpringUnitTest {
-  @MockBean protected RandomNumberGenerator randomNumberGenerator;
-
-  private Random random;
-
-  @BeforeEach
-  public void beforeEach() {
-    random = new Random(2022);
-    Mockito.doAnswer(invocation -> Math.abs(random.nextInt(Integer.MAX_VALUE)))
-        .when(randomNumberGenerator)
-        .getNext();
-  }
-}
+public class BaseSpringUnitTest {}


### PR DESCRIPTION
All authenticated endpoints start with v2, hence removing v2 prefix from version (in line with status endpoint). 
most monitoring setups use status endpoint, hence this change is unlikely to be a breaking change

----


verified that it runs in regular test suite 
https://github.com/DataBiosphere/tanagra/actions/runs/9275765397/job/25521235115?pr=865#step:8:182