### PR TITLE
Fetch studies by created_by email address

### DIFF
--- a/ui/src/sampleApp/studiesList.tsx
+++ b/ui/src/sampleApp/studiesList.tsx
@@ -42,9 +42,8 @@ export function StudiesList() {
   });
 
   const listStudies = useCallback(async () => {
-    const domain = userState.data?.email?.split("@")[1];
     return await studySource.listStudies({
-      createdBy: domain ? "@" + domain : undefined,
+      createdBy: userState.data?.email,
     });
   }, [studySource, userState.data?.email]);
 


### PR DESCRIPTION
- Draft change to fetch only studies created by the current logged in user -  meant as draft / proposal option and not intended as final change.
- Current: UI adds the email domain in createdBy filter field of listStudies
<img width="468" alt="image" src="https://github.com/user-attachments/assets/4e8918ad-94a1-4aea-8839-aaef0147256d">

- Change: send entire email address in the createdBy filter field of listStudies
<img width="487" alt="image" src="https://github.com/user-attachments/assets/e1e35bf9-14a2-463b-b53a-22907f1572b3">

https://verily.atlassian.net/browse/BENCH-3894


