### PR TITLE
Remove bootJar from build.gradle

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -187,10 +187,6 @@ tasks.withType(Test).configureEach {
     }
 }
 
-bootJar {
-    enabled = false
-}
-
 String includeDir = "$projectDir/gradle"
 apply from: "${includeDir}/jib.gradle"
 apply from: "${includeDir}/open-api.gradle"


### PR DESCRIPTION
Was preventing the main `*SNAPSHOT.jar` file from being generated in the gradle build