### PR TITLE
Don't show all survey answers when one matches

### DIFF
--- a/ui/src/components/treegrid.tsx
+++ b/ui/src/components/treegrid.tsx
@@ -22,6 +22,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -189,7 +190,8 @@ export function TreeGrid<ItemType extends TreeGridItem = TreeGridItem>(
     draft.set(id, itemState);
   };
 
-  useEffect(() => {
+  // Ensure default expansions take effect before rendering.
+  useLayoutEffect(() => {
     const de = props?.defaultExpanded;
     if (de && de.length > 0) {
       updateState((draft) => {


### PR DESCRIPTION
* Change survey search behavior so that when a search matches an answers, other answers to the same question are not also shown.
* Expand the hierarchy to show matched searches, or the first level by default.