### PR TITLE
Truncate timestamp to microseconds before passing to BQ.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/exception/NotFoundException.java
+++ b/underlay/src/main/java/bio/terra/tanagra/exception/NotFoundException.java
@@ -1,2 +1,23 @@
-package bio.terra.tanagra.exception;public class NotFoundException {
+package bio.terra.tanagra.exception;
+
+/** Custom exception class for not found exceptions. */
+public class NotFoundException extends RuntimeException {
+  /**
+   * Constructs an exception with the given message. The cause is set to null.
+   *
+   * @param message description of error that may help with debugging
+   */
+  public NotFoundException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs an exception with the given message and cause.
+   *
+   * @param message description of error that may help with debugging
+   * @param cause underlying exception that can be logged for debugging purposes
+   */
+  public NotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/exception/NotFoundException.java
+++ b/underlay/src/main/java/bio/terra/tanagra/exception/NotFoundException.java
@@ -1,0 +1,2 @@
+package bio.terra.tanagra.exception;public class NotFoundException {
+}

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -193,7 +193,7 @@ public class BQExecutor {
       String paramName =
           sqlParams.addParam(
               "currentDate",
-              Literal.forDate(DateTimeFormatter.ofPattern("yyyy-mm-dd").format(queryInstant)));
+              Literal.forDate(DateTimeFormatter.ofPattern("yyyy-MM-dd").format(queryInstant)));
       modifiedSql =
           sql.replace(currentDateParens, '@' + paramName).replace(currentDate, '@' + paramName);
     }
@@ -224,7 +224,10 @@ public class BQExecutor {
         return QueryParameterValue.float64(literal.getDoubleVal());
       case TIMESTAMP:
         return QueryParameterValue.timestamp(
-            literal.getTimestampVal() == null ? null : literal.getTimestampVal().toString());
+            literal.getTimestampVal() == null
+                ? null
+                : DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss.SSS")
+                    .format(literal.getTimestampVal().toLocalDateTime()));
       default:
         throw new SystemException("Unsupported data type for BigQuery: " + literal.getDataType());
     }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -34,7 +34,6 @@ import bio.terra.tanagra.underlay.indextable.ITEntityMain;
 import bio.terra.tanagra.underlay.indextable.ITInstanceLevelDisplayHints;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +53,7 @@ public class BQQueryRunner implements QueryRunner {
     // Build the SQL query.
     Instant queryInstant =
         listQueryRequest.getPageMarker() == null
-            ? instantNowMicros()
+            ? Instant.now()
             : listQueryRequest.getPageMarker().getInstant();
     SqlQueryRequest sqlQueryRequest =
         listQueryRequest.isAgainstSourceData()
@@ -98,7 +97,7 @@ public class BQQueryRunner implements QueryRunner {
   }
 
   public SqlQueryRequest buildListQuerySqlAgainstIndexData(ListQueryRequest listQueryRequest) {
-    return buildListQuerySqlAgainstIndexData(listQueryRequest, instantNowMicros());
+    return buildListQuerySqlAgainstIndexData(listQueryRequest, Instant.now());
   }
 
   @VisibleForTesting
@@ -225,7 +224,7 @@ public class BQQueryRunner implements QueryRunner {
             null);
     Instant queryInstant =
         listQueryRequest.getPageMarker() == null
-            ? instantNowMicros()
+            ? Instant.now()
             : listQueryRequest.getPageMarker().getInstant();
     SqlQueryRequest indexDataSqlRequest =
         buildListQuerySqlAgainstIndexData(indexDataQueryRequest, queryInstant);
@@ -398,7 +397,7 @@ public class BQQueryRunner implements QueryRunner {
     // Swap out any un-cacheable functions with SQL parameters.
     Instant queryInstant =
         countQueryRequest.getPageMarker() == null
-            ? instantNowMicros()
+            ? Instant.now()
             : countQueryRequest.getPageMarker().getInstant();
     String sqlWithOnlyCacheableFunctions =
         BQExecutor.replaceFunctionsThatPreventCaching(sql.toString(), sqlParams, queryInstant);
@@ -592,12 +591,5 @@ public class BQQueryRunner implements QueryRunner {
 
     return new ExportQueryResult(
         exportFileUrlAndFileName.getRight(), exportFileUrlAndFileName.getLeft());
-  }
-
-  // Java17 returns Instant with nanoseconds, BigQuery only supports upto microseconds
-  // Hence, use microseconds precision everywhere
-  @VisibleForTesting
-  public static Instant instantNowMicros() {
-    return Instant.now().truncatedTo(ChronoUnit.MICROS);
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/underlay/PageMarkerSerializationTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/underlay/PageMarkerSerializationTest.java
@@ -1,6 +1,5 @@
 package bio.terra.tanagra.underlay;
 
-import static bio.terra.tanagra.query.bigquery.BQQueryRunner.instantNowMicros;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -15,7 +14,7 @@ import org.junit.jupiter.api.Test;
 public class PageMarkerSerializationTest {
   private static final String TOKEN =
       "BEZ2NPLKRUAQAAASAUIIBAEAAUNAMCH2AEIPUAJA77777777777767ZKABFJ6AQKOAFB2CQSOZSXE2LMPEWXIYLOMFTXEYJNMRSXMEJVQROZRIIAAAABEKK7GI2TKMJUGJSDQYJQHFRTAZJZGUYDSOLGGY3GCOJTGI3TINJQMUZTCOBZGMZWIYZRDISDGOBRGY2TOYTEFUYGKZLCFU2GKZTFFU4TQNTEFUZGKNJWMY3TQMZSGM2DCESEMFXG63TDGZRTQMJTGU3DIZJQGVSGGNZRGA4TIYTGMJQWCZDEGI4DEODFGIYDCNBUMFSTINZWG43DKZJUMEZDGNLCMRQWKNTCMEYGENTEMMZWKGTFMM3GGOBRGM2TMNDFGA2WIYZXGEYDSNDCMZRGCYLEMQZDQMRYMUZDAMJUGRQWKNBXGY3TMNLFGRQTEMZVMJSGCZJWMJQTAYRWMRRTGZJDGZRTQYZSMRQTSLLGG43WKLJUMZSWILLBGFRTELJQGE2GMNJTGQ2GGZRRGI======";
-  private static final Instant INSTANT = instantNowMicros();
+  private static final Instant INSTANT = Instant.now();
   private static final String SERIALIZED =
       "{\"pageToken\":\""
           + TOKEN

--- a/underlay/src/test/resources/sql/BQRemoveParamsTest/timestamp.sql
+++ b/underlay/src/test/resources/sql/BQRemoveParamsTest/timestamp.sql
@@ -4,4 +4,4 @@
     FROM
         ${ENT_conditionOccurrence}      
     WHERE
-        end_date = TIMESTAMP('2024-01-24 11:54:32.0')
+        end_date = TIMESTAMP('2024-01-24 11:54:32.000')


### PR DESCRIPTION
Truncate at the point we pass the timestamp value to BQ. This would also guarantee that we truncate in any other/future instances where the timestamp is turned into a literal.