### PR TITLE
Verily indexer + service configs for AoU SC2023Q3R2 test data.

### DIFF
--- a/service/local-dev/run_server.sh
+++ b/service/local-dev/run_server.sh
@@ -54,7 +54,7 @@ fi
 
 if [[ ${useVerilyUnderlays} ]]; then
   echo "Using Verily underlays."
-  export TANAGRA_UNDERLAY_FILES=cmssynpuf_verily,aouSR2019q4r4_verily,sd20230831_verily,pilotsynthea2022q3_verily
+  export TANAGRA_UNDERLAY_FILES=cmssynpuf_verily,aouSR2019q4r4_verily,sd20230831_verily,pilotsynthea2022q3_verily,aouSC2023Q3R2_verily
   export TANAGRA_EXPORT_SHARED_GCP_PROJECT_ID=verily-tanagra-test
   export TANAGRA_EXPORT_SHARED_BQ_DATASET_IDS=service_export_us,service_export_uscentral1
   export TANAGRA_EXPORT_SHARED_GCS_BUCKET_NAMES=verily-tanagra-test-export-bucket,verily-tanagra-test-export-bucket-uscentral1

--- a/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
+++ b/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
@@ -1,0 +1,28 @@
+{
+  "underlay": "aouSC2023Q3R2",
+  "bigQuery": {
+    "sourceData": {
+      "projectId": "verily-tanagra-dev",
+      "datasetId": "aou_test_data_SC2023Q3R2",
+      "sqlSubstitutions": {
+        "omopDataset": "verily-tanagra-dev.aou_test_data_SC2023Q3R2",
+        "staticTablesDataset": "verily-tanagra-dev.aou_static_prep"
+      }
+    },
+    "indexData": {
+      "projectId": "verily-tanagra-dev",
+      "datasetId": "aou_test_data_SC2023Q3R2_index_090424",
+      "tablePrefix": "T"
+    },
+    "queryProjectId": "verily-tanagra-dev",
+    "dataLocation": "us"
+  },
+  "dataflow": {
+    "serviceAccountEmail": "backend-default@verily-tanagra-dev.iam.gserviceaccount.com",
+    "dataflowLocation": "us-central1",
+    "gcsTempDirectory": "gs://dataflow-staging-us-central1-694046000181/temp/",
+    "workerMachineType": "n1-standard-4",
+    "usePublicIps": false,
+    "vpcSubnetworkName": null
+  }
+}

--- a/underlay/src/main/resources/config/service/aouSC2023Q3R2_verily.json
+++ b/underlay/src/main/resources/config/service/aouSC2023Q3R2_verily.json
@@ -1,0 +1,21 @@
+{
+  "underlay": "aouSC2023Q3R2",
+  "bigQuery": {
+    "sourceData": {
+      "projectId": "verily-tanagra-dev",
+      "datasetId": "aou_test_data_SC2023Q3R2",
+      "sqlSubstitutions": {
+        "omopDataset": "verily-tanagra-dev.aou_test_data_SC2023Q3R2",
+        "staticTablesDataset": "verily-tanagra-dev.aou_static_prep"
+      }
+    },
+    "indexData": {
+      "projectId": "verily-tanagra-dev",
+      "datasetId": "aou_test_data_SC2023Q3R2_index_090424",
+      "tablePrefix": "T"
+    },
+    "queryProjectId": "verily-tanagra-dev",
+    "dataLocation": "us"
+  },
+  "uiConfigFile": "ui.json"
+}


### PR DESCRIPTION
No underlay or functionality changes, only config files for us to index and test against the AoU CT test data in our Verily dev project.

As part of this PR, I ran indexing on the `aouSC2023Q3R2` underlay (AoU CT test data) in `verily-tanagra-dev`.