### PR TITLE
DT-343 changing study label and data source to displayName instead

### DIFF
--- a/ui/src/export.tsx
+++ b/ui/src/export.tsx
@@ -136,7 +136,7 @@ export function Export() {
             <StudyName />
             <Typography variant="body1">•</Typography>
             <Typography variant="body1">
-              Data source: {underlay.name}
+              Data source: {underlay.underlayConfig.metadata.displayName}
             </Typography>
           </GridLayout>
         }

--- a/ui/src/studyName.tsx
+++ b/ui/src/studyName.tsx
@@ -1,12 +1,13 @@
 import Typography from "@mui/material/Typography";
 import Loading from "components/loading";
 import { useStudySource } from "data/studySourceContext";
-import { useStudyId } from "hooks";
+import { useStudyId, useUnderlay } from "hooks";
 import useSWR from "swr";
 
 export function StudyName() {
   const studySource = useStudySource();
   const studyId = useStudyId();
+  const underlay = useUnderlay();
 
   const studyState = useSWR({ type: "Study", studyId }, async () => {
     return await studySource.getStudy(studyId);
@@ -15,7 +16,8 @@ export function StudyName() {
   return (
     <Loading status={studyState} size="small">
       <Typography variant="body1">
-        Study: {studyState.data?.displayName}
+        {underlay.uiConfiguration.featureConfig?.renameStudyLabel ?? "Study"}:{" "}
+        {studyState.data?.displayName}
       </Typography>
     </Loading>
   );

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -33,6 +33,7 @@ export type FeatureConfig = {
   disableExportButton?: boolean;
   overrideExportButton?: boolean;
   disableFeatureSets?: boolean;
+  renameStudyLabel?: string;
 };
 
 export type DemographicChartConfig = {

--- a/underlay/src/main/resources/config/underlay/aouC2024Q3R4/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouC2024Q3R4/ui.json
@@ -1,6 +1,7 @@
 {
   "featureConfig": {
-    "overrideExportButton": true
+    "overrideExportButton": true,
+    "renameStudyLabel": "Workspace"
   },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],

--- a/underlay/src/main/resources/config/underlay/aouR2024Q3R4/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouR2024Q3R4/ui.json
@@ -1,6 +1,7 @@
 {
   "featureConfig": {
-    "overrideExportButton": true
+    "overrideExportButton": true,
+    "renameStudyLabel": "Workspace"
   },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R2/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R2/ui.json
@@ -1,6 +1,7 @@
 {
   "featureConfig": {
-    "overrideExportButton": true
+    "overrideExportButton": true,
+    "renameStudyLabel": "Workspace"
   },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],

--- a/underlay/src/main/resources/config/underlay/aouSC2023Q3R2_testonly/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSC2023Q3R2_testonly/ui.json
@@ -1,6 +1,7 @@
 {
   "featureConfig": {
-    "overrideExportButton": true
+    "overrideExportButton": true,
+    "renameStudyLabel": "Workspace"
   },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],

--- a/underlay/src/main/resources/config/underlay/aouSR2023Q3R2/ui.json
+++ b/underlay/src/main/resources/config/underlay/aouSR2023Q3R2/ui.json
@@ -1,6 +1,7 @@
 {
   "featureConfig": {
-    "overrideExportButton": true
+    "overrideExportButton": true,
+    "renameStudyLabel": "Workspace"
   },
   "demographicChartConfigs": {
     "groupByAttributes": ["gender", "race", "age"],


### PR DESCRIPTION
Added featureConfig attribute called renameStudyLabel. This will allow us to override the study label and use workspace instead. 
![Screen Shot 2025-01-13 at 12 01 11 PM](https://github.com/user-attachments/assets/6de3a6bc-9024-40ce-8905-8b9416a012f0)
Changed underlay name to now be displayName. @tjennison-work wanted to confirm with you that this change is ok. AoU users are used to seeing the display name instead of the actual dataset name. 
![Screen Shot 2025-01-13 at 12 01 31 PM](https://github.com/user-attachments/assets/309bd15c-3f26-4038-b6e5-13effa901a13)
