### PR TITLE
[bench-4474] Return Cohort SQL in previewExport response

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -86,10 +86,7 @@ public class CohortsApiController implements CohortsApi {
   @Override
   public ResponseEntity<ApiCohort> getCohort(
       String studyId, String cohortId, String cohortRevisionId) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(COHORT, READ),
-        ResourceId.forCohort(studyId, cohortId));
+    accessControlService.checkReadAccess(studyId, List.of(cohortId), List.of());
     return ResponseEntity.ok(ToApiUtils.toApiObject(cohortService.getCohort(studyId, cohortId)));
   }
 
@@ -162,10 +159,7 @@ public class CohortsApiController implements CohortsApi {
   @Override
   public ResponseEntity<ApiInstanceCountList> queryCohortCounts(
       String studyId, String cohortId, ApiCohortCountQuery body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(COHORT, READ),
-        ResourceId.forCohort(studyId, cohortId));
+    accessControlService.checkReadAccess(studyId, List.of(cohortId), List.of());
     Cohort cohort = cohortService.getCohort(studyId, cohortId);
 
     accessControlService.throwIfUnauthorized(

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -19,9 +19,6 @@ import bio.terra.tanagra.generated.model.ApiExportPreviewRequest;
 import bio.terra.tanagra.generated.model.ApiExportRequest;
 import bio.terra.tanagra.generated.model.ApiExportResult;
 import bio.terra.tanagra.generated.model.ApiInstanceListResult;
-import bio.terra.tanagra.query.bigquery.translator.BQApiTranslator;
-import bio.terra.tanagra.query.sql.SqlParams;
-import bio.terra.tanagra.query.sql.SqlQueryRequest;
 import bio.terra.tanagra.service.UnderlayService;
 import bio.terra.tanagra.service.accesscontrol.AccessControlService;
 import bio.terra.tanagra.service.artifact.CohortService;
@@ -229,22 +226,12 @@ public class ExportApiController implements ExportApi {
             cohorts.stream().map(Cohort::getMostRecentRevision).collect(Collectors.toList()));
     Entity idEntity = underlay.getPrimaryEntity();
     AttributeField idAttributeField =
-        new AttributeField(
-            underlay,
-            idEntity,
-            idEntity.getIdAttribute(),
-            true);
+        new AttributeField(underlay, idEntity, idEntity.getIdAttribute(), true);
     ListQueryRequest indexListQueryRequest =
         ListQueryRequest.dryRunAgainstIndexData(
-            underlay,
-            idEntity,
-            List.of(idAttributeField),
-            combinedCohortFilter,
-            null,
-            null);
-    String entityIdSql = underlay.getQueryRunner().run(indexListQueryRequest).getSql();
-
-    return ResponseEntity.ok(apiEntityOutputs.entityIdSql(entityIdSql));
+            underlay, idEntity, List.of(idAttributeField), combinedCohortFilter, null, null);
+    String entityIdSql = underlay.getQueryRunner().run(indexListQueryRequest).getSqlNoParams();
+    return ResponseEntity.ok(apiEntityOutputs.entityIdSql(SqlFormatter.format(entityIdSql)));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/ExportApiController.java
@@ -1,10 +1,5 @@
 package bio.terra.tanagra.app.controller;
 
-import static bio.terra.tanagra.service.accesscontrol.Action.READ;
-import static bio.terra.tanagra.service.accesscontrol.ResourceType.COHORT;
-import static bio.terra.tanagra.service.accesscontrol.ResourceType.FEATURE_SET;
-import static bio.terra.tanagra.service.accesscontrol.ResourceType.UNDERLAY;
-
 import bio.terra.tanagra.api.field.AttributeField;
 import bio.terra.tanagra.api.field.ValueDisplayField;
 import bio.terra.tanagra.api.query.list.ListQueryRequest;
@@ -25,8 +20,6 @@ import bio.terra.tanagra.generated.model.ApiExportResult;
 import bio.terra.tanagra.generated.model.ApiInstanceListResult;
 import bio.terra.tanagra.service.UnderlayService;
 import bio.terra.tanagra.service.accesscontrol.AccessControlService;
-import bio.terra.tanagra.service.accesscontrol.Permissions;
-import bio.terra.tanagra.service.accesscontrol.ResourceId;
 import bio.terra.tanagra.service.artifact.CohortService;
 import bio.terra.tanagra.service.artifact.FeatureSetService;
 import bio.terra.tanagra.service.artifact.StudyService;
@@ -83,10 +76,7 @@ public class ExportApiController implements ExportApi {
 
   @Override
   public ResponseEntity<ApiExportModelList> listExportModels(String underlayName) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     // Get a map of implementation name -> (display name, class instance).
     List<DataExportModel> exportModels = dataExportService.getModels(underlayName);
     ApiExportModelList apiExportImpls = new ApiExportModelList();
@@ -97,32 +87,18 @@ public class ExportApiController implements ExportApi {
   @Override
   public ResponseEntity<ApiInstanceListResult> previewExportInstances(
       String underlayName, String entityName, ApiExportPreviewRequest body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
-    for (String cohortId : body.getCohorts()) {
-      accessControlService.throwIfUnauthorized(
-          SpringAuthentication.getCurrentUser(),
-          Permissions.forActions(COHORT, READ),
-          ResourceId.forCohort(body.getStudy(), cohortId));
-    }
-    for (String featureSetId : body.getFeatureSets()) {
-      accessControlService.throwIfUnauthorized(
-          SpringAuthentication.getCurrentUser(),
-          Permissions.forActions(FEATURE_SET, READ),
-          ResourceId.forFeatureSet(body.getStudy(), featureSetId));
-    }
+    accessControlService.checkUnderlayAccess(underlayName);
+    accessControlService.checkReadAccess(body.getStudy(), body.getCohorts(), body.getFeatureSets());
 
-    // Build the entity outputs.
+    // Build the entity output previews.
     List<Cohort> cohorts =
         body.getCohorts().stream()
             .map(cohortId -> cohortService.getCohort(body.getStudy(), cohortId))
-            .collect(Collectors.toList());
+            .toList();
     List<FeatureSet> featureSets =
         body.getFeatureSets().stream()
             .map(featureSetId -> featureSetService.getFeatureSet(body.getStudy(), featureSetId))
-            .collect(Collectors.toList());
+            .toList();
     List<EntityOutputPreview> entityOutputPreviews =
         filterBuilderService.buildOutputPreviewsForExport(
             cohorts, featureSets, body.isIncludeAllAttributes());
@@ -169,26 +145,18 @@ public class ExportApiController implements ExportApi {
   @Override
   public ResponseEntity<ApiEntityOutputPreviewList> describeExport(
       String underlayName, ApiExportPreviewRequest body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
-    for (String featureSetId : body.getFeatureSets()) {
-      accessControlService.throwIfUnauthorized(
-          SpringAuthentication.getCurrentUser(),
-          Permissions.forActions(FEATURE_SET, READ),
-          ResourceId.forFeatureSet(body.getStudy(), featureSetId));
-    }
+    accessControlService.checkUnderlayAccess(underlayName);
+    accessControlService.checkReadAccess(body.getStudy(), body.getCohorts(), body.getFeatureSets());
 
     // Build the entity output previews.
     List<Cohort> cohorts =
         body.getCohorts().stream()
             .map(cohortId -> cohortService.getCohort(body.getStudy(), cohortId))
-            .collect(Collectors.toList());
+            .toList();
     List<FeatureSet> featureSets =
         body.getFeatureSets().stream()
             .map(featureSetId -> featureSetService.getFeatureSet(body.getStudy(), featureSetId))
-            .collect(Collectors.toList());
+            .toList();
     List<EntityOutputPreview> entityOutputPreviews =
         filterBuilderService.buildOutputPreviewsForExport(
             cohorts, featureSets, body.isIncludeAllAttributes());
@@ -256,26 +224,8 @@ public class ExportApiController implements ExportApi {
   @Override
   public ResponseEntity<ApiExportResult> exportInstancesAndAnnotations(
       String underlayName, ApiExportRequest body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
-    for (String cohortId : body.getCohorts()) {
-      accessControlService.throwIfUnauthorized(
-          SpringAuthentication.getCurrentUser(),
-          Permissions.forActions(COHORT, READ),
-          ResourceId.forCohort(body.getStudy(), cohortId));
-    }
-    List<String> featureSetIds = new ArrayList<>();
-    if (body.getFeatureSets() != null) {
-      featureSetIds.addAll(body.getFeatureSets());
-    }
-    for (String featureSetId : featureSetIds) {
-      accessControlService.throwIfUnauthorized(
-          SpringAuthentication.getCurrentUser(),
-          Permissions.forActions(FEATURE_SET, READ),
-          ResourceId.forFeatureSet(body.getStudy(), featureSetId));
-    }
+    accessControlService.checkUnderlayAccess(underlayName);
+    accessControlService.checkReadAccess(body.getStudy(), body.getCohorts(), body.getFeatureSets());
 
     Underlay underlay = underlayService.getUnderlay(underlayName);
     Study study = studyService.getStudy(body.getStudy());
@@ -284,7 +234,7 @@ public class ExportApiController implements ExportApi {
             .map(cohortId -> cohortService.getCohort(body.getStudy(), cohortId))
             .collect(Collectors.toList());
     List<FeatureSet> featureSets =
-        featureSetIds.stream()
+        body.getFeatureSets().stream()
             .map(featureSetId -> featureSetService.getFeatureSet(body.getStudy(), featureSetId))
             .collect(Collectors.toList());
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/FeatureSetsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/FeatureSetsApiController.java
@@ -75,10 +75,7 @@ public class FeatureSetsApiController implements FeatureSetsApi {
 
   @Override
   public ResponseEntity<ApiFeatureSet> getFeatureSet(String studyId, String featureSetId) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(FEATURE_SET, READ),
-        ResourceId.forFeatureSet(studyId, featureSetId));
+    accessControlService.checkReadAccess(studyId, List.of(), List.of(featureSetId));
     return ResponseEntity.ok(toApiObject(featureSetService.getFeatureSet(studyId, featureSetId)));
   }
 
@@ -138,10 +135,7 @@ public class FeatureSetsApiController implements FeatureSetsApi {
     UserId user = SpringAuthentication.getCurrentUser();
 
     // should have read access to original feature set
-    accessControlService.throwIfUnauthorized(
-        user,
-        Permissions.forActions(FEATURE_SET, READ),
-        ResourceId.forFeatureSet(studyId, featureSetId));
+    accessControlService.checkReadAccess(studyId, List.of(), List.of(featureSetId));
 
     // should have write access to create feature set in destination study
     String destinationStudyId =

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -93,10 +93,7 @@ public class UnderlaysApiController implements UnderlaysApi {
 
   @Override
   public ResponseEntity<ApiUnderlay> getUnderlay(String underlayName) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     Underlay underlay = underlayService.getUnderlay(underlayName);
     return ResponseEntity.ok(
         new ApiUnderlay()
@@ -107,10 +104,7 @@ public class UnderlaysApiController implements UnderlaysApi {
 
   @Override
   public ResponseEntity<ApiEntityList> listEntities(String underlayName) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     ApiEntityList apiEntities = new ApiEntityList();
     underlayService
         .getUnderlay(underlayName)
@@ -121,10 +115,7 @@ public class UnderlaysApiController implements UnderlaysApi {
 
   @Override
   public ResponseEntity<ApiEntity> getEntity(String underlayName, String entityName) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     Entity entity = underlayService.getUnderlay(underlayName).getEntity(entityName);
     return ResponseEntity.ok(toApiObject(entity));
   }
@@ -132,10 +123,7 @@ public class UnderlaysApiController implements UnderlaysApi {
   @Override
   public ResponseEntity<ApiInstanceListResult> listInstances(
       String underlayName, String entityName, ApiQuery body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     Underlay underlay = underlayService.getUnderlay(underlayName);
     ListQueryRequest listQueryRequest =
         FromApiUtils.fromApiObject(body, underlay.getEntity(entityName), underlay);
@@ -148,10 +136,7 @@ public class UnderlaysApiController implements UnderlaysApi {
   @Override
   public ResponseEntity<ApiInstanceListResult> listInstancesForPrimaryEntity(
       String underlayName, String entityName, ApiQueryFilterOnPrimaryEntity body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     Underlay underlay = underlayService.getUnderlay(underlayName);
 
     // Build the attribute fields to select.
@@ -205,10 +190,7 @@ public class UnderlaysApiController implements UnderlaysApi {
   @Override
   public ResponseEntity<ApiInstanceCountList> countInstances(
       String underlayName, String entityName, ApiCountQuery body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
 
     // Build the entity filter.
     Underlay underlay = underlayService.getUnderlay(underlayName);
@@ -236,10 +218,7 @@ public class UnderlaysApiController implements UnderlaysApi {
   @Override
   public ResponseEntity<ApiDisplayHintList> queryHints(
       String underlayName, String entityName, ApiHintQuery body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
     Underlay underlay = underlayService.getUnderlay(underlayName);
     Entity entity = underlay.getEntity(entityName);
     HintQueryResult hintQueryResult;
@@ -279,10 +258,7 @@ public class UnderlaysApiController implements UnderlaysApi {
   @Override
   public ResponseEntity<ApiInstanceCountList> queryCriteriaCounts(
       String underlayName, ApiCriteriaCountQuery body) {
-    accessControlService.throwIfUnauthorized(
-        SpringAuthentication.getCurrentUser(),
-        Permissions.forActions(UNDERLAY, READ),
-        ResourceId.forUnderlay(underlayName));
+    accessControlService.checkUnderlayAccess(underlayName);
 
     // Build the entity filter.
     List<CriteriaGroupSection> criteriaGroupSections =

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2087,9 +2087,6 @@ components:
       properties:
         sql:
           type: string
-        entityIdSql:
-          description: SQL for core entity ids, included in the primary sql
-          type: string
         instances:
           type: array
           items:
@@ -2867,10 +2864,14 @@ components:
           description: |
             SQL string against the source tables.
             This will be populated if source queries are configured for this entity.
+        entityIdSql:
+          type: string
+          description: SQL string for the entityId attribute.
       required:
         - entity
         - includedAttributes
         - criteria
+        - entityIdSql
 
     EntityOutputPreviewList:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2087,6 +2087,9 @@ components:
       properties:
         sql:
           type: string
+        entityIdSql:
+          description: SQL for core entity ids, included in the primary sql
+          type: string
         instances:
           type: array
           items:

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2868,7 +2868,6 @@ components:
         - entity
         - includedAttributes
         - criteria
-        - entityIdSql
 
     EntityOutputPreviewList:
       type: object

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -2864,9 +2864,6 @@ components:
           description: |
             SQL string against the source tables.
             This will be populated if source queries are configured for this entity.
-        entityIdSql:
-          type: string
-          description: SQL string for the entityId attribute.
       required:
         - entity
         - includedAttributes
@@ -2880,6 +2877,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EntityOutputPreview"
+        entityIdSql:
+          type: string
+          description: SQL string for the entityId attribute.
       required:
         - entityOutputs
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -344,8 +344,7 @@ public class BQQueryRunner implements QueryRunner {
     return buildListQuerySqlAgainstIndexData(listQueryRequest, Instant.now());
   }
 
-  @VisibleForTesting
-  public SqlQueryRequest buildListQuerySqlAgainstIndexData(
+  private SqlQueryRequest buildListQuerySqlAgainstIndexData(
       ListQueryRequest listQueryRequest, Instant queryInstant) {
     return buildQuerySqlAgainstIndexData(
         listQueryRequest.getUnderlay(),


### PR DESCRIPTION
change 1: Create a util function to check access to cohorts, feature sets. This will be used in controllers. Also updates access checks in controllers to verify that user has access to cohort and feature sets

change 2: Return Cohort SQL in describeExport response

cohorts
![image](https://github.com/user-attachments/assets/c90a548c-03b1-47af-9ee8-3e420b9cbf14)
![image](https://github.com/user-attachments/assets/2603c77c-d3bb-4ed2-b530-01b5f9bdbf43)

request 
```
http://localhost:3000/v2/underlays/cmssynpuf/describeExport
{study: "P63tR0rsZJ", cohorts: ["L8v1TKKCfG", "6RyN4mpOd7"], featureSets: ["GmyHqDVAqa", "JmXfpH6BKu"]}
```

response field
```
    SELECT id 
    FROM`verily-tanagra-dev.cmssynpuf_index_060724`.ENT_person 
    WHERE
        (
            (
                CAST(FLOOR(TIMESTAMP_DIFF(TIMESTAMP('2024-11-01 12:26:16.709'), age, DAY) / 365.25) AS INT64) BETWEEN 89.0 AND 95.0
            ) 
            AND (
                gender = 8507
            ) 
            AND (
                ethnicity = 38003564
            ) 
            AND (
                race = 8516
            )
        ) 
        OR (
            (
                CAST(FLOOR(TIMESTAMP_DIFF(TIMESTAMP('2024-11-01 12:26:16.709'), age, DAY) / 365.25) AS INT64) BETWEEN 96.0 AND 98.0
            ) 
            AND (
                gender = 8532
            ) 
            AND (
                race = 0
            ) 
            AND (
                ethnicity = 38003563
            )
        )
```