### PR TITLE
Consolidate count and list query SQL building logic.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/api/field/AttributeField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/AttributeField.java
@@ -43,6 +43,7 @@ public class AttributeField extends ValueDisplayField {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/CountDistinctField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/CountDistinctField.java
@@ -19,6 +19,7 @@ public class CountDistinctField extends ValueDisplayField {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyIsMemberField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyIsMemberField.java
@@ -20,6 +20,7 @@ public class HierarchyIsMemberField extends ValueDisplayField {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyIsRootField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyIsRootField.java
@@ -20,6 +20,7 @@ public class HierarchyIsRootField extends ValueDisplayField {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyNumChildrenField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyNumChildrenField.java
@@ -20,6 +20,7 @@ public class HierarchyNumChildrenField extends ValueDisplayField {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyPathField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/HierarchyPathField.java
@@ -20,6 +20,7 @@ public class HierarchyPathField extends ValueDisplayField {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/RelatedEntityIdCountField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/RelatedEntityIdCountField.java
@@ -52,6 +52,11 @@ public class RelatedEntityIdCountField extends ValueDisplayField {
   }
 
   @Override
+  public Entity getEntity() {
+    return getCountForEntity();
+  }
+
+  @Override
   public DataType getDataType() {
     return DataType.INT64;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/field/ValueDisplayField.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/field/ValueDisplayField.java
@@ -1,7 +1,10 @@
 package bio.terra.tanagra.api.field;
 
 import bio.terra.tanagra.api.shared.DataType;
+import bio.terra.tanagra.underlay.entitymodel.*;
 
 public abstract class ValueDisplayField {
+  public abstract Entity getEntity();
+
   public abstract DataType getDataType();
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/AttributeFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/AttributeFilter.java
@@ -69,6 +69,7 @@ public class AttributeFilter extends EntityFilter {
     return attribute;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanAndOrFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanAndOrFilter.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.api.filter;
 
+import bio.terra.tanagra.exception.*;
+import bio.terra.tanagra.underlay.entitymodel.*;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
@@ -24,6 +26,19 @@ public class BooleanAndOrFilter extends EntityFilter {
 
   public ImmutableList<EntityFilter> getSubFilters() {
     return ImmutableList.copyOf(subFilters);
+  }
+
+  @Override
+  public Entity getEntity() {
+    Entity entity = subFilters.get(0).getEntity();
+    if (subFilters.stream()
+        .filter(subFilter -> !subFilter.getEntity().equals(entity))
+        .findAny()
+        .isPresent()) {
+      throw new InvalidQueryException(
+          "All sub-filters of a boolean and/or filter must be for the same entity.");
+    }
+    return entity;
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanNotFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanNotFilter.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.api.filter;
 
+import bio.terra.tanagra.underlay.entitymodel.*;
 import java.util.Objects;
 
 public class BooleanNotFilter extends EntityFilter {
@@ -11,6 +12,11 @@ public class BooleanNotFilter extends EntityFilter {
 
   public EntityFilter getSubFilter() {
     return subFilter;
+  }
+
+  @Override
+  public Entity getEntity() {
+    return subFilter.getEntity();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
@@ -1,6 +1,10 @@
 package bio.terra.tanagra.api.filter;
 
+import bio.terra.tanagra.underlay.entitymodel.*;
+
 public abstract class EntityFilter {
+  public abstract Entity getEntity();
+
   // TODO: Add logic here to merge filters automatically to get a simpler filter overall.
   public boolean isMergeable(EntityFilter entityFilter) {
     return false;

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/GroupHasItemsFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/GroupHasItemsFilter.java
@@ -2,7 +2,7 @@ package bio.terra.tanagra.api.filter;
 
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.underlay.Underlay;
-import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.entitymodel.*;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
 import com.google.common.collect.ImmutableList;
 import jakarta.annotation.Nullable;
@@ -60,6 +60,11 @@ public class GroupHasItemsFilter extends EntityFilter {
   @Nullable
   public Integer getGroupByCountValue() {
     return groupByCountValue;
+  }
+
+  @Override
+  public Entity getEntity() {
+    return groupItems.getGroupEntity();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyHasAncestorFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyHasAncestorFilter.java
@@ -34,6 +34,7 @@ public class HierarchyHasAncestorFilter extends EntityFilter {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyHasParentFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyHasParentFilter.java
@@ -33,6 +33,7 @@ public class HierarchyHasParentFilter extends EntityFilter {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsMemberFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsMemberFilter.java
@@ -19,6 +19,7 @@ public class HierarchyIsMemberFilter extends EntityFilter {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsRootFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsRootFilter.java
@@ -19,6 +19,7 @@ public class HierarchyIsRootFilter extends EntityFilter {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/ItemInGroupFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/ItemInGroupFilter.java
@@ -2,7 +2,7 @@ package bio.terra.tanagra.api.filter;
 
 import bio.terra.tanagra.api.shared.BinaryOperator;
 import bio.terra.tanagra.underlay.Underlay;
-import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.entitymodel.*;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
 import com.google.common.collect.ImmutableList;
 import jakarta.annotation.Nullable;
@@ -60,6 +60,11 @@ public class ItemInGroupFilter extends EntityFilter {
   @Nullable
   public Integer getGroupByCountValue() {
     return groupByCountValue;
+  }
+
+  @Override
+  public Entity getEntity() {
+    return groupItems.getItemsEntity();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
@@ -56,6 +56,11 @@ public class OccurrenceForPrimaryFilter extends EntityFilter {
   }
 
   @Override
+  public Entity getEntity() {
+    return occurrenceEntity;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/PrimaryWithCriteriaFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/PrimaryWithCriteriaFilter.java
@@ -106,6 +106,11 @@ public class PrimaryWithCriteriaFilter extends EntityFilter {
   }
 
   @Override
+  public Entity getEntity() {
+    return underlay.getPrimaryEntity();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
@@ -108,6 +108,11 @@ public class RelationshipFilter extends EntityFilter {
   }
 
   @Override
+  public Entity getEntity() {
+    return getSelectEntity();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/TemporalPrimaryFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/TemporalPrimaryFilter.java
@@ -4,6 +4,7 @@ import bio.terra.tanagra.api.shared.JoinOperator;
 import bio.terra.tanagra.api.shared.ReducingOperator;
 import bio.terra.tanagra.filterbuilder.EntityOutput;
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.*;
 import com.google.common.collect.ImmutableList;
 import jakarta.annotation.Nullable;
 import java.util.*;
@@ -63,6 +64,11 @@ public class TemporalPrimaryFilter extends EntityFilter {
 
   public List<EntityOutput> getSecondCondition() {
     return secondCondition;
+  }
+
+  @Override
+  public Entity getEntity() {
+    return underlay.getPrimaryEntity();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/TextSearchFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/TextSearchFilter.java
@@ -35,6 +35,7 @@ public class TextSearchFilter extends EntityFilter {
     return underlay;
   }
 
+  @Override
   public Entity getEntity() {
     return entity;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -388,7 +388,8 @@ public class BQQueryRunner implements QueryRunner {
               && valueDisplayField instanceof AttributeField) {
             sqlQueryFields =
                 ((BQAttributeFieldTranslator) bqTranslator.translator(valueDisplayField))
-                    .buildSqlFieldsForCountSelectAndGroupBy(entityLevelHints.get(singleEntity));
+                    .buildSqlFieldsForCountSelectAndGroupBy(
+                        entityLevelHints.get(valueDisplayField.getEntity()));
           } else {
             sqlQueryFields =
                 bqTranslator.translator(valueDisplayField).buildSqlFieldsForListSelect();

--- a/underlay/src/test/resources/sql/BQCountQueryTest/groupByRuntimeCalculatedField.sql
+++ b/underlay/src/test/resources/sql/BQCountQueryTest/groupByRuntimeCalculatedField.sql
@@ -1,7 +1,7 @@
 
     SELECT
         COUNT(id) AS T_CTDT,
-        CAST(FLOOR(TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), age, DAY) / 365.25) AS INT64) AS age      
+        CAST(FLOOR(TIMESTAMP_DIFF(@currentTimestamp0, age, DAY) / 365.25) AS INT64) AS age      
     FROM
         ${ENT_person}      
     GROUP BY


### PR DESCRIPTION
- Added a required `getEntity` method to `ValueDisplayField` (used for `SELECT`, `GROUP BY`, `ORDER BY`) and `EntityFilter` (used for `WHERE`). This is to help build a list of the index entity tables we'll need to `JOIN` together once we support multi-entity queries.
- Fixed a bug for count queries where the returned SQL string didn't have current date/timestamp functions automatically substituted. This didn't affect the query that was actually run (that one did use a parameter for current date/timestamp functions to enable query caching), only the string that gets returned as part of the count query result.
- Consolidated the SQL building logic for count and list queries. This is in preparation for supporting multi-entity queries, where the `JOIN`s will need to be identical in both code paths.