### PR TITLE
Add support for rollup instances level hints

### DIFF
--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -860,6 +860,11 @@ Names of attributes that we want to calculate instance-level hints for.
 
 Instance-level hints are ranges of possible values for a particular criteria instance. They are used to support criteria-specific modifiers (e.g. range of values for measurement code "glucose test").
 
+### SZOccurrenceEntity.attributesWithRollupInstanceLevelHints
+**required** Set [ String ]
+
+Names of attributes that we want to calculate instance-level hints for which values should be rolled up and included in their ancestors hints as well.
+
 ### SZOccurrenceEntity.criteriaRelationship
 **required** [SZCriteriaRelationship](#szcriteriarelationship)
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -21,6 +21,7 @@ import bio.terra.tanagra.indexing.jobexecutor.SerialRunner;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
 import bio.terra.tanagra.underlay.entitymodel.Relationship;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.EntityGroup;
@@ -421,6 +422,12 @@ public final class JobSequencer {
     // TODO: Handle >1 occurrence entity.
     Entity occurrenceEntity = criteriaOccurrence.getOccurrenceEntities().get(0);
     if (criteriaOccurrence.hasInstanceLevelDisplayHints(occurrenceEntity)) {
+      // TODO: Handle >1 hierarchy.
+      Hierarchy hierarchy =
+          criteriaOccurrence.getCriteriaEntity().hasHierarchies()
+              ? criteriaOccurrence.getCriteriaEntity().getHierarchies().get(0)
+              : null;
+
       Relationship occurrenceCriteriaRelationship =
           criteriaOccurrence.getOccurrenceCriteriaRelationship(occurrenceEntity.getName());
       Relationship occurrencePrimaryRelationship =
@@ -458,7 +465,14 @@ public final class JobSequencer {
                   .getInstanceLevelDisplayHints(
                       criteriaOccurrence.getName(),
                       occurrenceEntity.getName(),
-                      criteriaOccurrence.getCriteriaEntity().getName())));
+                      criteriaOccurrence.getCriteriaEntity().getName()),
+              hierarchy,
+              hierarchy != null
+                  ? underlay
+                      .getIndexSchema()
+                      .getHierarchyAncestorDescendant(
+                          criteriaOccurrence.getCriteriaEntity().getName(), hierarchy.getName())
+                  : null));
     }
 
     if (criteriaOccurrence.getCriteriaEntity().hasHierarchies()) {

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/dataflow/WriteRollupCounts.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/dataflow/WriteRollupCounts.java
@@ -263,21 +263,13 @@ public class WriteRollupCounts extends BigQueryJob {
 
     // Optionally handle a hierarchy for the rollup entity.
     if (hierarchy != null) {
-      // Build a query to select all ancestor-descendant pairs from the ancestor-descendant table,
-      // and the pipeline step to read the results.
-      String ancestorDescendantSql =
-          "SELECT * FROM " + ancestorDescendantTable.getTablePointer().render();
-      LOGGER.info("ancestor-descendant query: {}", ancestorDescendantSql);
-      PCollection<KV<Long, Long>> ancestorDescendantRelationshipsPC =
-          BigQueryBeamUtils.readTwoFieldRowsFromBQ(
-              pipeline,
-              ancestorDescendantSql,
-              ITHierarchyAncestorDescendant.Column.DESCENDANT.getSchema().getColumnName(),
-              ITHierarchyAncestorDescendant.Column.ANCESTOR.getSchema().getColumnName());
+      PCollection<KV<Long, Long>> descendantAncestorRelationshipsPC =
+          BigQueryBeamUtils.readDescendantAncestorRelationshipsFromBQ(
+              pipeline, ancestorDescendantTable);
 
       // Expand the set of occurrences to include a repeat for each ancestor.
       idPairsPC =
-          CountUtils.repeatOccurrencesForHierarchy(idPairsPC, ancestorDescendantRelationshipsPC);
+          CountUtils.repeatOccurrencesForHierarchy(idPairsPC, descendantAncestorRelationshipsPC);
     }
 
     // Count the number of distinct occurrences per entity id.

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -152,6 +152,7 @@ export type SZMetadata = {
 
 export type SZOccurrenceEntity = {
   attributesWithInstanceLevelHints: string[];
+  attributesWithRollupInstanceLevelHints: string[];
   criteriaRelationship: SZCriteriaRelationship;
   occurrenceEntity: string;
   primaryRelationship: SZPrimaryRelationship;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
@@ -321,11 +321,16 @@ public final class ConfigReader {
               ? new HashSet<>()
               : szCriteriaOccurrence.occurrenceEntities;
       szCriteriaOccurrence.occurrenceEntities.forEach(
-          szOccurrenceEntity ->
-              szOccurrenceEntity.attributesWithInstanceLevelHints =
-                  szOccurrenceEntity.attributesWithInstanceLevelHints == null
-                      ? new HashSet<>()
-                      : szOccurrenceEntity.attributesWithInstanceLevelHints);
+          szOccurrenceEntity -> {
+            szOccurrenceEntity.attributesWithInstanceLevelHints =
+                szOccurrenceEntity.attributesWithInstanceLevelHints == null
+                    ? new HashSet<>()
+                    : szOccurrenceEntity.attributesWithInstanceLevelHints;
+            szOccurrenceEntity.attributesWithRollupInstanceLevelHints =
+                szOccurrenceEntity.attributesWithRollupInstanceLevelHints == null
+                    ? new HashSet<>()
+                    : szOccurrenceEntity.attributesWithRollupInstanceLevelHints;
+          });
 
       return szCriteriaOccurrence;
     } catch (IOException ioEx) {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -474,6 +474,7 @@ public final class Underlay {
     Map<String, Relationship> occurrenceCriteriaRelationships = new HashMap<>();
     Map<String, Relationship> occurrencePrimaryRelationships = new HashMap<>();
     Map<String, Set<String>> occurrenceAttributesWithInstanceLevelHints = new HashMap<>();
+    Map<String, Set<String>> occurrenceAttributesWithRollupInstanceLevelHints = new HashMap<>();
     szCriteriaOccurrence.occurrenceEntities.forEach(
         szOccurrenceEntity -> {
           // Get the occurrence entity.
@@ -518,6 +519,9 @@ public final class Underlay {
           // Get the attributes with instance-level hints.
           occurrenceAttributesWithInstanceLevelHints.put(
               occurrenceEntity.getName(), szOccurrenceEntity.attributesWithInstanceLevelHints);
+          occurrenceAttributesWithRollupInstanceLevelHints.put(
+              occurrenceEntity.getName(),
+              szOccurrenceEntity.attributesWithRollupInstanceLevelHints);
         });
 
     // Build the primary-criteria relationship.
@@ -532,7 +536,8 @@ public final class Underlay {
         occurrenceCriteriaRelationships,
         occurrencePrimaryRelationships,
         primaryCriteriaRelationship,
-        occurrenceAttributesWithInstanceLevelHints);
+        occurrenceAttributesWithInstanceLevelHints,
+        occurrenceAttributesWithRollupInstanceLevelHints);
   }
 
   @VisibleForTesting

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZCriteriaOccurrence.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZCriteriaOccurrence.java
@@ -73,6 +73,13 @@ public class SZCriteriaOccurrence {
                 + "code \"glucose test\").")
     public Set<String> attributesWithInstanceLevelHints;
 
+    @AnnotatedField(
+        name = "SZOccurrenceEntity.attributesWithRollupInstanceLevelHints",
+        markdown =
+            "Names of attributes that we want to calculate instance-level hints for which values "
+                + "should be rolled up and included in their ancestors hints as well.")
+    public Set<String> attributesWithRollupInstanceLevelHints;
+
     @AnnotatedClass(
         name = "SZCriteriaRelationship",
         markdown =

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQHintQueryResultsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQHintQueryResultsTest.java
@@ -124,7 +124,7 @@ public class BQHintQueryResultsTest extends BQRunnerTest {
               assertTrue(
                   criteriaOccurrence
                       .getAttributesWithInstanceLevelDisplayHints(hintedEntity)
-                      .contains(attribute));
+                      .containsKey(attribute));
               if (hintInstance.isRangeHint()) {
                 assertTrue(
                     List.of(DataType.INT64, DataType.DOUBLE)


### PR DESCRIPTION
This allows survey versions to be rolled up to questions (and topics). Currently there is only support for a single hierarchy but that limitation exists elsewhere already.

This will require re-indexing once the config has been updated.