### PR TITLE
Optionally use source id-pairs table for GroupItems relationship.

### DIFF
--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
@@ -1,20 +1,6 @@
 package bio.terra.tanagra.annotation;
 
-import bio.terra.tanagra.underlay.serialization.SZAttribute;
-import bio.terra.tanagra.underlay.serialization.SZBigQuery;
-import bio.terra.tanagra.underlay.serialization.SZCorePlugin;
-import bio.terra.tanagra.underlay.serialization.SZCriteriaOccurrence;
-import bio.terra.tanagra.underlay.serialization.SZCriteriaSelector;
-import bio.terra.tanagra.underlay.serialization.SZDataType;
-import bio.terra.tanagra.underlay.serialization.SZEntity;
-import bio.terra.tanagra.underlay.serialization.SZGroupItems;
-import bio.terra.tanagra.underlay.serialization.SZHierarchy;
-import bio.terra.tanagra.underlay.serialization.SZIndexer;
-import bio.terra.tanagra.underlay.serialization.SZPrepackagedCriteria;
-import bio.terra.tanagra.underlay.serialization.SZService;
-import bio.terra.tanagra.underlay.serialization.SZTextSearch;
-import bio.terra.tanagra.underlay.serialization.SZUnderlay;
-import bio.terra.tanagra.underlay.serialization.SZVisualization;
+import bio.terra.tanagra.underlay.serialization.*;
 import java.util.List;
 
 @SuppressWarnings("PMD.CouplingBetweenObjects")
@@ -52,6 +38,7 @@ public class UnderlayConfigPath extends AnnotationPath {
           SZCriteriaSelector.Display.class,
           SZCriteriaSelector.Modifier.class,
           SZPrepackagedCriteria.class,
+          SZRollupCountsSql.class,
           SZVisualization.class,
           SZCorePlugin.class);
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -23,6 +23,7 @@ This documentation is generated from annotations in the configuration classes.
 * [SZPrepackagedCriteria](#szprepackagedcriteria)
 * [SZPrimaryCriteriaRelationship](#szprimarycriteriarelationship)
 * [SZPrimaryRelationship](#szprimaryrelationship)
+* [SZRollupCountsSql](#szrollupcountssql)
 * [SZService](#szservice)
 * [SZSourceData](#szsourcedata)
 * [SZSourceQuery](#szsourcequery)
@@ -642,7 +643,7 @@ Required if the [id pairs SQL](#szgroupitemsidpairssqlfile) is defined.
 
 Name of the group entity - items entity id pairs SQL file.
 
-If this property is set, then the [id pairs SQL](#szgroupitemsidpairssqlfile) must be unset. File must be in the same directory as the entity group file. Name includes file extension.
+File must be in the same directory as the entity group file. Name includes file extension.
 
 There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the group and items entity ids are required. If this property is set, then the [foreign key atttribute](#szgroupitemsforeignkeyattributeitemsentity) must be unset.
 
@@ -668,6 +669,11 @@ Required if the [id pairs SQL](#szgroupitemsidpairssqlfile) is defined.
 Name of the entity group.
 
 This is the unique identifier for the entity group. In a single underlay, the entity group names of any group type cannot overlap. Name may not include spaces or special characters, only letters and numbers. The first character must be a letter.
+
+### SZGroupItems.rollupCountsSql
+**optional** [SZRollupCountsSql](#szrollupcountssql)
+
+Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs.
 
 ### SZGroupItems.useSourceIdPairsSql
 **optional** boolean
@@ -964,6 +970,36 @@ Name of the field or column name that maps to the occurrence entity id. Required
 Name of the field or column name that maps to the primary entity id. Required if the [id pairs SQL](#szprimaryrelationshipidpairssqlfile) is defined.
 
 *Example value:* `primary_id`
+
+
+
+## SZRollupCountsSql
+Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs (e.g. variant - number of people). Useful when there's an easy way to calculate these in SQL and we want to avoid ingesting the full entity - related entity relationship id pairs table into Dataflow.
+
+### SZRollupCountsSql.entityIdFieldName
+**required** String
+
+Name of the field or column name that maps to the entity id.
+
+*Example value:* `entity_id`
+
+### SZRollupCountsSql.rollupCountFieldName
+**required** String
+
+Name of the field or column name that maps to the rollup count per entity id.
+
+*Example value:* `rollup_count`
+
+### SZRollupCountsSql.rollupCountsSqlFile
+**required** String
+
+Name of the entity id - rollup counts (= number of items entity instances) pairs SQL file.
+
+File must be in the same directory as the entity/group file. Name includes file extension.
+
+There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the entity id and rollup count fields are required.
+
+*Example value:* `rollupCounts.sql`
 
 
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -669,6 +669,15 @@ Name of the entity group.
 
 This is the unique identifier for the entity group. In a single underlay, the entity group names of any group type cannot overlap. Name may not include spaces or special characters, only letters and numbers. The first character must be a letter.
 
+### SZGroupItems.useSourceIdPairsSql
+**optional** boolean
+
+True to skip copying the id-pairs SQL into a new index table, and use the source SQL directly.
+
+Ignored if the [id pairs SQL](#szgroupitemsidpairssqlfile) is undefined.
+
+*Default value:* `false`
+
 
 
 ## SZHierarchy

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -153,8 +153,8 @@ public final class JobSequencer {
 
     // If the relationship lives in an intermediate table, write the table to the index dataset.
     // e.g. To allow joins between brand-ingredient.
-    if (groupItems.getGroupItemsRelationship().isIntermediateTable()) {
-      Relationship relationship = groupItems.getGroupItemsRelationship();
+    Relationship relationship = groupItems.getGroupItemsRelationship();
+    if (relationship.isIntermediateTable()) {
       STRelationshipIdPairs sourceIdPairsTable =
           underlay
               .getSourceSchema()
@@ -169,10 +169,12 @@ public final class JobSequencer {
                   groupItems.getName(),
                   relationship.getEntityA().getName(),
                   relationship.getEntityB().getName());
-      jobSet.addJob(
-          new WriteRelationshipIntermediateTable(
-              indexerConfig, sourceIdPairsTable, indexIdPairsTable));
-      jobSet.startNewStage();
+      if (indexIdPairsTable.isGeneratedIndexTable()) {
+        jobSet.addJob(
+            new WriteRelationshipIntermediateTable(
+                indexerConfig, sourceIdPairsTable, indexIdPairsTable));
+        jobSet.startNewStage();
+      }
     }
 
     // Compute the criteria rollup counts for the group-items relationship.

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -31,11 +31,7 @@ import bio.terra.tanagra.underlay.indextable.ITHierarchyAncestorDescendant;
 import bio.terra.tanagra.underlay.indextable.ITHierarchyChildParent;
 import bio.terra.tanagra.underlay.indextable.ITRelationshipIdPairs;
 import bio.terra.tanagra.underlay.serialization.SZIndexer;
-import bio.terra.tanagra.underlay.sourcetable.STEntityAttributes;
-import bio.terra.tanagra.underlay.sourcetable.STHierarchyChildParent;
-import bio.terra.tanagra.underlay.sourcetable.STHierarchyRootFilter;
-import bio.terra.tanagra.underlay.sourcetable.STRelationshipIdPairs;
-import bio.terra.tanagra.underlay.sourcetable.STTextSearchTerms;
+import bio.terra.tanagra.underlay.sourcetable.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -192,6 +188,14 @@ public final class JobSequencer {
                     groupItems.getGroupEntity().getName(),
                     groupItems.getItemsEntity().getName())
             : null;
+    STRelationshipRollupCounts groupItemsRelationshipRollupCountsTable =
+        underlay
+            .getSourceSchema()
+            .getRelationshipRollupCounts(
+                groupItems.getName(),
+                groupItems.getGroupEntity().getName(),
+                groupItems.getItemsEntity().getName())
+            .orElse(null);
     jobSet.addJob(
         new WriteRollupCounts(
             indexerConfig,
@@ -203,7 +207,8 @@ public final class JobSequencer {
             itemsEntityIndexTable,
             groupItemsIdPairsTable,
             null,
-            null));
+            null,
+            groupItemsRelationshipRollupCountsTable));
 
     // If the criteria entity has hierarchies, then also compute the criteria rollup counts for each
     // hierarchy.
@@ -228,7 +233,8 @@ public final class JobSequencer {
                           underlay
                               .getIndexSchema()
                               .getHierarchyAncestorDescendant(
-                                  groupItems.getGroupEntity().getName(), hierarchy.getName()))));
+                                  groupItems.getGroupEntity().getName(), hierarchy.getName()),
+                          null)));
     }
 
     if (groupItems.getGroupEntity().hasHierarchies()) {
@@ -378,6 +384,7 @@ public final class JobSequencer {
             primaryEntityIndexTable,
             primaryCriteriaIdPairsTable,
             null,
+            null,
             null));
 
     // If the criteria entity has hierarchies, then also compute the criteria rollup counts for each
@@ -404,7 +411,8 @@ public final class JobSequencer {
                               .getIndexSchema()
                               .getHierarchyAncestorDescendant(
                                   criteriaOccurrence.getCriteriaEntity().getName(),
-                                  hierarchy.getName()))));
+                                  hierarchy.getName()),
+                          null)));
     }
 
     // Compute instance-level display hints for the occurrence entity attributes that are flagged as

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -114,6 +114,7 @@ export type SZGroupItems = {
   itemsEntity: string;
   itemsEntityIdFieldName?: string;
   name: string;
+  rollupCountsSql?: SZRollupCountsSql;
   useSourceIdPairsSql?: boolean;
 };
 
@@ -174,6 +175,12 @@ export type SZPrimaryRelationship = {
   idPairsSqlFile?: string;
   occurrenceEntityIdFieldName?: string;
   primaryEntityIdFieldName?: string;
+};
+
+export type SZRollupCountsSql = {
+  entityIdFieldName: string;
+  rollupCountFieldName: string;
+  sqlFile: string;
 };
 
 export type SZService = {

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -114,6 +114,7 @@ export type SZGroupItems = {
   itemsEntity: string;
   itemsEntityIdFieldName?: string;
   name: string;
+  useSourceIdPairsSql?: boolean;
 };
 
 export type SZHierarchy = {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -201,7 +201,8 @@ public final class Underlay {
     configReader.setUnderlay(szUnderlay.name);
     configReader.setSqlSubstitutions(szBigQuery.sourceData.sqlSubstitutions);
     SourceSchema sourceSchema = SourceSchema.fromConfig(szBigQuery, szUnderlay, configReader);
-    IndexSchema indexSchema = IndexSchema.fromConfig(szBigQuery, szUnderlay, configReader);
+    IndexSchema indexSchema =
+        IndexSchema.fromConfig(szBigQuery, szUnderlay, configReader, sourceSchema);
 
     // Build the entities.
     Set<SZEntity> szEntities = new HashSet<>();

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITRelationshipIdPairs.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITRelationshipIdPairs.java
@@ -84,6 +84,12 @@ public final class ITRelationshipIdPairs extends IndexTable {
     return entity.equals(entityA) ? getEntityAIdField() : getEntityBIdField();
   }
 
+  @Override
+  public boolean isGeneratedIndexTable() {
+    // TODO: Support using the source table instead of a generated index table for all IT* classes.
+    return sourceTable == null;
+  }
+
   public enum Column {
     ENTITY_A_ID(new ColumnSchema("entity_A_id", DataType.INT64)),
     ENTITY_B_ID(new ColumnSchema("entity_B_id", DataType.INT64));

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
@@ -35,4 +35,8 @@ public abstract class IndexTable {
   }
 
   public abstract ImmutableList<ColumnSchema> getColumnSchemas();
+
+  public boolean isGeneratedIndexTable() {
+    return true;
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
@@ -7,21 +7,31 @@ import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import com.google.common.collect.ImmutableList;
 
 public abstract class IndexTable {
-  protected final NameHelper namer;
-  protected final SZBigQuery.IndexData bigQueryConfig;
+  private final NameHelper namer;
+  private final SZBigQuery.IndexData bigQueryConfig;
+  private final String sql;
 
   protected IndexTable(NameHelper namer, SZBigQuery.IndexData bigQueryConfig) {
     this.namer = namer;
     this.bigQueryConfig = bigQueryConfig;
+    this.sql = null;
+  }
+
+  protected IndexTable(String sql) {
+    this.namer = null;
+    this.bigQueryConfig = null;
+    this.sql = sql;
   }
 
   public abstract String getTableBaseName();
 
   public BQTable getTablePointer() {
-    return new BQTable(
-        bigQueryConfig.projectId,
-        bigQueryConfig.datasetId,
-        namer.getReservedTableName(getTableBaseName()));
+    return sql == null
+        ? new BQTable(
+            bigQueryConfig.projectId,
+            bigQueryConfig.datasetId,
+            namer.getReservedTableName(getTableBaseName()))
+        : new BQTable(sql);
   }
 
   public abstract ImmutableList<ColumnSchema> getColumnSchemas();

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZGroupItems.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZGroupItems.java
@@ -48,6 +48,15 @@ public class SZGroupItems {
   public String idPairsSqlFile;
 
   @AnnotatedField(
+      name = "SZGroupItems.useSourceIdPairsSql",
+      markdown =
+          "True to skip copying the id-pairs SQL into a new index table, and use the source SQL directly.\n\n"
+              + "Ignored if the [id pairs SQL](${SZGroupItems.idPairsSqlFile}) is undefined.",
+      optional = true,
+      defaultValue = "false")
+  public boolean useSourceIdPairsSql;
+
+  @AnnotatedField(
       name = "SZGroupItems.groupEntityIdFieldName",
       markdown =
           "Name of the field or column name that maps to the group entity id.\n\n"

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZGroupItems.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZGroupItems.java
@@ -38,7 +38,6 @@ public class SZGroupItems {
       name = "SZGroupItems.idPairsSqlFile",
       markdown =
           "Name of the group entity - items entity id pairs SQL file.\n\n"
-              + "If this property is set, then the [id pairs SQL](${SZGroupItems.idPairsSqlFile}) must be unset. "
               + "File must be in the same directory as the entity group file. Name includes file extension.\n\n"
               + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the "
               + "group and items entity ids are required. If this property is set, then the "
@@ -73,4 +72,11 @@ public class SZGroupItems {
       optional = true,
       exampleValue = "items_id")
   public String itemsEntityIdFieldName;
+
+  @AnnotatedField(
+      name = "SZGroupItems.rollupCountsSql",
+      markdown =
+          "Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs.",
+      optional = true)
+  public SZRollupCountsSql rollupCountsSql;
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZRollupCountsSql.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZRollupCountsSql.java
@@ -1,0 +1,33 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.*;
+
+@AnnotatedClass(
+    name = "SZRollupCountsSql",
+    markdown =
+        "Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs "
+            + "(e.g. variant - number of people). Useful when there's an easy way to calculate these in SQL "
+            + "and we want to avoid ingesting the full entity - related entity relationship id pairs table into Dataflow.")
+public class SZRollupCountsSql {
+  @AnnotatedField(
+      name = "SZRollupCountsSql.rollupCountsSqlFile",
+      markdown =
+          "Name of the entity id - rollup counts (= number of items entity instances) pairs SQL file.\n\n"
+              + "File must be in the same directory as the entity/group file. Name includes file extension.\n\n"
+              + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the "
+              + "entity id and rollup count fields are required.",
+      exampleValue = "rollupCounts.sql")
+  public String sqlFile;
+
+  @AnnotatedField(
+      name = "SZRollupCountsSql.entityIdFieldName",
+      markdown = "Name of the field or column name that maps to the entity id.",
+      exampleValue = "entity_id")
+  public String entityIdFieldName;
+
+  @AnnotatedField(
+      name = "SZRollupCountsSql.rollupCountFieldName",
+      markdown = "Name of the field or column name that maps to the rollup count per entity id.",
+      exampleValue = "rollup_count")
+  public String rollupCountFieldName;
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STRelationshipRollupCounts.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STRelationshipRollupCounts.java
@@ -1,0 +1,55 @@
+package bio.terra.tanagra.underlay.sourcetable;
+
+import bio.terra.tanagra.api.shared.DataType;
+import bio.terra.tanagra.query.bigquery.BQTable;
+import bio.terra.tanagra.query.sql.SqlField;
+import bio.terra.tanagra.underlay.ColumnSchema;
+import com.google.common.collect.ImmutableList;
+
+public class STRelationshipRollupCounts extends SourceTable {
+  private final String entityGroup;
+  private final String entity;
+  private final String countedEntity;
+  private final ColumnSchema entityIdColumnSchema;
+  private final ColumnSchema countColumnSchema;
+
+  public STRelationshipRollupCounts(
+      BQTable bqTable,
+      String entityGroup,
+      String entity,
+      String countedEntity,
+      String entityIdFieldName,
+      String countFieldName) {
+    super(bqTable);
+    this.entityGroup = entityGroup;
+    this.entity = entity;
+    this.countedEntity = countedEntity;
+    this.entityIdColumnSchema = new ColumnSchema(entityIdFieldName, DataType.INT64);
+    this.countColumnSchema = new ColumnSchema(countFieldName, DataType.INT64);
+  }
+
+  @Override
+  public ImmutableList<ColumnSchema> getColumnSchemas() {
+    return ImmutableList.of(entityIdColumnSchema, countColumnSchema);
+  }
+
+  public String getEntityGroup() {
+    return entityGroup;
+  }
+
+  public String getEntity() {
+    return entity;
+  }
+
+  public String getCountedEntity() {
+    return countedEntity;
+  }
+
+  public SqlField getEntityIdField() {
+    return SqlField.of(entityIdColumnSchema.getColumnName());
+  }
+
+  public SqlField getCountField() {
+    return SqlField.of(countColumnSchema.getColumnName());
+  }
+}

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/entityGroup.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/entityGroup.json
@@ -3,6 +3,7 @@
   "groupEntity": "variant",
   "itemsEntity": "person",
   "idPairsSqlFile":  "idPairs.sql",
+  "useSourceIdPairsSql": true,
   "groupEntityIdFieldName": "variant_row_num",
   "itemsEntityIdFieldName": "flattened_person_id"
 }

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/entityGroup.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/entityGroup.json
@@ -5,5 +5,10 @@
   "idPairsSqlFile":  "idPairs.sql",
   "useSourceIdPairsSql": true,
   "groupEntityIdFieldName": "variant_row_num",
-  "itemsEntityIdFieldName": "flattened_person_id"
+  "itemsEntityIdFieldName": "flattened_person_id",
+  "rollupCountsSql": {
+    "sqlFile": "rollupCounts.sql",
+    "entityIdFieldName": "variant_row_num",
+    "rollupCountFieldName": "num_persons"
+  }
 }

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/rollupCounts.sql
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/rollupCounts.sql
@@ -1,7 +1,6 @@
-SELECT v.variant_row_num, flattened_person_id
+SELECT v.variant_row_num, ARRAY_LENGTH(vtop.person_ids) AS num_persons
 /* Wrap variant_to_person table in a SELECT DISTINCT because there is a duplicate row in the test data. */
 FROM (SELECT DISTINCT vid, person_ids FROM `${omopDataset}.variant_to_person`) AS vtop
 JOIN
   (SELECT ROW_NUMBER() OVER (ORDER BY vid) AS variant_row_num, vid FROM `${omopDataset}.prep_vat`)
   AS v ON v.vid = vtop.vid
-CROSS JOIN UNNEST(vtop.person_ids) AS flattened_person_id


### PR DESCRIPTION
Add a new config property `useSourceIdPairsSql` for `GroupItems` type entity groups. Default is false, matching existing behavior. When set to true:
- The indexer does not run the `WriteRelationshipIdPairs` job to copy the id pairs into the index dataset.
- The service queries the source table directly instead of the not-generated index table.

It would be good to support this config property for all source SQL, not just for this specific relationship in a single entity group type. However, this is the only change we need to support variant search, so we can plan to do the larger, more correct & comprehensive change in follow-on PRs.

The `aouCT_testonly/variantPerson` entity group is currently the only config that sets this flag to true. Manual tests:
- Tested indexing (dry run) this group and confirmed that the copy job doesn't run.
- Tested building a cohort with criteria that uses this group and confirmed that the generated SQL uses the source SQL.