### PR TITLE
Null check for instanceQueries in export API.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -292,12 +292,16 @@ public class ExportApiController implements ExportApi {
             .collect(Collectors.toList());
 
     List<ListQueryRequest> listQueryRequests =
-        body.getInstanceQuerys().stream()
-            .map(
-                apiQuery ->
-                    FromApiUtils.fromApiObject(
-                        apiQuery.getQuery(), underlay.getEntity(apiQuery.getEntity()), underlay))
-            .collect(Collectors.toList());
+        body.getInstanceQuerys() == null
+            ? new ArrayList<>()
+            : body.getInstanceQuerys().stream()
+                .map(
+                    apiQuery ->
+                        FromApiUtils.fromApiObject(
+                            apiQuery.getQuery(),
+                            underlay.getEntity(apiQuery.getEntity()),
+                            underlay))
+                .collect(Collectors.toList());
     EntityFilter primaryEntityFilter;
     if (body.getPrimaryEntityFilter() != null) {
       primaryEntityFilter =


### PR DESCRIPTION
`instanceQueries` property will be null when we use backend filter-building, which is now the only supported option. Adding a null check here for now, until we finish overhauling the API to remove the parts that were only to support frontend filter-building.