### PR TITLE
add logging for bytes processed

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -52,7 +52,6 @@ public class BQExecutor {
               '@' + paramName,
               toSql(toQueryParameterValue(queryRequest.getSqlParams().getParamValue(paramName))));
     }
-    LOGGER.info("SQL no parameters: {}", sqlNoParams);
 
     // Build a BQ parameter value object for each SQL query parameter.
     Map<String, QueryParameterValue> bqQueryParams =

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -258,7 +258,17 @@ public final class GoogleBigQuery {
           TableResult tableResult =
               job.getQueryResults(
                   queryJobConfig.getRight().toArray(new BigQuery.QueryResultsOption[0]));
-          LOGGER.info("SQL query returns {} rows across all pages", tableResult.getTotalRows());
+          Job completedJob = job.waitFor();
+          JobStatistics.QueryStatistics stats = completedJob.getStatistics();
+          Long totalBytesProcessed = stats.getTotalBytesProcessed();
+          String jobId = completedJob.getJobId().getJob();
+          LOGGER.info("job: {}, query: {}", jobId, sql);
+          LOGGER.info(
+              "job: {}, total rows: {}, cache hit: {}, total megabytes processed: {}MB",
+              jobId,
+              tableResult.getTotalRows(),
+              stats.getCacheHit(),
+              totalBytesProcessed / 1_048_576);
           return tableResult;
         },
         "Error running query: " + queryJobConfig.getLeft().getQuery());


### PR DESCRIPTION
When app executes a query it is useful to log total megabytes processed. 

job: 292cdb01-6fd8-4cf1-9a18-a8a6c2f5adc0, query: SELECT COUNT(id) AS T_CTDT FROM `all-of-us-ehr-dev.SR2023Q3R2`.T_ENT_person WHERE id IN (SELECT person_id AS primary_id FROM `all-of-us-ehr-dev.SR2023Q3R2`.T_ENT_procedureOccurrence WHERE procedure_concept_id IN (SELECT descendant FROM `all-of-us-ehr-dev.SR2023Q3R2`.T_HAD_procedureConcept_default WHERE ancestor IN (@val0,@val1) UNION ALL SELECT @val2 UNION ALL SELECT @val3)) ORDER BY T_CTDT DESC LIMIT 1000000
2025-01-16T15:42:39.544-06:00   INFO 10955 --- [tanagra] [nio-8080-exec-4] bio.terra.tanagra.utils.GoogleBigQuery   : job: 292cdb01-6fd8-4cf1-9a18-a8a6c2f5adc0, total rows: 1, cache hit: false, total megabytes processed: 50MB