### PR TITLE
Convert binary filter with null value to unary filter.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/SchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/SchemaUtils.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
-import bio.terra.tanagra.api.shared.Literal;
-import bio.terra.tanagra.exception.InvalidConfigException;
+import bio.terra.tanagra.api.shared.*;
 import bio.terra.tanagra.exception.SystemException;
 import bio.terra.tanagra.proto.criteriaselector.ValueOuterClass.Value;
 import java.sql.Timestamp;
@@ -10,7 +9,7 @@ import java.time.Instant;
 public final class SchemaUtils {
   private SchemaUtils() {}
 
-  public static Literal toLiteral(Value value) {
+  public static Literal toLiteral(Value value, DataType dataType) {
     switch (value.getValueCase()) {
       case BOOL_VALUE:
         return Literal.forBoolean(value.getBoolValue());
@@ -24,8 +23,7 @@ public final class SchemaUtils {
                 Instant.ofEpochSecond(
                     value.getTimestampValue().getSeconds(), value.getTimestampValue().getNanos())));
       case VALUE_NOT_SET:
-        throw new InvalidConfigException(
-            "Cannot convert a value with no type to a literal: " + value.getValueCase());
+        return Literal.forGeneric(dataType, null, null, null, null, null);
     }
     throw new SystemException("Error converting value to literal: " + value);
   }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/utils/AttributeSchemaUtils.java
@@ -50,14 +50,14 @@ public final class AttributeSchemaUtils {
               entity,
               attribute,
               BinaryOperator.EQUALS,
-              toLiteral(data.getSelected(0).getValue()))
+              toLiteral(data.getSelected(0).getValue(), attribute.getDataType()))
           : new AttributeFilter(
               underlay,
               entity,
               attribute,
               NaryOperator.IN,
               data.getSelectedList().stream()
-                  .map(selected -> toLiteral(selected.getValue()))
+                  .map(selected -> toLiteral(selected.getValue(), attribute.getDataType()))
                   .collect(Collectors.toList()));
     } else {
       // Numeric range filter.

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
@@ -81,6 +81,16 @@ public interface ApiTranslator {
       Literal value,
       @Nullable String tableAlias,
       SqlParams sqlParams) {
+    if (value.isNull()) {
+      return unaryFilterSql(
+          field,
+          BinaryOperator.EQUALS.equals(operator)
+              ? UnaryOperator.IS_NULL
+              : UnaryOperator.IS_NOT_NULL,
+          tableAlias,
+          sqlParams);
+    }
+
     String operatorTemplateSql =
         FUNCTION_TEMPLATE_FIELD_VAR_BRACES
             + ' '

--- a/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
@@ -2,6 +2,7 @@ package bio.terra.tanagra.query.sql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.TextSearchFilter;
@@ -56,6 +57,18 @@ public class ApiTranslatorTest {
     assertEquals("tableAlias.columnName <= @val0", sql);
     assertEquals(ImmutableMap.of("val0", val), sqlParams.getParams());
 
+    // Null literal converts to a unary filter.
+    sqlParams = new SqlParams();
+    val = Literal.forInt64(null);
+    sql = apiTranslator.binaryFilterSql(field, BinaryOperator.EQUALS, val, tableAlias, sqlParams);
+    assertEquals("tableAlias.columnName IS NULL", sql);
+    assertTrue(sqlParams.getParams().isEmpty());
+    sql =
+        apiTranslator.binaryFilterSql(field, BinaryOperator.NOT_EQUALS, val, tableAlias, sqlParams);
+    assertEquals("tableAlias.columnName IS NOT NULL", sql);
+    assertTrue(sqlParams.getParams().isEmpty());
+
+    // SQL function wrapper.
     field =
         SqlField.of(
             "columnName",


### PR DESCRIPTION
BigQuery requires converting `= NULL` to `IS NULL` and `!= NULL` to `IS NOT NULL`. Unfortunately, this doesn't give a syntax error when `NULL` is passed as a query parameter value, it just returns an incorrect result. This PR adds the conversion.

This was causing problems with the `bloodPressure` and `heartRate` entities in the AoU underlays, where one of the possible `status_code` values is `NULL`.