### PR TITLE
Remove duplicate display fields for AoU source queries

### DIFF
--- a/underlay/src/main/resources/config/datamapping/aouCT/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT/entity/person/entity.json
@@ -38,7 +38,7 @@
       }
     },
     { "name": "self_reported_category_concept_id", "dataType": "INT64" },
-    { "name": "self_reported_category", "dataType": "INT64", "valueFieldName": "self_reported_category_concept_id", "displayFieldName": "self_reported_category", "isComputeDisplayHint": true,
+    { "name": "self_reported_category", "dataType": "INT64", "valueFieldName": "self_reported_category_concept_id", "isComputeDisplayHint": true,
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
@@ -5,21 +5,21 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "condition_occurrence_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "condition_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "condition_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "condition_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "condition_concept_id", "displayFieldName": "standard_concept_code",
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "condition_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "condition_concept_id", "displayFieldName": "standard_vocabulary",
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "condition_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -29,7 +29,7 @@
     { "name": "condition_start_datetime", "dataType": "TIMESTAMP" },
     { "name": "condition_end_datetime", "dataType": "TIMESTAMP" },
     { "name": "condition_type_concept_id", "dataType": "INT64" },
-    { "name": "condition_type_concept_name", "dataType": "INT64", "valueFieldName": "condition_type_concept_id", "displayFieldName": "condition_type_concept_name",
+    { "name": "condition_type_concept_name", "dataType": "INT64", "valueFieldName": "condition_type_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -41,21 +41,21 @@
     { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "condition_source_value", "dataType": "STRING" },
     { "name": "condition_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "condition_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "displayFieldName": "source_concept_code",
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "condition_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "condition_source_concept_id", "displayFieldName": "source_vocabulary",
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "condition_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -64,7 +64,7 @@
     },
     { "name": "condition_status_source_value", "dataType": "STRING" },
     { "name": "condition_status_concept_id", "dataType": "INT64" },
-    { "name": "condition_status_concept_name", "dataType": "INT64", "valueFieldName": "condition_status_concept_id", "displayFieldName": "condition_status_concept_name",
+    { "name": "condition_status_concept_name", "dataType": "INT64", "valueFieldName": "condition_status_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/deviceOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/deviceOccurrence/entity.json
@@ -5,21 +5,21 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "device_exposure_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "device_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "device_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "device_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "device_concept_id", "displayFieldName": "standard_concept_code",
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "device_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "device_concept_id", "displayFieldName": "standard_vocabulary",
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "device_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -29,7 +29,7 @@
     { "name": "device_exposure_start_datetime", "dataType": "TIMESTAMP" },
     { "name": "device_exposure_end_datetime", "dataType": "TIMESTAMP" },
     { "name": "device_type_concept_id", "dataType": "INT64" },
-    { "name": "device_type_concept_name", "dataType": "INT64", "valueFieldName": "device_type_concept_id", "displayFieldName": "device_type_concept_name",
+    { "name": "device_type_concept_name", "dataType": "INT64", "valueFieldName": "device_type_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -40,21 +40,21 @@
     { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "device_source_value", "dataType": "STRING" },
     { "name": "device_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "device_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "device_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "device_source_concept_id", "displayFieldName": "source_concept_code",
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "device_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "device_source_concept_id", "displayFieldName": "source_vocabulary",
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "device_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientOccurrence/entity.json
@@ -5,21 +5,21 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "drug_exposure_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "drug_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "drug_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "drug_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "drug_concept_id", "displayFieldName": "standard_concept_code",
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "drug_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "drug_concept_id", "displayFieldName": "standard_vocabulary",
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "drug_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -30,7 +30,7 @@
     { "name": "drug_exposure_end_datetime", "dataType": "TIMESTAMP" },
     { "name": "verbatim_end_date", "dataType": "DATE" },
     { "name": "drug_type_concept_id", "dataType": "INT64" },
-    { "name": "drug_type_concept_name", "dataType": "INT64", "valueFieldName": "drug_type_concept_id", "displayFieldName": "drug_type_concept_name",
+    { "name": "drug_type_concept_name", "dataType": "INT64", "valueFieldName": "drug_type_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -43,7 +43,7 @@
     { "name": "days_supply", "dataType": "INT64" },
     { "name": "sig", "dataType": "STRING" },
     { "name": "route_concept_id", "dataType": "INT64" },
-    { "name": "route_concept_name", "dataType": "INT64", "valueFieldName": "route_concept_id", "displayFieldName": "route_concept_name",
+    { "name": "route_concept_name", "dataType": "INT64", "valueFieldName": "route_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -55,21 +55,21 @@
     { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "drug_source_value", "dataType": "STRING" },
     { "name": "drug_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "drug_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "drug_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "drug_source_concept_id", "displayFieldName": "source_concept_code",
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "drug_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "drug_source_concept_id", "displayFieldName": "source_vocabulary",
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "drug_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementOccurrence/entity.json
@@ -5,21 +5,21 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "measurement_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "measurement_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "measurement_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "measurement_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "measurement_concept_id", "displayFieldName": "standard_concept_code",
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "measurement_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "measurement_concept_id", "displayFieldName": "standard_vocabulary",
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "measurement_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -28,7 +28,7 @@
     },
     { "name": "measurement_datetime", "dataType": "TIMESTAMP" },
     { "name": "measurement_type_concept_id", "dataType": "INT64" },
-    { "name": "measurement_type_concept_name", "dataType": "INT64", "valueFieldName": "measurement_type_concept_id", "displayFieldName": "measurement_type_concept_name",
+    { "name": "measurement_type_concept_name", "dataType": "INT64", "valueFieldName": "measurement_type_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -36,7 +36,7 @@
       }
     },
     { "name": "operator_concept_id", "dataType": "INT64" },
-    { "name": "operator_concept_name", "dataType": "INT64", "valueFieldName": "operator_concept_id", "displayFieldName": "operator_concept_name",
+    { "name": "operator_concept_name", "dataType": "INT64", "valueFieldName": "operator_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -45,7 +45,7 @@
     },
     { "name": "value_as_number", "dataType": "DOUBLE" },
     { "name": "value_as_concept_id", "dataType": "INT64" },
-    { "name": "value_as_concept_name", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name",
+    { "name": "value_as_concept_name", "dataType": "INT64", "valueFieldName": "value_as_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -53,7 +53,7 @@
       }
     },
     { "name": "unit_concept_id", "dataType": "INT64" },
-    { "name": "unit_concept_name", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name",
+    { "name": "unit_concept_name", "dataType": "INT64", "valueFieldName": "unit_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -66,21 +66,21 @@
     { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "measurement_source_value", "dataType": "STRING" },
     { "name": "measurement_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id", "displayFieldName": "source_concept_code",
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id", "displayFieldName": "source_vocabulary",
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "measurement_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/observationOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/observationOccurrence/entity.json
@@ -5,21 +5,21 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "observation_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "observation_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "observation_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "observation_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "observation_concept_id", "displayFieldName": "standard_concept_code",
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "observation_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "observation_concept_id", "displayFieldName": "standard_vocabulary",
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "observation_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -28,7 +28,7 @@
     },
     { "name": "observation_datetime", "dataType": "TIMESTAMP" },
     { "name": "observation_type_concept_id", "dataType": "INT64" },
-    { "name": "observation_type_concept_name", "dataType": "INT64", "valueFieldName": "observation_type_concept_id", "displayFieldName": "observation_type_concept_name",
+    { "name": "observation_type_concept_name", "dataType": "INT64", "valueFieldName": "observation_type_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -38,7 +38,7 @@
     { "name": "value_as_number", "dataType": "DOUBLE" },
     { "name": "value_as_string", "dataType": "STRING" },
     { "name": "value_as_concept_id", "dataType": "INT64" },
-    { "name": "value_as_concept_name", "dataType": "INT64", "valueFieldName": "value_as_concept_id", "displayFieldName": "value_as_concept_name",
+    { "name": "value_as_concept_name", "dataType": "INT64", "valueFieldName": "value_as_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -46,7 +46,7 @@
       }
     },
     { "name": "qualifier_concept_id", "dataType": "INT64" },
-    { "name": "qualifier_concept_name", "dataType": "INT64", "valueFieldName": "qualifier_concept_id", "displayFieldName": "qualifier_concept_name",
+    { "name": "qualifier_concept_name", "dataType": "INT64", "valueFieldName": "qualifier_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -54,7 +54,7 @@
       }
     },
     { "name": "unit_concept_id", "dataType": "INT64" },
-    { "name": "unit_concept_name", "dataType": "INT64", "valueFieldName": "unit_concept_id", "displayFieldName": "unit_concept_name",
+    { "name": "unit_concept_name", "dataType": "INT64", "valueFieldName": "unit_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -65,21 +65,21 @@
     { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "observation_source_value", "dataType": "STRING" },
     { "name": "observation_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "observation_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "observation_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "observation_source_concept_id", "displayFieldName": "source_concept_code",
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "observation_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "observation_source_concept_id", "displayFieldName": "source_vocabulary",
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "observation_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/person/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/person/entity.json
@@ -38,7 +38,7 @@
       }
     },
     { "name": "self_reported_category_concept_id", "dataType": "INT64" },
-    { "name": "self_reported_category", "dataType": "INT64", "valueFieldName": "self_reported_category_concept_id", "displayFieldName": "self_reported_category", "isComputeDisplayHint": true,
+    { "name": "self_reported_category", "dataType": "INT64", "valueFieldName": "self_reported_category_concept_id", "isComputeDisplayHint": true,
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureOccurrence/entity.json
@@ -5,21 +5,21 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "procedure_occurrence_id", "isSuppressedForExport": true },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "procedure_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "procedure_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "procedure_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "procedure_concept_id", "displayFieldName": "standard_concept_code",
+    { "name": "standard_concept_code", "dataType": "INT64", "valueFieldName": "procedure_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "procedure_concept_id", "displayFieldName": "standard_vocabulary",
+    { "name": "standard_vocabulary", "dataType": "INT64", "valueFieldName": "procedure_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",
@@ -28,7 +28,7 @@
     },
     { "name": "procedure_datetime", "dataType": "TIMESTAMP" },
     { "name": "procedure_type_concept_id", "dataType": "INT64" },
-    { "name": "procedure_type_concept_name", "dataType": "INT64", "valueFieldName": "procedure_type_concept_id", "displayFieldName": "procedure_type_concept_name",
+    { "name": "procedure_type_concept_name", "dataType": "INT64", "valueFieldName": "procedure_type_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -36,7 +36,7 @@
       }
     },
     { "name": "modifier_concept_id", "dataType": "INT64" },
-    { "name": "modifier_concept_name", "dataType": "INT64", "valueFieldName": "modifier_concept_id", "displayFieldName": "modifier_concept_name",
+    { "name": "modifier_concept_name", "dataType": "INT64", "valueFieldName": "modifier_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -48,21 +48,21 @@
     { "name": "visit_occurrence_concept_name", "dataType": "STRING", "isSuppressedForExport": true },
     { "name": "procedure_source_value", "dataType": "STRING" },
     { "name": "procedure_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id", "displayFieldName": "source_concept_code",
+    { "name": "source_concept_code", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_code",
         "displayFieldTable": "${omopDataset}.concept",
         "displayFieldTableJoinFieldName": "concept_id"
       }
     },
-    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id", "displayFieldName": "source_vocabulary",
+    { "name": "source_vocabulary", "dataType": "INT64", "valueFieldName": "procedure_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "vocabulary_id",
         "displayFieldTable": "${omopDataset}.concept",

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/visitOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/visitOccurrence/entity.json
@@ -5,7 +5,7 @@
     { "name": "id", "dataType": "INT64", "valueFieldName": "visit_occurrence_id" },
     { "name": "person_id", "dataType": "INT64" },
     { "name": "visit_concept_id", "dataType": "INT64" },
-    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "standard_concept_name",
+    { "name": "standard_concept_name", "dataType": "INT64", "valueFieldName": "visit_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",
@@ -16,7 +16,7 @@
     { "name": "visit_end_datetime", "dataType": "TIMESTAMP" },
     { "name": "visit_source_value", "dataType": "STRING" },
     { "name": "visit_source_concept_id", "dataType": "INT64" },
-    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "visit_source_concept_id", "displayFieldName": "source_concept_name",
+    { "name": "source_concept_name", "dataType": "INT64", "valueFieldName": "visit_source_concept_id",
       "sourceQuery": {
         "displayFieldName": "concept_name",
         "displayFieldTable": "${omopDataset}.concept",


### PR DESCRIPTION
Remove `displayFieldName` attributes where the field is the same as `name`. Was causing an 'Unrecognized name' error in cohort review.