### PR TITLE
Rename auth option --> bearer-token to GCP-access-token

### DIFF
--- a/docs/CODEBASE_OVERVIEW.md
+++ b/docs/CODEBASE_OVERVIEW.md
@@ -184,7 +184,7 @@ the associated service or dao classes.
 ### Authentication
 **`service` Gradle sub-project `authentication` package**
 
-We support three types of authentication tokens: bearer access token, JWT from IAP in front of GKE, JWT from IAP in
+We support three types of authentication tokens: GCP access token, JWT from IAP in front of GKE, JWT from IAP in
 front of AppEngine. Utilities for processing these tokens lives in this package.
 
 ### Data export

--- a/docs/generated/APPLICATION_CONFIG.md
+++ b/docs/generated/APPLICATION_CONFIG.md
@@ -140,14 +140,7 @@ When true, the application database will have Liquibase changesets applied on se
 ## Authentication
 Configure the authentication model.
 
-There are four separate flags that control which model is used: `tanagra.auth.disableChecks`, `tanagra.auth.iapGkeJwt`, `tanagra.auth.iapAppEngineJwt`, `tanagra.auth.bearerToken`. In the future these will be combined into a single flag. For now, **you must set all four flags and only one should be true**. 
-
-### tanagra.auth.bearerToken
-**required** boolean
-
-When true, the service expects a Google OAuth bearer token. The service calls Google's `https://www.googleapis.com/oauth2/v2/userinfo` endpoint to get the email address of the user from the token. More details in the [GCP documentation](https://developers.google.com/identity/openid-connect/openid-connect#obtaininguserprofileinformation).
-
-*Environment variable:* `TANAGRA_AUTH_BEARER_TOKEN`
+There are four separate flags that control which model is used: `tanagra.auth.disableChecks`, `tanagra.auth.iapGkeJwt`, `tanagra.auth.iapAppEngineJwt`, `tanagra.auth.gcpAccessToken`. In the future these will be combined into a single flag. For now, **you must set all four flags and only one should be true**. 
 
 ### tanagra.auth.disableChecks
 **required** boolean
@@ -155,6 +148,13 @@ When true, the service expects a Google OAuth bearer token. The service calls Go
 When true, authentication checks will be disabled. This is helpful during testing, especially testing a locally deployed service. It should never be used for a production service.
 
 *Environment variable:* `TANAGRA_AUTH_DISABLE_CHECKS`
+
+### tanagra.auth.gcpAccessToken
+**required** boolean
+
+When true, the service expects a Google OAuth access token. The service calls Google's `https://www.googleapis.com/oauth2/v2/userinfo` endpoint to get the email address of the user from the token. More details in the [GCP documentation](https://developers.google.com/identity/openid-connect/openid-connect#obtaininguserprofileinformation).
+
+*Environment variable:* `TANAGRA_AUTH_GCP_ACCESS_TOKEN`
 
 ### tanagra.auth.gcpProjectId
 **optional** String

--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -94,12 +94,12 @@ export TANAGRA_AUTH_IAP_GKE_JWT=false
 if [[ ${disableAuthChecks} ]]; then
   echo "Disabling auth checks."
   export TANAGRA_AUTH_DISABLE_CHECKS=true
-  export TANAGRA_AUTH_BEARER_TOKEN=false
+  export TANAGRA_AUTH_GCP_ACCESS_TOKEN=false
   export TANAGRA_AUTH_IAP_GKE_JWT=false
 else
-  echo "Enabling auth checks. bearer-token"
+  echo "Enabling auth checks. gcp-access-token"
   export TANAGRA_AUTH_DISABLE_CHECKS=false
-  export TANAGRA_AUTH_BEARER_TOKEN=true
+  export TANAGRA_AUTH_GCP_ACCESS_TOKEN=true
   export TANAGRA_AUTH_IAP_GKE_JWT=false
 fi
 

--- a/service/src/main/java/bio/terra/tanagra/app/authentication/AuthInterceptor.java
+++ b/service/src/main/java/bio/terra/tanagra/app/authentication/AuthInterceptor.java
@@ -4,7 +4,7 @@ import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.tanagra.app.configuration.AuthenticationConfiguration;
-import bio.terra.tanagra.service.authentication.BearerTokenUtils;
+import bio.terra.tanagra.service.authentication.GcpAccessTokenUtils;
 import bio.terra.tanagra.service.authentication.IapJwtUtils;
 import bio.terra.tanagra.service.authentication.InvalidCredentialsException;
 import bio.terra.tanagra.service.authentication.UserId;
@@ -89,9 +89,9 @@ public class AuthInterceptor implements HandlerInterceptor {
                 jwt,
                 authenticationConfiguration.getGcpProjectNumber(),
                 authenticationConfiguration.getGcpProjectId());
-      } else if (authenticationConfiguration.isBearerToken()) {
+      } else if (authenticationConfiguration.isGcpAccessToken()) {
         BearerToken bearerToken = new BearerTokenFactory().from(request);
-        userId = BearerTokenUtils.getUserIdFromToken(bearerToken);
+        userId = GcpAccessTokenUtils.getUserIdFromToken(bearerToken.getToken());
       } else if (authenticationConfiguration.isDisableChecks()) {
         LOGGER.warn(
             "Authentication checks are disabled. This should only happen for local development.");

--- a/service/src/main/java/bio/terra/tanagra/app/configuration/AuthenticationConfiguration.java
+++ b/service/src/main/java/bio/terra/tanagra/app/configuration/AuthenticationConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Configuration;
     markdown =
         "Configure the authentication model.\n\n"
             + "There are four separate flags that control which model is used: "
-            + "`tanagra.auth.disableChecks`, `tanagra.auth.iapGkeJwt`, `tanagra.auth.iapAppEngineJwt`, `tanagra.auth.bearerToken`. "
+            + "`tanagra.auth.disableChecks`, `tanagra.auth.iapGkeJwt`, `tanagra.auth.iapAppEngineJwt`, `tanagra.auth.gcpAccessToken`. "
             + "In the future these will be combined into a single flag. "
             + "For now, **you must set all four flags and only one should be true**. ")
 public class AuthenticationConfiguration {
@@ -51,13 +51,13 @@ public class AuthenticationConfiguration {
   private boolean iapAppEngineJwt;
 
   @AnnotatedField(
-      name = "tanagra.auth.bearerToken",
+      name = "tanagra.auth.gcpAccessToken",
       markdown =
-          "When true, the service expects a Google OAuth bearer token. "
+          "When true, the service expects a Google OAuth access token. "
               + "The service calls Google's `https://www.googleapis.com/oauth2/v2/userinfo` endpoint to get the email address of the user from the token. "
               + "More details in the [GCP documentation](https://developers.google.com/identity/openid-connect/openid-connect#obtaininguserprofileinformation).",
-      environmentVariable = "TANAGRA_AUTH_BEARER_TOKEN")
-  private boolean bearerToken;
+      environmentVariable = "TANAGRA_AUTH_GCP_ACCESS_TOKEN")
+  private boolean gcpAccessToken;
 
   @AnnotatedField(
       name = "tanagra.auth.gcpProjectNumber",
@@ -108,8 +108,8 @@ public class AuthenticationConfiguration {
     return iapAppEngineJwt;
   }
 
-  public boolean isBearerToken() {
-    return bearerToken;
+  public boolean isGcpAccessToken() {
+    return gcpAccessToken;
   }
 
   public long getGcpProjectNumber() {
@@ -148,8 +148,8 @@ public class AuthenticationConfiguration {
     this.iapAppEngineJwt = iapAppEngineJwt;
   }
 
-  public void setBearerToken(boolean bearerToken) {
-    this.bearerToken = bearerToken;
+  public void setGcpAccessToken(boolean gcpAccessToken) {
+    this.gcpAccessToken = gcpAccessToken;
   }
 
   public void setGcpProjectNumber(String gcpProjectNumber) {
@@ -168,7 +168,7 @@ public class AuthenticationConfiguration {
     LOGGER.info("Authentication: disable-checks: {}", isDisableChecks());
     LOGGER.info("Authentication: iap-gke-jwt: {}", isIapGkeJwt());
     LOGGER.info("Authentication: iap-appengine-jwt: {}", isIapAppEngineJwt());
-    LOGGER.info("Authentication: bearer-token: {}", isBearerToken());
+    LOGGER.info("Authentication: gcp-access-token: {}", isGcpAccessToken());
     LOGGER.info("Authentication: gcp-project-number: {}", getGcpProjectNumber());
     LOGGER.info("Authentication: gcp-project-id: {}", getGcpProjectId());
     LOGGER.info("Authentication: gke-backend-service-id: {}", getGkeBackendServiceId());

--- a/service/src/main/java/bio/terra/tanagra/service/authentication/GcpAccessTokenUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/authentication/GcpAccessTokenUtils.java
@@ -1,6 +1,5 @@
 package bio.terra.tanagra.service.authentication;
 
-import bio.terra.common.iam.BearerToken;
 import bio.terra.tanagra.utils.RetryUtils;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -9,13 +8,13 @@ import com.google.api.services.oauth2.Oauth2;
 import com.google.api.services.oauth2.model.Userinfo;
 import java.io.IOException;
 
-public final class BearerTokenUtils {
-  private BearerTokenUtils() {}
+public final class GcpAccessTokenUtils {
+  private GcpAccessTokenUtils() {}
 
   @SuppressWarnings("deprecation")
-  public static UserId getUserIdFromToken(BearerToken bearerToken)
+  public static UserId getUserIdFromToken(String accessToken)
       throws InterruptedException, IOException {
-    GoogleCredential credential = new GoogleCredential().setAccessToken(bearerToken.getToken());
+    GoogleCredential credential = new GoogleCredential().setAccessToken(accessToken);
     Oauth2 oauth2 =
         new Oauth2.Builder(new NetHttpTransport(), new JacksonFactory(), credential)
             .setApplicationName("tanagra")
@@ -23,6 +22,6 @@ public final class BearerTokenUtils {
     Userinfo userInfo =
         RetryUtils.callWithRetries(
             () -> oauth2.userinfo().get().execute(), ex -> ex instanceof IOException);
-    return UserId.fromToken(userInfo.getId(), userInfo.getEmail(), bearerToken.getToken());
+    return UserId.fromToken(userInfo.getId(), userInfo.getEmail(), accessToken);
   }
 }


### PR DESCRIPTION
No change to functionality. From discussions: renaming the option

Tested with local deployment: in swagger use the access token from gcloud