### PR TITLE
Re-add ch.qos.logback to indexer build

### DIFF
--- a/indexer/build.gradle
+++ b/indexer/build.gradle
@@ -29,10 +29,6 @@ dependencies {
         runtimeOnly 'com.charleskorn.kaml:kaml:0.60.0'
     }
 
-    configurations.all {
-        exclude group: 'ch.qos.logback', module: 'logback-classic'
-    }
-
     implementation project(':underlay')
     testImplementation(testFixtures(project(':underlay')))
 

--- a/indexer/gradle.lockfile
+++ b/indexer/gradle.lockfile
@@ -2,6 +2,8 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 args4j:args4j:2.33=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+ch.qos.logback:logback-classic:1.5.8=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+ch.qos.logback:logback-core:1.5.8=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.charleskorn.kaml:kaml-jvm:0.60.0=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.charleskorn.kaml:kaml:0.60.0=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.18.0=compileClasspath,testCompileClasspath


### PR DESCRIPTION
The code is currently using it but it doesn't result in warnings from Spring here because Spring isn't used by the indexer.