### PR TITLE
Add config option to override export function

### DIFF
--- a/ui/src/export.tsx
+++ b/ui/src/export.tsx
@@ -394,6 +394,20 @@ function Preview(props: PreviewProps) {
   const empty =
     props.selectedCohorts.size === 0 || props.selectedFeatureSets.size === 0;
 
+  const onExportClick = () =>
+    underlay.uiConfiguration.featureConfig?.overrideExportButton
+      ? window.parent.postMessage(
+          {
+            message: "EXPORT",
+            resources: {
+              cohorts: filteredCohorts.map((c) => c.id),
+              featureSets: filteredFeatureSets.map((fs) => fs.id),
+            },
+          },
+          process.env.REACT_APP_POST_MESSAGE_ORIGIN ?? window.location.origin
+        )
+      : showExportDialog();
+
   return (
     <Loading status={occurrenceFiltersState}>
       <TanagraTabs
@@ -441,7 +455,7 @@ function Preview(props: PreviewProps) {
                 underlay.uiConfiguration.featureConfig?.disableExportButton
               }
               onClick={() => {
-                showExportDialog();
+                onExportClick();
               }}
             >
               Export dataset

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -32,6 +32,7 @@ export type UIConfiguration = {
 
 export type FeatureConfig = {
   disableExportButton?: boolean;
+  overrideExportButton?: boolean;
 };
 
 export type DemographicChartConfig = {

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R2/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R2/ui.json
@@ -1,4 +1,7 @@
 {
+  "featureConfig": {
+    "overrideExportButton": true
+  },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],
     "chartConfigs": [

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R2/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R2/ui.json
@@ -1,4 +1,7 @@
 {
+  "featureConfig": {
+    "overrideExportButton": true
+  },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],
     "chartConfigs": [


### PR DESCRIPTION
Adds a new option `overrideExportButton` to the ui config. If enabled, will send a `postMessage` event with ids for the selected cohorts and feature sets instead of rendering the Tanagra export modal. This should allow us to use the existing Workbench export functionality.