### PR TITLE
Fix selecting inside inline criteria controls deselecting the criteria

### DIFF
--- a/ui/src/components/hintDataSelect.tsx
+++ b/ui/src/components/hintDataSelect.tsx
@@ -63,6 +63,9 @@ export function HintDataSelect(props: HintDataSelectProps) {
         e.preventDefault();
         e.stopPropagation();
       }}
+      onMouseUp={(e) => {
+        e.stopPropagation();
+      }}
     >
       <Select
         multiple
@@ -81,6 +84,9 @@ export function HintDataSelect(props: HintDataSelectProps) {
                     onMouseDown={(e) => {
                       e.stopPropagation();
                       e.preventDefault();
+                    }}
+                    onMouseUp={(e) => {
+                      e.stopPropagation();
                     }}
                     onDelete={(e) => {
                       e.stopPropagation();

--- a/ui/src/criteria/textSearch.tsx
+++ b/ui/src/criteria/textSearch.tsx
@@ -217,6 +217,9 @@ function TextSearchInline(props: TextSearchInlineProps) {
             e.preventDefault();
             e.stopPropagation();
           }}
+          onMouseUp={(e) => {
+            e.stopPropagation();
+          }}
         >
           <GridLayout rows spacing={1} height="auto">
             <TextField
@@ -242,6 +245,9 @@ function TextSearchInline(props: TextSearchInlineProps) {
                         onMouseDown={(e) => {
                           e.stopPropagation();
                           e.preventDefault();
+                        }}
+                        onMouseUp={(e) => {
+                          e.stopPropagation();
                         }}
                         onDelete={(e) => {
                           e.stopPropagation();

--- a/ui/src/criteria/unhintedValue.tsx
+++ b/ui/src/criteria/unhintedValue.tsx
@@ -233,6 +233,9 @@ function UnhintedValueInline(props: UnhintedValueInlineProps) {
           e.preventDefault();
           e.stopPropagation();
         }}
+        onMouseUp={(e) => {
+          e.stopPropagation();
+        }}
       >
         <Select
           value={decodedData.operator}

--- a/ui/src/criteria/valueData.tsx
+++ b/ui/src/criteria/valueData.tsx
@@ -234,6 +234,9 @@ export function ValueDataEdit(props: ValueDataEditProps) {
                 e.preventDefault();
                 e.stopPropagation();
               }}
+              onMouseUp={(e) => {
+                e.stopPropagation();
+              }}
             >
               <Select
                 value={props.valueData[0].attribute}

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -879,6 +879,9 @@ function ParticipantsGroup(props: {
                   e.preventDefault();
                   e.stopPropagation();
                 }}
+                onMouseUp={(e) => {
+                  e.stopPropagation();
+                }}
               >
                 {!!plugin.renderEdit ? (
                   <IconButton
@@ -979,6 +982,9 @@ function ParticipantsGroup(props: {
                         <GridBox
                           onClick={(e) => {
                             e.preventDefault();
+                            e.stopPropagation();
+                          }}
+                          onMouseUp={(e) => {
                             e.stopPropagation();
                           }}
                         >

--- a/ui/src/plugins/vumc/biovu.tsx
+++ b/ui/src/plugins/vumc/biovu.tsx
@@ -218,6 +218,9 @@ function BioVUInline(props: BioVUInlineProps) {
           e.preventDefault();
           e.stopPropagation();
         }}
+        onMouseUp={(e) => {
+          e.stopPropagation();
+        }}
       >
         <Select
           value={decodedData.sampleFilter}
@@ -235,6 +238,9 @@ function BioVUInline(props: BioVUInlineProps) {
         <GridBox
           onClick={(e) => {
             e.preventDefault();
+            e.stopPropagation();
+          }}
+          onMouseUp={(e) => {
             e.stopPropagation();
           }}
         >
@@ -258,6 +264,9 @@ function BioVUInline(props: BioVUInlineProps) {
         <GridBox
           onClick={(e) => {
             e.preventDefault();
+            e.stopPropagation();
+          }}
+          onMouseUp={(e) => {
             e.stopPropagation();
           }}
         >


### PR DESCRIPTION
Dragging to select the value in inline criteria controls (e.g. age) would cause the criteria to be selected on mouse button up. This prevents that specific case from from happening but there's an unavoidable case where the button down is in the text box and the button up is elsewhere in the criteria. This is part of the way browsers generate click events so we can't really do anything about it. We'll have to consider alternative UXs (e.g. a more standard accordion with an arrow).