### PR TITLE
Add enum UnderlayTestConfigs to list test underlays

### DIFF
--- a/underlay/src/test/java/bio/terra/tanagra/UnderlayTestConfigs.java
+++ b/underlay/src/test/java/bio/terra/tanagra/UnderlayTestConfigs.java
@@ -1,0 +1,19 @@
+package bio.terra.tanagra;
+
+public enum UnderlayTestConfigs {
+  AOUSC2023Q3R2("aouSC2023Q3R2_verily"),
+  AOUSR2019Q4R4("aouSR2019q4r4_broad"),
+  CMSSYNPUF("cmssynpuf_broad"),
+  SD20230331("sd20230331_verily"),
+  SD20230831("sd20230831_verily");
+
+  private final String fileName;
+
+  UnderlayTestConfigs(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String fileName() {
+    return fileName;
+  }
+}

--- a/underlay/src/test/java/bio/terra/tanagra/datasetspecific/cmssynpuf/CmsSynpufHintsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/datasetspecific/cmssynpuf/CmsSynpufHintsTest.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.datasetspecific.cmssynpuf;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
+
 import bio.terra.tanagra.api.query.hint.HintInstance;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.api.shared.ValueDisplay;
@@ -15,7 +17,7 @@ public class CmsSynpufHintsTest extends BaseHintsTest {
 
   @Override
   protected String getServiceConfigName() {
-    return "cmssynpuf_broad";
+    return CMSSYNPUF.fileName();
   }
 
   @Test

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/BioVUFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/BioVUFilterBuilderTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230831;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,7 +33,7 @@ public class BioVUFilterBuilderTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230831_verily");
+    SZService szService = configReader.readService(SD20230831.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForCriteriaOccurrenceTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.AOUSR2019Q4R4;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,7 +49,7 @@ public class EntityGroupFilterBuilderForCriteriaOccurrenceTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("aouSR2019q4r4_broad");
+    SZService szService = configReader.readService(AOUSR2019Q4R4.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForGroupTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230831;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -42,7 +43,7 @@ public class EntityGroupFilterBuilderForGroupTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230831_verily");
+    SZService szService = configReader.readService(SD20230831.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/EntityGroupFilterBuilderForItemsTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230831;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,7 +37,7 @@ public class EntityGroupFilterBuilderForItemsTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230831_verily");
+    SZService szService = configReader.readService(SD20230831.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/FilterableGroupFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/FilterableGroupFilterBuilderTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.AOUSC2023Q3R2;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,7 +44,7 @@ public class FilterableGroupFilterBuilderTest {
   private static GroupItems groupItems_variant;
 
   // Double escaped for Java then for JSON.
-  private static String configJson =
+  private static final String configJson =
       """
 {
   "entityGroup": "variantPerson",
@@ -109,7 +110,7 @@ public class FilterableGroupFilterBuilderTest {
   @BeforeAll
   static void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("aouSC2023Q3R2_verily");
+    SZService szService = configReader.readService(AOUSC2023Q3R2.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
 

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/MultiAttributeFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/MultiAttributeFilterBuilderTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230831;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,7 +41,7 @@ public class MultiAttributeFilterBuilderTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230831_verily");
+    SZService szService = configReader.readService(SD20230831.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/OutputUnfilteredFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/OutputUnfilteredFilterBuilderTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -25,7 +26,7 @@ public class OutputUnfilteredFilterBuilderTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("cmssynpuf_broad");
+    SZService szService = configReader.readService(CMSSYNPUF.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/PrimaryEntityFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/PrimaryEntityFilterBuilderTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,7 +33,7 @@ public class PrimaryEntityFilterBuilderTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("cmssynpuf_broad");
+    SZService szService = configReader.readService(CMSSYNPUF.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/filterbuilder/TextSearchFilterBuilderTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.filterbuilder;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230831;
 import static bio.terra.tanagra.utils.ProtobufUtils.serializeToJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,7 +44,7 @@ public class TextSearchFilterBuilderTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230831_verily");
+    SZService szService = configReader.readService(SD20230831.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/BQRunnerTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/BQRunnerTest.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.query.bigquery;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
+
 import bio.terra.tanagra.testing.GeneratedSqlUtils;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.Underlay;
@@ -24,7 +26,7 @@ public abstract class BQRunnerTest {
   }
 
   protected String getServiceConfigName() {
-    return "cmssynpuf_broad";
+    return CMSSYNPUF.fileName();
   }
 
   protected void assertSqlMatchesWithTableNameOnly(String testName, String sql, BQTable... tables)

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQCountQueryPaginationTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQCountQueryPaginationTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.query.bigquery.pagination;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -27,13 +28,12 @@ import org.junit.jupiter.api.Test;
 @Tag("requires-cloud-access")
 @Tag("broad-underlays")
 public class BQCountQueryPaginationTest {
-  private static final String SERVICE_CONFIG_NAME = "cmssynpuf_broad";
   private Underlay underlay;
 
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService(SERVICE_CONFIG_NAME);
+    SZService szService = configReader.readService(CMSSYNPUF.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQListQueryPaginationTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/pagination/BQListQueryPaginationTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.query.bigquery.pagination;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -22,13 +23,12 @@ import org.junit.jupiter.api.Test;
 @Tag("requires-cloud-access")
 @Tag("broad-underlays")
 public class BQListQueryPaginationTest {
-  private static final String SERVICE_CONFIG_NAME = "cmssynpuf_broad";
   private Underlay underlay;
 
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService(SERVICE_CONFIG_NAME);
+    SZService szService = configReader.readService(CMSSYNPUF.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQHintQueryResultsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/resultparsing/BQHintQueryResultsTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.query.bigquery.resultparsing;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.AOUSR2019Q4R4;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 public class BQHintQueryResultsTest extends BQRunnerTest {
   @Override
   protected String getServiceConfigName() {
-    return "aouSR2019q4r4_broad";
+    return AOUSR2019Q4R4.fileName();
   }
 
   @Test

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQHintQueryTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQHintQueryTest.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.query.bigquery.sqlbuilding;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.AOUSR2019Q4R4;
+
 import bio.terra.tanagra.api.query.hint.HintQueryRequest;
 import bio.terra.tanagra.api.query.hint.HintQueryResult;
 import bio.terra.tanagra.api.shared.Literal;
@@ -13,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class BQHintQueryTest extends BQRunnerTest {
   @Override
   protected String getServiceConfigName() {
-    return "aouSR2019q4r4_broad";
+    return AOUSR2019Q4R4.fileName();
   }
 
   @Test

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.query.bigquery.sqlbuilding;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.tanagra.api.field.AttributeField;
@@ -99,7 +100,7 @@ public class BQRemoveParamsTest extends BQRunnerTest {
     // The aouSR2019q4r4 underlay does not have an example of a field with DATE type.
     // So for this test, we use the cmssynpuf underlay.
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("cmssynpuf_broad");
+    SZService szService = configReader.readService(CMSSYNPUF.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
     BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/BQRemoveParamsTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.query.bigquery.sqlbuilding;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.AOUSR2019Q4R4;
 import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class BQRemoveParamsTest extends BQRunnerTest {
   @Override
   protected String getServiceConfigName() {
-    return "aouSR2019q4r4_broad";
+    return AOUSR2019Q4R4.fileName();
   }
 
   @Test

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQGroupItemsFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQGroupItemsFilterTest.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.query.bigquery.sqlbuilding.filter;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230331;
+
 import bio.terra.tanagra.api.field.AttributeField;
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.EntityFilter;
@@ -204,7 +206,7 @@ public class BQGroupItemsFilterTest extends BQRunnerTest {
     // of the test, we use the SD underlay. But since we the GHA does not have
     // credentials to query against an SD dataset, here we just check the generated SQL.
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230331_verily");
+    SZService szService = configReader.readService(SD20230331.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
     BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();

--- a/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQRelationshipFilterTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/query/bigquery/sqlbuilding/filter/BQRelationshipFilterTest.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.query.bigquery.sqlbuilding.filter;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.SD20230331;
+
 import bio.terra.tanagra.api.field.AttributeField;
 import bio.terra.tanagra.api.filter.AttributeFilter;
 import bio.terra.tanagra.api.filter.RelationshipFilter;
@@ -253,7 +255,7 @@ public class BQRelationshipFilterTest extends BQRunnerTest {
     // of the test, we use the SD underlay. But since we the GHA does not have
     // credentials to query against an SD dataset, here we just check the generated SQL.
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230331_verily");
+    SZService szService = configReader.readService(SD20230331.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
     BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();
@@ -817,7 +819,7 @@ public class BQRelationshipFilterTest extends BQRunnerTest {
     // of the test, we use the SD underlay. But since we the GHA does not have
     // credentials to query against an SD dataset, here we just check the generated SQL.
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("sd20230331_verily");
+    SZService szService = configReader.readService(SD20230331.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     Underlay underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
     BQQueryRunner bqQueryRunner = (BQQueryRunner) underlay.getQueryRunner();

--- a/underlay/src/test/java/bio/terra/tanagra/underlay/CriteriaSelectorTest.java
+++ b/underlay/src/test/java/bio/terra/tanagra/underlay/CriteriaSelectorTest.java
@@ -1,5 +1,6 @@
 package bio.terra.tanagra.underlay;
 
+import static bio.terra.tanagra.UnderlayTestConfigs.CMSSYNPUF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -21,7 +22,7 @@ public class CriteriaSelectorTest {
   @BeforeEach
   void setup() {
     ConfigReader configReader = ConfigReader.fromJarResources();
-    SZService szService = configReader.readService("cmssynpuf_broad");
+    SZService szService = configReader.readService(CMSSYNPUF.fileName());
     SZUnderlay szUnderlay = configReader.readUnderlay(szService.underlay);
     underlay = Underlay.fromConfig(szService.bigQuery, szUnderlay, configReader);
   }


### PR DESCRIPTION
Adding enum UnderlayTestConfigs to avoid hardcoding underay config names in java test files. This will make it easier to swap out config files downstream with minimal diff / patch files 