### PR TITLE
Persist temporal criteria group sections in DB.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -10,29 +10,9 @@ import bio.terra.tanagra.api.query.count.CountInstance;
 import bio.terra.tanagra.api.query.count.CountQueryResult;
 import bio.terra.tanagra.api.query.list.ListInstance;
 import bio.terra.tanagra.api.query.list.ListQueryResult;
-import bio.terra.tanagra.api.shared.Literal;
-import bio.terra.tanagra.api.shared.ValueDisplay;
+import bio.terra.tanagra.api.shared.*;
 import bio.terra.tanagra.exception.SystemException;
-import bio.terra.tanagra.generated.model.ApiAnnotationValue;
-import bio.terra.tanagra.generated.model.ApiAttribute;
-import bio.terra.tanagra.generated.model.ApiCohort;
-import bio.terra.tanagra.generated.model.ApiCriteria;
-import bio.terra.tanagra.generated.model.ApiCriteriaGroup;
-import bio.terra.tanagra.generated.model.ApiCriteriaGroupSection;
-import bio.terra.tanagra.generated.model.ApiDataType;
-import bio.terra.tanagra.generated.model.ApiInstance;
-import bio.terra.tanagra.generated.model.ApiInstanceCount;
-import bio.terra.tanagra.generated.model.ApiInstanceCountList;
-import bio.terra.tanagra.generated.model.ApiInstanceHierarchyFields;
-import bio.terra.tanagra.generated.model.ApiInstanceListResult;
-import bio.terra.tanagra.generated.model.ApiInstanceRelationshipFields;
-import bio.terra.tanagra.generated.model.ApiLiteral;
-import bio.terra.tanagra.generated.model.ApiLiteralValueUnion;
-import bio.terra.tanagra.generated.model.ApiProperties;
-import bio.terra.tanagra.generated.model.ApiPropertyKeyValue;
-import bio.terra.tanagra.generated.model.ApiStudy;
-import bio.terra.tanagra.generated.model.ApiUnderlaySummary;
-import bio.terra.tanagra.generated.model.ApiValueDisplay;
+import bio.terra.tanagra.generated.model.*;
 import bio.terra.tanagra.service.artifact.model.AnnotationValue;
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.service.artifact.model.CohortRevision;
@@ -118,17 +98,37 @@ public final class ToApiUtils {
 
   public static ApiCriteriaGroupSection toApiObject(
       CohortRevision.CriteriaGroupSection criteriaGroupSection) {
+    ApiCriteriaGroupSection.OperatorEnum operator =
+        criteriaGroupSection.getJoinOperator() == null
+            ? ApiCriteriaGroupSection.OperatorEnum.valueOf(
+                criteriaGroupSection.getOperator().name())
+            : ApiCriteriaGroupSection.OperatorEnum.valueOf(
+                criteriaGroupSection.getJoinOperator().name());
+
     return new ApiCriteriaGroupSection()
         .id(criteriaGroupSection.getId())
         .displayName(criteriaGroupSection.getDisplayName())
-        .operator(
-            ApiCriteriaGroupSection.OperatorEnum.fromValue(
-                criteriaGroupSection.getOperator().name()))
-        .excluded(criteriaGroupSection.isExcluded())
         .criteriaGroups(
             criteriaGroupSection.getCriteriaGroups().stream()
                 .map(ToApiUtils::toApiObject)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList()))
+        .secondBlockCriteriaGroups(
+            criteriaGroupSection.getSecondConditionCriteriaGroups().stream()
+                .map(ToApiUtils::toApiObject)
+                .collect(Collectors.toList()))
+        .operator(operator)
+        .operatorValue(criteriaGroupSection.getJoinOperatorValue())
+        .firstBlockReducingOperator(
+            toApiObject(criteriaGroupSection.getFirstConditionReducingOperator()))
+        .secondBlockReducingOperator(
+            toApiObject(criteriaGroupSection.getSecondConditionRedcuingOperator()))
+        .excluded(criteriaGroupSection.isExcluded());
+  }
+
+  private static ApiReducingOperator toApiObject(ReducingOperator reducingOperator) {
+    return reducingOperator == null
+        ? ApiReducingOperator.ANY
+        : ApiReducingOperator.valueOf(reducingOperator.name());
   }
 
   private static ApiCriteriaGroup toApiObject(CohortRevision.CriteriaGroup criteriaGroup) {

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -25,4 +25,6 @@
     <include file="changesets/20230922_initial_schema.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20231116_output_attribute.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20240304_selector_column.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240326_remove_criteria_group_columns.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240709_temporal_criteria_group_sections.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20240709_temporal_criteria_group_sections.yaml
+++ b/service/src/main/resources/db/changesets/20240709_temporal_criteria_group_sections.yaml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: temporal_criteria_group_sections
+      author: marikomedlock
+      dbms: postgresql,mariadb,mysql
+      changes:
+        - addColumn:
+            tableName: criteria_group_section
+            columns:
+              - column:
+                  name: first_condition_reducing_operator
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  name: second_condition_reducing_operator
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  name: join_operator
+                  type: ${text.type}
+                  constraints:
+                    nullable: true
+              - column:
+                  name: join_operator_value
+                  type: ${integer.type}
+                  constraints:
+                    nullable: true
+
+        - addColumn:
+            tableName: criteria_group
+            columns:
+              - column:
+                  name: condition_index
+                  type: ${integer.type}
+                  constraints:
+                    nullable: true

--- a/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
@@ -2,6 +2,8 @@ package bio.terra.tanagra.service;
 
 import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
 import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_PROCEDURE;
+import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_TEMPORAL_DURING_SAME_ENCOUNTER;
+import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_TEMPORAL_WITHIN_NUM_DAYS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -294,7 +296,7 @@ public class CohortServiceTest {
     Cohort updatedCohort2 =
         cohortService.updateCohort(
             study1.getId(),
-            cohort1.getId(),
+            cohort2.getId(),
             userEmail,
             null,
             null,
@@ -307,5 +309,41 @@ public class CohortServiceTest {
     assertEquals(
         List.of(CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION),
         updatedCohort2.getMostRecentRevision().getSections());
+
+    // Create cohort3 with temporal criteria group sections.
+    Cohort cohort3 =
+        cohortService.createCohort(
+            study1.getId(),
+            Cohort.builder()
+                .underlay(UNDERLAY_NAME)
+                .displayName("cohort 3")
+                .description("third cohort"),
+            userEmail,
+            List.of(CRITERIA_GROUP_SECTION_TEMPORAL_WITHIN_NUM_DAYS));
+    assertNotNull(cohort3);
+    LOGGER.info("Created cohort {} at {}", cohort3.getId(), cohort3.getCreated());
+    assertEquals(1, cohort3.getMostRecentRevision().getSections().size());
+    assertEquals(
+        List.of(CRITERIA_GROUP_SECTION_TEMPORAL_WITHIN_NUM_DAYS),
+        cohort3.getMostRecentRevision().getSections());
+
+    // Update cohort3 criteria only.
+    TimeUnit.SECONDS.sleep(1); // Wait briefly, so the last modified and created timestamps differ.
+    Cohort updatedCohort3 =
+        cohortService.updateCohort(
+            study1.getId(),
+            cohort3.getId(),
+            userEmail,
+            null,
+            null,
+            List.of(CRITERIA_GROUP_SECTION_TEMPORAL_DURING_SAME_ENCOUNTER));
+    assertNotNull(updatedCohort3);
+    LOGGER.info(
+        "Updated cohort {} at {}", updatedCohort3.getId(), updatedCohort3.getLastModified());
+    assertTrue(updatedCohort3.getLastModified().isAfter(updatedCohort3.getCreated()));
+    assertEquals(1, updatedCohort3.getMostRecentRevision().getSections().size());
+    assertEquals(
+        List.of(CRITERIA_GROUP_SECTION_TEMPORAL_DURING_SAME_ENCOUNTER),
+        updatedCohort3.getMostRecentRevision().getSections());
   }
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroupSection.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroupSection.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.service.criteriaconstants.cmssynpuf;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
+import bio.terra.tanagra.api.shared.*;
 import bio.terra.tanagra.service.artifact.model.CohortRevision;
 import java.util.List;
 
@@ -40,4 +41,35 @@ public final class CriteriaGroupSection {
           .operator(BooleanAndOrFilter.LogicalOperator.AND)
           .setIsExcluded(true)
           .build();
+
+  public static final CohortRevision.CriteriaGroupSection
+      CRITERIA_GROUP_SECTION_TEMPORAL_WITHIN_NUM_DAYS =
+          CohortRevision.CriteriaGroupSection.builder()
+              .displayName("temporal section")
+              .criteriaGroups(List.of(CriteriaGroup.CRITERIA_GROUP_CONDITION))
+              .secondConditionCriteriaGroups(List.of(CriteriaGroup.CRITERIA_GROUP_PROCEDURE))
+              .operator(BooleanAndOrFilter.LogicalOperator.OR)
+              .firstConditionReducingOperator(ReducingOperator.FIRST_MENTION_OF)
+              .secondConditionReducingOperator(ReducingOperator.LAST_MENTION_OF)
+              .joinOperator(JoinOperator.WITHIN_NUM_DAYS)
+              .joinOperatorValue(5)
+              .setIsExcluded(false)
+              .build();
+
+  public static final CohortRevision.CriteriaGroupSection
+      CRITERIA_GROUP_SECTION_TEMPORAL_DURING_SAME_ENCOUNTER =
+          CohortRevision.CriteriaGroupSection.builder()
+              .displayName("temporal section")
+              .criteriaGroups(
+                  List.of(
+                      CriteriaGroup.CRITERIA_GROUP_CONDITION, CriteriaGroup.CRITERIA_GROUP_GENDER))
+              .secondConditionCriteriaGroups(
+                  List.of(CriteriaGroup.CRITERIA_GROUP_AGE, CriteriaGroup.CRITERIA_GROUP_PROCEDURE))
+              .operator(BooleanAndOrFilter.LogicalOperator.OR)
+              .firstConditionReducingOperator(ReducingOperator.FIRST_MENTION_OF)
+              .secondConditionReducingOperator(null)
+              .joinOperator(JoinOperator.DURING_SAME_ENCOUNTER)
+              .joinOperatorValue(null)
+              .setIsExcluded(false)
+              .build();
 }

--- a/underlay/src/main/resources/config/criteria/cmssynpuf/criteriaselector/conditions/selector.json
+++ b/underlay/src/main/resources/config/criteria/cmssynpuf/criteriaselector/conditions/selector.json
@@ -11,6 +11,7 @@
   "plugin": "entityGroup",
   "pluginConfig": null,
   "pluginConfigFile": "conditions.json",
+  "supportsTemporalQueries": true,
   "modifiers": [
     {
       "name": "ageAtOccurrence",


### PR DESCRIPTION
Persist temporal criteria group sections in PostGres/MySQL application DB. Enabled temporal modifiers for the conditions criteria selector on the `cmssynpuf` underlay, for testing.

This PR does not include changes to the filter building, so the counts generated for these temporal criteria group sections are incorrect -- they will be the same as if the operator were `OR/ANY` and use criteria only for the top block of criteria groups. The filter building changes are coming in a follow-on PR.