### PR TITLE
Add support for non-person visualizations

### DIFF
--- a/docs/generated/PROTOCOL_BUFFERS.md
+++ b/docs/generated/PROTOCOL_BUFFERS.md
@@ -86,6 +86,7 @@
     - [VizConfig.Source.Join](#tanagra-viz-VizConfig-Source-Join)
     - [VizConfig.Source.Join.Aggregation](#tanagra-viz-VizConfig-Source-Join-Aggregation)
   
+    - [VizConfig.Source.Attribute.SortType](#tanagra-viz-VizConfig-Source-Attribute-SortType)
     - [VizConfig.Source.Join.Aggregation.AggregationType](#tanagra-viz-VizConfig-Source-Join-Aggregation-AggregationType)
   
 - [Scalar Value Types](#scalar-value-types)
@@ -985,7 +986,8 @@ The configuration of a underlay or cohort level visualization.
 | ----- | ---- | ----- | ----------- |
 | attribute | [string](#string) |  | The attribute to read. |
 | numeric_bucketing | [VizConfig.Source.Attribute.NumericBucketing](#tanagra-viz-VizConfig-Source-Attribute-NumericBucketing) |  |  |
-| sort_order | [tanagra.SortOrder](#tanagra-SortOrder) | optional | How to sort the data for display. |
+| sort_type | [VizConfig.Source.Attribute.SortType](#tanagra-viz-VizConfig-Source-Attribute-SortType) | optional | How to sort this attribute for display. Defaults to NAME. |
+| sort_descending | [bool](#bool) | optional | Whether to sort in descending order. |
 | limit | [int64](#int64) | optional | Whether a limited amount of data should be returned (e.g. 10 most common conditions). |
 
 
@@ -1061,6 +1063,19 @@ and [3, 5).
 
 
  
+
+
+<a name="tanagra-viz-VizConfig-Source-Attribute-SortType"></a>
+
+### VizConfig.Source.Attribute.SortType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN | 0 |  |
+| NAME | 1 |  |
+| VALUE | 2 |  |
+
 
 
 <a name="tanagra-viz-VizConfig-Source-Join-Aggregation-AggregationType"></a>

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -423,7 +423,8 @@ export interface StudySource {
     cohortId: string,
     groupSectionId?: string,
     groupId?: string,
-    groupByAttributes?: string[]
+    groupByAttributes?: string[],
+    entity?: string
   ): Promise<FilterCountValue[]>;
 
   getFeatureSetMetadata(
@@ -1409,7 +1410,8 @@ export class BackendStudySource implements StudySource {
     cohortId: string,
     groupSectionId?: string,
     groupId?: string,
-    groupByAttributes?: string[]
+    groupByAttributes?: string[],
+    entity?: string
   ): Promise<FilterCountValue[]> {
     let pageMarker: string | undefined;
     const instanceCounts: tanagra.InstanceCount[] = [];
@@ -1424,6 +1426,7 @@ export class BackendStudySource implements StudySource {
             criteriaGroupSectionId: groupSectionId,
             criteriaGroupId: groupId,
             pageMarker,
+            entity,
           },
         })
       );

--- a/ui/src/viz/plugins/core/bar.tsx
+++ b/ui/src/viz/plugins/core/bar.tsx
@@ -3,7 +3,6 @@ import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { compareDataValues } from "data/types";
 import { useMemo } from "react";
 import {
   Bar,
@@ -86,9 +85,9 @@ function BarViz(props: BarVizProps) {
 
   const stackedProperties = useMemo(
     () =>
-      Array.from(new Set(props.data.map((d) => d.keys[1]?.name)))
-        .filter(isValid)
-        .sort(),
+      Array.from(new Set(props.data.map((d) => d.keys[1]?.name))).filter(
+        isValid
+      ),
     [props.data]
   );
 
@@ -115,7 +114,7 @@ function BarViz(props: BarVizProps) {
         ...barData[k],
       });
     }
-    return arr.sort((a, b) => compareDataValues(a.name, b.name));
+    return arr;
   }, [props.data]);
 
   const barColors = props.config.colors ?? defaultColors;

--- a/underlay/src/main/proto/viz/viz_config.proto
+++ b/underlay/src/main/proto/viz/viz_config.proto
@@ -5,8 +5,6 @@ package tanagra.viz;
 option java_package = "bio.terra.tanagra.proto.viz";
 option java_outer_classname = "Viz";
 
-import "sort_order.proto";
-
 // The configuration of a underlay or cohort level visualization.
 message VizConfig {
   message Source {
@@ -87,12 +85,20 @@ message VizConfig {
         NumericBucketing numeric_bucketing = 2;
       }
 
-      // How to sort the data for display.
-      optional SortOrder sort_order = 3;
+      enum SortType {
+        UNKNOWN = 0;
+        NAME = 1;
+        VALUE = 2;
+      }
+      // How to sort this attribute for display. Defaults to NAME.
+      optional SortType sort_type = 3;
+
+      // Whether to sort in descending order.
+      optional bool sort_descending = 4;
 
       // Whether a limited amount of data should be returned (e.g. 10 most
       // common conditions).
-      optional int64 limit = 4;
+      optional int64 limit = 5;
     }
 
     // Which attributes should be returned from the selected data source (e.g.

--- a/underlay/src/main/resources/config/ui/omop/viz/topConditions/topConditions.json
+++ b/underlay/src/main/resources/config/ui/omop/viz/topConditions/topConditions.json
@@ -1,0 +1,16 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "condition",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "condition",
+          "sortType": "VALUE",
+          "sortDescending": true,
+          "limit": 10
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/omop/viz/topConditions/viz.json
+++ b/underlay/src/main/resources/config/ui/omop/viz/topConditions/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "topConditions",
+  "title": "Top 10 conditions",
+  "dataConfigFile": "topConditions.json",
+  "plugin": "bar"
+}

--- a/underlay/src/main/resources/config/underlay/cmssynpuf/underlay.json
+++ b/underlay/src/main/resources/config/underlay/cmssynpuf/underlay.json
@@ -57,7 +57,8 @@
   ],
   "visualizations": [
     "omop/gender",
-    "omop/raceAndAge"
+    "omop/raceAndAge",
+    "omop/topConditions"
   ],
   "metadata": {
     "displayName": "Centers for Medicare and Medicaid Services (CMS) Medicare Claims Synthetic Public Use Files (SynPUF)",

--- a/underlay/src/main/resources/config/underlay/sd/underlay.json
+++ b/underlay/src/main/resources/config/underlay/sd/underlay.json
@@ -115,7 +115,8 @@
   ],
   "visualizations": [
     "omop/gender",
-    "omop/raceAndAge"
+    "omop/raceAndAge",
+    "omop/topConditions"
   ],
   "metadata": {
     "displayName": "Synthetic Derivative Discover Dataset",


### PR DESCRIPTION
Update sorting viz options since the attribute is already present but the value needs to be an option.

This support is not fully generic since the UI no longer know which occurrences to query for a given selector. For now the references will be hard coded until M2 when the backend takes over viz query generation.