### PR TITLE
Pass AttrSwapFields to nested translators

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
@@ -32,6 +32,7 @@ import bio.terra.tanagra.query.sql.*;
 import bio.terra.tanagra.query.sql.translator.ApiFieldTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import jakarta.annotation.*;
 import java.util.*;
 
@@ -72,61 +73,83 @@ public final class BQApiTranslator implements ApiTranslator {
   }
 
   @Override
-  public ApiFilterTranslator translator(AttributeFilter attributeFilter) {
-    return new BQAttributeFilterTranslator(this, attributeFilter);
+  public ApiFilterTranslator translator(
+      AttributeFilter attributeFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQAttributeFilterTranslator(this, attributeFilter, attributeSwapFields);
   }
 
   @Override
   public Optional<ApiFilterTranslator> mergedTranslator(
-      List<AttributeFilter> attributeFilters, LogicalOperator logicalOperator) {
+      List<AttributeFilter> attributeFilters,
+      LogicalOperator logicalOperator,
+      Map<Attribute, SqlField> attributeSwapFields) {
     return BQAttributeFilterTranslator.canMergeTranslation(attributeFilters)
-        ? Optional.of(new BQAttributeFilterTranslator(this, attributeFilters, logicalOperator))
+        ? Optional.of(
+            new BQAttributeFilterTranslator(
+                this, attributeFilters, logicalOperator, attributeSwapFields))
         : Optional.empty();
   }
 
   @Override
-  public ApiFilterTranslator translator(HierarchyHasAncestorFilter hierarchyHasAncestorFilter) {
-    return new BQHierarchyHasAncestorFilterTranslator(this, hierarchyHasAncestorFilter);
+  public ApiFilterTranslator translator(
+      HierarchyHasAncestorFilter hierarchyHasAncestorFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQHierarchyHasAncestorFilterTranslator(
+        this, hierarchyHasAncestorFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(HierarchyHasParentFilter hierarchyHasParentFilter) {
-    return new BQHierarchyHasParentFilterTranslator(this, hierarchyHasParentFilter);
+  public ApiFilterTranslator translator(
+      HierarchyHasParentFilter hierarchyHasParentFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQHierarchyHasParentFilterTranslator(
+        this, hierarchyHasParentFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(HierarchyIsLeafFilter hierarchyIsLeafFilter) {
-    return new BQHierarchyIsLeafFilterTranslator(this, hierarchyIsLeafFilter);
+  public ApiFilterTranslator translator(
+      HierarchyIsLeafFilter hierarchyIsLeafFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQHierarchyIsLeafFilterTranslator(this, hierarchyIsLeafFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(HierarchyIsMemberFilter hierarchyIsMemberFilter) {
-    return new BQHierarchyIsMemberFilterTranslator(this, hierarchyIsMemberFilter);
+  public ApiFilterTranslator translator(
+      HierarchyIsMemberFilter hierarchyIsMemberFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQHierarchyIsMemberFilterTranslator(
+        this, hierarchyIsMemberFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(HierarchyIsRootFilter hierarchyIsRootFilter) {
-    return new BQHierarchyIsRootFilterTranslator(this, hierarchyIsRootFilter);
+  public ApiFilterTranslator translator(
+      HierarchyIsRootFilter hierarchyIsRootFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQHierarchyIsRootFilterTranslator(this, hierarchyIsRootFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(PrimaryWithCriteriaFilter primaryWithCriteriaFilter) {
-    return new BQPrimaryWithCriteriaFilterTranslator(this, primaryWithCriteriaFilter);
+  public ApiFilterTranslator translator(
+      PrimaryWithCriteriaFilter primaryWithCriteriaFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQPrimaryWithCriteriaFilterTranslator(
+        this, primaryWithCriteriaFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(RelationshipFilter relationshipFilter) {
-    return new BQRelationshipFilterTranslator(this, relationshipFilter);
+  public ApiFilterTranslator translator(
+      RelationshipFilter relationshipFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQRelationshipFilterTranslator(this, relationshipFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(TextSearchFilter textSearchFilter) {
-    return new BQTextSearchFilterTranslator(this, textSearchFilter);
+  public ApiFilterTranslator translator(
+      TextSearchFilter textSearchFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQTextSearchFilterTranslator(this, textSearchFilter, attributeSwapFields);
   }
 
   @Override
-  public ApiFilterTranslator translator(TemporalPrimaryFilter temporalPrimaryFilter) {
-    return new BQTemporalPrimaryFilterTranslator(this, temporalPrimaryFilter);
+  public ApiFilterTranslator translator(
+      TemporalPrimaryFilter temporalPrimaryFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BQTemporalPrimaryFilterTranslator(this, temporalPrimaryFilter, attributeSwapFields);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQAttributeFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQAttributeFilterTranslator.java
@@ -14,6 +14,7 @@ import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
 import bio.terra.tanagra.underlay.indextable.ITEntitySearchByAttribute;
 import java.util.List;
+import java.util.Map;
 
 public class BQAttributeFilterTranslator extends ApiFilterTranslator {
   private final AttributeFilter attributeFilter;
@@ -21,8 +22,10 @@ public class BQAttributeFilterTranslator extends ApiFilterTranslator {
   private final LogicalOperator logicalOperatorForList;
 
   public BQAttributeFilterTranslator(
-      ApiTranslator apiTranslator, AttributeFilter singleAttributeFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      AttributeFilter singleAttributeFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.attributeFilter = singleAttributeFilter;
     this.attributeFilterList = null;
     this.logicalOperatorForList = null;
@@ -31,8 +34,9 @@ public class BQAttributeFilterTranslator extends ApiFilterTranslator {
   public BQAttributeFilterTranslator(
       ApiTranslator apiTranslator,
       List<AttributeFilter> attributeFilters,
-      LogicalOperator logicalOperator) {
-    super(apiTranslator);
+      LogicalOperator logicalOperator,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.attributeFilter = null;
     this.attributeFilterList = attributeFilters;
     this.logicalOperatorForList = logicalOperator;

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyHasAncestorFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyHasAncestorFilterTranslator.java
@@ -10,13 +10,16 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITHierarchyAncestorDescendant;
+import java.util.Map;
 
 public class BQHierarchyHasAncestorFilterTranslator extends ApiFilterTranslator {
   private final HierarchyHasAncestorFilter hierarchyHasAncestorFilter;
 
   public BQHierarchyHasAncestorFilterTranslator(
-      ApiTranslator apiTranslator, HierarchyHasAncestorFilter hierarchyHasAncestorFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      HierarchyHasAncestorFilter hierarchyHasAncestorFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.hierarchyHasAncestorFilter = hierarchyHasAncestorFilter;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyHasParentFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyHasParentFilterTranslator.java
@@ -9,13 +9,16 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITHierarchyChildParent;
+import java.util.Map;
 
 public class BQHierarchyHasParentFilterTranslator extends ApiFilterTranslator {
   private final HierarchyHasParentFilter hierarchyHasParentFilter;
 
   public BQHierarchyHasParentFilterTranslator(
-      ApiTranslator apiTranslator, HierarchyHasParentFilter hierarchyHasParentFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      HierarchyHasParentFilter hierarchyHasParentFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.hierarchyHasParentFilter = hierarchyHasParentFilter;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyIsLeafFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyIsLeafFilterTranslator.java
@@ -8,13 +8,16 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
+import java.util.Map;
 
 public class BQHierarchyIsLeafFilterTranslator extends ApiFilterTranslator {
   private final HierarchyIsLeafFilter hierarchyIsLeafFilter;
 
   public BQHierarchyIsLeafFilterTranslator(
-      ApiTranslator apiTranslator, HierarchyIsLeafFilter hierarchyIsLeafFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      HierarchyIsLeafFilter hierarchyIsLeafFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.hierarchyIsLeafFilter = hierarchyIsLeafFilter;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyIsMemberFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyIsMemberFilterTranslator.java
@@ -8,13 +8,16 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
+import java.util.Map;
 
 public class BQHierarchyIsMemberFilterTranslator extends ApiFilterTranslator {
   private final HierarchyIsMemberFilter hierarchyIsMemberFilter;
 
   public BQHierarchyIsMemberFilterTranslator(
-      ApiTranslator apiTranslator, HierarchyIsMemberFilter hierarchyIsMemberFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      HierarchyIsMemberFilter hierarchyIsMemberFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.hierarchyIsMemberFilter = hierarchyIsMemberFilter;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyIsRootFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQHierarchyIsRootFilterTranslator.java
@@ -8,13 +8,16 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
+import java.util.Map;
 
 public class BQHierarchyIsRootFilterTranslator extends ApiFilterTranslator {
   private final HierarchyIsRootFilter hierarchyIsRootFilter;
 
   public BQHierarchyIsRootFilterTranslator(
-      ApiTranslator apiTranslator, HierarchyIsRootFilter hierarchyIsRootFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      HierarchyIsRootFilter hierarchyIsRootFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.hierarchyIsRootFilter = hierarchyIsRootFilter;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQPrimaryWithCriteriaFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQPrimaryWithCriteriaFilterTranslator.java
@@ -18,14 +18,17 @@ import bio.terra.tanagra.underlay.indextable.ITEntityMain;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class BQPrimaryWithCriteriaFilterTranslator extends ApiFilterTranslator {
   private final PrimaryWithCriteriaFilter primaryWithCriteriaFilter;
 
   public BQPrimaryWithCriteriaFilterTranslator(
-      ApiTranslator apiTranslator, PrimaryWithCriteriaFilter primaryWithCriteriaFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      PrimaryWithCriteriaFilter primaryWithCriteriaFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.primaryWithCriteriaFilter = primaryWithCriteriaFilter;
   }
 
@@ -152,7 +155,9 @@ public class BQPrimaryWithCriteriaFilterTranslator extends ApiFilterTranslator {
                       + " FROM "
                       + occurrenceEntityTable.getTablePointer().render()
                       + " WHERE "
-                      + apiTranslator.translator(allOccurrenceFilters).buildSql(sqlParams, null));
+                      + apiTranslator
+                          .translator(allOccurrenceFilters, attributeSwapFields)
+                          .buildSql(sqlParams, null));
             });
 
     ITEntityMain selectEntityTable =

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQTemporalPrimaryFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQTemporalPrimaryFilterTranslator.java
@@ -34,8 +34,10 @@ public class BQTemporalPrimaryFilterTranslator extends ApiFilterTranslator {
   private final TemporalPrimaryFilter temporalPrimaryFilter;
 
   public BQTemporalPrimaryFilterTranslator(
-      ApiTranslator apiTranslator, TemporalPrimaryFilter temporalPrimaryFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      TemporalPrimaryFilter temporalPrimaryFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.temporalPrimaryFilter = temporalPrimaryFilter;
   }
 
@@ -165,7 +167,7 @@ public class BQTemporalPrimaryFilterTranslator extends ApiFilterTranslator {
                 subSelectSql +=
                     " WHERE "
                         + apiTranslator
-                            .translator(entityOutput.getDataFeatureFilter())
+                            .translator(entityOutput.getDataFeatureFilter(), attributeSwapFields)
                             .buildSql(sqlParams, null);
               }
               subSelectSqls.add(subSelectSql);

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQTextSearchFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQTextSearchFilterTranslator.java
@@ -8,13 +8,16 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain;
+import java.util.Map;
 
 public class BQTextSearchFilterTranslator extends ApiFilterTranslator {
   private final TextSearchFilter textSearchFilter;
 
   public BQTextSearchFilterTranslator(
-      ApiTranslator apiTranslator, TextSearchFilter textSearchFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      TextSearchFilter textSearchFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.textSearchFilter = textSearchFilter;
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiFilterTranslator.java
@@ -11,8 +11,12 @@ public abstract class ApiFilterTranslator {
   protected final ApiTranslator apiTranslator;
   protected final Map<Attribute, SqlField> attributeSwapFields = new HashMap<>();
 
-  protected ApiFilterTranslator(ApiTranslator apiTranslator) {
+  protected ApiFilterTranslator(
+      ApiTranslator apiTranslator, Map<Attribute, SqlField> attributeSwapFields) {
     this.apiTranslator = apiTranslator;
+    if (attributeSwapFields != null) {
+      this.attributeSwapFields.putAll(attributeSwapFields);
+    }
   }
 
   public abstract String buildSql(SqlParams sqlParams, String tableAlias);

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/ApiTranslator.java
@@ -26,6 +26,7 @@ import bio.terra.tanagra.query.sql.translator.filter.BooleanNotFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.filter.GroupHasItemsFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.filter.ItemInGroupFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.filter.OccurrenceForPrimaryFilterTranslator;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -291,87 +292,117 @@ public interface ApiTranslator {
     }
   }
 
-  ApiFilterTranslator translator(AttributeFilter attributeFilter);
+  ApiFilterTranslator translator(
+      AttributeFilter attributeFilter, Map<Attribute, SqlField> attributeSwapFields);
 
   Optional<ApiFilterTranslator> mergedTranslator(
-      List<AttributeFilter> attributeFilter, LogicalOperator logicalOperator);
+      List<AttributeFilter> attributeFilter,
+      LogicalOperator logicalOperator,
+      Map<Attribute, SqlField> attributeSwapFields);
 
-  default ApiFilterTranslator translator(BooleanAndOrFilter booleanAndOrFilter) {
-    return new BooleanAndOrFilterTranslator(this, booleanAndOrFilter);
+  default ApiFilterTranslator translator(
+      BooleanAndOrFilter booleanAndOrFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BooleanAndOrFilterTranslator(this, booleanAndOrFilter, attributeSwapFields);
   }
 
-  default ApiFilterTranslator translator(BooleanNotFilter booleanNotFilter) {
-    return new BooleanNotFilterTranslator(this, booleanNotFilter);
+  default ApiFilterTranslator translator(
+      BooleanNotFilter booleanNotFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new BooleanNotFilterTranslator(this, booleanNotFilter, attributeSwapFields);
   }
 
-  ApiFilterTranslator translator(HierarchyHasAncestorFilter hierarchyHasAncestorFilter);
+  ApiFilterTranslator translator(
+      HierarchyHasAncestorFilter hierarchyHasAncestorFilter,
+      Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(HierarchyHasParentFilter hierarchyHasParentFilter);
+  ApiFilterTranslator translator(
+      HierarchyHasParentFilter hierarchyHasParentFilter,
+      Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(HierarchyIsLeafFilter hierarchyIsLeafFilter);
+  ApiFilterTranslator translator(
+      HierarchyIsLeafFilter hierarchyIsLeafFilter, Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(HierarchyIsMemberFilter hierarchyIsMemberFilter);
+  ApiFilterTranslator translator(
+      HierarchyIsMemberFilter hierarchyIsMemberFilter,
+      Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(HierarchyIsRootFilter hierarchyIsRootFilter);
+  ApiFilterTranslator translator(
+      HierarchyIsRootFilter hierarchyIsRootFilter, Map<Attribute, SqlField> attributeSwapFields);
 
-  default ApiFilterTranslator translator(GroupHasItemsFilter groupHasItemsFilter) {
-    return new GroupHasItemsFilterTranslator(this, groupHasItemsFilter);
+  default ApiFilterTranslator translator(
+      GroupHasItemsFilter groupHasItemsFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new GroupHasItemsFilterTranslator(this, groupHasItemsFilter, attributeSwapFields);
   }
 
-  default ApiFilterTranslator translator(ItemInGroupFilter itemInGroupFilter) {
-    return new ItemInGroupFilterTranslator(this, itemInGroupFilter);
+  default ApiFilterTranslator translator(
+      ItemInGroupFilter itemInGroupFilter, Map<Attribute, SqlField> attributeSwapFields) {
+    return new ItemInGroupFilterTranslator(this, itemInGroupFilter, attributeSwapFields);
   }
 
-  default ApiFilterTranslator translator(OccurrenceForPrimaryFilter occurrenceForPrimaryFilter) {
-    return new OccurrenceForPrimaryFilterTranslator(this, occurrenceForPrimaryFilter);
+  default ApiFilterTranslator translator(
+      OccurrenceForPrimaryFilter occurrenceForPrimaryFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    return new OccurrenceForPrimaryFilterTranslator(
+        this, occurrenceForPrimaryFilter, attributeSwapFields);
   }
 
-  ApiFilterTranslator translator(PrimaryWithCriteriaFilter primaryWithCriteriaFilter);
+  ApiFilterTranslator translator(
+      PrimaryWithCriteriaFilter primaryWithCriteriaFilter,
+      Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(RelationshipFilter relationshipFilter);
+  ApiFilterTranslator translator(
+      RelationshipFilter relationshipFilter, Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(TextSearchFilter textSearchFilter);
+  ApiFilterTranslator translator(
+      TextSearchFilter textSearchFilter, Map<Attribute, SqlField> attributeSwapFields);
 
-  ApiFilterTranslator translator(TemporalPrimaryFilter temporalPrimaryFilter);
+  ApiFilterTranslator translator(
+      TemporalPrimaryFilter temporalPrimaryFilter, Map<Attribute, SqlField> attributeSwapFields);
 
   default ApiFilterTranslator translator(EntityFilter entityFilter) {
+    return translator(entityFilter, null);
+  }
+
+  default ApiFilterTranslator translator(
+      EntityFilter entityFilter, Map<Attribute, SqlField> attributeSwapFields) {
     if (entityFilter instanceof AttributeFilter) {
-      return translator((AttributeFilter) entityFilter);
+      return translator((AttributeFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof BooleanAndOrFilter) {
-      return translator((BooleanAndOrFilter) entityFilter);
+      return translator((BooleanAndOrFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof BooleanNotFilter) {
-      return translator((BooleanNotFilter) entityFilter);
+      return translator((BooleanNotFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof HierarchyHasAncestorFilter) {
-      return translator((HierarchyHasAncestorFilter) entityFilter);
+      return translator((HierarchyHasAncestorFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof HierarchyHasParentFilter) {
-      return translator((HierarchyHasParentFilter) entityFilter);
+      return translator((HierarchyHasParentFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof HierarchyIsLeafFilter) {
-      return translator((HierarchyIsLeafFilter) entityFilter);
+      return translator((HierarchyIsLeafFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof HierarchyIsMemberFilter) {
-      return translator((HierarchyIsMemberFilter) entityFilter);
+      return translator((HierarchyIsMemberFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof HierarchyIsRootFilter) {
-      return translator((HierarchyIsRootFilter) entityFilter);
+      return translator((HierarchyIsRootFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof GroupHasItemsFilter) {
-      return translator((GroupHasItemsFilter) entityFilter);
+      return translator((GroupHasItemsFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof ItemInGroupFilter) {
-      return translator((ItemInGroupFilter) entityFilter);
+      return translator((ItemInGroupFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof OccurrenceForPrimaryFilter) {
-      return translator((OccurrenceForPrimaryFilter) entityFilter);
+      return translator((OccurrenceForPrimaryFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof PrimaryWithCriteriaFilter) {
-      return translator((PrimaryWithCriteriaFilter) entityFilter);
+      return translator((PrimaryWithCriteriaFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof RelationshipFilter) {
-      return translator((RelationshipFilter) entityFilter);
+      return translator((RelationshipFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof TextSearchFilter) {
-      return translator((TextSearchFilter) entityFilter);
+      return translator((TextSearchFilter) entityFilter, attributeSwapFields);
     } else if (entityFilter instanceof TemporalPrimaryFilter) {
-      return translator((TemporalPrimaryFilter) entityFilter);
+      return translator((TemporalPrimaryFilter) entityFilter, attributeSwapFields);
     } else {
       throw new InvalidQueryException("No SQL translator defined for filter");
     }
   }
 
   default Optional<ApiFilterTranslator> optionalMergedTranslator(
-      List<EntityFilter> entityFilters, LogicalOperator logicalOperator) {
+      List<EntityFilter> entityFilters,
+      LogicalOperator logicalOperator,
+      Map<Attribute, SqlField> attributeSwapFields) {
     // A list of sub-filters can be merged (optimized) if they are of the same type
     // Additional checks may be needed for individual sub-filter types
     EntityFilter firstFilter = entityFilters.get(0);
@@ -382,6 +413,8 @@ public interface ApiTranslator {
       return Optional.empty();
     }
     return mergedTranslator(
-        entityFilters.stream().map(filter -> (AttributeFilter) filter).toList(), logicalOperator);
+        entityFilters.stream().map(filter -> (AttributeFilter) filter).toList(),
+        logicalOperator,
+        attributeSwapFields);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/BooleanAndOrFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/BooleanAndOrFilterTranslator.java
@@ -7,6 +7,7 @@ import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -16,16 +17,20 @@ public class BooleanAndOrFilterTranslator extends ApiFilterTranslator {
   private final Optional<ApiFilterTranslator> mergedSubFiltersTranslator;
 
   public BooleanAndOrFilterTranslator(
-      ApiTranslator apiTranslator, BooleanAndOrFilter booleanAndOrFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      BooleanAndOrFilter booleanAndOrFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.booleanAndOrFilter = booleanAndOrFilter;
     this.mergedSubFiltersTranslator =
         apiTranslator.optionalMergedTranslator(
-            booleanAndOrFilter.getSubFilters(), booleanAndOrFilter.getOperator());
+            booleanAndOrFilter.getSubFilters(),
+            booleanAndOrFilter.getOperator(),
+            attributeSwapFields);
     this.subFilterTranslators =
         mergedSubFiltersTranslator.isEmpty()
             ? booleanAndOrFilter.getSubFilters().stream()
-                .map(apiTranslator::translator)
+                .map(filter -> apiTranslator.translator(filter, attributeSwapFields))
                 .collect(Collectors.toList())
             : List.of();
   }

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/BooleanNotFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/BooleanNotFilterTranslator.java
@@ -6,14 +6,18 @@ import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import java.util.Map;
 
 public class BooleanNotFilterTranslator extends ApiFilterTranslator {
   private final ApiFilterTranslator subFilterTranslator;
 
   public BooleanNotFilterTranslator(
-      ApiTranslator apiTranslator, BooleanNotFilter booleanNotFilter) {
-    super(apiTranslator);
-    this.subFilterTranslator = apiTranslator.translator(booleanNotFilter.getSubFilter());
+      ApiTranslator apiTranslator,
+      BooleanNotFilter booleanNotFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
+    this.subFilterTranslator =
+        apiTranslator.translator(booleanNotFilter.getSubFilter(), attributeSwapFields);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/GroupHasItemsFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/GroupHasItemsFilterTranslator.java
@@ -2,18 +2,22 @@ package bio.terra.tanagra.query.sql.translator.filter;
 
 import bio.terra.tanagra.api.filter.GroupHasItemsFilter;
 import bio.terra.tanagra.api.filter.RelationshipFilter;
+import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
+import java.util.Map;
 
 public class GroupHasItemsFilterTranslator extends ApiFilterTranslator {
   private final GroupHasItemsFilter groupHasItemsFilter;
 
   public GroupHasItemsFilterTranslator(
-      ApiTranslator apiTranslator, GroupHasItemsFilter groupHasItemsFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      GroupHasItemsFilter groupHasItemsFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.groupHasItemsFilter = groupHasItemsFilter;
   }
 
@@ -30,7 +34,9 @@ public class GroupHasItemsFilterTranslator extends ApiFilterTranslator {
             groupHasItemsFilter.getGroupByCountAttributes(),
             groupHasItemsFilter.getGroupByCountOperator(),
             groupHasItemsFilter.getGroupByCountValue());
-    return apiTranslator.translator(relationshipFilter).buildSql(sqlParams, tableAlias);
+    return apiTranslator
+        .translator(relationshipFilter, attributeSwapFields)
+        .buildSql(sqlParams, tableAlias);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/ItemInGroupFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/ItemInGroupFilterTranslator.java
@@ -2,18 +2,22 @@ package bio.terra.tanagra.query.sql.translator.filter;
 
 import bio.terra.tanagra.api.filter.ItemInGroupFilter;
 import bio.terra.tanagra.api.filter.RelationshipFilter;
+import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.GroupItems;
+import java.util.Map;
 
 public class ItemInGroupFilterTranslator extends ApiFilterTranslator {
   private final ItemInGroupFilter itemInGroupFilter;
 
   public ItemInGroupFilterTranslator(
-      ApiTranslator apiTranslator, ItemInGroupFilter itemInGroupFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      ItemInGroupFilter itemInGroupFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.itemInGroupFilter = itemInGroupFilter;
   }
 
@@ -30,7 +34,9 @@ public class ItemInGroupFilterTranslator extends ApiFilterTranslator {
             itemInGroupFilter.getGroupByCountAttributes(),
             itemInGroupFilter.getGroupByCountOperator(),
             itemInGroupFilter.getGroupByCountValue());
-    return apiTranslator.translator(relationshipFilter).buildSql(sqlParams, tableAlias);
+    return apiTranslator
+        .translator(relationshipFilter, attributeSwapFields)
+        .buildSql(sqlParams, tableAlias);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/OccurrenceForPrimaryFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/OccurrenceForPrimaryFilterTranslator.java
@@ -4,18 +4,22 @@ import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
 import bio.terra.tanagra.api.filter.OccurrenceForPrimaryFilter;
 import bio.terra.tanagra.api.filter.RelationshipFilter;
 import bio.terra.tanagra.exception.InvalidQueryException;
+import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
 import bio.terra.tanagra.query.sql.translator.ApiTranslator;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import java.util.List;
+import java.util.Map;
 
 public class OccurrenceForPrimaryFilterTranslator extends ApiFilterTranslator {
   private final OccurrenceForPrimaryFilter occurrenceForPrimaryFilter;
 
   public OccurrenceForPrimaryFilterTranslator(
-      ApiTranslator apiTranslator, OccurrenceForPrimaryFilter occurrenceForPrimaryFilter) {
-    super(apiTranslator);
+      ApiTranslator apiTranslator,
+      OccurrenceForPrimaryFilter occurrenceForPrimaryFilter,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    super(apiTranslator, attributeSwapFields);
     this.occurrenceForPrimaryFilter = occurrenceForPrimaryFilter;
   }
 
@@ -55,12 +59,17 @@ public class OccurrenceForPrimaryFilterTranslator extends ApiFilterTranslator {
           .translator(
               new BooleanAndOrFilter(
                   BooleanAndOrFilter.LogicalOperator.AND,
-                  List.of(primaryRelationshipFilter, criteriaRelationshipFilter)))
+                  List.of(primaryRelationshipFilter, criteriaRelationshipFilter)),
+              attributeSwapFields)
           .buildSql(sqlParams, tableAlias);
     } else if (occurrenceForPrimaryFilter.hasPrimarySubFilter()) {
-      return apiTranslator.translator(primaryRelationshipFilter).buildSql(sqlParams, tableAlias);
+      return apiTranslator
+          .translator(primaryRelationshipFilter, attributeSwapFields)
+          .buildSql(sqlParams, tableAlias);
     } else if (occurrenceForPrimaryFilter.hasCriteriaSubFilter()) {
-      return apiTranslator.translator(criteriaRelationshipFilter).buildSql(sqlParams, tableAlias);
+      return apiTranslator
+          .translator(criteriaRelationshipFilter, attributeSwapFields)
+          .buildSql(sqlParams, tableAlias);
     } else {
       throw new InvalidQueryException("At least one of the sub-filters must be not-null");
     }


### PR DESCRIPTION
Issue
![image](https://github.com/user-attachments/assets/2f65ee1a-581a-4f02-9933-09833829e334)

When changing the slider to 17 - 100 it also produces another incorrect query for top 10 conditions, procedures, labs and drugs. The query is matching domain occurrence id to person_id which gives incorrect results:

root cause - the attribute swap function is initialized on one filter translator, but not applied when it is actually translated to sql since it is done by a different filter translator. Possible fix - pass on attribute swap object

before change

```
SELECT COUNT(DISTINCT person_id) AS T_CTDT, procedure, T_DISP_procedure 
FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_index_121624`.T_ENT_procedureOccurrence 
WHERE id IN (
	SELECT person_id 
	FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_index_121624`.T_ENT_heartRate 
	WHERE value_numeric BETWEEN 17.0 AND 100.0) 
GROUP BY procedure, T_DISP_procedure 
ORDER BY T_CTDT DESC 
LIMIT 1000000
```

debug:
added swapAttributeField (id / person_id) to GroupHasItemsFilterTranslator in BQRelationshipFilterTranslator.foreignKeyOnSelectEntity (object @387bd4ac)
checking attributeSwapFields (id) in BQRelationshipFilterTranslator.foreignKeyOnFilterEntity (object @5fc6cc6b)

after changes

```
SELECT COUNT(DISTINCT person_id) AS T_CTDT, procedure, T_DISP_procedure 
FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_index_121624`.T_ENT_procedureOccurrence 
WHERE person_id IN (
	SELECT person_id 
	FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_index_121624`.T_ENT_heartRate 
	WHERE value_numeric BETWEEN 17.0 AND 100.0) 
GROUP BY procedure, T_DISP_procedure 
ORDER BY T_CTDT DESC 
LIMIT 1000000
```

----

also fixes bug in the top 10 charts for conditions, procedures, labs and drugs queries.
When selecting a Physical Measurement criteria first time in the query produced is incorrect and referencing columns that don’t exist in the entity table. Example query (T_RCNT_heartRatePerson_NOHIER doesn’t exist in T_ENT_measurementOccurrence table

```
SELECT COUNT(DISTINCT person_id) AS T_CTDT, measurement, T_DISP_measurement
FROM `all-of-us-ehr-dev.SR2023Q3R2`.T_ENT_measurementOccurrence
WHERE T_RCNT_heartRatePerson_NOHIER > 0
GROUP BY measurement, T_DISP_measurement
ORDER BY T_CTDT DESC
LIMIT 1000000
```
after change

```
SELECT COUNT(DISTINCT person_id) AS T_CTDT, measurement, T_DISP_measurement 
FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_index_121624`.T_ENT_measurementOccurrence 
WHERE person_id IN (
    SELECT person_id 
    FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_index_121624`.T_ENT_heartRate) 
GROUP BY measurement, T_DISP_measurement 
ORDER BY T_CTDT DESC 
LIMIT 1000000
```