### PR TITLE
Boolean not filter missing parentheses.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
@@ -228,7 +228,7 @@ public interface ApiTranslator {
   }
 
   default String booleanNotFilterSql(String subFilterSql) {
-    return "NOT " + subFilterSql;
+    return "NOT (" + subFilterSql + ")";
   }
 
   default String logicalOperatorSql(BooleanAndOrFilter.LogicalOperator operator) {

--- a/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/sql/ApiTranslatorTest.java
@@ -259,7 +259,7 @@ public class ApiTranslatorTest {
         apiTranslator.binaryFilterSql(
             field, BinaryOperator.LESS_THAN_OR_EQUAL, val, tableAlias, sqlParams);
     String sql = apiTranslator.booleanNotFilterSql(subFilterSql);
-    assertEquals("NOT tableAlias.columnName <= @val0", sql);
+    assertEquals("NOT (tableAlias.columnName <= @val0)", sql);
     assertEquals(ImmutableMap.of("val0", val), sqlParams.getParams());
   }
 

--- a/underlay/src/test/resources/sql/BQBooleanLogicFilterTest/booleanNotFilterWithNestedBooleanAndFilter.sql
+++ b/underlay/src/test/resources/sql/BQBooleanLogicFilterTest/booleanNotFilterWithNestedBooleanAndFilter.sql
@@ -4,4 +4,5 @@
     FROM
         ${ENT_person}      
     WHERE
-        NOT (year_of_birth != @val0)
+        NOT ((year_of_birth != @val0)          
+        AND (gender = @val1))

--- a/underlay/src/test/resources/sql/BQBooleanLogicFilterTest/booleanNotFilterWithSwapFields.sql
+++ b/underlay/src/test/resources/sql/BQBooleanLogicFilterTest/booleanNotFilterWithSwapFields.sql
@@ -4,7 +4,7 @@
     FROM
         ${ENT_conditionOccurrence}      
     WHERE
-        NOT condition IN (SELECT
+        NOT (condition IN (SELECT
             descendant          
         FROM
             ${HAD_condition_default}          
@@ -12,4 +12,4 @@
             ancestor = @val0          
         UNION
         ALL SELECT
-            @val1)
+            @val1))


### PR DESCRIPTION
Bug reported by @tjennison-work. Found when trying to exclude a criteria with multiple sub-filters.