### PR TITLE
Support per attribute cluster table for variant search

### DIFF
--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
@@ -25,6 +25,7 @@ public class UnderlayConfigPath extends AnnotationPath {
           SZEntity.TemporalQuery.class,
           SZAttribute.class,
           SZAttribute.SourceQuery.class,
+          SZAttributeSearch.class,
           SZHierarchy.class,
           SZTextSearch.class,
           SZDataType.class,

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -4,6 +4,7 @@ This file lists all the configuration properties available for an underlay, incl
 This documentation is generated from annotations in the configuration classes.
 
 * [SZAttribute](#szattribute)
+* [SZAttributeSearch](#szattributesearch)
 * [SZBigQuery](#szbigquery)
 * [SZCorePlugin](#szcoreplugin)
 * [SZCriteriaOccurrence](#szcriteriaoccurrence)
@@ -124,6 +125,27 @@ If unspecified and exporting queries against the source data is supported for th
 **optional** String
 
 Field or column name in the [all instances SQL file](#szentityallinstancessqlfile) that maps to the value of this attribute. If unset, we assume the field name is the same as the attribute name.
+
+
+
+## SZAttributeSearch
+Configuration to optimize entity search by attributes.
+
+Define the list of attributes to group together for optimization and specific is search for null attribute values is supported. 
+
+### SZAttributeSearch.attributes
+**required** List [ String ]
+
+List of attributes grouped together for search optimization.
+
+ Order matter. Each entry is a list of attributes that are search for together. For example search is typically performed for contig and position together. 
+
+### SZAttributeSearch.includeNullValues
+**optional** boolean
+
+True if search for null values in attributes is supported. 
+
+*Default value:* `false`
 
 
 
@@ -591,9 +613,9 @@ The typical use case for this is to optimize cohort breakdown queries on the pri
 You can currently specify a maximum of four attributes, because we implement this using BigQuery clustering which has this [limitation](https://cloud.google.com/bigquery/docs/clustered-tables#limitations).
 
 ### SZEntity.optimizeSearchByAttributes
-**optional** List [ List [ String ] ]
+**optional** List [ SZAttributeSearch ]
 
-List of (list of) attributes to optimize for search queries.
+List of search configs to optimize entity search by attributes.
 
 The typical use case for this is to optimize attribute based search on large entity tables that cannot be optimised for search on multiple attribute fields. For example, to optimize search on the variant table using attributes values for gene and rs_number. Each entry is a list of attributes that are search for together. For example search is typically performed for contig and position together. 
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -590,6 +590,13 @@ The typical use case for this is to optimize cohort breakdown queries on the pri
 
 You can currently specify a maximum of four attributes, because we implement this using BigQuery clustering which has this [limitation](https://cloud.google.com/bigquery/docs/clustered-tables#limitations).
 
+### SZEntity.optimizeSearchByAttributes
+**optional** List [ List [ String ] ]
+
+List of (list of) attributes to optimize for search queries.
+
+The typical use case for this is to optimize attribute based search on large entity tables that cannot be optimised for search on multiple attribute fields. For example, to optimize search on the variant table using attributes values for gene and rs_number. Each entry is a list of attributes that are search for together. For example search is typically performed for contig and position together. 
+
 ### SZEntity.sourceQueryTableName
 **optional** String
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/JobSequencer.java
@@ -8,6 +8,7 @@ import bio.terra.tanagra.indexing.job.bigquery.ValidateUniqueIds;
 import bio.terra.tanagra.indexing.job.bigquery.WriteChildParent;
 import bio.terra.tanagra.indexing.job.bigquery.WriteEntityAttributes;
 import bio.terra.tanagra.indexing.job.bigquery.WriteEntityLevelDisplayHints;
+import bio.terra.tanagra.indexing.job.bigquery.WriteEntitySearchByAttribute;
 import bio.terra.tanagra.indexing.job.bigquery.WriteRelationshipIntermediateTable;
 import bio.terra.tanagra.indexing.job.bigquery.WriteTextSearchField;
 import bio.terra.tanagra.indexing.job.dataflow.WriteAncestorDescendant;
@@ -28,6 +29,7 @@ import bio.terra.tanagra.underlay.entitymodel.entitygroup.EntityGroup;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
 import bio.terra.tanagra.underlay.indextable.ITEntityLevelDisplayHints;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
+import bio.terra.tanagra.underlay.indextable.ITEntitySearchByAttribute;
 import bio.terra.tanagra.underlay.indextable.ITHierarchyAncestorDescendant;
 import bio.terra.tanagra.underlay.indextable.ITHierarchyChildParent;
 import bio.terra.tanagra.underlay.indextable.ITRelationshipIdPairs;
@@ -62,6 +64,23 @@ public final class JobSequencer {
         underlay.getIndexSchema().getEntityLevelDisplayHints(entity.getName());
     jobSet.addJob(
         new WriteEntityLevelDisplayHints(indexerConfig, entity, indexEntityMain, indexEntityHints));
+
+    if (entity.hasOptimizeSearchByAttributes()) {
+      jobSet.startNewStage();
+
+      entity
+          .getOptimizeSearchByAttributes()
+          .forEach(
+              searchTableAttributes -> {
+                ITEntitySearchByAttribute searchTable =
+                    underlay
+                        .getIndexSchema()
+                        .getEntitySearchByAttributeTable(entity, searchTableAttributes);
+                jobSet.addJob(
+                    new WriteEntitySearchByAttribute(
+                        indexerConfig, entity, indexEntityMain, searchTable));
+              });
+    }
 
     if (entity.hasTextSearch() || entity.hasHierarchies()) {
       jobSet.startNewStage();

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntitySearchByAttribute.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntitySearchByAttribute.java
@@ -1,0 +1,113 @@
+package bio.terra.tanagra.indexing.job.bigquery;
+
+import bio.terra.tanagra.indexing.job.BigQueryJob;
+import bio.terra.tanagra.indexing.job.dataflow.beam.BigQueryBeamUtils;
+import bio.terra.tanagra.underlay.entitymodel.Entity;
+import bio.terra.tanagra.underlay.indextable.ITEntityMain;
+import bio.terra.tanagra.underlay.indextable.ITEntitySearchByAttribute;
+import bio.terra.tanagra.underlay.serialization.SZIndexer;
+import com.google.cloud.bigquery.Clustering;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableId;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WriteEntitySearchByAttribute extends BigQueryJob {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WriteEntitySearchByAttribute.class);
+
+  private final Entity entity;
+  private final ITEntityMain entityTable;
+  private final ITEntitySearchByAttribute searchTable;
+
+  public WriteEntitySearchByAttribute(
+      SZIndexer indexerConfig,
+      Entity entity,
+      ITEntityMain entityTable,
+      ITEntitySearchByAttribute searchTable) {
+    super(indexerConfig);
+    this.entity = entity;
+    this.entityTable = entityTable;
+    this.searchTable = searchTable;
+  }
+
+  @Override
+  public String getEntity() {
+    return entity.getName();
+  }
+
+  @Override
+  protected String getOutputTableName() {
+    return searchTable.getTablePointer().getTableName();
+  }
+
+  @Override
+  public JobStatus checkStatus() {
+    return outputTableHasAtLeastOneRow() ? JobStatus.COMPLETE : JobStatus.NOT_STARTED;
+  }
+
+  @Override
+  public void run(boolean isDryRun) {
+    List<Field> fields =
+        searchTable.getColumnSchemas().stream()
+            .map(
+                columnSchema ->
+                    Field.newBuilder(
+                            columnSchema.getColumnName(),
+                            BigQueryBeamUtils.fromDataType(columnSchema.getDataType()))
+                        .build())
+            .toList();
+
+    // Build a clustering specification.
+    Clustering clustering =
+        Clustering.newBuilder().setFields(searchTable.getAttributeNames()).build();
+
+    // Create an empty table with this schema.
+    TableId destinationTable =
+        TableId.of(
+            indexerConfig.bigQuery.indexData.projectId,
+            indexerConfig.bigQuery.indexData.datasetId,
+            getOutputTableName());
+    googleBigQuery.createTableFromSchema(destinationTable, Schema.of(fields), clustering, isDryRun);
+
+    // Build the query to insert to the search table using a select from the main entity table.
+    List<String> insertColumns = new ArrayList<>();
+    insertColumns.add(entity.getIdAttribute().getName());
+
+    List<String> selectColumns = new ArrayList<>();
+    selectColumns.add(entity.getIdAttribute().getName());
+
+    List<String> crossJoins = new ArrayList<>();
+    searchTable
+        .getAttributeNames()
+        .forEach(
+            attribute -> {
+              insertColumns.add(attribute);
+
+              if (entity.getAttribute(attribute).isDataTypeRepeated()) {
+                String alias = "flattened_" + attribute;
+                selectColumns.add(alias);
+                crossJoins.add(" CROSS JOIN UNNEST(" + attribute + ") AS " + alias);
+              } else {
+                selectColumns.add(attribute);
+              }
+            });
+
+    // TODO-dex: check is select distinct is feasible
+    String insertFromSelectSql =
+        "INSERT INTO "
+            + searchTable.getTablePointer().render()
+            + " ("
+            + String.join(", ", insertColumns)
+            + ") SELECT "
+            + String.join(", ", selectColumns)
+            + " FROM "
+            + entityTable.getTablePointer().render()
+            + String.join(" ", crossJoins);
+    LOGGER.info("Generated insert SQL: {}", insertFromSelectSql);
+
+    runQueryIfTableExists(searchTable.getTablePointer(), insertFromSelectSql, isDryRun);
+  }
+}

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntitySearchByAttribute.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntitySearchByAttribute.java
@@ -95,13 +95,12 @@ public class WriteEntitySearchByAttribute extends BigQueryJob {
               }
             });
 
-    // TODO-dex: check is select distinct is feasible
     String insertFromSelectSql =
         "INSERT INTO "
             + searchTable.getTablePointer().render()
             + " ("
             + String.join(", ", insertColumns)
-            + ") SELECT "
+            + ") SELECT DISTINCT "
             + String.join(", ", selectColumns)
             + " FROM "
             + entityTable.getTablePointer().render()

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -13,6 +13,11 @@ export type SZAttribute = {
   valueFieldName?: string;
 };
 
+export type SZAttributeSearch = {
+  attributes: string[];
+  includeNullValues?: boolean;
+};
+
 export type SZBigQuery = {
   dataLocation: string;
   exportBucketNames?: string[];
@@ -102,7 +107,7 @@ export type SZEntity = {
   idAttribute: string;
   name: string;
   optimizeGroupByAttributes?: string[];
-  optimizeSearchByAttributes?: string[][];
+  optimizeSearchByAttributes?: SZAttributeSearch[];
   sourceQueryTableName?: string;
   temporalQuery?: SZTemporalQuery;
   textSearch?: SZTextSearch;

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -102,6 +102,7 @@ export type SZEntity = {
   idAttribute: string;
   name: string;
   optimizeGroupByAttributes?: string[];
+  optimizeSearchByAttributes?: string[][];
   sourceQueryTableName?: string;
   temporalQuery?: SZTemporalQuery;
   textSearch?: SZTextSearch;

--- a/underlay/src/main/java/bio/terra/tanagra/annotation/MarkdownWalker.java
+++ b/underlay/src/main/java/bio/terra/tanagra/annotation/MarkdownWalker.java
@@ -71,7 +71,7 @@ public class MarkdownWalker extends AnnotationWalker {
                               nestedTypeParam ->
                                   annotationPath
                                           .getClassesToWalk()
-                                          .contains(nestedTypeParam.getTypeName())
+                                          .contains(nestedTypeParam.getClass())
                                       ? "${" + nestedTypeParam.getTypeName() + "}"
                                       : getSimpleName(nestedTypeParam.getTypeName()))
                           .collect(Collectors.joining(", ")))
@@ -80,7 +80,7 @@ public class MarkdownWalker extends AnnotationWalker {
 
         } else {
           params.add(
-              annotationPath.getClassesToWalk().contains(typeParam.getTypeName())
+              annotationPath.getClassesToWalk().contains(typeParam.getClass())
                   ? "${" + typeParam.getTypeName() + "}"
                   : getSimpleName(typeParam.getTypeName()));
         }

--- a/underlay/src/main/java/bio/terra/tanagra/annotation/MarkdownWalker.java
+++ b/underlay/src/main/java/bio/terra/tanagra/annotation/MarkdownWalker.java
@@ -2,6 +2,7 @@ package bio.terra.tanagra.annotation;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,18 +56,37 @@ public class MarkdownWalker extends AnnotationWalker {
     // Add the markdown for field type.
     if (field.getGenericType() instanceof ParameterizedType pType) {
       // This is a type-parameterized class (e.g. List, Map).
-      markdown
-          .append(getSimpleName(pType.getRawType().getTypeName()))
-          .append(" [ ")
-          .append(
-              Arrays.stream(pType.getActualTypeArguments())
-                  .map(
-                      typeParam ->
-                          annotationPath.getClassesToWalk().contains(typeParam.getTypeName())
-                              ? "${" + typeParam.getTypeName() + "}"
-                              : getSimpleName(typeParam.getTypeName()))
-                  .collect(Collectors.joining(", ")))
-          .append(" ]");
+      markdown.append(getSimpleName(pType.getRawType().getTypeName())).append(" [ ");
+
+      List<String> params = new ArrayList<>();
+      for (Type typeParam : pType.getActualTypeArguments()) {
+        if (typeParam instanceof ParameterizedType pNestedType) {
+          StringBuilder sb =
+              new StringBuilder()
+                  .append(getSimpleName(pNestedType.getRawType().getTypeName()))
+                  .append(" [ ")
+                  .append(
+                      Arrays.stream(pNestedType.getActualTypeArguments())
+                          .map(
+                              nestedTypeParam ->
+                                  annotationPath
+                                          .getClassesToWalk()
+                                          .contains(nestedTypeParam.getTypeName())
+                                      ? "${" + nestedTypeParam.getTypeName() + "}"
+                                      : getSimpleName(nestedTypeParam.getTypeName()))
+                          .collect(Collectors.joining(", ")))
+                  .append(" ]");
+          params.add(sb.toString());
+
+        } else {
+          params.add(
+              annotationPath.getClassesToWalk().contains(typeParam.getTypeName())
+                  ? "${" + typeParam.getTypeName() + "}"
+                  : getSimpleName(typeParam.getTypeName()));
+        }
+      }
+      markdown.append(String.join(", ", params)).append(" ]");
+
     } else {
       markdown.append(
           annotationPath.getClassesToWalk().contains(field.getType())

--- a/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/FilterableGroupFilterBuilder.java
+++ b/underlay/src/main/java/bio/terra/tanagra/filterbuilder/impl/core/FilterableGroupFilterBuilder.java
@@ -175,7 +175,7 @@ public class FilterableGroupFilterBuilder
       return List.of();
     }
 
-    if (config.getSearchConfigsList().size() == 0) {
+    if (config.getSearchConfigsList().isEmpty()) {
       return List.of(
           new TextSearchFilter(underlay, entity, TextSearchOperator.EXACT_MATCH, query, null));
     }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQTextSearchFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQTextSearchFilterTranslator.java
@@ -28,15 +28,7 @@ public class BQTextSearchFilterTranslator extends ApiFilterTranslator {
     SqlField textSearchField;
     if (textSearchFilter.isForSpecificAttribute()) {
       // Search only on the specified attribute.
-      Attribute attribute = textSearchFilter.getAttribute();
-      textSearchField =
-          attributeSwapFields.containsKey(attribute)
-              ? attributeSwapFields.get(attribute)
-              : indexTable.getAttributeValueField(attribute.getName());
-      if (attribute.hasRuntimeSqlFunctionWrapper()) {
-        textSearchField =
-            textSearchField.cloneWithFunctionWrapper(attribute.getRuntimeSqlFunctionWrapper());
-      }
+      textSearchField = fetchSelectField(indexTable, textSearchFilter.getAttribute());
     } else {
       // Search the text index specified in the underlay config.
       textSearchField = indexTable.getTextSearchField();

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiFilterTranslator.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.query.sql.translator;
 import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.indextable.IndexTable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,5 +22,17 @@ public abstract class ApiFilterTranslator {
   public ApiFilterTranslator swapAttributeField(Attribute attribute, SqlField swappedField) {
     attributeSwapFields.put(attribute, swappedField);
     return this;
+  }
+
+  protected SqlField fetchSelectField(IndexTable indexTable, Attribute attribute) {
+    SqlField field =
+        attributeSwapFields.containsKey(attribute)
+            ? attributeSwapFields.get(attribute)
+            : indexTable.getAttributeValueField(attribute.getName());
+
+    if (attribute.hasRuntimeSqlFunctionWrapper()) {
+      field = field.cloneWithFunctionWrapper(attribute.getRuntimeSqlFunctionWrapper());
+    }
+    return field;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/IndexSchema.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/IndexSchema.java
@@ -250,10 +250,10 @@ public final class IndexSchema {
     // EntitySearchByAttribute tables.
     if (szEntity.optimizeSearchByAttributes != null) {
       szEntity.optimizeSearchByAttributes.forEach(
-          attributes ->
+          attributeSearch ->
               entitySearchByAttributeTables.add(
                   new ITEntitySearchByAttribute(
-                      nameHelper, szBigQueryIndexData, szEntity, attributes)));
+                      nameHelper, szBigQueryIndexData, szEntity, attributeSearch)));
     }
 
     szEntity.hierarchies.forEach(

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -95,16 +95,13 @@ public final class Underlay {
     return displayName == null || displayName.isEmpty() ? name : displayName;
   }
 
+  @Nullable
   public String getDescription() {
     return description;
   }
 
   public ImmutableMap<String, String> getProperties() {
     return properties;
-  }
-
-  public String getMetadataProperty(String key) {
-    return properties.get(key);
   }
 
   public ImmutableList<Entity> getEntities() {
@@ -393,8 +390,22 @@ public final class Underlay {
       optimizeGroupByAttributes =
           attributes.stream()
               .filter(attribute -> szEntity.optimizeGroupByAttributes.contains(attribute.getName()))
-              .collect(Collectors.toList());
+              .toList();
     }
+
+    List<List<Attribute>> optimizeSearchByAttributes = new ArrayList<>();
+    if (szEntity.optimizeSearchByAttributes != null) {
+      optimizeSearchByAttributes =
+          szEntity.optimizeSearchByAttributes.stream()
+              .map(
+                  attrList ->
+                      attributes.stream()
+                          .filter(attribute -> attrList.contains(attribute.getName()))
+                          .toList())
+              .filter(attrList -> !attrList.isEmpty())
+              .toList();
+    }
+
     List<Attribute> optimizeTextSearchAttributes = new ArrayList<>();
     if (szEntity.textSearch != null && szEntity.textSearch.attributes != null) {
       optimizeTextSearchAttributes =
@@ -426,6 +437,7 @@ public final class Underlay {
         attributes,
         hierarchies,
         optimizeGroupByAttributes,
+        optimizeSearchByAttributes,
         szEntity.textSearch != null,
         optimizeTextSearchAttributes,
         szEntity.sourceQueryTableName);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/Underlay.java
@@ -398,9 +398,10 @@ public final class Underlay {
       optimizeSearchByAttributes =
           szEntity.optimizeSearchByAttributes.stream()
               .map(
-                  attrList ->
+                  attributeSearch ->
                       attributes.stream()
-                          .filter(attribute -> attrList.contains(attribute.getName()))
+                          .filter(
+                              attribute -> attributeSearch.attributes.contains(attribute.getName()))
                           .toList())
               .filter(attrList -> !attrList.isEmpty())
               .toList();

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
@@ -151,12 +151,6 @@ public final class Entity {
     return optimizeTextSearchAttributes;
   }
 
-  public boolean containsOptimizeTextSearchAttribute(String attributeName) {
-    return optimizeTextSearchAttributes != null
-        && optimizeTextSearchAttributes.stream()
-            .anyMatch(attr -> attr.getName().equals(attributeName));
-  }
-
   public String getSourceQueryTableName() {
     return sourceQueryTableName;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/entitymodel/Entity.java
@@ -5,8 +5,6 @@ import bio.terra.tanagra.exception.SystemException;
 import com.google.common.collect.ImmutableList;
 import jakarta.annotation.Nullable;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public final class Entity {
   private final String name;
@@ -16,9 +14,7 @@ public final class Entity {
   private final ImmutableList<Attribute> attributes;
   private final ImmutableList<Hierarchy> hierarchies;
   private final ImmutableList<Attribute> optimizeGroupByAttributes;
-  // TODO-dex: remove this optimizeSearchByAttributes
   private final ImmutableList<ImmutableList<Attribute>> optimizeSearchByAttributes;
-  private final Set<String> optimizeSearchByAttributeNames;
   private final boolean hasTextSearch;
   private final ImmutableList<Attribute> optimizeTextSearchAttributes;
   private final String sourceQueryTableName;
@@ -46,11 +42,6 @@ public final class Entity {
     this.optimizeSearchByAttributes =
         ImmutableList.copyOf(
             optimizeSearchByAttributes.stream().map(ImmutableList::copyOf).toList());
-    this.optimizeSearchByAttributeNames =
-        optimizeSearchByAttributes.stream()
-            .flatMap(List::stream)
-            .map(Attribute::getName)
-            .collect(Collectors.toUnmodifiableSet());
     this.hasTextSearch = hasTextSearch;
     this.optimizeTextSearchAttributes = ImmutableList.copyOf(optimizeTextSearchAttributes);
     this.sourceQueryTableName = sourceQueryTableName;
@@ -139,8 +130,10 @@ public final class Entity {
     return optimizeSearchByAttributes;
   }
 
-  public boolean containsOptimizeSearchByAttribute(String attribute) {
-    return optimizeSearchByAttributeNames.contains(attribute);
+  public boolean containsOptimizeSearchByAttribute(String attributeName) {
+    return optimizeSearchByAttributes.stream()
+        .flatMap(List::stream)
+        .anyMatch(attribute -> attribute.getName().equals(attributeName));
   }
 
   public boolean hasTextSearch() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityMain.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityMain.java
@@ -5,7 +5,6 @@ import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.NameHelper;
-import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.serialization.SZAttribute;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import bio.terra.tanagra.underlay.serialization.SZHierarchy;
@@ -103,24 +102,6 @@ public final class ITEntityMain extends IndexTable {
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
     return columnSchemas;
-  }
-
-  public SqlField getAttributeValueField(String attribute) {
-    return SqlField.of(attribute);
-  }
-
-  public ColumnSchema getAttributeValueColumnSchema(Attribute attribute) {
-    return new ColumnSchema(
-        attribute.getName(), attribute.getDataType(), attribute.isDataTypeRepeated(), false);
-  }
-
-  public SqlField getAttributeDisplayField(String attribute) {
-    return SqlField.of(getAttributeDisplayFieldName(attribute));
-  }
-
-  private String getAttributeDisplayFieldName(String attribute) {
-    return NameHelper.getReservedFieldName(
-        ColumnTemplate.ATTRIBUTE_DISPLAY.getColumnNamePrefixed(attribute));
   }
 
   public SqlField getHierarchyPathField(String hierarchy) {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttribute.java
@@ -4,6 +4,7 @@ import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.NameHelper;
 import bio.terra.tanagra.underlay.serialization.SZAttribute;
+import bio.terra.tanagra.underlay.serialization.SZAttributeSearch;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import bio.terra.tanagra.underlay.serialization.SZEntity;
 import com.google.common.collect.ImmutableList;
@@ -15,13 +16,14 @@ public class ITEntitySearchByAttribute extends IndexTable {
 
   private final String entity;
   private final ImmutableList<String> attributeNames;
+  private final boolean includeNullValues;
   private final ImmutableList<ColumnSchema> columnSchemas;
 
   public ITEntitySearchByAttribute(
       NameHelper namer,
       SZBigQuery.IndexData bigQueryConfig,
       SZEntity entity,
-      List<String> attributes) {
+      SZAttributeSearch attributeSearch) {
     super(namer, bigQueryConfig);
     this.entity = entity.name;
 
@@ -34,7 +36,7 @@ public class ITEntitySearchByAttribute extends IndexTable {
         new ColumnSchema(
             idAttribute.name, ConfigReader.deserializeDataType(idAttribute.dataType), false, true));
 
-    attributes.forEach(
+    attributeSearch.attributes.forEach(
         attribute -> {
           SZAttribute searchAttribute = entity.getAttribute(attribute);
           attrNames.add(searchAttribute.name);
@@ -47,6 +49,7 @@ public class ITEntitySearchByAttribute extends IndexTable {
         });
 
     this.attributeNames = ImmutableList.copyOf(attrNames);
+    this.includeNullValues = attributeSearch.includeNullValues;
     this.columnSchemas = ImmutableList.copyOf(attrSchemas);
   }
 
@@ -66,5 +69,9 @@ public class ITEntitySearchByAttribute extends IndexTable {
 
   public ImmutableList<String> getAttributeNames() {
     return attributeNames;
+  }
+
+  public boolean includeNullValues() {
+    return includeNullValues;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttribute.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttribute.java
@@ -1,0 +1,70 @@
+package bio.terra.tanagra.underlay.indextable;
+
+import bio.terra.tanagra.underlay.ColumnSchema;
+import bio.terra.tanagra.underlay.ConfigReader;
+import bio.terra.tanagra.underlay.NameHelper;
+import bio.terra.tanagra.underlay.serialization.SZAttribute;
+import bio.terra.tanagra.underlay.serialization.SZBigQuery;
+import bio.terra.tanagra.underlay.serialization.SZEntity;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ITEntitySearchByAttribute extends IndexTable {
+  public static final String TABLE_NAME = "ESA";
+
+  private final String entity;
+  private final ImmutableList<String> attributeNames;
+  private final ImmutableList<ColumnSchema> columnSchemas;
+
+  public ITEntitySearchByAttribute(
+      NameHelper namer,
+      SZBigQuery.IndexData bigQueryConfig,
+      SZEntity entity,
+      List<String> attributes) {
+    super(namer, bigQueryConfig);
+    this.entity = entity.name;
+
+    // id + columns in tables optimized for search (clustered) cannot be repeated
+    List<String> attrNames = new ArrayList<>();
+    List<ColumnSchema> attrSchemas = new ArrayList<>();
+
+    SZAttribute idAttribute = entity.getAttribute(entity.idAttribute);
+    attrSchemas.add(
+        new ColumnSchema(
+            idAttribute.name, ConfigReader.deserializeDataType(idAttribute.dataType), false, true));
+
+    attributes.forEach(
+        attribute -> {
+          SZAttribute searchAttribute = entity.getAttribute(attribute);
+          attrNames.add(searchAttribute.name);
+          attrSchemas.add(
+              new ColumnSchema(
+                  searchAttribute.name,
+                  ConfigReader.deserializeDataType(searchAttribute.dataType),
+                  false,
+                  false));
+        });
+
+    this.attributeNames = ImmutableList.copyOf(attrNames);
+    this.columnSchemas = ImmutableList.copyOf(attrSchemas);
+  }
+
+  @Override
+  public String getTableBaseName() {
+    return TABLE_NAME + "_" + entity + "_" + String.join("_", attributeNames);
+  }
+
+  @Override
+  public ImmutableList<ColumnSchema> getColumnSchemas() {
+    return columnSchemas;
+  }
+
+  public String getEntity() {
+    return entity;
+  }
+
+  public ImmutableList<String> getAttributeNames() {
+    return attributeNames;
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
@@ -1,8 +1,11 @@
 package bio.terra.tanagra.underlay.indextable;
 
 import bio.terra.tanagra.query.bigquery.BQTable;
+import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.NameHelper;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.indextable.ITEntityMain.ColumnTemplate;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import com.google.common.collect.ImmutableList;
 
@@ -38,5 +41,23 @@ public abstract class IndexTable {
 
   public boolean isGeneratedIndexTable() {
     return true;
+  }
+
+  public SqlField getAttributeValueField(String attribute) {
+    return SqlField.of(attribute);
+  }
+
+  public ColumnSchema getAttributeValueColumnSchema(Attribute attribute) {
+    return new ColumnSchema(
+        attribute.getName(), attribute.getDataType(), attribute.isDataTypeRepeated(), false);
+  }
+
+  public SqlField getAttributeDisplayField(String attribute) {
+    return SqlField.of(getAttributeDisplayFieldName(attribute));
+  }
+
+  public String getAttributeDisplayFieldName(String attribute) {
+    return NameHelper.getReservedFieldName(
+        ColumnTemplate.ATTRIBUTE_DISPLAY.getColumnNamePrefixed(attribute));
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttributeSearch.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttributeSearch.java
@@ -1,0 +1,28 @@
+package bio.terra.tanagra.underlay.serialization;
+
+import bio.terra.tanagra.annotation.AnnotatedClass;
+import bio.terra.tanagra.annotation.AnnotatedField;
+import java.util.List;
+
+@AnnotatedClass(
+    name = "SZAttributeSearch",
+    markdown =
+        "Configuration to optimize entity search by attributes.\n\n"
+            + "Define the list of attributes to group together for optimization "
+            + "and specific is search for null attribute values is supported. ")
+public class SZAttributeSearch {
+  @AnnotatedField(
+      name = "SZAttributeSearch.attributes",
+      markdown =
+          "List of attributes grouped together for search optimization.\n\n"
+              + " Order matter. Each entry is a list of attributes that are search for together. "
+              + "For example search is typically performed for contig and position together. ")
+  public List<String> attributes;
+
+  @AnnotatedField(
+      name = "SZAttributeSearch.includeNullValues",
+      markdown = "True if search for null values in attributes is supported. ",
+      optional = true,
+      defaultValue = "false")
+  public boolean includeNullValues;
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
@@ -69,14 +69,14 @@ public class SZEntity {
   @AnnotatedField(
       name = "SZEntity.optimizeSearchByAttributes",
       markdown =
-          "List of (list of) attributes to optimize for search queries.\n\n"
+          "List of search configs to optimize entity search by attributes.\n\n"
               + "The typical use case for this is to optimize attribute based search on large entity tables that "
               + "cannot be optimised for search on multiple attribute fields. For example, to optimize search "
               + "on the variant table using attributes values for gene and rs_number. "
               + "Each entry is a list of attributes that are search for together. "
               + "For example search is typically performed for contig and position together. ",
       optional = true)
-  public List<List<String>> optimizeSearchByAttributes;
+  public List<SZAttributeSearch> optimizeSearchByAttributes;
 
   @AnnotatedField(
       name = "SZEntity.hierarchies",

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZEntity.java
@@ -67,6 +67,18 @@ public class SZEntity {
   public List<String> optimizeGroupByAttributes;
 
   @AnnotatedField(
+      name = "SZEntity.optimizeSearchByAttributes",
+      markdown =
+          "List of (list of) attributes to optimize for search queries.\n\n"
+              + "The typical use case for this is to optimize attribute based search on large entity tables that "
+              + "cannot be optimised for search on multiple attribute fields. For example, to optimize search "
+              + "on the variant table using attributes values for gene and rs_number. "
+              + "Each entry is a list of attributes that are search for together. "
+              + "For example search is typically performed for contig and position together. ",
+      optional = true)
+  public List<List<String>> optimizeSearchByAttributes;
+
+  @AnnotatedField(
       name = "SZEntity.hierarchies",
       markdown =
           "List of hierarchies.\n\n"
@@ -117,5 +129,9 @@ public class SZEntity {
             "Name of the attribute to use for the visit (occurrence) id in a temporal query.",
         exampleValue = "visit_occurrence_id")
     public String visitIdAttribute;
+  }
+
+  public SZAttribute getAttribute(String attrName) {
+    return attributes.stream().filter(attr -> attr.name.equals(attrName)).findFirst().orElseThrow();
   }
 }

--- a/underlay/src/main/resources/config/criteria/aouSC2023Q3R2_testonly/criteriaselector/variant/variant.json
+++ b/underlay/src/main/resources/config/criteria/aouSC2023Q3R2_testonly/criteriaselector/variant/variant.json
@@ -107,15 +107,15 @@
       "regex": "(\\w+):(\\d+)-(\\d+)",
       "parameters": [
         {
-          "attribute": "gene",
+          "attribute": "contig",
           "operator": "OPERATOR_EQUALS"
         },
         {
-          "attribute": "allele_number",
+          "attribute": "position",
           "operator": "OPERATOR_GREATER_THAN_OR_EQUAL"
         },
         {
-          "attribute": "allele_number",
+          "attribute": "position",
           "operator": "OPERATOR_LESS_THAN_OR_EQUAL"
         }
       ]

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entity/variant/all.sql
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entity/variant/all.sql
@@ -27,7 +27,7 @@ WITH sorted_transcripts AS (
     ORDER BY vid, row_number),
 
     genes AS (
-         SELECT vid, ARRAY_TO_STRING(ARRAY_AGG(DISTINCT gene_symbol IGNORE NULLS ORDER BY gene_symbol), ', ') AS genes
+         SELECT vid, ARRAY_AGG(DISTINCT gene_symbol IGNORE NULLS ORDER BY gene_symbol) AS genes
          FROM `${omopDataset}.prep_vat`
          GROUP BY vid
     )

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entity/variant/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entity/variant/entity.json
@@ -15,8 +15,10 @@
     { "name": "position", "dataType": "INT64" }
   ],
   "idAttribute": "id",
-  "textSearch": {
-    "attributes": [ "gene", "rs_number", "contig", "position" ]
-  },
-  "optimizeGroupByAttributes": [ "id" ]
+  "optimizeGroupByAttributes": [ "id" ],
+  "optimizeSearchByAttributes": [
+    [ "gene" ],
+    [ "rs_number" ],
+    [ "contig", "position" ]
+  ]
 }

--- a/underlay/src/main/resources/config/datamapping/aouCT_testonly/entity/variant/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouCT_testonly/entity/variant/entity.json
@@ -3,7 +3,7 @@
   "allInstancesSqlFile": "all.sql",
   "attributes": [
     { "name": "id", "dataType": "STRING", "valueFieldName": "vid" },
-    { "name": "gene", "dataType": "STRING", "valueFieldName": "gene_symbol", "isComputeDisplayHint": true },
+    { "name": "gene", "dataType": "STRING", "isDataTypeRepeated": true, "valueFieldName": "gene_symbol", "isComputeDisplayHint": true },
     { "name": "rs_number", "dataType": "STRING", "isDataTypeRepeated": true, "valueFieldName": "dbsnp_rsid" },
     { "name": "consequence", "dataType": "STRING", "isDataTypeRepeated":  true, "isComputeDisplayHint": true },
     { "name": "protein_change", "dataType": "STRING", "valueFieldName": "aa_change" },
@@ -17,8 +17,8 @@
   "idAttribute": "id",
   "optimizeGroupByAttributes": [ "id" ],
   "optimizeSearchByAttributes": [
-    [ "gene" ],
-    [ "rs_number" ],
-    [ "contig", "position" ]
+    { "attributes": [ "gene" ] },
+    { "attributes": [ "rs_number" ] },
+    { "attributes": [ "contig", "position" ] }
   ]
 }

--- a/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
+++ b/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "prj-e-dexamundsen-hd2",
-      "datasetId": "aou_test_data_SC2023Q3R2_index_121324",
+      "datasetId": "aou_test_data_SC2023Q3R2_index_121524",
       "tablePrefix": "T"
     },
     "queryProjectId": "prj-e-dexamundsen-hd2",

--- a/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
+++ b/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
@@ -2,26 +2,26 @@
   "underlay": "aouSC2023Q3R2_testonly",
   "bigQuery": {
     "sourceData": {
-      "projectId": "verily-tanagra-dev",
+      "projectId": "prj-e-dexamundsen-hd2",
       "datasetId": "aou_test_data_SC2023Q3R2",
       "sqlSubstitutions": {
-        "omopDataset": "verily-tanagra-dev.aou_test_data_SC2023Q3R2",
-        "staticTablesDataset": "verily-tanagra-dev.aou_static_prep"
+        "omopDataset": "prj-e-dexamundsen-hd2.aou_test_data_SC2023Q3R2",
+        "staticTablesDataset": "prj-e-dexamundsen-hd2.aou_static_prep_us"
       }
     },
     "indexData": {
-      "projectId": "verily-tanagra-dev",
-      "datasetId": "aou_test_data_SC2023Q3R2_index_090424",
+      "projectId": "prj-e-dexamundsen-hd2",
+      "datasetId": "aou_test_data_SC2023Q3R2_index_121324",
       "tablePrefix": "T"
     },
-    "queryProjectId": "verily-tanagra-dev",
+    "queryProjectId": "prj-e-dexamundsen-hd2",
     "dataLocation": "us"
   },
   "dataflow": {
-    "serviceAccountEmail": "backend-default@verily-tanagra-dev.iam.gserviceaccount.com",
+    "serviceAccountEmail": "indexer-sa@prj-e-dexamundsen-hd2.iam.gserviceaccount.com",
     "dataflowLocation": "us-central1",
-    "gcsTempDirectory": "gs://dataflow-staging-us-central1-694046000181/temp/",
-    "workerMachineType": "n1-standard-4",
+    "gcsTempDirectory": "gs://indexing_us_central1/temp/",
+    "workerMachineType": "n1-standard-8",
     "usePublicIps": false,
     "vpcSubnetworkName": null
   }

--- a/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
+++ b/underlay/src/main/resources/config/indexer/aouSC2023Q3R2_verily.json
@@ -11,7 +11,7 @@
     },
     "indexData": {
       "projectId": "prj-e-dexamundsen-hd2",
-      "datasetId": "aou_test_data_SC2023Q3R2_index_121524",
+      "datasetId": "aou_test_data_SC2023Q3R2_index_121624",
       "tablePrefix": "T"
     },
     "queryProjectId": "prj-e-dexamundsen-hd2",


### PR DESCRIPTION
design
- add field to entity (config & model)
- read field from config (underlay.fromConfig))
- define index tables (IndexSchema)
- add indexing step to build table per declared attribute (Job sequencer)
- Update ApiTranslator to use the new tables

Test generated SQL, indexing and UI integration - https://docs.google.com/document/d/1EIS9V-PBlkZ5aAVYk9GsHx5huL3rldIF0iZi5m3uohk

Changes included:
- config file update to support optimizeSearchByAttributes in variant entity. Also remove test search for variant
- Update generated docs + related code to generate the same (Added support for nested list (2 level only))
- Indexing code changes to generate tables for optimizeSearchByAttributes (step WriteEntitySearchByAttribute)
- Create and use util `fetchSelectField`
- Update BQAttributeFilterTranslator to use optimizeSearchByAttributes tables when available


Pending (will be done in follow up pr, in progress)
- in api translator : combine boolean filters into a single select from statement
