### PR TITLE
Support setting regression test properties as env var

### DIFF
--- a/docs/REGRESSION_TESTING.md
+++ b/docs/REGRESSION_TESTING.md
@@ -111,3 +111,5 @@ for running these tests in a "downstream" repo. To get this working in your own 
     - The `env.DEFAULT_UNDERLAYS` variable for on-PR (or other triggered) runs.
 - If your regression test files are stored in your "downstream" repo, update the name of the Gradle parameter in the 
   run command from `-PregressionTestUnderlays` to `-PregressionTestDirs`.
+- As an alternate to  `-PregressionTestDirs`, `-PregressionTestUnderlays` and `-PregressionTestFiles` set
+  environment variables `REGRESSION_TEST_DIRS`, `REGRESSION_TEST_UNDERLAYS` and `REGRESSION_TEST_FILES` respectively.

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -154,12 +154,18 @@ tasks.withType(Test).configureEach {
     // See bio.terra.tanagra.regression.QueryCountRegressionTest for how it's used.
     if (project.findProperty('regressionTestDirs')) {
         systemProperty('REGRESSION_TEST_DIRS', project.findProperty('regressionTestDirs'))
+    } else {
+        systemProperty('REGRESSION_TEST_DIRS', System.getenv('REGRESSION_TEST_DIRS'))
     }
     if (project.findProperty('regressionTestUnderlays')) {
         systemProperty('REGRESSION_TEST_UNDERLAYS', project.findProperty('regressionTestUnderlays'))
+    } else {
+        systemProperty('REGRESSION_TEST_UNDERLAYS', System.getenv('REGRESSION_TEST_UNDERLAYS'))
     }
     if (project.findProperty('regressionTestFiles')) {
         systemProperty('REGRESSION_TEST_FILES', project.findProperty('regressionTestFiles'))
+    } else {
+        systemProperty('REGRESSION_TEST_FILES', System.getenv('REGRESSION_TEST_FILES'))
     }
 }
 


### PR DESCRIPTION
Required downstream


hitting this error with common workflows that cannot be changed only for our service 
```
Cannot locate tasks that match ':service:regressionTests -PregressionTestUnderlays=cmssynpuf,aouSR2019q4r4,pilotsynthea2022q3,sd' as task 'regressionTests -PregressionTestUnderlays=cmssynpuf,aouSR2019q4r4,pilotsynthea2022q3,sd' not found in project ':service'.
For more on this, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
```