### PR TITLE
Temporal modifier OpenAPI and config properties.

### DIFF
--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -321,6 +321,8 @@ If this property is specified, the value of the `pluginConfig` property is ignor
 
 True if this criteria selector supports temporal queries.
 
+*Default value:* `false`
+
 
 
 ## SZCriteriaSelectorDisplay
@@ -344,11 +346,6 @@ criteria page. (e.g. "Source Codes")
 
 ## SZCriteriaSelectorModifier
 Criteria selector display configuration.
-
-### SZCriteriaSelector.supportsTemporalQueries
-**required** boolean
-
-True if this modifier supports temporal queries.
 
 ### SZCriteriaSelectorModifier.displayName
 **required** String
@@ -388,6 +385,13 @@ Name of the file that contains the serialized configuration of the modifier UI d
 This file should be in the same directory as the criteria selector (e.g. `visitType.json`).
 
 If this property is specified, the value of the `pluginConfig` property is ignored.
+
+### SZCriteriaSelectorModifier.supportsTemporalQueries
+**required** boolean
+
+True if this modifier supports temporal queries.
+
+*Default value:* `false`
 
 
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -316,6 +316,11 @@ This file should be in the same directory as the criteria selector (e.g. `gender
 
 If this property is specified, the value of the `pluginConfig` property is ignored.
 
+### SZCriteriaSelector.supportsTemporalQueries
+**required** boolean
+
+True if this criteria selector supports temporal queries.
+
 
 
 ## SZCriteriaSelectorDisplay
@@ -339,6 +344,11 @@ criteria page. (e.g. "Source Codes")
 
 ## SZCriteriaSelectorModifier
 Criteria selector display configuration.
+
+### SZCriteriaSelector.supportsTemporalQueries
+**required** boolean
+
+True if this modifier supports temporal queries.
 
 ### SZCriteriaSelectorModifier.displayName
 **required** String

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2308,13 +2308,35 @@ components:
           description: Name of the section
         criteriaGroups:
           type: array
-          description: Set of criteria groups in the section
+          description: |
+            For a temporal section, this is the set of groups that define the first condition.
+            For a non-temporal section, the set of groups are the union of this list and the secondConditionCriteriaGroups list.
           items:
             $ref: "#/components/schemas/CriteriaGroup"
+        firstConditionReducingOperator:
+          description: |
+            Reducing operator for the first set of criteria groups.
+            Only applies for a temporal section.
+          $ref: "#/components/schemas/ReducingOperator"
+        secondConditionCriteriaGroups:
+          type: array
+          description: |
+            For a temporal section, this is the set of groups that define the second condition.
+            For a non-temporal section, the set of groups are the union of this list and the criteriaGroups list.
+          items:
+            $ref: "#/components/schemas/CriteriaGroup"
+        secondConditionReducingOperator:
+          description: |
+            Reducing operator for the second set of criteria groups.
+            Only applies for a temporal section.
+          $ref: "#/components/schemas/ReducingOperator"
         operator:
           type: string
           description: Operator to use when combining the criteria groups in the section
-          enum: ["AND", "OR"]
+          enum: ["AND", "OR", "DURING_SAME_ENCOUNTER", "NUM_DAYS_BEFORE", "NUM_DAYS_AFTER", "WITHIN_NUM_DAYS"]
+        operatorValue:
+          type: integer
+          description: Value associated with the operator (e.g. num days)
         excluded:
           type: boolean
           description: True to exclude the section, false to include it
@@ -2324,6 +2346,10 @@ components:
         - criteriaGroups
         - operator
         - excluded
+
+    ReducingOperator:
+      type: string
+      enum: ["ANY", "FIRST_MENTION_OF", "LAST_MENTION_OF"]
 
     CriteriaGroup:
       type: object

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -62,12 +62,12 @@ export type SZCriteriaSelectorDisplay = {
 };
 
 export type SZCriteriaSelectorModifier = {
-  supportsTemporalQueries: boolean;
   displayName: string;
   name: string;
   plugin: string;
   pluginConfig: string;
   pluginConfigFile: string;
+  supportsTemporalQueries: boolean;
 };
 
 export enum SZDataType {

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -53,6 +53,7 @@ export type SZCriteriaSelector = {
   plugin: string;
   pluginConfig: string;
   pluginConfigFile: string;
+  supportsTemporalQueries: boolean;
 };
 
 export type SZCriteriaSelectorDisplay = {
@@ -61,6 +62,7 @@ export type SZCriteriaSelectorDisplay = {
 };
 
 export type SZCriteriaSelectorModifier = {
+  supportsTemporalQueries: boolean;
   displayName: string;
   name: string;
   plugin: string;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZCriteriaSelector.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZCriteriaSelector.java
@@ -71,7 +71,8 @@ public class SZCriteriaSelector {
 
   @AnnotatedField(
       name = "SZCriteriaSelector.supportsTemporalQueries",
-      markdown = "True if this criteria selector supports temporal queries.")
+      markdown = "True if this criteria selector supports temporal queries.",
+      defaultValue = "false")
   public boolean supportsTemporalQueries;
 
   @AnnotatedField(name = "SZCriteriaSelector.modifiers", markdown = "Configuration for modifiers.")
@@ -138,8 +139,9 @@ public class SZCriteriaSelector {
     public String pluginConfigFile;
 
     @AnnotatedField(
-        name = "SZCriteriaSelector.supportsTemporalQueries",
-        markdown = "True if this modifier supports temporal queries.")
+        name = "SZCriteriaSelectorModifier.supportsTemporalQueries",
+        markdown = "True if this modifier supports temporal queries.",
+        defaultValue = "false")
     public boolean supportsTemporalQueries;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZCriteriaSelector.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZCriteriaSelector.java
@@ -69,6 +69,11 @@ public class SZCriteriaSelector {
               + "If this property is specified, the value of the `pluginConfig` property is ignored.")
   public String pluginConfigFile;
 
+  @AnnotatedField(
+      name = "SZCriteriaSelector.supportsTemporalQueries",
+      markdown = "True if this criteria selector supports temporal queries.")
+  public boolean supportsTemporalQueries;
+
   @AnnotatedField(name = "SZCriteriaSelector.modifiers", markdown = "Configuration for modifiers.")
   public List<Modifier> modifiers;
 
@@ -131,5 +136,10 @@ public class SZCriteriaSelector {
                 + "This file should be in the same directory as the criteria selector (e.g. `visitType.json`).\n\n"
                 + "If this property is specified, the value of the `pluginConfig` property is ignored.")
     public String pluginConfigFile;
+
+    @AnnotatedField(
+        name = "SZCriteriaSelector.supportsTemporalQueries",
+        markdown = "True if this modifier supports temporal queries.")
+    public boolean supportsTemporalQueries;
   }
 }


### PR DESCRIPTION
- Added a config property to the criteria selector and modifier to indicate whether temporal queries are supported. Default is false.
- Made the OpenAPI schema changes to support temporal query criteria group sections.
- This PR does not include the backend implementation of the OpenAPI changes, those will come in a follow-on PR.