### PR TITLE
Handle empty selection list in EntityGroupFilterBuilder.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
@@ -51,7 +51,7 @@ public class EntityGroupFilterBuilder extends FilterBuilder {
     DTEntityGroup.EntityGroup entityGroupSelectionData =
         deserializeData(selectionData.get(0).getPluginData());
     List<SelectionData> modifiersSelectionData = selectionData.subList(1, selectionData.size());
-    if (entityGroupSelectionData == null) {
+    if (entityGroupSelectionData == null || entityGroupSelectionData.getSelectedList().isEmpty()) {
       // Empty selection data = null filter for a cohort.
       return null;
     }
@@ -100,7 +100,7 @@ public class EntityGroupFilterBuilder extends FilterBuilder {
         deserializeData(selectionData.get(0).getPluginData());
     List<SelectionData> modifiersSelectionData = selectionData.subList(1, selectionData.size());
 
-    if (entityGroupSelectionData == null) {
+    if (entityGroupSelectionData == null || entityGroupSelectionData.getSelectedList().isEmpty()) {
       // Empty selection data = output all occurrence entities with null filters.
       // Use the list of all possible entity groups in the config.
       CFEntityGroup.EntityGroup entityGroupConfig = deserializeConfig();

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
@@ -651,6 +651,12 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
     selectionData = new SelectionData("condition", "");
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
     assertNull(cohortFilter);
+
+    // Empty list selection.
+    DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
+    selectionData = new SelectionData("condition", serializeToJson(data));
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
   }
 
   @Test
@@ -1258,6 +1264,14 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
     // Empty string selection data.
     selectionData = new SelectionData("icd9proc", "");
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(2, dataFeatureOutputs.size());
+    assertTrue(dataFeatureOutputs.contains(expectedEntityOutput1));
+    assertTrue(dataFeatureOutputs.contains(expectedEntityOutput2));
+
+    // Empty list selection.
+    DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
+    selectionData = new SelectionData("icd9proc", serializeToJson(data));
     dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
     assertEquals(2, dataFeatureOutputs.size());
     assertTrue(dataFeatureOutputs.contains(expectedEntityOutput1));

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
@@ -434,6 +434,12 @@ public class EntityGroupFilterBuilderForGroupTest {
     selectionData = new SelectionData("genotyping", "");
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
     assertNull(cohortFilter);
+
+    // Empty list selection.
+    DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
+    selectionData = new SelectionData("genotyping", serializeToJson(data));
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
   }
 
   @Test
@@ -782,6 +788,13 @@ public class EntityGroupFilterBuilderForGroupTest {
 
     // Empty string selection data.
     selectionData = new SelectionData("genotyping", "");
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
+
+    // Empty list selection.
+    DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
+    selectionData = new SelectionData("genotyping", serializeToJson(data));
     dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
     assertEquals(1, dataFeatureOutputs.size());
     assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
@@ -261,12 +261,18 @@ public class EntityGroupFilterBuilderForItemsTest {
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
     // Null selection data.
-    SelectionData selectionData = new SelectionData("genotyping", null);
+    SelectionData selectionData = new SelectionData("bloodPressure", null);
     EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
     assertNull(cohortFilter);
 
     // Empty string selection data.
-    selectionData = new SelectionData("genotyping", "");
+    selectionData = new SelectionData("bloodPressure", "");
+    cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
+    assertNull(cohortFilter);
+
+    // Empty list selection.
+    DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
     assertNull(cohortFilter);
   }
@@ -511,6 +517,13 @@ public class EntityGroupFilterBuilderForItemsTest {
 
     // Empty string selection data.
     selectionData = new SelectionData("bloodPressure", "");
+    dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
+    assertEquals(1, dataFeatureOutputs.size());
+    assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));
+
+    // Empty list selection.
+    DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
+    selectionData = new SelectionData("bloodPressure", serializeToJson(data));
     dataFeatureOutputs = filterBuilder.buildForDataFeature(underlay, List.of(selectionData));
     assertEquals(1, dataFeatureOutputs.size());
     assertEquals(expectedEntityOutput, dataFeatureOutputs.get(0));


### PR DESCRIPTION
Fix a query engine bug where for a criteria with multi-select enabled, but no actual ids selected, we generated an empty `WHERE` clause instead of skipping it altogether.