### PR TITLE
Updating source queries to consolidate left joins and aliases.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -521,10 +521,16 @@ public class BQQueryRunner implements QueryRunner {
     // Using a set since source queries can reuse the same join key with many columns from joined
     // table.
     Set<String> selectFields = new LinkedHashSet<>();
-    // Map of all joins which allows for removal of repeating join conditions
+    // Map of all joins which allows for removal of repeating join conditions. Key contains both
+    // valueFieldName and displayFieldTable which supports joins to different tables on the same
+    // attribute value.
+    // e.g. displayTableJoins: sourceQuery.valueFieldName, sourceQuery.displayFieldTable -> joinSql
     Table<String, String, String> displayTableJoins = HashBasedTable.create();
     // Map of table join aliases allows for multiple columns from same join condition to reuse
-    // aliases.
+    // aliases. Key contains both valueFieldName and displayFieldTable which supports joins to
+    // different tables on the same attribute value.
+    // e.g. tableJoinAliases: sourceQuery.valueFieldName, sourceQuery.displayFieldTable ->
+    // joinTableAlias
     Table<String, String, String> tableJoinAliases = HashBasedTable.create();
     listQueryRequest
         .getSelectFields()

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -516,11 +516,13 @@ public class BQQueryRunner implements QueryRunner {
 
     // Now build the outer SQL query against the source data.
     final String sourceTableAlias = "st";
-    // Using a set since source queries can reuse the same join key with many columns from joined table.
+    // Using a set since source queries can reuse the same join key with many columns from joined
+    // table.
     Set<String> selectFields = new LinkedHashSet<>();
     // Map of all joins which allows for removal of repeating join conditions
     Map<String, String> displayTableJoins = new LinkedHashMap<>();
-    // Map of table join aliases allows for multiple columns from same join condition to reuse aliases.
+    // Map of table join aliases allows for multiple columns from same join condition to reuse
+    // aliases.
     Map<String, String> tableJoinAliases = new HashMap<>();
     listQueryRequest
         .getSelectFields()
@@ -545,7 +547,7 @@ public class BQQueryRunner implements QueryRunner {
                   String joinTableAlias = "dt" + displayTableJoins.size();
 
                   if (displayTableJoins.get(attrSourcePointer.getValueFieldName()) == null) {
-                      // Add new table joins and aliases
+                    // Add new table joins and aliases
                     StringBuilder joinSql = new StringBuilder();
                     joinSql
                         .append(" LEFT JOIN ")
@@ -563,7 +565,7 @@ public class BQQueryRunner implements QueryRunner {
                     tableJoinAliases.put(attrSourcePointer.getValueFieldName(), joinTableAlias);
                     selectFields.add(displaySqlField.renderForSelect(joinTableAlias));
                   } else {
-                      // Use existing table joins and aliases
+                    // Use existing table joins and aliases
                     selectFields.add(
                         displaySqlField.renderForSelect(
                             tableJoinAliases.get(attrSourcePointer.getValueFieldName())));

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
@@ -5,24 +5,72 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "condition_occurrence_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "condition_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "STRING"},
-    { "name": "standard_concept_code", "dataType": "STRING"},
-    { "name": "standard_vocabulary", "dataType": "STRING"},
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "condition_concept_id", "displayFieldName": "standard_concept_name",
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "condition_concept_id", "displayFieldName": "standard_concept_code",
+      "sourceQuery": {
+        "displayFieldName": "concept_code",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "condition_concept_id", "displayFieldName": "standard_vocabulary",
+      "sourceQuery": {
+        "displayFieldName": "vocabulary_id",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
     { "name": "condition_start_datetime", "dataType": "TIMESTAMP" },
     { "name": "condition_end_datetime", "dataType": "TIMESTAMP" },
     { "name": "condition_type_concept_id", "dataType": "INT64" },
-    { "name": "condition_type_concept_name", "dataType": "STRING" },
+    { "name": "condition_type_concept_name", "dataType": "INT64", "valueFieldName": "condition_type_concept_id", "displayFieldName": "condition_type_concept_name",
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
     { "name": "stop_reason", "dataType": "STRING" },
     { "name": "visit_occurrence_id", "dataType": "INT64" },
-    { "name": "visit_occurrence_concept_name", "dataType": "STRING" },
+    { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "condition_source_value", "dataType": "STRING" },
     { "name": "condition_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "STRING" },
-    { "name": "source_concept_code", "dataType": "STRING" },
-    { "name": "source_vocabulary", "dataType": "STRING" },
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "displayFieldName": "source_concept_name",
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "displayFieldName": "source_concept_code",
+      "sourceQuery": {
+        "displayFieldName": "concept_code",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "displayFieldName": "source_vocabulary",
+      "sourceQuery": {
+        "displayFieldName": "vocabulary_id",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
     { "name": "condition_status_source_value", "dataType": "STRING" },
     { "name": "condition_status_concept_id", "dataType": "INT64" },
-    { "name": "condition_status_concept_name", "dataType": "STRING" },
+    { "name": "condition_status_concept_name", "dataType": "INT64", "valueFieldName": "condition_status_concept_id", "displayFieldName": "condition_status_concept_name",
+      "sourceQuery": {
+        "displayFieldName": "concept_name",
+        "displayFieldTable": "${omopDataset}.concept",
+        "displayFieldTableJoinFieldName": "concept_id"
+      }
+    },
     { "name": "source_value", "dataType": "STRING", "valueFieldName": "condition_source_value", "isSuppressedForExport": true },
     { "name": "source_criteria_id", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "isSuppressedForExport": true },
     { "name": "age_at_occurrence", "dataType": "INT64", "isComputeDisplayHint": true, "displayHintRangeMin": 0, "displayHintRangeMax": 100, "isSuppressedForExport": true },
@@ -33,5 +81,6 @@
   "temporalQuery": {
     "visitDateAttribute": "start_date",
     "visitIdAttribute": "visit_occurrence_id"
-  }
+  },
+  "sourceQueryTableName": "${omopDataset}.condition_occurrence"
 }

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -6,7 +6,6 @@
         st.race_concept_id,
         st.birth_datetime,
         st.person_id,
-        st.gender_concept_id,
         dt1.concept_name AS T_DISP_genderSuppressed,
         st.person_source_value,
         st.ethnicity_concept_id AS T_DISP_ethnicityNoDisplayJoin      

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -6,7 +6,7 @@
         st.race_concept_id,
         st.birth_datetime,
         st.person_id,
-        dt1.concept_name AS T_DISP_genderSuppressed,
+        dt0.concept_name AS T_DISP_genderSuppressed,
         st.person_source_value,
         st.ethnicity_concept_id AS T_DISP_ethnicityNoDisplayJoin      
     FROM

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -13,10 +13,7 @@
         ${person} AS st      
     LEFT JOIN
         ${concept} AS dt0              
-            ON dt0.concept_id = st.gender_concept_id      
-    LEFT JOIN
-        ${concept} AS dt1              
-            ON dt1.concept_id = st.gender_concept_id      
+            ON dt0.concept_id = st.gender_concept_id
     WHERE
         st.person_id IN (SELECT
             id          

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -13,7 +13,7 @@
         ${person} AS st      
     LEFT JOIN
         ${concept} AS dt0              
-            ON dt0.concept_id = st.gender_concept_id
+            ON dt0.concept_id = st.gender_concept_id      
     WHERE
         st.person_id IN (SELECT
             id          


### PR DESCRIPTION
Problem: When configuring source queries for export AoU needs to select many columns from a joined table and the current config uses a table join per sourceQuery entry. This PR reuses table joins/aliases based on the valueFieldName. This makes for a more readable/efficient source query.

@tjennison-work When we meet a week or so ago and discussed showing the concept_id, concept_name pairs as a change in the UI... well that is now no longer relevant. I was able to get everything working as needed with this PR regarding AoU.

![Screen Shot 2024-08-26 at 12 07 17 PM](https://github.com/user-attachments/assets/cbb2ec57-212d-4a5a-82f1-2d23e80d0842)
