### PR TITLE
DT-888 adding config fix for entities that do not have a primary key in the source table.

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -616,7 +616,7 @@ public class BQQueryRunner implements QueryRunner {
 
     // SELECT [select fields] FROM [source table]
     // JOIN [display table] ON [display join field]
-    // WHERE [source id field] IN [inner query against index data]
+    // WHERE [index id field] IN [inner query against index data] -> this where clause won't exist in all cases
     sql.append("SELECT ")
         .append(String.join(", ", selectFields))
         .append(" FROM ")

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -624,11 +624,7 @@ public class BQQueryRunner implements QueryRunner {
         .append(" AS ")
         .append(sourceTableAlias)
         .append(String.join("", displayTableJoins.values().stream().toList()))
-        .append(" WHERE ")
-        .append(sourceIdAttrSqlField.renderForSelect(sourceTableAlias))
-        .append(" IN (")
-        .append(indexDataSqlRequest.getSql())
-        .append(')');
+        .append(indexDataSqlRequest.getWhereClause());
     return new SqlQueryRequest(
         sql.toString(),
         sqlParams,

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlQueryRequest.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/SqlQueryRequest.java
@@ -2,6 +2,7 @@ package bio.terra.tanagra.query.sql;
 
 import bio.terra.tanagra.api.query.PageMarker;
 import jakarta.annotation.Nullable;
+import java.util.Optional;
 
 public class SqlQueryRequest {
   private final String sql;
@@ -25,6 +26,13 @@ public class SqlQueryRequest {
 
   public String getSql() {
     return sql;
+  }
+
+  public String getWhereClause() {
+    return Optional.of(sql.indexOf(" WHERE"))
+        .filter(index -> index != -1)
+        .map(index -> sql.substring(index))
+        .orElse("");
   }
 
   public SqlParams getSqlParams() {

--- a/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
+++ b/underlay/src/test/resources/sql/BQFieldTest/attributeFieldAgainstSourceData.sql
@@ -15,9 +15,4 @@
         ${concept} AS dt0              
             ON dt0.concept_id = st.gender_concept_id      
     WHERE
-        st.person_id IN (SELECT
-            id          
-        FROM
-            ${ENT_person}          
-        WHERE
-            person_source_value IS NOT NULL)
+        person_source_value IS NOT NULL


### PR DESCRIPTION
Adding config fix for entities that do not have a primary key in the source table. This change removes the outer source where clause and replaces it with the index where clause. 

Example:
Original SQL - expects the source table to have a primary key which doesn't exist in this case. This was making it impossible to config source queries in this case.
```
SELECT
  attributes...
FROM
  ${dataset}.activity_summary AS st
WHERE
  st.row_id IN (
  SELECT
    id
  FROM
    ${dataset}.T_ENT_activitySummary
  WHERE
    person_id IN (.... data feature sql....)
)
``` 

Revised SQL - using the where clause from index sql which makes the cleaner and it's not dependent on primary keys
```
SELECT
  attributes...
FROM
  ${dataset}.activity_summary AS st
WHERE
  person_id IN (.... data feature sql....)
``` 