### PR TITLE
Respect isSuppressedForExport flag on attribute at export time.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
@@ -301,7 +301,10 @@ public class FilterBuilderService {
                                       .getRight()
                                   : new HashSet<>();
                           entityOutput.getEntity().getAttributes().stream()
-                              .filter(attribute -> !excludeAttrNames.contains(attribute.getName()))
+                              .filter(
+                                  attribute ->
+                                      !excludeAttrNames.contains(attribute.getName())
+                                          && !attribute.isSuppressedForExport())
                               .forEach(includeAttributes::add);
 
                           outputEntitiesAndFiltersAndAttributes.put(

--- a/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/DataExportServiceTest.java
@@ -341,7 +341,7 @@ public class DataExportServiceTest {
     assertFalse(fileContents.isEmpty());
     String fileContentsFirstLine = fileContents.split(System.lineSeparator())[0];
     assertEquals(
-        "age,ethnicity,T_DISP_ethnicity,gender,T_DISP_gender,id,person_source_value,race,T_DISP_race,year_of_birth",
+        "ethnicity,T_DISP_ethnicity,gender,T_DISP_gender,id,person_source_value,race,T_DISP_race,year_of_birth",
         fileContentsFirstLine);
     assertEquals(6, fileContents.split("\n").length); // 5 instances + header row
 
@@ -461,7 +461,7 @@ public class DataExportServiceTest {
     LOGGER.info("Entity instances fileContents: {}", entityInstancesFileContents);
     String fileContentsFirstLine = entityInstancesFileContents.split(System.lineSeparator())[0];
     assertEquals(
-        "age,ethnicity,T_DISP_ethnicity,gender,T_DISP_gender,id,person_source_value,race,T_DISP_race,year_of_birth",
+        "ethnicity,T_DISP_ethnicity,gender,T_DISP_gender,id,person_source_value,race,T_DISP_race,year_of_birth",
         fileContentsFirstLine);
     assertEquals(6, entityInstancesFileContents.split("\n").length); // 5 instances + header row
   }

--- a/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
@@ -290,23 +290,35 @@ public class FilterBuilderServiceTest {
   void suppressedAttribute() {
     Underlay cmssynpuf = underlayService.getUnderlay("cmssynpuf");
 
-    // One suppressed attribute.
-    List<EntityOutputPreview> entityOutputs =
+    // One suppressed attribute, includeAllAttributes=true for data feature set page.
+    List<EntityOutputPreview> entityOutputsForDataFeatureSetPage =
         filterBuilderService.buildOutputPreviewsForConceptSets(
             List.of(
                 bio.terra.tanagra.service.criteriaconstants.cmssynpuf.ConceptSet.CS_DEMOGRAPHICS),
             true);
-    assertEquals(1, entityOutputs.size());
+    assertEquals(1, entityOutputsForDataFeatureSetPage.size());
     assertEquals(
         cmssynpuf.getPrimaryEntity().getAttributes().size() - 1,
-        entityOutputs.get(0).getEntityOutput().getAttributes().size());
+        entityOutputsForDataFeatureSetPage.get(0).getEntityOutput().getAttributes().size());
     EntityOutput expectedOutput =
         EntityOutput.unfiltered(
             cmssynpuf.getPrimaryEntity(),
             cmssynpuf.getPrimaryEntity().getAttributes().stream()
                 .filter(attribute -> !attribute.isSuppressedForExport())
                 .collect(Collectors.toList()));
-    assertEquals(expectedOutput, entityOutputs.get(0).getEntityOutput());
+    assertEquals(expectedOutput, entityOutputsForDataFeatureSetPage.get(0).getEntityOutput());
+
+    // One suppressed attribute, includeAllAttributes=false for export page.
+    List<EntityOutputPreview> entityOutputsForExportPage =
+        filterBuilderService.buildOutputPreviewsForConceptSets(
+            List.of(
+                bio.terra.tanagra.service.criteriaconstants.cmssynpuf.ConceptSet.CS_DEMOGRAPHICS),
+            false);
+    assertEquals(1, entityOutputsForExportPage.size());
+    assertEquals(
+        cmssynpuf.getPrimaryEntity().getAttributes().size() - 1,
+        entityOutputsForExportPage.get(0).getEntityOutput().getAttributes().size());
+    assertEquals(expectedOutput, entityOutputsForExportPage.get(0).getEntityOutput());
   }
 
   @Test


### PR DESCRIPTION
Fix a bug in the export page where we were not respecting the `isSuppressedForExport` flag on attributes. Thanks to @freemabd for reporting and debugging.