### PR TITLE
Support DATE and TIMESTAMP for visit date attribute for temporal modifiers.

### DIFF
--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputAnyAnySameVisit.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputAnyAnySameVisit.sql
@@ -10,8 +10,9 @@
             FROM
                 (SELECT
                     person_id AS primaryEntityId,
-                    start_date AS visitDate,
-                    visit_occurrence_id AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
+                    TIMESTAMP(start_date) AS visitDate,
+                    IFNULL(visit_occurrence_id,
+                    0) AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
                 WHERE
                     condition IN (
                         SELECT
@@ -27,8 +28,9 @@
                 UNION
                 ALL SELECT
                     person_id AS primaryEntityId,
-                    date AS visitDate,
-                    visit_occurrence_id AS visitOccurrenceId FROM${ENT_procedureOccurrence}                  
+                    TIMESTAMP(date) AS visitDate,
+                    IFNULL(visit_occurrence_id,
+                    0) AS visitOccurrenceId FROM${ENT_procedureOccurrence}                  
                 WHERE
                     procedure IN (
                         SELECT
@@ -46,8 +48,9 @@
             (
                 SELECT
                     person_id AS primaryEntityId,
-                    start_date AS visitDate,
-                    visit_occurrence_id AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
+                    TIMESTAMP(start_date) AS visitDate,
+                    IFNULL(visit_occurrence_id,
+                    0) AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
                 WHERE
                     condition IN (
                         SELECT
@@ -63,8 +66,9 @@
                 UNION
                 ALL SELECT
                     person_id AS primaryEntityId,
-                    date AS visitDate,
-                    visit_occurrence_id AS visitOccurrenceId FROM${ENT_procedureOccurrence}                  
+                    TIMESTAMP(date) AS visitDate,
+                    IFNULL(visit_occurrence_id,
+                    0) AS visitOccurrenceId FROM${ENT_procedureOccurrence}                  
                 WHERE
                     procedure IN (
                         SELECT
@@ -80,6 +84,5 @@
             ) AS secondCondition                  
                 ON firstCondition.primaryEntityId = secondCondition.primaryEntityId                  
                 AND firstCondition.visitDate = secondCondition.visitDate                  
-                AND IFNULL(firstCondition.visitOccurrenceId,
-            0) = IFNULL(secondCondition.visitOccurrenceId,
-            0))
+                AND firstCondition.visitOccurrenceId = secondCondition.visitOccurrenceId             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputFirstLastWithinDays.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputFirstLastWithinDays.sql
@@ -22,7 +22,7 @@
                     FROM
                         (SELECT
                             person_id AS primaryEntityId,
-                            start_date AS visitDate FROM${ENT_conditionOccurrence}                          
+                            TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                          
                         WHERE
                             condition IN (
                                 SELECT
@@ -38,7 +38,7 @@
                         UNION
                         ALL SELECT
                             person_id AS primaryEntityId,
-                            start_date AS visitDate FROM${ENT_conditionOccurrence}                          
+                            TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                          
                         WHERE
                             condition IN (
                                 SELECT
@@ -72,7 +72,7 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        start_date AS visitDate FROM${ENT_conditionOccurrence}                      
+                        TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                      
                     WHERE
                         condition IN (
                             SELECT
@@ -88,7 +88,7 @@
                     UNION
                     ALL SELECT
                         person_id AS primaryEntityId,
-                        start_date AS visitDate FROM${ENT_conditionOccurrence}                      
+                        TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                      
                     WHERE
                         condition IN (
                             SELECT

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputLastAnyDaysAfter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputLastAnyDaysAfter.sql
@@ -22,7 +22,7 @@
                     FROM
                         (SELECT
                             person_id AS primaryEntityId,
-                            start_date AS visitDate FROM${ENT_conditionOccurrence}                          
+                            TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                          
                         WHERE
                             condition IN (
                                 SELECT
@@ -38,7 +38,7 @@
                         UNION
                         ALL SELECT
                             person_id AS primaryEntityId,
-                            date AS visitDate FROM${ENT_procedureOccurrence}                          
+                            TIMESTAMP(date) AS visitDate FROM${ENT_procedureOccurrence}                          
                         WHERE
                             procedure IN (
                                 SELECT
@@ -60,7 +60,7 @@
         (
             SELECT
                 person_id AS primaryEntityId,
-                start_date AS visitDate FROM${ENT_conditionOccurrence}              
+                TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}              
             WHERE
                 condition IN (
                     SELECT
@@ -76,7 +76,7 @@
             UNION
             ALL SELECT
                 person_id AS primaryEntityId,
-                date AS visitDate FROM${ENT_procedureOccurrence}              
+                TIMESTAMP(date) AS visitDate FROM${ENT_procedureOccurrence}              
             WHERE
                 procedure IN (
                     SELECT

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputLastLastDaysBefore.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterMultipleOutputLastLastDaysBefore.sql
@@ -22,7 +22,7 @@
                     FROM
                         (SELECT
                             person_id AS primaryEntityId,
-                            date AS visitDate FROM${ENT_procedureOccurrence}                          
+                            TIMESTAMP(date) AS visitDate FROM${ENT_procedureOccurrence}                          
                         WHERE
                             procedure IN (
                                 SELECT
@@ -38,7 +38,7 @@
                         UNION
                         ALL SELECT
                             person_id AS primaryEntityId,
-                            date AS visitDate FROM${ENT_procedureOccurrence}                          
+                            TIMESTAMP(date) AS visitDate FROM${ENT_procedureOccurrence}                          
                         WHERE
                             procedure IN (
                                 SELECT
@@ -72,7 +72,7 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        start_date AS visitDate FROM${ENT_conditionOccurrence}                      
+                        TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                      
                     WHERE
                         condition IN (
                             SELECT
@@ -88,7 +88,7 @@
                     UNION
                     ALL SELECT
                         person_id AS primaryEntityId,
-                        start_date AS visitDate FROM${ENT_conditionOccurrence}                      
+                        TIMESTAMP(start_date) AS visitDate FROM${ENT_conditionOccurrence}                      
                     WHERE
                         condition IN (
                             SELECT

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputAnyAnySameVisit.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputAnyAnySameVisit.sql
@@ -10,8 +10,9 @@
             FROM
                 (SELECT
                     person_id AS primaryEntityId,
-                    start_date AS visitDate,
-                    visit_occurrence_id AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
+                    TIMESTAMP(start_date) AS visitDate,
+                    IFNULL(visit_occurrence_id,
+                    0) AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
                 WHERE
                     condition IN (
                         SELECT
@@ -29,8 +30,9 @@
             (
                 SELECT
                     person_id AS primaryEntityId,
-                    start_date AS visitDate,
-                    visit_occurrence_id AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
+                    TIMESTAMP(start_date) AS visitDate,
+                    IFNULL(visit_occurrence_id,
+                    0) AS visitOccurrenceId FROM${ENT_conditionOccurrence}                  
                 WHERE
                     condition IN (
                         SELECT
@@ -46,6 +48,5 @@
             ) AS secondCondition                  
                 ON firstCondition.primaryEntityId = secondCondition.primaryEntityId                  
                 AND firstCondition.visitDate = secondCondition.visitDate                  
-                AND IFNULL(firstCondition.visitOccurrenceId,
-            0) = IFNULL(secondCondition.visitOccurrenceId,
-            0))
+                AND firstCondition.visitOccurrenceId = secondCondition.visitOccurrenceId             
+            )

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputFirstFirstDaysBefore.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputFirstFirstDaysBefore.sql
@@ -13,12 +13,12 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        start_date AS visitDate,
+                        TIMESTAMP(start_date) AS visitDate,
                         RANK() OVER (PARTITION                      
                     BY
                         person_id                      
                     ORDER BY
-                        start_date ASC) AS orderRank FROM${ENT_conditionOccurrence}                      
+                        TIMESTAMP(start_date) ASC) AS orderRank FROM${ENT_conditionOccurrence}                      
                     WHERE
                         condition IN (
                             SELECT
@@ -42,12 +42,12 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        date AS visitDate,
+                        TIMESTAMP(date) AS visitDate,
                         RANK() OVER (PARTITION                      
                     BY
                         person_id                      
                     ORDER BY
-                        date ASC) AS orderRank FROM${ENT_procedureOccurrence}                      
+                        TIMESTAMP(date) ASC) AS orderRank FROM${ENT_procedureOccurrence}                      
                     WHERE
                         procedure IN (
                             SELECT

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputFirstLastWithinDays.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputFirstLastWithinDays.sql
@@ -13,12 +13,12 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        date AS visitDate,
+                        TIMESTAMP(date) AS visitDate,
                         RANK() OVER (PARTITION                      
                     BY
                         person_id                      
                     ORDER BY
-                        date ASC) AS orderRank FROM${ENT_procedureOccurrence}                      
+                        TIMESTAMP(date) ASC) AS orderRank FROM${ENT_procedureOccurrence}                      
                     WHERE
                         procedure IN (
                             SELECT
@@ -42,12 +42,12 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        date AS visitDate,
+                        TIMESTAMP(date) AS visitDate,
                         RANK() OVER (PARTITION                      
                     BY
                         person_id                      
                     ORDER BY
-                        date DESC) AS orderRank FROM${ENT_procedureOccurrence}                      
+                        TIMESTAMP(date) DESC) AS orderRank FROM${ENT_procedureOccurrence}                      
                     WHERE
                         procedure IN (
                             SELECT

--- a/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputLastLastDaysAfter.sql
+++ b/underlay/src/test/resources/sql/BQFilterTest/temporalPrimaryFilterSingleOutputLastLastDaysAfter.sql
@@ -13,12 +13,12 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        date AS visitDate,
+                        TIMESTAMP(date) AS visitDate,
                         RANK() OVER (PARTITION                      
                     BY
                         person_id                      
                     ORDER BY
-                        date DESC) AS orderRank FROM${ENT_procedureOccurrence}                      
+                        TIMESTAMP(date) DESC) AS orderRank FROM${ENT_procedureOccurrence}                      
                     WHERE
                         procedure IN (
                             SELECT
@@ -42,12 +42,12 @@
                 FROM
                     (SELECT
                         person_id AS primaryEntityId,
-                        start_date AS visitDate,
+                        TIMESTAMP(start_date) AS visitDate,
                         RANK() OVER (PARTITION                      
                     BY
                         person_id                      
                     ORDER BY
-                        start_date DESC) AS orderRank FROM${ENT_conditionOccurrence}                      
+                        TIMESTAMP(start_date) DESC) AS orderRank FROM${ENT_conditionOccurrence}                      
                     WHERE
                         condition IN (
                             SELECT


### PR DESCRIPTION
For temporal modifiers, allow the `visitDate` attribute to be either `DATE` or `TIMESTAMP` data type. Previously, we only supported `TIMESTAMP`. Also moved the `IFNULL` check on the `visitOccurrenceId` field into the join sub-queries instead of in the join clause.