### PR TITLE
Criteria group and section is disabled flag.

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -243,6 +243,7 @@ public class CohortsApiController implements CohortsApi {
         .joinOperator(joinOperator)
         .joinOperatorValue(apiObj.getOperatorValue())
         .setIsExcluded(apiObj.isExcluded())
+        .setIsDisabled(apiObj.isDisabled())
         .build();
   }
 
@@ -254,6 +255,7 @@ public class CohortsApiController implements CohortsApi {
             apiObj.getCriteria().stream()
                 .map(FromApiUtils::fromApiObject)
                 .collect(Collectors.toList()))
+        .isDisabled(apiObj.isDisabled())
         .build();
   }
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -132,7 +132,8 @@ public final class ToApiUtils {
             toApiObject(criteriaGroupSection.getFirstConditionReducingOperator()))
         .secondBlockReducingOperator(
             toApiObject(criteriaGroupSection.getSecondConditionRedcuingOperator()))
-        .excluded(criteriaGroupSection.isExcluded());
+        .excluded(criteriaGroupSection.isExcluded())
+        .disabled(criteriaGroupSection.isDisabled());
   }
 
   private static ApiReducingOperator toApiObject(ReducingOperator reducingOperator) {
@@ -148,7 +149,8 @@ public final class ToApiUtils {
         .criteria(
             criteriaGroup.getCriteria().stream()
                 .map(ToApiUtils::toApiObject)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList()))
+        .disabled(criteriaGroup.isDisabled());
   }
 
   public static ApiCriteria toApiObject(Criteria criteria) {

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -629,6 +629,7 @@ public class CohortDao {
                   cgs.getJoinOperator() == null ? null : cgs.getJoinOperator().name())
               .addValue("join_operator_value", cgs.getJoinOperatorValue())
               .addValue("is_excluded", cgs.isExcluded())
+              .addValue("is_disabled", cgs.isDisabled())
               .addValue("list_index", cgsListIndex));
 
       buildParamsForUpdateCriteriaHelper(
@@ -650,8 +651,8 @@ public class CohortDao {
     }
 
     sql =
-        "INSERT INTO criteria_group_section (cohort_revision_id, id, display_name, operator, is_excluded, first_condition_reducing_operator, second_condition_reducing_operator, join_operator, join_operator_value, list_index) "
-            + "VALUES (:cohort_revision_id, :id, :display_name, :operator, :is_excluded, :first_condition_reducing_operator, :second_condition_reducing_operator, :join_operator, :join_operator_value, :list_index)";
+        "INSERT INTO criteria_group_section (cohort_revision_id, id, display_name, operator, is_excluded, is_disabled, first_condition_reducing_operator, second_condition_reducing_operator, join_operator, join_operator_value, list_index) "
+            + "VALUES (:cohort_revision_id, :id, :display_name, :operator, :is_excluded, :is_disabled, :first_condition_reducing_operator, :second_condition_reducing_operator, :join_operator, :join_operator_value, :list_index)";
     LOGGER.debug("CREATE criteria_group_section: {}", sql);
     rowsAffected =
         Arrays.stream(
@@ -661,8 +662,8 @@ public class CohortDao {
     LOGGER.debug("CREATE criteria_group_section rowsAffected = {}", rowsAffected);
 
     sql =
-        "INSERT INTO criteria_group (cohort_revision_id, criteria_group_section_id, id, display_name, condition_index, list_index) "
-            + "VALUES (:cohort_revision_id, :criteria_group_section_id, :id, :display_name, :condition_index, :list_index)";
+        "INSERT INTO criteria_group (cohort_revision_id, criteria_group_section_id, id, display_name, condition_index, list_index, is_disabled) "
+            + "VALUES (:cohort_revision_id, :criteria_group_section_id, :id, :display_name, :condition_index, :list_index, :is_disabled)";
     LOGGER.debug("CREATE criteria_group: {}", sql);
     rowsAffected =
         Arrays.stream(
@@ -709,7 +710,8 @@ public class CohortDao {
               .addValue("id", cg.getId())
               .addValue("display_name", cg.getDisplayName())
               .addValue("list_index", cgListIndex)
-              .addValue("condition_index", criteriaGroupConditionIndex));
+              .addValue("condition_index", criteriaGroupConditionIndex)
+              .addValue("is_disabled", cg.isDisabled()));
 
       for (int cListIndex = 0; cListIndex < cg.getCriteria().size(); cListIndex++) {
         Criteria c = cg.getCriteria().get(cListIndex);

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -69,7 +69,7 @@ public class CohortDao {
 
   // SQL query and row mapper for reading a criteria group section.
   private static final String CRITERIA_GROUP_SECTION_SELECT_SQL =
-      "SELECT cohort_revision_id, id, display_name, operator, is_excluded, first_condition_reducing_operator, second_condition_reducing_operator, join_operator, join_operator_value FROM criteria_group_section";
+      "SELECT cohort_revision_id, id, display_name, operator, is_excluded, is_disabled, first_condition_reducing_operator, second_condition_reducing_operator, join_operator, join_operator_value FROM criteria_group_section";
   private static final RowMapper<Pair<String, CohortRevision.CriteriaGroupSection.Builder>>
       CRITERIA_GROUP_SECTION_ROW_MAPPER =
           (rs, rowNum) ->
@@ -81,6 +81,7 @@ public class CohortDao {
                       .operator(
                           BooleanAndOrFilter.LogicalOperator.valueOf(rs.getString("operator")))
                       .setIsExcluded(rs.getBoolean("is_excluded"))
+                      .setIsDisabled(rs.getBoolean("is_disabled"))
                       .firstConditionReducingOperator(
                           rs.getString("first_condition_reducing_operator") == null
                               ? null
@@ -99,7 +100,7 @@ public class CohortDao {
 
   // SQL query and row mapper for reading a criteria group.
   private static final String CRITERIA_GROUP_SELECT_SQL =
-      "SELECT cohort_revision_id, criteria_group_section_id, id, display_name, condition_index FROM criteria_group";
+      "SELECT cohort_revision_id, criteria_group_section_id, id, display_name, condition_index, is_disabled FROM criteria_group";
   private static final RowMapper<
           Pair<Pair<List<String>, Integer>, CohortRevision.CriteriaGroup.Builder>>
       CRITERIA_GROUP_ROW_MAPPER =
@@ -112,7 +113,8 @@ public class CohortDao {
                       rs.getObject("condition_index", Integer.class)),
                   CohortRevision.CriteriaGroup.builder()
                       .id(rs.getString("id"))
-                      .displayName(rs.getString("display_name")));
+                      .displayName(rs.getString("display_name"))
+                      .isDisabled(rs.getBoolean("is_disabled")));
 
   // SQL query and row mapper for reading a criteria.
   private static final String CRITERIA_SELECT_SQL =

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/CohortRevision.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/CohortRevision.java
@@ -234,6 +234,7 @@ public final class CohortRevision {
     private final JoinOperator joinOperator;
     private final Integer joinOperatorValue;
     private final boolean isExcluded;
+    private final boolean isDisabled;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     private CriteriaGroupSection(
@@ -246,7 +247,8 @@ public final class CohortRevision {
         ReducingOperator secondConditionReducingOperator,
         JoinOperator joinOperator,
         Integer joinOperatorValue,
-        boolean isExcluded) {
+        boolean isExcluded,
+        boolean isDisabled) {
       this.id = id;
       this.displayName = displayName;
       this.criteriaGroups = criteriaGroups;
@@ -257,6 +259,7 @@ public final class CohortRevision {
       this.joinOperator = joinOperator;
       this.joinOperatorValue = joinOperatorValue;
       this.isExcluded = isExcluded;
+      this.isDisabled = isDisabled;
     }
 
     public static Builder builder() {
@@ -310,6 +313,10 @@ public final class CohortRevision {
       return isExcluded;
     }
 
+    public boolean isDisabled() {
+      return isDisabled;
+    }
+
     public static class Builder {
       private String id;
       private String displayName;
@@ -321,6 +328,7 @@ public final class CohortRevision {
       private JoinOperator joinOperator;
       private Integer joinOperatorValue;
       private boolean isExcluded;
+      private boolean isDisabled;
 
       public Builder id(String id) {
         this.id = id;
@@ -375,6 +383,11 @@ public final class CohortRevision {
         return this;
       }
 
+      public Builder setIsDisabled(boolean isDisabled) {
+        this.isDisabled = isDisabled;
+        return this;
+      }
+
       public CriteriaGroupSection build() {
         if (id == null) {
           id = ServiceUtils.newArtifactId();
@@ -389,7 +402,8 @@ public final class CohortRevision {
             secondConditionReducingOperator,
             joinOperator,
             joinOperatorValue,
-            isExcluded);
+            isExcluded,
+            isDisabled);
       }
 
       public String getId() {
@@ -415,6 +429,7 @@ public final class CohortRevision {
       }
       CriteriaGroupSection that = (CriteriaGroupSection) o;
       return isExcluded == that.isExcluded
+          && isDisabled == that.isDisabled
           && id.equals(that.id)
           && Objects.equals(displayName, that.displayName)
           && criteriaGroups.equals(that.criteriaGroups)
@@ -438,7 +453,8 @@ public final class CohortRevision {
           secondConditionRedcuingOperator,
           joinOperator,
           joinOperatorValue,
-          isExcluded);
+          isExcluded,
+          isDisabled);
     }
   }
 
@@ -446,11 +462,14 @@ public final class CohortRevision {
     private final String id;
     private final String displayName;
     private final List<Criteria> criteria;
+    private final boolean isDisabled;
 
-    private CriteriaGroup(String id, String displayName, List<Criteria> criteria) {
+    private CriteriaGroup(
+        String id, String displayName, List<Criteria> criteria, boolean isDisabled) {
       this.id = id;
       this.displayName = displayName;
       this.criteria = criteria;
+      this.isDisabled = isDisabled;
     }
 
     public static Builder builder() {
@@ -469,10 +488,15 @@ public final class CohortRevision {
       return Collections.unmodifiableList(criteria);
     }
 
+    public boolean isDisabled() {
+      return isDisabled;
+    }
+
     public static class Builder {
       private String id;
       private String displayName;
       private List<Criteria> criteria = new ArrayList<>();
+      private boolean isDisabled;
 
       public Builder id(String id) {
         this.id = id;
@@ -489,11 +513,16 @@ public final class CohortRevision {
         return this;
       }
 
+      public Builder isDisabled(boolean isDisabled) {
+        this.isDisabled = isDisabled;
+        return this;
+      }
+
       public CriteriaGroup build() {
         if (id == null) {
           id = ServiceUtils.newArtifactId();
         }
-        return new CriteriaGroup(id, displayName, criteria);
+        return new CriteriaGroup(id, displayName, criteria, isDisabled);
       }
 
       public String getId() {
@@ -516,12 +545,13 @@ public final class CohortRevision {
       CriteriaGroup that = (CriteriaGroup) o;
       return id.equals(that.id)
           && displayName.equals(that.displayName)
-          && criteria.equals(that.criteria);
+          && criteria.equals(that.criteria)
+          && isDisabled == that.isDisabled;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(id, displayName, criteria);
+      return Objects.hash(id, displayName, criteria, isDisabled);
     }
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/filter/FilterBuilderService.java
@@ -47,7 +47,7 @@ public class FilterBuilderService {
 
   public EntityFilter buildCohortFilterForCriteriaGroup(
       String underlayName, CohortRevision.CriteriaGroup criteriaGroup) {
-    if (criteriaGroup.getCriteria().isEmpty()) {
+    if (criteriaGroup.isDisabled() || criteriaGroup.getCriteria().isEmpty()) {
       return null;
     }
 
@@ -95,6 +95,9 @@ public class FilterBuilderService {
 
   public EntityFilter buildFilterForCriteriaGroupSection(
       String underlayName, CohortRevision.CriteriaGroupSection criteriaGroupSection) {
+    if (criteriaGroupSection.isDisabled()) {
+      return null;
+    }
     EntityFilter includeFilter;
     if (criteriaGroupSection.getJoinOperator() != null) {
       // Temporal section.

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2402,12 +2402,16 @@ components:
         excluded:
           type: boolean
           description: True to exclude the section, false to include it
+        disabled:
+          type: boolean
+          description: True to disable the section
       required:
         - id
         - displayName
         - criteriaGroups
         - operator
         - excluded
+        - disabled
 
     ReducingOperator:
       description: |
@@ -2431,10 +2435,14 @@ components:
           description: Set of criteria in the group
           items:
             $ref: "#/components/schemas/Criteria"
+        disabled:
+          type: boolean
+          description: True to disable the group
       required:
         - id
         - displayName
         - criteria
+        - disabled
 
     Criteria:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2405,13 +2405,13 @@ components:
         disabled:
           type: boolean
           description: True to disable the section
+          default: false
       required:
         - id
         - displayName
         - criteriaGroups
         - operator
         - excluded
-        - disabled
 
     ReducingOperator:
       description: |
@@ -2438,11 +2438,11 @@ components:
         disabled:
           type: boolean
           description: True to disable the group
+          default: false
       required:
         - id
         - displayName
         - criteria
-        - disabled
 
     Criteria:
       type: object

--- a/service/src/main/resources/db/changelog.xml
+++ b/service/src/main/resources/db/changelog.xml
@@ -27,4 +27,5 @@
     <include file="changesets/20240304_selector_column.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20240326_remove_criteria_group_columns.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20240709_temporal_criteria_group_sections.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240913_disable_criteria_group_section.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/service/src/main/resources/db/changesets/20240913_disable_criteria_group_section.yaml
+++ b/service/src/main/resources/db/changesets/20240913_disable_criteria_group_section.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: disable_criteria_group_section
+      author: marikomedlock
+      dbms: postgresql,mariadb,mysql
+      changes:
+        - addColumn:
+            tableName: criteria_group_section
+            columns:
+              - column:
+                  name: is_disabled
+                  type: ${boolean.type}
+                  constraints:
+                    nullable: true
+
+        - addColumn:
+            tableName: criteria_group
+            columns:
+              - column:
+                  name: is_disabled
+                  type: ${boolean.type}
+                  constraints:
+                    nullable: true

--- a/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/CohortServiceTest.java
@@ -1,9 +1,11 @@
 package bio.terra.tanagra.service;
 
+import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_CONDITION_AND_DISABLED_DEMOGRAPHICS;
 import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
 import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_PROCEDURE;
 import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_TEMPORAL_DURING_SAME_ENCOUNTER;
 import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.CRITERIA_GROUP_SECTION_TEMPORAL_WITHIN_NUM_DAYS;
+import static bio.terra.tanagra.service.criteriaconstants.cmssynpuf.CriteriaGroupSection.DISABLED_CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -279,6 +281,27 @@ public class CohortServiceTest {
     assertEquals(
         List.of(
             CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION, CRITERIA_GROUP_SECTION_PROCEDURE),
+        updatedCohort1.getMostRecentRevision().getSections());
+
+    // Update cohort1 with disabled criteria group section and disabled criteria group.
+    updatedCohort1 =
+        cohortService.updateCohort(
+            study1.getId(),
+            cohort1.getId(),
+            USER_EMAIL_1,
+            null,
+            null,
+            List.of(
+                DISABLED_CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+                CRITERIA_GROUP_SECTION_CONDITION_AND_DISABLED_DEMOGRAPHICS));
+    assertNotNull(updatedCohort1);
+    LOGGER.info(
+        "Updated cohort {} at {}", updatedCohort1.getId(), updatedCohort1.getLastModified());
+    assertEquals(2, updatedCohort1.getMostRecentRevision().getSections().size());
+    assertEquals(
+        List.of(
+            DISABLED_CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION,
+            CRITERIA_GROUP_SECTION_CONDITION_AND_DISABLED_DEMOGRAPHICS),
         updatedCohort1.getMostRecentRevision().getSections());
 
     // Create cohort2 with criteria.

--- a/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
+++ b/service/src/test/java/bio/terra/tanagra/service/FilterBuilderServiceTest.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.service;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.CR_CONDITION_EXCLUDED;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.CR_CONDITION_EXCLUDED_AND_GENDER;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.CR_EMPTY;
+import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.CR_GENDER_AND_DISABLED_CONDITION;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.C_CONDITION_EXCLUDED;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.C_CONDITION_EXCLUDED_AND_GENDER;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CohortRevision.C_EMPTY;
@@ -12,6 +13,8 @@ import static bio.terra.tanagra.service.criteriaconstants.sd.Criteria.PROCEDURE_
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_CONDITION_WITH_MODIFIER;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_EMPTY;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_GENDER;
+import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.DISABLED_CG_GENDER;
+import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_CONDITION_AND_DISABLED_GENDER;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_CONDITION_EXCLUDED;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_EMPTY;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_GENDER_AND_CONDITION;
@@ -21,6 +24,7 @@ import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSectio
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_TEMPORAL_SINGLE_GROUP_PER_CONDITION;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_TEMPORAL_UNSUPPORTED_CRITERIA_SELECTOR;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_TEMPORAL_UNSUPPORTED_MODIFIER;
+import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.DISABLED_CGS_CONDITION;
 import static bio.terra.tanagra.service.criteriaconstants.sd.FeatureSet.CS_CONDITION_AND_PROCEDURE;
 import static bio.terra.tanagra.service.criteriaconstants.sd.FeatureSet.CS_DEMOGRAPHICS;
 import static bio.terra.tanagra.service.criteriaconstants.sd.FeatureSet.CS_DEMOGRAPHICS_EXCLUDE_ID_AGE;
@@ -91,6 +95,11 @@ public class FilterBuilderServiceTest {
         filterBuilderService.buildCohortFilterForCriteriaGroup(
             UNDERLAY_NAME, CG_CONDITION_WITH_MODIFIER);
     assertEquals(conditionWithModifierCohortFilter(), cohortFilter);
+
+    // Disabled group = null filter.
+    cohortFilter =
+        filterBuilderService.buildCohortFilterForCriteriaGroup(UNDERLAY_NAME, DISABLED_CG_GENDER);
+    assertNull(cohortFilter);
   }
 
   @Test
@@ -148,6 +157,19 @@ public class FilterBuilderServiceTest {
         filterBuilderService.buildFilterForCriteriaGroupSection(
             UNDERLAY_NAME, CGS_NON_TEMPORAL_GROUPS_IN_SECOND_CONDITION);
     assertEquals(genderAndConditionWithModifierCohortFilter(), cohortFilter);
+
+    // Disabled section = null filter.
+    cohortFilter =
+        filterBuilderService.buildFilterForCriteriaGroupSection(
+            UNDERLAY_NAME, DISABLED_CGS_CONDITION);
+    assertNull(cohortFilter);
+
+    // Enabled section with one disabled group and one enabled group = filter for only enabled
+    // group.
+    cohortFilter =
+        filterBuilderService.buildFilterForCriteriaGroupSection(
+            UNDERLAY_NAME, CGS_CONDITION_AND_DISABLED_GENDER);
+    assertEquals(conditionWithModifierCohortFilter(), cohortFilter);
   }
 
   @Test
@@ -177,6 +199,12 @@ public class FilterBuilderServiceTest {
         filterBuilderService.buildFilterForCohortRevisions(
             UNDERLAY_NAME, List.of(CR_EMPTY, CR_CONDITION_EXCLUDED_AND_GENDER));
     assertEquals(conditionExcludedAndGenderCohortFilter(), cohortFilter);
+
+    // One disabled section and one enabled section = filter for only enabled section.
+    cohortFilter =
+        filterBuilderService.buildFilterForCohortRevision(
+            UNDERLAY_NAME, CR_GENDER_AND_DISABLED_CONDITION);
+    assertEquals(genderEqWomanCohortFilter(), cohortFilter);
   }
 
   @Test

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroup.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroup.java
@@ -26,6 +26,12 @@ public final class CriteriaGroup {
           .displayName("group 1")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_HISPANIC_OR_LATINO.getValue()))
           .build();
+  public static final CohortRevision.CriteriaGroup DISABLED_CRITERIA_GROUP_DEMOGRAPHICS =
+      CohortRevision.CriteriaGroup.builder()
+          .displayName("disabled group demographics")
+          .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_HISPANIC_OR_LATINO.getValue()))
+          .isDisabled(true)
+          .build();
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_CONDITION =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group condition")

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroupSection.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroupSection.java
@@ -34,6 +34,29 @@ public final class CriteriaGroupSection {
               .operator(BooleanAndOrFilter.LogicalOperator.OR)
               .build();
 
+  public static final CohortRevision.CriteriaGroupSection
+      DISABLED_CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION =
+          CohortRevision.CriteriaGroupSection.builder()
+              .displayName("disabled section demographics and condition")
+              .criteriaGroups(
+                  List.of(
+                      CriteriaGroup.CRITERIA_GROUP_DEMOGRAPHICS,
+                      CriteriaGroup.CRITERIA_GROUP_CONDITION))
+              .operator(BooleanAndOrFilter.LogicalOperator.OR)
+              .setIsDisabled(true)
+              .build();
+
+  public static final CohortRevision.CriteriaGroupSection
+      CRITERIA_GROUP_SECTION_CONDITION_AND_DISABLED_DEMOGRAPHICS =
+          CohortRevision.CriteriaGroupSection.builder()
+              .displayName("section condition and disabled demographics")
+              .criteriaGroups(
+                  List.of(
+                      CriteriaGroup.CRITERIA_GROUP_CONDITION,
+                      CriteriaGroup.DISABLED_CRITERIA_GROUP_DEMOGRAPHICS))
+              .operator(BooleanAndOrFilter.LogicalOperator.OR)
+              .build();
+
   public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_PROCEDURE =
       CohortRevision.CriteriaGroupSection.builder()
           .displayName("section procedure")

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CohortRevision.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CohortRevision.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.service.criteriaconstants.sd;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_CONDITION_EXCLUDED;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_GENDER;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.CGS_PROCEDURE;
+import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroupSection.DISABLED_CGS_CONDITION;
 
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import java.util.List;
@@ -39,6 +40,14 @@ public final class CohortRevision {
           .sections(List.of(CGS_PROCEDURE))
           .setIsMostRecent(true)
           .build();
+  public static final bio.terra.tanagra.service.artifact.model.CohortRevision
+      CR_GENDER_AND_DISABLED_CONDITION =
+          bio.terra.tanagra.service.artifact.model.CohortRevision.builder()
+              .id("cr5")
+              .sections(List.of(CGS_GENDER, DISABLED_CGS_CONDITION))
+              .setIsMostRecent(true)
+              .build();
+
   public static final Cohort C_EMPTY =
       Cohort.builder().underlay(UNDERLAY_NAME).id("c1").revisions(List.of(CR_EMPTY)).build();
   public static final Cohort C_CONDITION_EXCLUDED =

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroup.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroup.java
@@ -17,6 +17,12 @@ public final class CriteriaGroup {
       CohortRevision.CriteriaGroup.builder().id("cg1").build();
   public static final CohortRevision.CriteriaGroup CG_GENDER =
       CohortRevision.CriteriaGroup.builder().id("cg2").criteria(List.of(GENDER_EQ_WOMAN)).build();
+  public static final CohortRevision.CriteriaGroup DISABLED_CG_GENDER =
+      CohortRevision.CriteriaGroup.builder()
+          .id("cg2d")
+          .criteria(List.of(GENDER_EQ_WOMAN))
+          .isDisabled(true)
+          .build();
   public static final CohortRevision.CriteriaGroup CG_CONDITION =
       CohortRevision.CriteriaGroup.builder()
           .id("cg3")

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroupSection.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroupSection.java
@@ -6,6 +6,7 @@ import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_CO
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_GENDER;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_PROCEDURE;
 import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.CG_PROCEDURE_WITH_MODIFIER;
+import static bio.terra.tanagra.service.criteriaconstants.sd.CriteriaGroup.DISABLED_CG_GENDER;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.shared.*;
@@ -27,6 +28,20 @@ public final class CriteriaGroupSection {
       CohortRevision.CriteriaGroupSection.builder()
           .id("cgs3")
           .criteriaGroups(List.of(CG_GENDER, CG_CONDITION_WITH_MODIFIER))
+          .operator(BooleanAndOrFilter.LogicalOperator.AND)
+          .build();
+
+  public static final CohortRevision.CriteriaGroupSection DISABLED_CGS_CONDITION =
+      CohortRevision.CriteriaGroupSection.builder()
+          .id("cgs2d")
+          .criteriaGroups(List.of(CG_CONDITION_WITH_MODIFIER))
+          .setIsExcluded(true)
+          .setIsDisabled(true)
+          .build();
+  public static final CohortRevision.CriteriaGroupSection CGS_CONDITION_AND_DISABLED_GENDER =
+      CohortRevision.CriteriaGroupSection.builder()
+          .id("cgs3d")
+          .criteriaGroups(List.of(CG_CONDITION_WITH_MODIFIER, DISABLED_CG_GENDER))
           .operator(BooleanAndOrFilter.LogicalOperator.AND)
           .build();
   public static final CohortRevision.CriteriaGroupSection CGS_GENDER =


### PR DESCRIPTION
Added an optional `disabled` flag to criteria groups and criteria group sections. When set, the group/section is excluded from the cohort filter. This applies to all places where a cohort is used: on the cohort overview page, when exporting, when creating a review. The flags are saved as part of the cohort, they are not ephemeral, so refreshing the page should not affect the state of the flags.