### PR TITLE
Check for token expiry in auth0

### DIFF
--- a/ui/src/auth/auth0OAuth.tsx
+++ b/ui/src/auth/auth0OAuth.tsx
@@ -43,7 +43,8 @@ function Auth0ProviderWithClient() {
     logout,
   } = useAuth0();
 
-  // Needed for user state to get updated: calls auth0 if token is expired
+  // Needed for user state to get updated. getAccessTokenSilently: calls auth0
+  // if there is no valid token in the cache, does not check expiry
   useEffect(() => {
     if (isAuthenticated) {
       getAccessTokenSilently();

--- a/ui/src/auth/auth0OAuth.tsx
+++ b/ui/src/auth/auth0OAuth.tsx
@@ -37,17 +37,18 @@ function Auth0ProviderWithClient() {
     user,
     isLoading,
     isAuthenticated,
+    getAccessTokenSilently,
     getIdTokenClaims,
     loginWithRedirect,
     logout,
   } = useAuth0();
 
-  // This is needed for user state to get updated.
+  // Needed for user state to get updated: calls auth0 if token is expired
   useEffect(() => {
     if (isAuthenticated) {
-      getIdTokenClaims();
+      getAccessTokenSilently();
     }
-  }, [isAuthenticated, getIdTokenClaims]);
+  }, [isAuthenticated, getAccessTokenSilently]);
 
   if (user && !user.email) {
     throw new Error("User profile has no email address");
@@ -69,6 +70,7 @@ function Auth0ProviderWithClient() {
         logout({ logoutParams: { returnTo: window.location.origin } });
       },
       getAuthToken: async () => {
+        await getAccessTokenSilently();
         const claims = await getIdTokenClaims();
         return claims?.__raw || "";
       },
@@ -78,6 +80,7 @@ function Auth0ProviderWithClient() {
       isAuthenticated,
       user,
       error,
+      getAccessTokenSilently,
       getIdTokenClaims,
       loginWithRedirect,
       logout,

--- a/ui/src/auth/provider.tsx
+++ b/ui/src/auth/provider.tsx
@@ -86,7 +86,7 @@ export function CheckAuthorization() {
 }
 
 export const LoginPage = () => {
-  const { loaded, profile, error, signIn } = useAuth();
+  const { loaded, profile, signIn } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -115,7 +115,6 @@ export const LoginPage = () => {
           alt={imageTitle}
         />
         {imageTitle}
-        <ErrorList errors={error} />
         <Button variant="contained" onClick={() => signIn()} disabled={!loaded}>
           {signInText}
         </Button>


### PR DESCRIPTION
issue - authcontext.expired was set to false as long as the authentication created a valid token in the local cache, even if it was expired. hence the relogin (re-authorize) flow was not called in UI, but when the token was validated in backend proxy it would fail

fix - there is no out of the box way in auth0-react to validate if the token is expired. Check if the token is close to expiration (60 seconds) and set a state.tokenExpired to true. This state in turn will reset the authcontext.expired, thus triggering the auth flow again. As long as the access token is valid and not expired, the user does not need to re-login. Auth0 updates the idToken with new expiry 

testing - 
- in auth0 set the token expiry to 60 seconds
- trigger fresh login flow
- verify that the exp claim in idToken is in 60 seconds; expiresAt in access_token may be different
- after a few minutes reopen or refresh the page. since it is past the expiry time, you see a login page 