### PR TITLE
Allow configuring export infrastructure per underlay.

### DIFF
--- a/docs/generated/APPLICATION_CONFIG.md
+++ b/docs/generated/APPLICATION_CONFIG.md
@@ -286,7 +286,7 @@ Comma separated list of all GCS bucket names that all export models can use. Onl
 
 *Environment variable:* `TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES`
 
-*Example value:* `broad-tanagra-dev-bq-export-uscentral1,broad-tanagra-dev-bq-export-useast1`
+*Example value:* `bq-export-uscentral1,bq-export-useast1`
 
 
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -127,6 +127,32 @@ Pointers to the source and index BigQuery datasets.
 
 Valid locations for BigQuery are listed in the GCP [documentation](https://cloud.google.com/bigquery/docs/locations).
 
+### SZBigQuery.exportBucketNames
+**optional** List [ String ]
+
+Comma separated list of all GCS bucket names that all export models can use. Only include the bucket name, not the gs:// prefix. Required if there are any export models that need to write to GCS.
+
+These buckets must live in the [query project](#szbigqueryqueryprojectid) specified above.
+
+You can also specify these export buckets per-deployment, instead of per-underlay, by using
+
+the service application properties.
+
+*Example value:* `bq-export-uscentral1,bq-export-useast1`
+
+### SZBigQuery.exportDatasetIds
+**optional** List [ String ]
+
+Comma separated list of all BQ dataset ids that all export models can use. Required if there are any export models that need to export from BQ to GCS.
+
+These datasets must live in the [query project](#szbigqueryqueryprojectid) specified above.
+
+You can also specify these export datasets per-deployment, instead of per-underlay, by using
+
+the service application properties.
+
+*Example value:* `service_export_us,service_export_uscentral1`
+
 ### SZBigQuery.indexData
 **required** [SZIndexData](#szindexdata)
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -134,9 +134,7 @@ Comma separated list of all GCS bucket names that all export models can use. Onl
 
 These buckets must live in the [query project](#szbigqueryqueryprojectid) specified above.
 
-You can also specify these export buckets per-deployment, instead of per-underlay, by using
-
-the service application properties.
+You can also specify these export buckets per-deployment, instead of per-underlay, by using the service application properties.
 
 *Example value:* `bq-export-uscentral1,bq-export-useast1`
 
@@ -147,9 +145,7 @@ Comma separated list of all BQ dataset ids that all export models can use. Requi
 
 These datasets must live in the [query project](#szbigqueryqueryprojectid) specified above.
 
-You can also specify these export datasets per-deployment, instead of per-underlay, by using
-
-the service application properties.
+You can also specify these export datasets per-deployment, instead of per-underlay, by using the service application properties.
 
 *Example value:* `service_export_us,service_export_uscentral1`
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntityLevelDisplayHints.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntityLevelDisplayHints.java
@@ -7,8 +7,7 @@ import bio.terra.tanagra.exception.InvalidConfigException;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.indexing.job.BigQueryJob;
 import bio.terra.tanagra.indexing.job.dataflow.beam.BigQueryBeamUtils;
-import bio.terra.tanagra.query.bigquery.BQExecutor;
-import bio.terra.tanagra.query.bigquery.BQTable;
+import bio.terra.tanagra.query.bigquery.*;
 import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.query.sql.SqlQueryField;
@@ -199,8 +198,7 @@ public class WriteEntityLevelDisplayHints extends BigQueryJob {
       LOGGER.info("Skipping query dry run because output table does not exist yet.");
     } else {
       BQExecutor bqExecutor =
-          new BQExecutor(
-              indexerConfig.bigQuery.queryProjectId, indexerConfig.bigQuery.dataLocation);
+          new BQExecutor(BQExecutorInfrastructure.forQuery(indexerConfig.bigQuery.queryProjectId));
       SqlQueryRequest sqlQueryRequest =
           new SqlQueryRequest(insertLiteralsSql, sqlParams, null, null, isDryRun);
       bqExecutor.run(sqlQueryRequest);

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/ExportConfiguration.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/ExportConfiguration.java
@@ -84,7 +84,7 @@ public class ExportConfiguration {
                 + "Required if there are any export models that need to write to GCS.",
         environmentVariable = "TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES",
         optional = true,
-        exampleValue = "broad-tanagra-dev-bq-export-uscentral1,broad-tanagra-dev-bq-export-useast1")
+        exampleValue = "bq-export-uscentral1,bq-export-useast1")
     private List<String> gcsBucketNames;
 
     public String getGcpProjectId() {

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -298,9 +298,6 @@ public class DataExportHelper {
                       listQueryRequest,
                       entityOutput.getEntity().getName(),
                       substitutedFilename,
-                      sharedExportConfig.getGcpProjectId(),
-                      sharedExportConfig.getBqDatasetIds(),
-                      sharedExportConfig.getGcsBucketNames(),
                       true);
                 })
             .collect(Collectors.toList());

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -18,7 +18,6 @@ import bio.terra.tanagra.utils.NameUtils;
 import bio.terra.tanagra.utils.threadpool.Job;
 import bio.terra.tanagra.utils.threadpool.JobResult;
 import bio.terra.tanagra.utils.threadpool.ThreadPoolUtils;
-import com.google.cloud.storage.BlobId;
 import com.google.common.collect.ImmutableList;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -38,7 +37,6 @@ import org.slf4j.LoggerFactory;
 public class DataExportHelper {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataExportHelper.class);
   private final Integer maxChildThreads;
-  private final ExportConfiguration.Shared sharedExportConfig;
   private final RandomNumberGenerator randomNumberGenerator;
   private final ReviewService reviewService;
   private final ExportRequest exportRequest;
@@ -55,7 +53,6 @@ public class DataExportHelper {
       List<EntityOutput> entityOutputs,
       EntityFilter primaryEntityFilter) {
     this.maxChildThreads = maxChildThreads;
-    this.sharedExportConfig = sharedExportConfig;
     this.randomNumberGenerator = randomNumberGenerator;
     this.reviewService = reviewService;
     this.exportRequest = exportRequest;
@@ -294,7 +291,7 @@ public class DataExportHelper {
                           String.valueOf(randomNumberGenerator.getNext()));
                   String substitutedFilename =
                       StringSubstitutor.replace(fileNameTemplate, substitutions);
-                  return new ExportQueryRequest(
+                  return ExportQueryRequest.forListQuery(
                       listQueryRequest,
                       entityOutput.getEntity().getName(),
                       substitutedFilename,
@@ -404,9 +401,6 @@ public class DataExportHelper {
    *     gs://bucket/filename.csv).
    */
   public List<ExportFileResult> writeAnnotationDataToGcs(String fileNameTemplate) {
-    // Just pick the first GCS bucket name.
-    String bucketName = sharedExportConfig.getGcsBucketNames().get(0);
-
     // Write the annotations for each cohort to a separate file.
     List<ExportFileResult> exportFileResults = new ArrayList<>();
     exportRequest
@@ -437,10 +431,11 @@ public class DataExportHelper {
                   if (!fileName.endsWith(".csv")) {
                     fileName += ".csv";
                   }
-                  BlobId blobId = getStorageService().writeFile(bucketName, fileName, fileContents);
-                  String gcsUrl = getStorageService().createSignedUrl(blobId.toGsUtilUri());
+
+                  ExportQueryResult exportQueryResult = exportRawData(fileContents, fileName, true);
                   exportFileResults.add(
-                      ExportFileResult.forAnnotationData(fileName, gcsUrl, cohort, null, null));
+                      ExportFileResult.forAnnotationData(
+                          fileName, exportQueryResult.getFilePath(), cohort, null, null));
                 }
               } catch (Exception ex) {
                 exportFileResults.add(
@@ -451,13 +446,15 @@ public class DataExportHelper {
     return exportFileResults;
   }
 
-  /** Maintain a single reference to the GCS client object, so we don't keep recreating it. */
-  public GoogleCloudStorage getStorageService() {
-    if (googleCloudStorage == null) {
-      googleCloudStorage =
-          GoogleCloudStorage.forApplicationDefaultCredentials(sharedExportConfig.getGcpProjectId());
-    }
-    return googleCloudStorage;
+  public ExportQueryResult exportRawData(
+      String fileContents, String fileName, boolean generateSignedUrl) {
+    ExportQueryRequest exportQueryRequest =
+        ExportQueryRequest.forRawData(fileContents, fileName, generateSignedUrl);
+    return exportQueryRequest
+        .getListQueryRequest()
+        .getUnderlay()
+        .getQueryRunner()
+        .run(exportQueryRequest);
   }
 
   public static String urlEncode(String param) {

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -450,11 +450,7 @@ public class DataExportHelper {
       String fileContents, String fileName, boolean generateSignedUrl) {
     ExportQueryRequest exportQueryRequest =
         ExportQueryRequest.forRawData(fileContents, fileName, generateSignedUrl);
-    return exportQueryRequest
-        .getListQueryRequest()
-        .getUnderlay()
-        .getQueryRunner()
-        .run(exportQueryRequest);
+    return exportRequest.getUnderlay().getQueryRunner().run(exportQueryRequest);
   }
 
   public static String urlEncode(String param) {

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -14,6 +14,8 @@ export type SZAttribute = {
 
 export type SZBigQuery = {
   dataLocation: string;
+  exportBucketNames?: string[];
+  exportDatasetIds?: string[];
   indexData: SZIndexData;
   queryProjectId: string;
   sourceData: SZSourceData;

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
@@ -1,31 +1,21 @@
 package bio.terra.tanagra.api.query.export;
 
 import bio.terra.tanagra.api.query.list.ListQueryRequest;
-import java.util.List;
 
 public class ExportQueryRequest {
   private final ListQueryRequest listQueryRequest;
   private final String fileDisplayName;
   private final String fileNamePrefix;
-  private final String gcsProjectId;
-  private final List<String> availableBqDatasetIds;
-  private final List<String> availableGcsBucketNames;
   private final boolean generateSignedUrl;
 
   public ExportQueryRequest(
       ListQueryRequest listQueryRequest,
       String fileDisplayName,
       String fileNamePrefix,
-      String gcsProjectId,
-      List<String> availableBqDatasetIds,
-      List<String> availableGcsBucketNames,
       boolean generateSignedUrl) {
     this.listQueryRequest = listQueryRequest;
     this.fileDisplayName = fileDisplayName;
     this.fileNamePrefix = fileNamePrefix;
-    this.gcsProjectId = gcsProjectId;
-    this.availableBqDatasetIds = availableBqDatasetIds;
-    this.availableGcsBucketNames = availableGcsBucketNames;
     this.generateSignedUrl = generateSignedUrl;
   }
 
@@ -39,18 +29,6 @@ public class ExportQueryRequest {
 
   public String getFileNamePrefix() {
     return fileNamePrefix;
-  }
-
-  public String getGcsProjectId() {
-    return gcsProjectId;
-  }
-
-  public List<String> getAvailableBqDatasetIds() {
-    return availableBqDatasetIds;
-  }
-
-  public List<String> getAvailableGcsBucketNames() {
-    return availableGcsBucketNames;
   }
 
   public boolean isGenerateSignedUrl() {

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/export/ExportQueryRequest.java
@@ -4,23 +4,48 @@ import bio.terra.tanagra.api.query.list.ListQueryRequest;
 
 public class ExportQueryRequest {
   private final ListQueryRequest listQueryRequest;
+  private final String fileContents;
   private final String fileDisplayName;
   private final String fileNamePrefix;
   private final boolean generateSignedUrl;
 
-  public ExportQueryRequest(
+  private ExportQueryRequest(
       ListQueryRequest listQueryRequest,
+      String fileContents,
       String fileDisplayName,
       String fileNamePrefix,
       boolean generateSignedUrl) {
     this.listQueryRequest = listQueryRequest;
+    this.fileContents = fileContents;
     this.fileDisplayName = fileDisplayName;
     this.fileNamePrefix = fileNamePrefix;
     this.generateSignedUrl = generateSignedUrl;
   }
 
+  public static ExportQueryRequest forListQuery(
+      ListQueryRequest listQueryRequest,
+      String fileDisplayName,
+      String fileNamePrefix,
+      boolean generateSignedUrl) {
+    return new ExportQueryRequest(
+        listQueryRequest, null, fileDisplayName, fileNamePrefix, generateSignedUrl);
+  }
+
+  public static ExportQueryRequest forRawData(
+      String fileContents, String fileDisplayName, boolean generateSignedUrl) {
+    return new ExportQueryRequest(null, fileContents, fileDisplayName, null, generateSignedUrl);
+  }
+
   public ListQueryRequest getListQueryRequest() {
     return listQueryRequest;
+  }
+
+  public String getFileContents() {
+    return fileContents;
+  }
+
+  public boolean isForRawData() {
+    return listQueryRequest == null;
   }
 
   public String getFileDisplayName() {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutorInfrastructure.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutorInfrastructure.java
@@ -1,0 +1,54 @@
+package bio.terra.tanagra.query.bigquery;
+
+import com.google.common.collect.*;
+import jakarta.annotation.*;
+import java.util.*;
+
+public class BQExecutorInfrastructure {
+  private final String queryProjectId;
+  private final @Nullable String datasetLocation;
+  private final @Nullable ImmutableList<String> exportDatasetIds;
+  private final @Nullable ImmutableList<String> exportBucketNames;
+
+  private BQExecutorInfrastructure(
+      String queryProjectId,
+      String datasetLocation,
+      List<String> exportDatasetIds,
+      List<String> exportBucketNames) {
+    this.queryProjectId = queryProjectId;
+    this.datasetLocation = datasetLocation;
+    this.exportDatasetIds =
+        exportDatasetIds == null ? null : ImmutableList.copyOf(exportDatasetIds);
+    this.exportBucketNames =
+        exportBucketNames == null ? null : ImmutableList.copyOf(exportBucketNames);
+  }
+
+  public static BQExecutorInfrastructure forQuery(String queryProjectId) {
+    return new BQExecutorInfrastructure(queryProjectId, null, null, null);
+  }
+
+  public static BQExecutorInfrastructure forQueryAndExport(
+      String queryProjectId,
+      String datasetLocation,
+      List<String> exportDatasetIds,
+      List<String> exportBucketNames) {
+    return new BQExecutorInfrastructure(
+        queryProjectId, datasetLocation, exportDatasetIds, exportBucketNames);
+  }
+
+  public String getQueryProjectId() {
+    return queryProjectId;
+  }
+
+  public String getDatasetLocation() {
+    return datasetLocation;
+  }
+
+  public ImmutableList<String> getExportDatasetIds() {
+    return exportDatasetIds;
+  }
+
+  public ImmutableList<String> getExportBucketNames() {
+    return exportBucketNames;
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -44,8 +44,8 @@ import org.apache.commons.lang3.tuple.Pair;
 public class BQQueryRunner implements QueryRunner {
   private final BQExecutor bigQueryExecutor;
 
-  public BQQueryRunner(String queryProjectId, String datasetLocation) {
-    this.bigQueryExecutor = new BQExecutor(queryProjectId, datasetLocation);
+  public BQQueryRunner(BQExecutorInfrastructure queryInfrastructure) {
+    this.bigQueryExecutor = new BQExecutor(queryInfrastructure);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -575,17 +575,26 @@ public class BQQueryRunner implements QueryRunner {
 
   @Override
   public ExportQueryResult run(ExportQueryRequest exportQueryRequest) {
-    // Build the SQL query.
-    SqlQueryRequest sqlQueryRequest =
-        buildListQuerySqlAgainstIndexData(exportQueryRequest.getListQueryRequest());
+    Pair<String, String> exportFileUrlAndFileName;
+    if (exportQueryRequest.isForRawData()) {
+      // Export the raw data to GCS.
+      exportFileUrlAndFileName =
+          bigQueryExecutor.exportRawData(
+              exportQueryRequest.getFileContents(),
+              exportQueryRequest.getFileDisplayName(),
+              exportQueryRequest.isGenerateSignedUrl());
+    } else {
+      // Build the SQL query.
+      SqlQueryRequest sqlQueryRequest =
+          buildListQuerySqlAgainstIndexData(exportQueryRequest.getListQueryRequest());
 
-    // Execute the SQL query and export the results to GCS.
-    Pair<String, String> exportFileUrlAndFileName =
-        bigQueryExecutor.export(
-            sqlQueryRequest,
-            exportQueryRequest.getFileNamePrefix(),
-            exportQueryRequest.isGenerateSignedUrl());
-
+      // Execute the SQL query and export the results to GCS.
+      exportFileUrlAndFileName =
+          bigQueryExecutor.exportQuery(
+              sqlQueryRequest,
+              exportQueryRequest.getFileNamePrefix(),
+              exportQueryRequest.isGenerateSignedUrl());
+    }
     return new ExportQueryResult(
         exportFileUrlAndFileName.getRight(), exportFileUrlAndFileName.getLeft());
   }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -584,9 +584,6 @@ public class BQQueryRunner implements QueryRunner {
         bigQueryExecutor.export(
             sqlQueryRequest,
             exportQueryRequest.getFileNamePrefix(),
-            exportQueryRequest.getGcsProjectId(),
-            exportQueryRequest.getAvailableBqDatasetIds(),
-            exportQueryRequest.getAvailableGcsBucketNames(),
             exportQueryRequest.isGenerateSignedUrl());
 
     return new ExportQueryResult(

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -4,7 +4,7 @@ import bio.terra.tanagra.exception.InvalidConfigException;
 import bio.terra.tanagra.exception.NotFoundException;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.query.QueryRunner;
-import bio.terra.tanagra.query.bigquery.BQQueryRunner;
+import bio.terra.tanagra.query.bigquery.*;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
@@ -245,7 +245,12 @@ public final class Underlay {
 
     // Build the query executor.
     BQQueryRunner queryRunner =
-        new BQQueryRunner(szBigQuery.queryProjectId, szBigQuery.dataLocation);
+        new BQQueryRunner(
+            BQExecutorInfrastructure.forQueryAndExport(
+                szBigQuery.queryProjectId,
+                szBigQuery.dataLocation,
+                szBigQuery.exportDatasetIds,
+                szBigQuery.exportBucketNames));
 
     // Build the criteria selectors.
     List<SZCriteriaSelector> szCriteriaSelectors = new ArrayList<>();

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZBigQuery.java
@@ -2,7 +2,9 @@ package bio.terra.tanagra.underlay.serialization;
 
 import bio.terra.tanagra.annotation.AnnotatedClass;
 import bio.terra.tanagra.annotation.AnnotatedField;
-import java.util.Map;
+import com.google.common.collect.*;
+import jakarta.annotation.*;
+import java.util.*;
 
 @AnnotatedClass(
     name = "SZBigQuery",
@@ -38,6 +40,31 @@ public class SZBigQuery {
           "Valid locations for BigQuery are listed in the GCP "
               + "[documentation](https://cloud.google.com/bigquery/docs/locations).")
   public String dataLocation;
+
+  @AnnotatedField(
+      name = "SZBigQuery.exportDatasetIds",
+      markdown =
+          "Comma separated list of all BQ dataset ids that all export models can use. "
+              + "Required if there are any export models that need to export from BQ to GCS.\n\n"
+              + "These datasets must live in the [query project](${SZBigQuery.queryProjectId}) specified above.\n\n"
+              + "You can also specify these export datasets per-deployment, instead of per-underlay, by using\n\n"
+              + "the service application properties.",
+      optional = true,
+      exampleValue = "service_export_us,service_export_uscentral1")
+  public List<String> exportDatasetIds;
+
+  @AnnotatedField(
+      name = "SZBigQuery.exportBucketNames",
+      markdown =
+          "Comma separated list of all GCS bucket names that all export models can use. "
+              + "Only include the bucket name, not the gs:// prefix. "
+              + "Required if there are any export models that need to write to GCS.\n\n"
+              + "These buckets must live in the [query project](${SZBigQuery.queryProjectId}) specified above.\n\n"
+              + "You can also specify these export buckets per-deployment, instead of per-underlay, by using\n\n"
+              + "the service application properties.",
+      optional = true,
+      exampleValue = "bq-export-uscentral1,bq-export-useast1")
+  public List<String> exportBucketNames;
 
   @AnnotatedClass(name = "SZSourceData", markdown = "Pointer to the source BigQuery dataset.")
   public static class SourceData {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZBigQuery.java
@@ -47,7 +47,7 @@ public class SZBigQuery {
           "Comma separated list of all BQ dataset ids that all export models can use. "
               + "Required if there are any export models that need to export from BQ to GCS.\n\n"
               + "These datasets must live in the [query project](${SZBigQuery.queryProjectId}) specified above.\n\n"
-              + "You can also specify these export datasets per-deployment, instead of per-underlay, by using\n\n"
+              + "You can also specify these export datasets per-deployment, instead of per-underlay, by using "
               + "the service application properties.",
       optional = true,
       exampleValue = "service_export_us,service_export_uscentral1")
@@ -60,7 +60,7 @@ public class SZBigQuery {
               + "Only include the bucket name, not the gs:// prefix. "
               + "Required if there are any export models that need to write to GCS.\n\n"
               + "These buckets must live in the [query project](${SZBigQuery.queryProjectId}) specified above.\n\n"
-              + "You can also specify these export buckets per-deployment, instead of per-underlay, by using\n\n"
+              + "You can also specify these export buckets per-deployment, instead of per-underlay, by using "
               + "the service application properties.",
       optional = true,
       exampleValue = "bq-export-uscentral1,bq-export-useast1")

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/BQRunnerTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/BQRunnerTest.java
@@ -20,8 +20,7 @@ public abstract class BQRunnerTest {
     szService = configReader.readService(getServiceConfigName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
-    bqQueryRunner =
-        new BQQueryRunner(szService.bigQuery.queryProjectId, szService.bigQuery.dataLocation);
+    bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();
   }
 
   protected String getServiceConfigName() {

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
@@ -102,8 +102,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
     SZService szService = configReader.readService("cmssynpuf_broad");
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
-    BQQueryRunner bqQueryRunner =
-        new BQQueryRunner(szService.bigQuery.queryProjectId, szService.bigQuery.dataLocation);
+    BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();
 
     Entity entity = underlay.getEntity("conditionOccurrence");
     AttributeField simpleAttribute =

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQGroupItemsFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQGroupItemsFilterTest.java
@@ -207,8 +207,7 @@ public class BQGroupItemsFilterTest extends BQRunnerTest {
     SZService szService = configReader.readService("sd20230331_verily");
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
-    BQQueryRunner bqQueryRunner =
-        new BQQueryRunner(szService.bigQuery.queryProjectId, szService.bigQuery.dataLocation);
+    BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();
 
     groupItems = (GroupItems) underlay.getEntityGroup("pulsePerson");
     groupHasItemsFilter = new GroupHasItemsFilter(underlay, groupItems, null, null, null, null);

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQRelationshipFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQRelationshipFilterTest.java
@@ -256,8 +256,7 @@ public class BQRelationshipFilterTest extends BQRunnerTest {
     SZService szService = configReader.readService("sd20230331_verily");
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
-    BQQueryRunner bqQueryRunner =
-        new BQQueryRunner(szService.bigQuery.queryProjectId, szService.bigQuery.dataLocation);
+    BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();
     GroupItems pulsePerson = (GroupItems) underlay.getEntityGroup("pulsePerson");
     relationshipFilter =
         new RelationshipFilter(
@@ -821,8 +820,7 @@ public class BQRelationshipFilterTest extends BQRunnerTest {
     SZService szService = configReader.readService("sd20230331_verily");
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
-    BQQueryRunner bqQueryRunner =
-        new BQQueryRunner(szService.bigQuery.queryProjectId, szService.bigQuery.dataLocation);
+    BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();
 
     // e.g. SELECT conditionOccurrence FILTER ON (person FILTER ON HAS ANY bmi).
     CriteriaOccurrence criteriaOccurrence =


### PR DESCRIPTION
Previously export infrastructure (temporary BQ datasets, GCS buckets) could only be configured per service deployment, using the service application properties. This PR allows it to be configured per underlay. If export infrastructure is not specified per underlay, it defaults to the per service values. This is to better support coming service deployments that serve multiple underlays (e.g. SD + eMerge, Verily Workbench).

Also moved the logic for writing raw data to GCS behind the `QueryRunner` interface, so we can use the underlay-specific config and in the future, potentially different implementations per underlay.