### PR TITLE
Add option to get all studies

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesApiController.java
@@ -88,8 +88,9 @@ public class StudiesApiController implements StudiesApi {
       Integer offset,
       Integer limit) {
     ResourceCollection authorizedStudyIds =
-        allStudies ? ResourceCollection.allResourcesAllPermissions(STUDY, null) :
-            accessControlService.listAuthorizedResources(
+        allStudies
+            ? ResourceCollection.allResourcesAllPermissions(STUDY, null)
+            : accessControlService.listAuthorizedResources(
                 SpringAuthentication.getCurrentUser(),
                 Permissions.forActions(STUDY, READ),
                 offset,

--- a/service/src/main/java/bio/terra/tanagra/app/controller/StudiesApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/StudiesApiController.java
@@ -84,14 +84,16 @@ public class StudiesApiController implements StudiesApi {
       String createdBy,
       Boolean includeDeleted,
       List<String> properties,
+      Boolean allStudies,
       Integer offset,
       Integer limit) {
     ResourceCollection authorizedStudyIds =
-        accessControlService.listAuthorizedResources(
-            SpringAuthentication.getCurrentUser(),
-            Permissions.forActions(STUDY, READ),
-            offset,
-            limit);
+        allStudies ? ResourceCollection.allResourcesAllPermissions(STUDY, null) :
+            accessControlService.listAuthorizedResources(
+                SpringAuthentication.getCurrentUser(),
+                Permissions.forActions(STUDY, READ),
+                offset,
+                limit);
     List<Study> authorizedStudies =
         studyService.listStudies(
             authorizedStudyIds,

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -250,6 +250,7 @@ paths:
         - $ref: "#/components/parameters/StudyFilterCreatedBy"
         - $ref: "#/components/parameters/StudyFilterIncludeDeleted"
         - $ref: "#/components/parameters/StudyFilterProperties"
+        - $ref: "#/components/parameters/StudyFilterAllStudies"
         - $ref: "#/components/parameters/Offset"
         - $ref: "#/components/parameters/Limit"
       summary: List all studies a user can read
@@ -1219,6 +1220,15 @@ components:
         type: array
         items:
           type: string
+
+    StudyFilterAllStudies:
+      name: allStudies
+      in: query
+      description: True to include studies for all users
+      required: false
+      schema:
+        type: boolean
+        default: false
 
     ActivityLogFilterUserEmail:
       name: userEmail


### PR DESCRIPTION
Not sure this is the best way to handle this but we need a way to get the list of studies for all users for the SD/eMERGE admin pages. I've added an optional flag to the `listStudies` endpoint here but could also just do a separate endpoint.