### PR TITLE
Optionally use rollup counts SQL instead of Dataflow job for GroupItems entity group.

### DIFF
--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -642,7 +642,7 @@ Required if the [id pairs SQL](#szgroupitemsidpairssqlfile) is defined.
 
 Name of the group entity - items entity id pairs SQL file.
 
-If this property is set, then the [id pairs SQL](#szgroupitemsidpairssqlfile) must be unset. File must be in the same directory as the entity group file. Name includes file extension.
+File must be in the same directory as the entity group file. Name includes file extension.
 
 There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the group and items entity ids are required. If this property is set, then the [foreign key atttribute](#szgroupitemsforeignkeyattributeitemsentity) must be unset.
 
@@ -668,6 +668,11 @@ Required if the [id pairs SQL](#szgroupitemsidpairssqlfile) is defined.
 Name of the entity group.
 
 This is the unique identifier for the entity group. In a single underlay, the entity group names of any group type cannot overlap. Name may not include spaces or special characters, only letters and numbers. The first character must be a letter.
+
+### SZGroupItems.rollupCountsSql
+**optional** SZRollupCountsSql
+
+Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs.
 
 ### SZGroupItems.useSourceIdPairsSql
 **optional** boolean

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -31,11 +31,7 @@ import bio.terra.tanagra.underlay.indextable.ITHierarchyAncestorDescendant;
 import bio.terra.tanagra.underlay.indextable.ITHierarchyChildParent;
 import bio.terra.tanagra.underlay.indextable.ITRelationshipIdPairs;
 import bio.terra.tanagra.underlay.serialization.SZIndexer;
-import bio.terra.tanagra.underlay.sourcetable.STEntityAttributes;
-import bio.terra.tanagra.underlay.sourcetable.STHierarchyChildParent;
-import bio.terra.tanagra.underlay.sourcetable.STHierarchyRootFilter;
-import bio.terra.tanagra.underlay.sourcetable.STRelationshipIdPairs;
-import bio.terra.tanagra.underlay.sourcetable.STTextSearchTerms;
+import bio.terra.tanagra.underlay.sourcetable.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -192,6 +188,14 @@ public final class JobSequencer {
                     groupItems.getGroupEntity().getName(),
                     groupItems.getItemsEntity().getName())
             : null;
+    STRelationshipRollupCounts groupItemsRelationshipRollupCountsTable =
+        underlay
+            .getSourceSchema()
+            .getRelationshipRollupCounts(
+                groupItems.getName(),
+                groupItems.getGroupEntity().getName(),
+                groupItems.getItemsEntity().getName())
+            .orElse(null);
     jobSet.addJob(
         new WriteRollupCounts(
             indexerConfig,
@@ -203,7 +207,8 @@ public final class JobSequencer {
             itemsEntityIndexTable,
             groupItemsIdPairsTable,
             null,
-            null));
+            null,
+            groupItemsRelationshipRollupCountsTable));
 
     // If the criteria entity has hierarchies, then also compute the criteria rollup counts for each
     // hierarchy.
@@ -228,7 +233,8 @@ public final class JobSequencer {
                           underlay
                               .getIndexSchema()
                               .getHierarchyAncestorDescendant(
-                                  groupItems.getGroupEntity().getName(), hierarchy.getName()))));
+                                  groupItems.getGroupEntity().getName(), hierarchy.getName()),
+                          null)));
     }
 
     if (groupItems.getGroupEntity().hasHierarchies()) {
@@ -378,6 +384,7 @@ public final class JobSequencer {
             primaryEntityIndexTable,
             primaryCriteriaIdPairsTable,
             null,
+            null,
             null));
 
     // If the criteria entity has hierarchies, then also compute the criteria rollup counts for each
@@ -404,7 +411,8 @@ public final class JobSequencer {
                               .getIndexSchema()
                               .getHierarchyAncestorDescendant(
                                   criteriaOccurrence.getCriteriaEntity().getName(),
-                                  hierarchy.getName()))));
+                                  hierarchy.getName()),
+                          null)));
     }
 
     // Compute instance-level display hints for the occurrence entity attributes that are flagged as

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -114,6 +114,7 @@ export type SZGroupItems = {
   itemsEntity: string;
   itemsEntityIdFieldName?: string;
   name: string;
+  rollupCountsSql?: szrollupcountssql;
   useSourceIdPairsSql?: boolean;
 };
 

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZGroupItems.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZGroupItems.java
@@ -38,7 +38,6 @@ public class SZGroupItems {
       name = "SZGroupItems.idPairsSqlFile",
       markdown =
           "Name of the group entity - items entity id pairs SQL file.\n\n"
-              + "If this property is set, then the [id pairs SQL](${SZGroupItems.idPairsSqlFile}) must be unset. "
               + "File must be in the same directory as the entity group file. Name includes file extension.\n\n"
               + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the "
               + "group and items entity ids are required. If this property is set, then the "
@@ -73,4 +72,11 @@ public class SZGroupItems {
       optional = true,
       exampleValue = "items_id")
   public String itemsEntityIdFieldName;
+
+  @AnnotatedField(
+      name = "SZGroupItems.rollupCountsSql",
+      markdown =
+          "Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs.",
+      optional = true)
+  public SZRollupCountsSql rollupCountsSql;
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZRollupCountsSql.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZRollupCountsSql.java
@@ -1,0 +1,33 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.*;
+
+@AnnotatedClass(
+    name = "SZRollupCountsSql",
+    markdown =
+        "Pointer to SQL that returns entity id - rollup count (= number of related entity instances) pairs "
+            + "(e.g. variant - number of people). Useful when there's an easy way to calculate these in SQL "
+            + "and we want to avoid ingesting the full entity - related entity relationship id pairs table into Dataflow.")
+public class SZRollupCountsSql {
+  @AnnotatedField(
+      name = "SZRollupCountsSql.rollupCountsSqlFile",
+      markdown =
+          "Name of the entity id - rollup counts (= number of items entity instances) pairs SQL file.\n\n"
+              + "File must be in the same directory as the entity/group file. Name includes file extension.\n\n"
+              + "There can be other columns selected in the SQL file (e.g. `SELECT * FROM relationships`), but the "
+              + "entity id and rollup count fields are required.",
+      exampleValue = "rollupCounts.sql")
+  public String sqlFile;
+
+  @AnnotatedField(
+      name = "SZRollupCountsSql.entityIdFieldName",
+      markdown = "Name of the field or column name that maps to the entity id.",
+      exampleValue = "entity_id")
+  public String entityIdFieldName;
+
+  @AnnotatedField(
+      name = "SZRollupCountsSql.rollupCountFieldName",
+      markdown = "Name of the field or column name that maps to the rollup count per entity id.",
+      exampleValue = "rollup_count")
+  public String rollupCountFieldName;
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STRelationshipRollupCounts.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/sourcetable/STRelationshipRollupCounts.java
@@ -1,0 +1,55 @@
+package bio.terra.tanagra.underlay.sourcetable;
+
+import bio.terra.tanagra.api.shared.DataType;
+import bio.terra.tanagra.query.bigquery.BQTable;
+import bio.terra.tanagra.query.sql.SqlField;
+import bio.terra.tanagra.underlay.ColumnSchema;
+import com.google.common.collect.ImmutableList;
+
+public class STRelationshipRollupCounts extends SourceTable {
+  private final String entityGroup;
+  private final String entity;
+  private final String countedEntity;
+  private final ColumnSchema entityIdColumnSchema;
+  private final ColumnSchema countColumnSchema;
+
+  public STRelationshipRollupCounts(
+      BQTable bqTable,
+      String entityGroup,
+      String entity,
+      String countedEntity,
+      String entityIdFieldName,
+      String countFieldName) {
+    super(bqTable);
+    this.entityGroup = entityGroup;
+    this.entity = entity;
+    this.countedEntity = countedEntity;
+    this.entityIdColumnSchema = new ColumnSchema(entityIdFieldName, DataType.INT64);
+    this.countColumnSchema = new ColumnSchema(countFieldName, DataType.INT64);
+  }
+
+  @Override
+  public ImmutableList<ColumnSchema> getColumnSchemas() {
+    return ImmutableList.of(entityIdColumnSchema, countColumnSchema);
+  }
+
+  public String getEntityGroup() {
+    return entityGroup;
+  }
+
+  public String getEntity() {
+    return entity;
+  }
+
+  public String getCountedEntity() {
+    return countedEntity;
+  }
+
+  public SqlField getEntityIdField() {
+    return SqlField.of(entityIdColumnSchema.getColumnName());
+  }
+
+  public SqlField getCountField() {
+    return SqlField.of(countColumnSchema.getColumnName());
+  }
+}

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/entityGroup.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/entityGroup.json
@@ -5,5 +5,10 @@
   "idPairsSqlFile":  "idPairs.sql",
   "useSourceIdPairsSql": true,
   "groupEntityIdFieldName": "variant_row_num",
-  "itemsEntityIdFieldName": "flattened_person_id"
+  "itemsEntityIdFieldName": "flattened_person_id",
+  "rollupCountsSql": {
+    "sqlFile": "rollupCounts.sql",
+    "entityIdFieldName": "variant_row_num",
+    "rollupCountFieldName": "num_persons"
+  }
 }

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/rollupCounts.sql
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entitygroup/variantPerson/rollupCounts.sql
@@ -1,7 +1,6 @@
-SELECT v.variant_row_num, flattened_person_id
+SELECT v.variant_row_num, ARRAY_LENGTH(vtop.person_ids) AS num_persons
 /* Wrap variant_to_person table in a SELECT DISTINCT because there is a duplicate row in the test data. */
 FROM (SELECT DISTINCT vid, person_ids FROM `${omopDataset}.variant_to_person`) AS vtop
 JOIN
   (SELECT ROW_NUMBER() OVER (ORDER BY vid) AS variant_row_num, vid FROM `${omopDataset}.prep_vat`)
   AS v ON v.vid = vtop.vid
-CROSS JOIN UNNEST(vtop.person_ids) AS flattened_person_id


### PR DESCRIPTION
Add a new config property `rollupCountsSql` for `GroupItems` type entity groups. Default is null, matching existing behavior. When specified the indexer does not use Dataflow to compute rollup counts in the `WriteRollupCounts` job. Instead it reads it directly from the specified query.

It would be good to support this config property for all entity groups, not just for this specific relationship in a single entity group type. However, this is the only change could help support variant search, so we can plan to do the larger, more correct & comprehensive change in follow-on PRs.

The `aouCT_testonly/variantPerson` entity group is currently the only config that specifies this property. Manually tested indexing this group and confirmed that the Dataflow job doesn't run.
