### PR TITLE
Fix global search

### DIFF
--- a/ui/src/cohort.ts
+++ b/ui/src/cohort.ts
@@ -240,7 +240,7 @@ export function searchCriteria(
     data: mergeLists(
       responses,
       100,
-      SortDirection.Asc,
+      SortDirection.Desc,
       (value: DataEntry) => value[ROLLUP_COUNT_ATTRIBUTE]
     ),
   }));


### PR DESCRIPTION
Results from each criteria were being merged incorrectly so the highest count items were not necessarily included in the results.