### PR TITLE
Allow specifying an attribute other than the id for count queries.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -181,7 +181,8 @@ public class CohortsApiController implements CohortsApi {
         underlayService.runCountQuery(
             underlay,
             outputEntity,
-            body.getAttributes() == null ? List.of() : body.getAttributes(),
+            body.getCountDistinctAttribute(),
+            body.getGroupByAttributes() == null ? List.of() : body.getGroupByAttributes(),
             outputEntityFilteredOnCohort,
             body.getOrderByDirection() == null
                 ? OrderByDirection.DESCENDING

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -216,6 +216,7 @@ public class UnderlaysApiController implements UnderlaysApi {
         underlayService.runCountQuery(
             underlay,
             entity,
+            null,
             body.getAttributes() == null ? List.of() : body.getAttributes(),
             filter,
             OrderByDirection.DESCENDING,

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
@@ -15,9 +15,10 @@ import bio.terra.tanagra.service.accesscontrol.ResourceCollection;
 import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.Underlay;
-import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.*;
 import bio.terra.tanagra.underlay.serialization.*;
 import com.google.common.collect.ImmutableMap;
+import jakarta.annotation.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -104,6 +105,7 @@ public class UnderlayService {
   public CountQueryResult runCountQuery(
       Underlay underlay,
       Entity entity,
+      @Nullable String countDistinctAttributeName,
       List<String> groupByAttributeNames,
       EntityFilter entityFilter,
       OrderByDirection orderByDirection,
@@ -134,6 +136,9 @@ public class UnderlayService {
         new CountQueryRequest(
             underlay,
             entity,
+            countDistinctAttributeName == null
+                ? null
+                : entity.getAttribute(countDistinctAttributeName),
             attributeFields,
             entityFilter,
             orderByDirection,

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/CohortService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/CohortService.java
@@ -147,6 +147,7 @@ public class CohortService {
         new CountQueryRequest(
             underlay,
             underlay.getPrimaryEntity(),
+            null,
             List.of(),
             entityFilter,
             OrderByDirection.DESCENDING,

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/ReviewService.java
@@ -409,6 +409,7 @@ public class ReviewService {
         new CountQueryRequest(
             underlay,
             entity,
+            null,
             groupByAttributeFields,
             entityFilter,
             OrderByDirection.DESCENDING,

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportService.java
@@ -102,6 +102,7 @@ public class DataExportService {
         underlayService.runCountQuery(
             request.getUnderlay(),
             request.getUnderlay().getPrimaryEntity(),
+            null,
             List.of(),
             helper.getPrimaryEntityFilter(),
             OrderByDirection.DESCENDING,

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1563,7 +1563,12 @@ components:
         entity:
           description: Entity to count. Defaults to primary entity.
           type: string
-        attributes:
+        countDistinctAttribute:
+          description: |
+            Attribute to count (e.g. person_id will return counts for the number of distinct person_ids 
+            per group by combination). Defaults to id attribute.
+          type: string
+        groupByAttributes:
           description: |
             Attributes to group by. One count will be returned for each possible combination of attribute values 
             (e.g. [gender, hair_color] will return counts for man+red, man+black, woman+red, woman+black).
@@ -1578,6 +1583,8 @@ components:
           $ref: "#/components/schemas/PageSize"
         pageMarker:
           $ref: "#/components/schemas/PageMarker"
+      required:
+        - groupByAttributes
 
     ReviewQuery:
       type: object

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -1276,7 +1276,9 @@ export class BackendStudySource implements StudySource {
           studyId,
           cohortId,
           cohortCountQuery: {
-            attributes: groupByAttributes,
+            countDistinctAttribute: undefined,
+            groupByAttributes:
+              groupByAttributes == null ? [] : groupByAttributes,
             criteriaGroupSectionId: groupSectionId,
             criteriaGroupId: groupId,
             pageMarker,

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/CountDistinctField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/CountDistinctField.java
@@ -2,15 +2,17 @@ package bio.terra.tanagra.api.field;
 
 import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.underlay.Underlay;
-import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.*;
 
-public class EntityIdCountField extends ValueDisplayField {
+public class CountDistinctField extends ValueDisplayField {
   private final Underlay underlay;
   private final Entity entity;
+  private final Attribute attribute;
 
-  public EntityIdCountField(Underlay underlay, Entity entity) {
+  public CountDistinctField(Underlay underlay, Entity entity, Attribute attribute) {
     this.underlay = underlay;
     this.entity = entity;
+    this.attribute = attribute;
   }
 
   public Underlay getUnderlay() {
@@ -19,6 +21,10 @@ public class EntityIdCountField extends ValueDisplayField {
 
   public Entity getEntity() {
     return entity;
+  }
+
+  public Attribute getAttribute() {
+    return attribute;
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/query/count/CountQueryRequest.java
@@ -6,7 +6,7 @@ import bio.terra.tanagra.api.query.PageMarker;
 import bio.terra.tanagra.api.query.hint.HintQueryResult;
 import bio.terra.tanagra.api.shared.OrderByDirection;
 import bio.terra.tanagra.underlay.Underlay;
-import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.*;
 import com.google.common.collect.ImmutableList;
 import jakarta.annotation.Nullable;
 import java.util.List;
@@ -18,6 +18,7 @@ public class CountQueryRequest {
 
   private final Underlay underlay;
   private final Entity entity;
+  private final @Nullable Attribute countDistinctAttribute;
   private final ImmutableList<ValueDisplayField> groupByFields;
   private final @Nullable EntityFilter filter;
   private final OrderByDirection orderByDirection;
@@ -31,6 +32,7 @@ public class CountQueryRequest {
   public CountQueryRequest(
       Underlay underlay,
       Entity entity,
+      @Nullable Attribute countDistinctAttribute,
       List<ValueDisplayField> groupByFields,
       @Nullable EntityFilter filter,
       OrderByDirection orderByDirection,
@@ -41,6 +43,7 @@ public class CountQueryRequest {
       boolean isDryRun) {
     this.underlay = underlay;
     this.entity = entity;
+    this.countDistinctAttribute = countDistinctAttribute;
     this.groupByFields = ImmutableList.copyOf(groupByFields);
     this.filter = filter;
     this.orderByDirection = orderByDirection;
@@ -57,6 +60,10 @@ public class CountQueryRequest {
 
   public Entity getEntity() {
     return entity;
+  }
+
+  public Attribute getCountDistinctAttribute() {
+    return countDistinctAttribute == null ? entity.getIdAttribute() : countDistinctAttribute;
   }
 
   public ImmutableList<ValueDisplayField> getGroupByFields() {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.query.bigquery.translator;
 
 import bio.terra.tanagra.api.field.AttributeField;
-import bio.terra.tanagra.api.field.EntityIdCountField;
+import bio.terra.tanagra.api.field.CountDistinctField;
 import bio.terra.tanagra.api.field.HierarchyIsMemberField;
 import bio.terra.tanagra.api.field.HierarchyIsRootField;
 import bio.terra.tanagra.api.field.HierarchyNumChildrenField;
@@ -17,7 +17,7 @@ import bio.terra.tanagra.api.filter.RelationshipFilter;
 import bio.terra.tanagra.api.filter.TemporalPrimaryFilter;
 import bio.terra.tanagra.api.filter.TextSearchFilter;
 import bio.terra.tanagra.query.bigquery.translator.field.BQAttributeFieldTranslator;
-import bio.terra.tanagra.query.bigquery.translator.field.BQEntityIdCountFieldTranslator;
+import bio.terra.tanagra.query.bigquery.translator.field.BQCountDistinctFieldTranslator;
 import bio.terra.tanagra.query.bigquery.translator.field.BQHierarchyIsMemberFieldTranslator;
 import bio.terra.tanagra.query.bigquery.translator.field.BQHierarchyIsRootFieldTranslator;
 import bio.terra.tanagra.query.bigquery.translator.field.BQHierarchyNumChildrenFieldTranslator;
@@ -43,8 +43,8 @@ public final class BQApiTranslator implements ApiTranslator {
   }
 
   @Override
-  public ApiFieldTranslator translator(EntityIdCountField entityIdCountField) {
-    return new BQEntityIdCountFieldTranslator(entityIdCountField);
+  public ApiFieldTranslator translator(CountDistinctField countDistinctField) {
+    return new BQCountDistinctFieldTranslator(countDistinctField);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/field/BQCountDistinctFieldTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/field/BQCountDistinctFieldTranslator.java
@@ -1,6 +1,6 @@
 package bio.terra.tanagra.query.bigquery.translator.field;
 
-import bio.terra.tanagra.api.field.EntityIdCountField;
+import bio.terra.tanagra.api.field.CountDistinctField;
 import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.api.shared.ValueDisplay;
 import bio.terra.tanagra.query.sql.SqlField;
@@ -11,12 +11,12 @@ import bio.terra.tanagra.underlay.NameHelper;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
 import java.util.List;
 
-public class BQEntityIdCountFieldTranslator implements ApiFieldTranslator {
-  private static final String FIELD_ALIAS = "IDCT";
-  private final EntityIdCountField entityIdCountField;
+public class BQCountDistinctFieldTranslator implements ApiFieldTranslator {
+  private static final String FIELD_ALIAS = "CTDT";
+  private final CountDistinctField countDistinctField;
 
-  public BQEntityIdCountFieldTranslator(EntityIdCountField entityIdCountField) {
-    this.entityIdCountField = entityIdCountField;
+  public BQCountDistinctFieldTranslator(CountDistinctField countDistinctField) {
+    this.countDistinctField = countDistinctField;
   }
 
   @Override
@@ -36,14 +36,16 @@ public class BQEntityIdCountFieldTranslator implements ApiFieldTranslator {
 
   private List<SqlQueryField> buildSqlFields() {
     ITEntityMain indexTable =
-        entityIdCountField
+        countDistinctField
             .getUnderlay()
             .getIndexSchema()
-            .getEntityMain(entityIdCountField.getEntity().getName());
-    final String countFnStr = "COUNT";
+            .getEntityMain(countDistinctField.getEntity().getName());
+
+    final String countFnStr =
+        countDistinctField.getAttribute().isId() ? "COUNT" : "COUNT(DISTINCT ${fieldSql})";
     SqlField field =
         indexTable
-            .getAttributeValueField(entityIdCountField.getEntity().getIdAttribute().getName())
+            .getAttributeValueField(countDistinctField.getAttribute().getName())
             .cloneWithFunctionWrapper(countFnStr);
     return List.of(SqlQueryField.of(field, getFieldAlias()));
   }

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.query.sql.translator;
 
 import bio.terra.tanagra.api.field.AttributeField;
-import bio.terra.tanagra.api.field.EntityIdCountField;
+import bio.terra.tanagra.api.field.CountDistinctField;
 import bio.terra.tanagra.api.field.HierarchyIsMemberField;
 import bio.terra.tanagra.api.field.HierarchyIsRootField;
 import bio.terra.tanagra.api.field.HierarchyNumChildrenField;
@@ -283,7 +283,7 @@ public interface ApiTranslator {
 
   ApiFieldTranslator translator(AttributeField attributeField);
 
-  ApiFieldTranslator translator(EntityIdCountField entityIdCountField);
+  ApiFieldTranslator translator(CountDistinctField countDistinctField);
 
   ApiFieldTranslator translator(HierarchyIsMemberField hierarchyIsMemberField);
 
@@ -298,8 +298,8 @@ public interface ApiTranslator {
   default ApiFieldTranslator translator(ValueDisplayField valueDisplayField) {
     if (valueDisplayField instanceof AttributeField) {
       return translator((AttributeField) valueDisplayField);
-    } else if (valueDisplayField instanceof EntityIdCountField) {
-      return translator((EntityIdCountField) valueDisplayField);
+    } else if (valueDisplayField instanceof CountDistinctField) {
+      return translator((CountDistinctField) valueDisplayField);
     } else if (valueDisplayField instanceof HierarchyIsMemberField) {
       return translator((HierarchyIsMemberField) valueDisplayField);
     } else if (valueDisplayField instanceof HierarchyIsRootField) {

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQCountQueryPaginationTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQCountQueryPaginationTest.java
@@ -65,6 +65,7 @@ public class BQCountQueryPaginationTest {
                 new CountQueryRequest(
                     underlay,
                     entity,
+                    null,
                     groupBys,
                     null,
                     OrderByDirection.DESCENDING,
@@ -108,6 +109,7 @@ public class BQCountQueryPaginationTest {
                 new CountQueryRequest(
                     underlay,
                     entity,
+                    null,
                     groupBys,
                     null,
                     OrderByDirection.DESCENDING,
@@ -131,6 +133,7 @@ public class BQCountQueryPaginationTest {
                 new CountQueryRequest(
                     underlay,
                     entity,
+                    null,
                     groupBys,
                     null,
                     OrderByDirection.DESCENDING,

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQCountQueryResultsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQCountQueryResultsTest.java
@@ -64,6 +64,7 @@ public class BQCountQueryResultsTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 groupBys,
                 null,
                 OrderByDirection.DESCENDING,
@@ -137,6 +138,7 @@ public class BQCountQueryResultsTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 groupBys,
                 null,
                 OrderByDirection.DESCENDING,
@@ -201,6 +203,7 @@ public class BQCountQueryResultsTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 countForEntity,
+                null,
                 groupBys,
                 null,
                 OrderByDirection.DESCENDING,

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQListQueryResultsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQListQueryResultsTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.field.AttributeField;
-import bio.terra.tanagra.api.field.EntityIdCountField;
+import bio.terra.tanagra.api.field.CountDistinctField;
 import bio.terra.tanagra.api.field.HierarchyIsMemberField;
 import bio.terra.tanagra.api.field.HierarchyIsRootField;
 import bio.terra.tanagra.api.field.HierarchyNumChildrenField;
@@ -98,10 +98,11 @@ public class BQListQueryResultsTest extends BQRunnerTest {
   @Test
   void entityIdCountField() {
     Entity entity = underlay.getPrimaryEntity();
-    EntityIdCountField entityIdCountField = new EntityIdCountField(underlay, entity);
+    CountDistinctField countDistinctField =
+        new CountDistinctField(underlay, entity, entity.getIdAttribute());
 
-    List<ValueDisplayField> selectAttributes = List.of(entityIdCountField);
-    List<OrderBy> orderBys = List.of(new OrderBy(entityIdCountField, OrderByDirection.DESCENDING));
+    List<ValueDisplayField> selectAttributes = List.of(countDistinctField);
+    List<OrderBy> orderBys = List.of(new OrderBy(countDistinctField, OrderByDirection.DESCENDING));
     int limit = 11;
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
@@ -116,7 +117,7 @@ public class BQListQueryResultsTest extends BQRunnerTest {
         .getListInstances()
         .forEach(
             listInstance -> {
-              ValueDisplay entityIdCount = listInstance.getEntityFieldValue(entityIdCountField);
+              ValueDisplay entityIdCount = listInstance.getEntityFieldValue(countDistinctField);
               assertNotNull(entityIdCount);
               assertEquals(DataType.INT64, entityIdCount.getValue().getDataType());
               assertNotNull(entityIdCount.getValue().getInt64Val());

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQCountQueryTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQCountQueryTest.java
@@ -37,6 +37,7 @@ public class BQCountQueryTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 List.of(groupByAttribute),
                 attributeFilter,
                 OrderByDirection.DESCENDING,
@@ -60,6 +61,7 @@ public class BQCountQueryTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 List.of(groupByAttribute),
                 null,
                 OrderByDirection.DESCENDING,
@@ -81,6 +83,7 @@ public class BQCountQueryTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 List.of(),
                 null,
                 OrderByDirection.DESCENDING,
@@ -105,6 +108,7 @@ public class BQCountQueryTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 List.of(groupByAttribute),
                 null,
                 OrderByDirection.DESCENDING,
@@ -137,6 +141,7 @@ public class BQCountQueryTest extends BQRunnerTest {
             new CountQueryRequest(
                 underlay,
                 entity,
+                null,
                 List.of(groupByAttributeField),
                 null,
                 OrderByDirection.DESCENDING,
@@ -149,5 +154,39 @@ public class BQCountQueryTest extends BQRunnerTest {
         underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
     assertSqlMatchesWithTableNameOnly(
         "groupByValueDisplayField", countQueryResult.getSql(), entityMainTable);
+  }
+
+  @Test
+  void countDistinctAttributeNotId() throws IOException {
+    Entity entity = underlay.getEntity("conditionOccurrence");
+    Attribute countDistinctAttribute = entity.getAttribute("person_id");
+    Attribute groupByAttribute = entity.getAttribute("condition");
+    AttributeField groupByAttributeField =
+        new AttributeField(underlay, entity, groupByAttribute, false);
+    HintQueryResult hintQueryResult =
+        new HintQueryResult(
+            "",
+            List.of(
+                new HintInstance(
+                    groupByAttribute,
+                    Map.of(new ValueDisplay(Literal.forInt64(8_532L), "Female"), 100L))));
+    CountQueryResult countQueryResult =
+        bqQueryRunner.run(
+            new CountQueryRequest(
+                underlay,
+                entity,
+                countDistinctAttribute,
+                List.of(groupByAttributeField),
+                null,
+                OrderByDirection.DESCENDING,
+                null,
+                null,
+                null,
+                hintQueryResult,
+                true));
+    BQTable entityMainTable =
+        underlay.getIndexSchema().getEntityMain(entity.getName()).getTablePointer();
+    assertSqlMatchesWithTableNameOnly(
+        "countDistinctAttributeNotId", countQueryResult.getSql(), entityMainTable);
   }
 }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFieldTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQFieldTest.java
@@ -1,7 +1,7 @@
 package bio.terra.tanagra.query.bigquery.sqlbuilding;
 
 import bio.terra.tanagra.api.field.AttributeField;
-import bio.terra.tanagra.api.field.EntityIdCountField;
+import bio.terra.tanagra.api.field.CountDistinctField;
 import bio.terra.tanagra.api.field.HierarchyIsMemberField;
 import bio.terra.tanagra.api.field.HierarchyIsRootField;
 import bio.terra.tanagra.api.field.HierarchyNumChildrenField;
@@ -161,10 +161,11 @@ public class BQFieldTest extends BQRunnerTest {
   @Test
   void entityIdCountField() throws IOException {
     Entity entity = underlay.getPrimaryEntity();
-    EntityIdCountField entityIdCountField = new EntityIdCountField(underlay, entity);
+    CountDistinctField countDistinctField =
+        new CountDistinctField(underlay, entity, entity.getIdAttribute());
 
-    List<ValueDisplayField> selectAttributes = List.of(entityIdCountField);
-    List<OrderBy> orderBys = List.of(new OrderBy(entityIdCountField, OrderByDirection.DESCENDING));
+    List<ValueDisplayField> selectAttributes = List.of(countDistinctField);
+    List<OrderBy> orderBys = List.of(new OrderBy(countDistinctField, OrderByDirection.DESCENDING));
     ListQueryResult listQueryResult =
         bqQueryRunner.run(
             ListQueryRequest.dryRunAgainstIndexData(

--- a/underlay/src/test/resources/sql/BQCountQueryTest/countDistinctAttributeNotId.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/countDistinctAttributeNotId.sql
@@ -1,0 +1,10 @@
+
+    SELECT
+        COUNT(DISTINCT person_id) AS T_CTDT,
+        condition      
+    FROM
+        ${ENT_conditionOccurrence}      
+    GROUP BY
+        condition      
+    ORDER BY
+        T_CTDT DESC

--- a/underlay/src/test/resources/sql/BQCountQueryTest/groupByRuntimeCalculatedField.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/groupByRuntimeCalculatedField.sql
@@ -1,10 +1,10 @@
 
     SELECT
-        COUNT(id) AS T_IDCT,
+        COUNT(id) AS T_CTDT,
         CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), age, DAY) / 365.25) AS INT64) AS age      
     FROM
         ${ENT_person}      
     GROUP BY
         age      
     ORDER BY
-        T_IDCT DESC
+        T_CTDT DESC

--- a/underlay/src/test/resources/sql/BQCountQueryTest/groupByValueDisplayField.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/groupByValueDisplayField.sql
@@ -1,10 +1,10 @@
 
     SELECT
-        COUNT(id) AS T_IDCT,
+        COUNT(id) AS T_CTDT,
         gender      
     FROM
         ${ENT_person}      
     GROUP BY
         gender      
     ORDER BY
-        T_IDCT DESC
+        T_CTDT DESC

--- a/underlay/src/test/resources/sql/BQCountQueryTest/noFilter.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/noFilter.sql
@@ -1,10 +1,10 @@
 
     SELECT
-        COUNT(id) AS T_IDCT,
+        COUNT(id) AS T_CTDT,
         year_of_birth      
     FROM
         ${ENT_person}      
     GROUP BY
         year_of_birth      
     ORDER BY
-        T_IDCT DESC
+        T_CTDT DESC

--- a/underlay/src/test/resources/sql/BQCountQueryTest/noGroupByFields.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/noGroupByFields.sql
@@ -1,7 +1,7 @@
 
     SELECT
-        COUNT(id) AS T_IDCT      
+        COUNT(id) AS T_CTDT      
     FROM
         ${ENT_person}      
     ORDER BY
-        T_IDCT DESC
+        T_CTDT DESC

--- a/underlay/src/test/resources/sql/BQCountQueryTest/withFilter.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/withFilter.sql
@@ -1,6 +1,6 @@
 
     SELECT
-        COUNT(id) AS T_IDCT,
+        COUNT(id) AS T_CTDT,
         year_of_birth      
     FROM
         ${ENT_person}      
@@ -9,4 +9,4 @@
     GROUP BY
         year_of_birth      
     ORDER BY
-        T_IDCT DESC
+        T_CTDT DESC

--- a/underlay/src/test/resources/sql/BQFieldTest/entityIdCountField.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/entityIdCountField.sql
@@ -1,7 +1,7 @@
 
     SELECT
-        COUNT(id) AS T_IDCT      
+        COUNT(id) AS T_CTDT      
     FROM
         ${ENT_person}      
     ORDER BY
-        T_IDCT DESC
+        T_CTDT DESC


### PR DESCRIPTION
Previously we only allowed counting the number of unique entity instances, i.e. `COUNT(id)`. This change adds the ability to count the number of distinct values of any attribute, i.e. `COUNT(non id attribute)`.

This supports, in the query engine, top 10 chart queries counted per person for standard codes (i.e. single occurrence entity).

Also added this new optional attribute property to the `queryCohortCounts` API. While this is not the long-term vision for how we'll handle chart queries in the API, adding it to the API here allows us to fix the existing top 10 chart queries sooner than waiting for all the visualizations query engine work to finish, if we decide that's worth it.