### PR TITLE
Empty entity group criteria should match any occurrences

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilder.java
@@ -5,13 +5,12 @@ import static bio.terra.tanagra.utils.ProtobufUtils.deserializeFromJsonOrProtoBy
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.proto.criteriaselector.ValueDataOuterClass;
 import bio.terra.tanagra.proto.criteriaselector.configschema.CFEntityGroup;
-import bio.terra.tanagra.proto.criteriaselector.configschema.CFEntityGroup.EntityGroup.EntityGroupConfig;
 import bio.terra.tanagra.proto.criteriaselector.dataschema.DTEntityGroup;
 import bio.terra.tanagra.underlay.uiplugin.CriteriaSelector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class EntityGroupFilterBuilder
     extends EntityGroupFilterBuilderBase<CFEntityGroup.EntityGroup, DTEntityGroup.EntityGroup> {
@@ -36,9 +35,12 @@ public class EntityGroupFilterBuilder
 
   @Override
   protected List<String> entityGroupIds() {
-    return deserializeConfig().getClassificationEntityGroupsList().stream()
-        .map(EntityGroupConfig::getId)
-        .collect(Collectors.toList());
+    CFEntityGroup.EntityGroup config = deserializeConfig();
+    return Stream.concat(
+            config.getClassificationEntityGroupsList().stream(),
+            config.getGroupingEntityGroupsList().stream())
+        .map(CFEntityGroup.EntityGroup.EntityGroupConfig::getId)
+        .toList();
   }
 
   @Override
@@ -59,6 +61,8 @@ public class EntityGroupFilterBuilder
   @Override
   protected ValueDataOuterClass.ValueData valueData(String serializedSelectionData) {
     DTEntityGroup.EntityGroup selectionData = deserializeData(serializedSelectionData);
-    return selectionData.hasValueData() ? selectionData.getValueData() : null;
+    return selectionData != null && selectionData.hasValueData()
+        ? selectionData.getValueData()
+        : null;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilderBase.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/EntityGroupFilterBuilderBase.java
@@ -53,11 +53,6 @@ public abstract class EntityGroupFilterBuilderBase<CF, DT> extends FilterBuilder
     // We want to build one filter per entity group, not one filter per selected id.
     Map<EntityGroup, List<Literal>> selectedIdsPerEntityGroup =
         selectedIdsPerEntityGroup(underlay, criteriaSelectionData);
-    if (selectedIdsPerEntityGroup.isEmpty() && modifiersSelectionData.isEmpty()) {
-      // Empty selection data = null filter for a cohort.
-      return null;
-    }
-
     List<EntityGroup> selectedEntityGroups =
         selectedEntityGroups(underlay, selectedIdsPerEntityGroup);
 
@@ -139,9 +134,9 @@ public abstract class EntityGroupFilterBuilderBase<CF, DT> extends FilterBuilder
         throw new InvalidQueryException("Group by modifiers are not supported for data features");
       }
 
-      // We want to build filters per entity group, not per selected id.
       ValueDataOuterClass.ValueData valueData = valueData(criteriaSelectionData);
 
+      // We want to build filters per entity group, not per selected id.
       Map<Entity, List<EntityFilter>> filtersPerEntity = new HashMap<>();
       selectedEntityGroups.forEach(
           entityGroup -> {

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
@@ -3,7 +3,6 @@ package bio.terra.tanagra.filterbuilder;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
@@ -56,7 +55,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void criteriaOnlyCohortFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup = CFEntityGroup.EntityGroup.newBuilder().build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "condition",
@@ -65,7 +64,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
@@ -629,7 +628,13 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void emptyCriteriaCohortFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup =
+        CFEntityGroup.EntityGroup.newBuilder()
+            .addClassificationEntityGroups(
+                CFEntityGroup.EntityGroup.EntityGroupConfig.newBuilder()
+                    .setId("conditionPerson")
+                    .build())
+            .build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "condition",
@@ -638,25 +643,37 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+    EntityFilter expectedCohortFilter =
+        new PrimaryWithCriteriaFilter(
+            underlay,
+            (CriteriaOccurrence) underlay.getEntityGroup("conditionPerson"),
+            null,
+            Map.of(),
+            null,
+            null,
+            null);
 
     // Null selection data.
     SelectionData selectionData = new SelectionData("condition", null);
     EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
 
     // Empty string selection data.
     selectionData = new SelectionData("condition", "");
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
 
     // Empty list selection.
     DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
     selectionData = new SelectionData("condition", serializeToJson(data));
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
   }
 
   @Test
@@ -669,7 +686,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             SZCorePlugin.ATTRIBUTE.getIdInConfig(),
             serializeToJson(ageAtOccurrenceConfig));
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup = CFEntityGroup.EntityGroup.newBuilder().build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "condition",
@@ -678,7 +695,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of(ageAtOccurrenceModifier));
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
@@ -743,7 +760,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             false,
             SZCorePlugin.UNHINTED_VALUE.getIdInConfig(),
             serializeToJson(groupByConfig));
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup = CFEntityGroup.EntityGroup.newBuilder().build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "condition",
@@ -752,7 +769,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of(groupByModifier));
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
@@ -803,7 +820,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void criteriaOnlySingleOccurrenceDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup = CFEntityGroup.EntityGroup.newBuilder().build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "condition",
@@ -812,7 +829,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
@@ -1015,7 +1032,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void criteriaOnlyMultipleOccurrencesDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup = CFEntityGroup.EntityGroup.newBuilder().build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "icd9cm",
@@ -1024,7 +1041,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
@@ -1153,7 +1170,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void criteriaWithAttrModifiersMultipleOccurrencesDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup entityGroup = CFEntityGroup.EntityGroup.newBuilder().build();
     CFAttribute.Attribute ageAtOccurrenceConfig =
         CFAttribute.Attribute.newBuilder().setAttribute("age_at_occurrence").build();
     CriteriaSelector.Modifier ageAtOccurrenceModifier =
@@ -1170,7 +1187,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of(ageAtOccurrenceModifier));
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
@@ -1231,7 +1248,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
 
   @Test
   void emptyCriteriaDataFeatureFilter() {
-    CFEntityGroup.EntityGroup config =
+    CFEntityGroup.EntityGroup entityGroup =
         CFEntityGroup.EntityGroup.newBuilder()
             .addClassificationEntityGroups(
                 CFEntityGroup.EntityGroup.EntityGroupConfig.newBuilder()
@@ -1246,7 +1263,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
             true,
             "core.EntityGroupFilterBuilder",
             SZCorePlugin.ENTITY_GROUP.getIdInConfig(),
-            serializeToJson(config),
+            serializeToJson(entityGroup),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
     EntityOutput expectedEntityOutput1 =

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
@@ -3,7 +3,6 @@ package bio.terra.tanagra.filterbuilder;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
@@ -412,7 +411,13 @@ public class EntityGroupFilterBuilderForGroupTest {
 
   @Test
   void emptyCriteriaCohortFilter() {
-    CFEntityGroup.EntityGroup config = CFEntityGroup.EntityGroup.newBuilder().build();
+    CFEntityGroup.EntityGroup config =
+        CFEntityGroup.EntityGroup.newBuilder()
+            .addClassificationEntityGroups(
+                CFEntityGroup.EntityGroup.EntityGroupConfig.newBuilder()
+                    .setId("genotypingPerson")
+                    .build())
+            .build();
     CriteriaSelector criteriaSelector =
         new CriteriaSelector(
             "genotyping",
@@ -424,22 +429,33 @@ public class EntityGroupFilterBuilderForGroupTest {
             serializeToJson(config),
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
+    EntityFilter expectedCohortFilter =
+        new ItemInGroupFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("genotypingPerson"),
+            null,
+            null,
+            null,
+            null);
 
     // Null selection data.
     SelectionData selectionData = new SelectionData("genotyping", null);
     EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
 
     // Empty string selection data.
     selectionData = new SelectionData("genotyping", "");
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
 
     // Empty list selection.
     DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
     selectionData = new SelectionData("genotyping", serializeToJson(data));
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
   }
 
   @Test

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
@@ -3,7 +3,6 @@ package bio.terra.tanagra.filterbuilder;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -266,21 +265,33 @@ public class EntityGroupFilterBuilderForItemsTest {
             List.of());
     EntityGroupFilterBuilder filterBuilder = new EntityGroupFilterBuilder(criteriaSelector);
 
+    EntityFilter expectedCohortFilter =
+        new GroupHasItemsFilter(
+            underlay,
+            (GroupItems) underlay.getEntityGroup("bloodPressurePerson"),
+            null,
+            null,
+            null,
+            null);
+
     // Null selection data.
     SelectionData selectionData = new SelectionData("bloodPressure", null);
     EntityFilter cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
 
     // Empty string selection data.
     selectionData = new SelectionData("bloodPressure", "");
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
 
     // Empty list selection.
     DTEntityGroup.EntityGroup data = DTEntityGroup.EntityGroup.newBuilder().build();
     selectionData = new SelectionData("bloodPressure", serializeToJson(data));
     cohortFilter = filterBuilder.buildForCohort(underlay, List.of(selectionData));
-    assertNull(cohortFilter);
+    assertNotNull(cohortFilter);
+    assertEquals(expectedCohortFilter, cohortFilter);
   }
 
   @Test


### PR DESCRIPTION
The current behavior of empty entity group criteria is to returna null filter, which effetively ignores the criteria. Instead, empty entity group criteria should check for the existence of any matching occurrence (e.g. any conditionOccurence for a person in a condition criteria).