### PR TITLE
Add minimum width to 100% width columns

### DIFF
--- a/ui/src/components/__snapshots__/treegrid.test.tsx.snap
+++ b/ui/src/components/__snapshots__/treegrid.test.tsx.snap
@@ -8,12 +8,25 @@ exports[`Table renders correctly 1`] = `
     <table
       style="table-layout: fixed; width: 100%; text-align: left; border-collapse: collapse;"
     >
+      <colgroup>
+        <col
+          style="width: 200px;"
+        />
+        <col />
+        <col
+          style="width: 150px;"
+        />
+        <col
+          style="width: 50px;"
+        />
+      </colgroup>
       <thead>
         <tr
           style="height: 48px;"
         >
           <th
-            style="position: sticky; top: 0px; max-width: 100%; width: 100%; min-width: 100%; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
+            colspan="2"
+            style="position: sticky; top: 0px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
           >
             <div
               class="MuiBox-root css-1381h1c"
@@ -74,7 +87,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </th>
           <th
-            style="position: sticky; top: 0px; max-width: 150px; width: 150px; min-width: 150px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
+            style="position: sticky; top: 0px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
           >
             <div
               class="MuiBox-root css-1381h1c"
@@ -135,7 +148,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </th>
           <th
-            style="position: sticky; top: 0px; max-width: 50px; width: 50px; min-width: 50px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
+            style="position: sticky; top: 0px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
           >
             <div
               class="MuiBox-root css-1381h1c"
@@ -188,7 +201,8 @@ exports[`Table renders correctly 1`] = `
           style="height: 48px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-ttlwsw-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-141kssz-MuiTableCell-root"
+            colspan="2"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -202,7 +216,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-o3sd3r-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-141kssz-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -216,7 +230,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1gu6ett-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-141kssz-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -232,7 +246,8 @@ exports[`Table renders correctly 1`] = `
           style="display: none; height: 48px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
+            colspan="2"
           >
             <div
               class="MuiStack-root css-kv8qlv-MuiStack-root"
@@ -266,7 +281,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -280,7 +295,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -298,7 +313,8 @@ exports[`Table renders correctly 1`] = `
           style="height: 48px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
+            colspan="2"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -312,7 +328,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -326,7 +342,7 @@ exports[`Table renders correctly 1`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -364,12 +380,25 @@ exports[`Table renders correctly 2`] = `
     <table
       style="table-layout: fixed; width: 100%; text-align: left; border-collapse: collapse;"
     >
+      <colgroup>
+        <col
+          style="width: 200px;"
+        />
+        <col />
+        <col
+          style="width: 150px;"
+        />
+        <col
+          style="width: 50px;"
+        />
+      </colgroup>
       <thead>
         <tr
           style="height: 48px;"
         >
           <th
-            style="position: sticky; top: 0px; max-width: 100%; width: 100%; min-width: 100%; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
+            colspan="2"
+            style="position: sticky; top: 0px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
           >
             <div
               class="MuiBox-root css-1381h1c"
@@ -439,7 +468,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </th>
           <th
-            style="position: sticky; top: 0px; max-width: 150px; width: 150px; min-width: 150px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
+            style="position: sticky; top: 0px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
           >
             <div
               class="MuiBox-root css-1381h1c"
@@ -500,7 +529,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </th>
           <th
-            style="position: sticky; top: 0px; max-width: 50px; width: 50px; min-width: 50px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
+            style="position: sticky; top: 0px; background-color: rgb(255, 255, 255); box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.12); z-index: 1;"
           >
             <div
               class="MuiBox-root css-1381h1c"
@@ -553,7 +582,8 @@ exports[`Table renders correctly 2`] = `
           style="height: 48px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-ttlwsw-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-141kssz-MuiTableCell-root"
+            colspan="2"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -567,7 +597,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-o3sd3r-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-141kssz-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -581,7 +611,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1gu6ett-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-141kssz-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -597,7 +627,8 @@ exports[`Table renders correctly 2`] = `
           style="display: none; height: 48px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
+            colspan="2"
           >
             <div
               class="MuiStack-root css-kv8qlv-MuiStack-root"
@@ -631,7 +662,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -645,7 +676,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -663,7 +694,8 @@ exports[`Table renders correctly 2`] = `
           style="height: 48px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1fr3au9-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
+            colspan="2"
           >
             <div
               class="MuiStack-root css-1sg8hwy-MuiStack-root"
@@ -677,7 +709,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-km028r-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"
@@ -691,7 +723,7 @@ exports[`Table renders correctly 2`] = `
             </div>
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-sizeMedium css-1io7e9v-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-sizeMedium css-109mdx-MuiTableCell-root"
           >
             <div
               class="MuiStack-root css-1d9cypr-MuiStack-root"

--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -258,6 +258,17 @@ export function TreeGrid(props: TreeGridProps) {
           borderCollapse: "collapse",
         }}
       >
+        <colgroup>
+          {props.columns.flatMap((col, i) => [
+            <col
+              key={i}
+              style={{
+                width: col.width === "100%" ? "200px" : col.width,
+              }}
+            />,
+            ...(col.width === "100%" ? [<col key="resize" />] : []),
+          ])}
+        </colgroup>
         <thead>
           <tr
             style={{
@@ -267,14 +278,10 @@ export function TreeGrid(props: TreeGridProps) {
             {props.columns.map((col, i) => (
               <th
                 key={i}
+                colSpan={col.width === "100%" ? 2 : undefined}
                 style={{
                   position: "sticky",
                   top: 0,
-                  ...(col.width && {
-                    maxWidth: col.width,
-                    width: col.width,
-                    minWidth: col.width,
-                  }),
                   backgroundColor: paperColor,
                   boxShadow: `inset 0 -2px 0 ${theme.palette.divider}`,
                   zIndex: 1,
@@ -542,13 +549,9 @@ function renderChildren(
           return (
             <TableCell
               key={i}
+              colSpan={col.width === "100%" ? 2 : undefined}
               sx={[
                 {
-                  ...(col.width && {
-                    maxWidth: col.width,
-                    width: col.width,
-                    minWidth: col.width,
-                  }),
                   boxShadow: !first
                     ? `inset 0 1px 0 ${theme.palette.divider}`
                     : undefined,


### PR DESCRIPTION
This prevents them from collapsing to nothing in small windows which hides the most important column (i.e. name) and makes the checkbox hard to click.