### PR TITLE
Create concept index tables clustered by primary entity id

### DIFF
--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -140,6 +140,13 @@ List of attributes grouped together for search optimization.
 
  Order matter. Each entry is a list of attributes that are search for together. For example search is typically performed for contig and position together. 
 
+### SZAttributeSearch.includeEntityMainColumns
+**optional** boolean
+
+True if all columns from the EntityMain table should be included in this table. 
+
+*Default value:* `false`
+
 ### SZAttributeSearch.includeNullValues
 **optional** boolean
 

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -143,7 +143,7 @@ List of attributes grouped together for search optimization.
 ### SZAttributeSearch.includeEntityMainColumns
 **optional** boolean
 
-True if all columns from the EntityMain table should be included in this table. 
+Whether all columns in the entity main table should also be included in this search table. Improves performance if other attributes are also fetched when performing this search by attributes.
 
 *Default value:* `false`
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntitySearchByAttributes.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/bigquery/WriteEntitySearchByAttributes.java
@@ -53,9 +53,8 @@ public class WriteEntitySearchByAttributes extends BigQueryJob {
 
   @Override
   public void run(boolean isDryRun) {
-
-    // Define create table definition
-    // Build the query to insert to the search table using a select from the main entity table.
+    // Create table definition & build the query to insert into the search table
+    // using a select from the main entity table.
     List<Field> fields = new ArrayList<>();
     List<String> insertColumns = new ArrayList<>();
     List<String> selectColumns = new ArrayList<>();
@@ -82,7 +81,6 @@ public class WriteEntitySearchByAttributes extends BigQueryJob {
               }
 
               Mode mode;
-
               if (searchTable.getAttributeNames().contains(attribute)) {
                 if (searchTable.includeNullValues()) {
                   mode = Mode.NULLABLE;

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
@@ -183,7 +183,7 @@ public class UnderlayService {
             pageMarker,
             pageSize,
             entityLevelHints,
-            true);
+            false);
     return underlay.getQueryRunner().run(countQueryRequest);
   }
 

--- a/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
+++ b/service/src/main/java/bio/terra/tanagra/service/UnderlayService.java
@@ -183,7 +183,7 @@ public class UnderlayService {
             pageMarker,
             pageSize,
             entityLevelHints,
-            false);
+            true);
     return underlay.getQueryRunner().run(countQueryRequest);
   }
 

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -15,6 +15,7 @@ export type SZAttribute = {
 
 export type SZAttributeSearch = {
   attributes: string[];
+  includeEntityMainColumns?: boolean;
   includeNullValues?: boolean;
 };
 

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/AttributeFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/AttributeFilter.java
@@ -57,8 +57,9 @@ public class AttributeFilter extends EntityFilter {
     this.values = ImmutableList.copyOf(values);
   }
 
-  public Attribute getAttribute() {
-    return attribute;
+  @Override
+  public List<Attribute> getFilterAttributes() {
+    return List.of(attribute);
   }
 
   public UnaryOperator getUnaryOperator() {

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanAndOrFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanAndOrFilter.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.api.filter;
 
 import bio.terra.tanagra.exception.InvalidQueryException;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -41,6 +42,15 @@ public class BooleanAndOrFilter extends EntityFilter {
           "All sub-filters of a boolean and/or filter must be for the same entity.");
     }
     return entity;
+  }
+
+  @Override
+  public List<Attribute> getFilterAttributes() {
+    return subFilters.stream()
+        .map(EntityFilter::getFilterAttributes)
+        .flatMap(List::stream)
+        .distinct()
+        .toList();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanNotFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/BooleanNotFilter.java
@@ -1,5 +1,7 @@
 package bio.terra.tanagra.api.filter;
 
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import java.util.List;
 import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +18,11 @@ public class BooleanNotFilter extends EntityFilter {
 
   public EntityFilter getSubFilter() {
     return subFilter;
+  }
+
+  @Override
+  public List<Attribute> getFilterAttributes() {
+    return subFilter.getFilterAttributes();
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
@@ -32,8 +32,7 @@ public abstract class EntityFilter {
   }
 
   public List<Attribute> getFilterAttributes() {
-    logger.debug(
-        "FilterAttributes not supported/implemented for " + this.getClass().getSimpleName());
+    // not supported or not implemented
     return List.of();
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
@@ -1,6 +1,7 @@
 package bio.terra.tanagra.api.filter;
 
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import java.util.List;
 import java.util.Objects;
@@ -28,6 +29,12 @@ public abstract class EntityFilter {
 
   public Entity getEntity() {
     return entity;
+  }
+
+  public List<Attribute> getFilterAttributes() {
+    logger.debug(
+        "FilterAttributes not supported/implemented for " + this.getClass().getSimpleName());
+    return List.of();
   }
 
   // TODO: Add logic here to merge filters automatically to get a simpler filter overall.

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/OccurrenceForPrimaryFilter.java
@@ -1,9 +1,11 @@
 package bio.terra.tanagra.api.filter;
 
 import bio.terra.tanagra.underlay.Underlay;
+import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.entitygroup.CriteriaOccurrence;
 import jakarta.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +25,15 @@ public class OccurrenceForPrimaryFilter extends EntityFilter {
     this.criteriaOccurrence = criteriaOccurrence;
     this.primarySubFilter = primarySubFilter;
     this.criteriaSubFilter = criteriaSubFilter;
+  }
+
+  @Override
+  public List<Attribute> getFilterAttributes() {
+    Attribute attribute =
+        criteriaOccurrence
+            .getOccurrencePrimaryRelationship(getOccurrenceEntity().getName())
+            .getForeignKeyAttribute(getOccurrenceEntity());
+    return attribute != null ? List.of(attribute) : List.of();
   }
 
   public CriteriaOccurrence getCriteriaOccurrence() {

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/RelationshipFilter.java
@@ -47,6 +47,12 @@ public class RelationshipFilter extends EntityFilter {
     this.groupByCountValue = groupByCountValue;
   }
 
+  @Override
+  public List<Attribute> getFilterAttributes() {
+    Attribute attribute = relationship.getForeignKeyAttribute(getSelectEntity());
+    return attribute != null ? List.of(attribute) : List.of();
+  }
+
   public EntityGroup getEntityGroup() {
     return entityGroup;
   }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/TextSearchFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/TextSearchFilter.java
@@ -4,6 +4,7 @@ import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import jakarta.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
@@ -30,13 +31,9 @@ public class TextSearchFilter extends EntityFilter {
     this.attribute = attribute;
   }
 
-  public boolean isForSpecificAttribute() {
-    return attribute != null;
-  }
-
-  @Nullable
-  public Attribute getAttribute() {
-    return attribute;
+  @Override
+  public List<Attribute> getFilterAttributes() {
+    return (attribute != null) ? List.of(attribute) : List.of();
   }
 
   public TextSearchOperator getOperator() {

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -43,8 +43,7 @@ public class BQExecutor {
   }
 
   public SqlQueryResult run(SqlQueryRequest queryRequest) {
-    // Log the SQL statement with parameters substituted locally (i.e. not by BQ) to help with
-    // debugging.
+    // Log the SQL statement with parameters substituted locally (i.e. not by BQ) for debugging.
     String sqlNoParams = queryRequest.getSql();
     for (String paramName : queryRequest.getSqlParams().getParamNamesLongestFirst()) {
       sqlNoParams =
@@ -73,7 +72,6 @@ public class BQExecutor {
               null);
       return new SqlQueryResult(List.of(), null, 0, sqlNoParams);
     } else {
-      LOGGER.error("DEX -- " + queryRequest.getSql());
       // For a regular run, convert the BQ query results to our internal result objects.
       TableResult tableResult =
           getBigQueryService()
@@ -85,7 +83,6 @@ public class BQExecutor {
                   null,
                   null,
                   null);
-      LOGGER.error("DEX success -- " + queryRequest.getSql());
       Iterable<SqlRowResult> rowResults =
           Iterables.transform(
               tableResult.getValues() /* Single page of results. */, BQRowResult::new);

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQExecutor.java
@@ -73,6 +73,7 @@ public class BQExecutor {
               null);
       return new SqlQueryResult(List.of(), null, 0, sqlNoParams);
     } else {
+      LOGGER.error("DEX -- " + queryRequest.getSql());
       // For a regular run, convert the BQ query results to our internal result objects.
       TableResult tableResult =
           getBigQueryService()
@@ -84,6 +85,7 @@ public class BQExecutor {
                   null,
                   null,
                   null);
+      LOGGER.error("DEX success -- " + queryRequest.getSql());
       Iterable<SqlRowResult> rowResults =
           Iterables.transform(
               tableResult.getValues() /* Single page of results. */, BQRowResult::new);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/IndexSchema.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/IndexSchema.java
@@ -213,7 +213,7 @@ public final class IndexSchema {
             entityGroupsWithCount.add(szCriteriaOccurrence.name);
           }
         });
-    entityMainTables.add(
+    ITEntityMain entityMain =
         new ITEntityMain(
             nameHelper,
             szBigQueryIndexData,
@@ -221,7 +221,8 @@ public final class IndexSchema {
             szEntity.attributes,
             szEntity.hierarchies,
             szEntity.textSearch != null,
-            entityGroupsWithCount));
+            entityGroupsWithCount);
+    entityMainTables.add(entityMain);
 
     // EntityLevelDisplayHints table.
     entityLevelDisplayHintTables.add(
@@ -233,7 +234,7 @@ public final class IndexSchema {
           attributeSearch ->
               entitySearchByAttributesTables.add(
                   new ITEntitySearchByAttributes(
-                      nameHelper, szBigQueryIndexData, szEntity, attributeSearch)));
+                      nameHelper, szBigQueryIndexData, entityMain, szEntity, attributeSearch)));
     }
 
     szEntity.hierarchies.forEach(

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttributes.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttributes.java
@@ -14,6 +14,7 @@ public class ITEntitySearchByAttributes extends IndexTable {
   private final String entity;
   private final ImmutableList<String> attributeNames;
   private final boolean includeNullValues;
+  private final boolean includeEntityMainColumns;
   private final ImmutableList<ColumnSchema> columnSchemas;
 
   public ITEntitySearchByAttributes(
@@ -54,6 +55,7 @@ public class ITEntitySearchByAttributes extends IndexTable {
             });
     this.columnSchemas = ImmutableList.copyOf(attrSchemas);
     this.includeNullValues = attributeSearch.includeNullValues;
+    this.includeEntityMainColumns = attributeSearch.includeEntityMainColumns;
   }
 
   @Override
@@ -76,5 +78,9 @@ public class ITEntitySearchByAttributes extends IndexTable {
 
   public boolean includeNullValues() {
     return includeNullValues;
+  }
+
+  public boolean includeEntityMainColumns() {
+    return includeEntityMainColumns;
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttributes.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntitySearchByAttributes.java
@@ -1,9 +1,7 @@
 package bio.terra.tanagra.underlay.indextable;
 
 import bio.terra.tanagra.underlay.ColumnSchema;
-import bio.terra.tanagra.underlay.ConfigReader;
 import bio.terra.tanagra.underlay.NameHelper;
-import bio.terra.tanagra.underlay.serialization.SZAttribute;
 import bio.terra.tanagra.underlay.serialization.SZAttributeSearch;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import bio.terra.tanagra.underlay.serialization.SZEntity;
@@ -13,7 +11,6 @@ import java.util.List;
 
 public class ITEntitySearchByAttributes extends IndexTable {
   public static final String TABLE_NAME = "ESA";
-
   private final String entity;
   private final ImmutableList<String> attributeNames;
   private final boolean includeNullValues;
@@ -22,35 +19,41 @@ public class ITEntitySearchByAttributes extends IndexTable {
   public ITEntitySearchByAttributes(
       NameHelper namer,
       SZBigQuery.IndexData bigQueryConfig,
+      ITEntityMain entityMain,
       SZEntity entity,
       SZAttributeSearch attributeSearch) {
     super(namer, bigQueryConfig);
     this.entity = entity.name;
 
-    // id + columns in tables optimized for search (clustered) cannot be repeated
-    List<String> attrNames = new ArrayList<>();
+    this.attributeNames =
+        ImmutableList.copyOf(
+            attributeSearch.attributes.stream()
+                .map(attribute -> entity.getAttribute(attribute).name)
+                .toList());
+
     List<ColumnSchema> attrSchemas = new ArrayList<>();
+    entityMain
+        .getColumnSchemas()
+        .forEach(
+            colSchema -> {
+              String colName = colSchema.getColumnName();
 
-    SZAttribute idAttribute = entity.getAttribute(entity.idAttribute);
-    attrSchemas.add(
-        new ColumnSchema(
-            idAttribute.name, ConfigReader.deserializeDataType(idAttribute.dataType), false, true));
-
-    attributeSearch.attributes.forEach(
-        attribute -> {
-          SZAttribute searchAttribute = entity.getAttribute(attribute);
-          attrNames.add(searchAttribute.name);
-          attrSchemas.add(
-              new ColumnSchema(
-                  searchAttribute.name,
-                  ConfigReader.deserializeDataType(searchAttribute.dataType),
-                  false,
-                  false));
-        });
-
-    this.attributeNames = ImmutableList.copyOf(attrNames);
-    this.includeNullValues = attributeSearch.includeNullValues;
+              if (entity.idAttribute.equals(colName) || (attributeNames.contains(colName))) {
+                // id + attr in tables optimized for search (clustered) cannot be repeated
+                attrSchemas.add(
+                    new ColumnSchema(
+                        colName, colSchema.getDataType(), false, colSchema.isRequired()));
+              } else if (attributeSearch.includeEntityMainColumns) {
+                attrSchemas.add(
+                    new ColumnSchema(
+                        colName,
+                        colSchema.getDataType(),
+                        colSchema.isDataTypeRepeated(),
+                        colSchema.isRequired()));
+              }
+            });
     this.columnSchemas = ImmutableList.copyOf(attrSchemas);
+    this.includeNullValues = attributeSearch.includeNullValues;
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
@@ -8,6 +8,7 @@ import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain.ColumnTemplate;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 
 public abstract class IndexTable {
   private final NameHelper namer;
@@ -38,6 +39,10 @@ public abstract class IndexTable {
   }
 
   public abstract ImmutableList<ColumnSchema> getColumnSchemas();
+
+  public List<String> getColumnNames() {
+    return getColumnSchemas().stream().map(ColumnSchema::getColumnName).toList();
+  }
 
   public boolean isGeneratedIndexTable() {
     return true;

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttributeSearch.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttributeSearch.java
@@ -25,4 +25,11 @@ public class SZAttributeSearch {
       optional = true,
       defaultValue = "false")
   public boolean includeNullValues;
+
+  @AnnotatedField(
+      name = "SZAttributeSearch.includeEntityMainColumns",
+      markdown = "True if all columns from the EntityMain table should be included in this table. ",
+      optional = true,
+      defaultValue = "false")
+  public boolean includeEntityMainColumns;
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttributeSearch.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZAttributeSearch.java
@@ -28,7 +28,10 @@ public class SZAttributeSearch {
 
   @AnnotatedField(
       name = "SZAttributeSearch.includeEntityMainColumns",
-      markdown = "True if all columns from the EntityMain table should be included in this table. ",
+      markdown =
+          "Whether all columns in the entity main table should also be included "
+              + "in this search table. Improves performance if other attributes are also fetched "
+              + "when performing this search by attributes.",
       optional = true,
       defaultValue = "false")
   public boolean includeEntityMainColumns;

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -266,7 +266,7 @@ public final class GoogleBigQuery {
           JobStatistics.QueryStatistics stats = completedJob.getStatistics();
           LOGGER.info(
               "BQ SQL run stats: jobId={}, totalRows={}, cacheHit={}, totalMegaBytesProcessed={}, totalSlotMs={}",
-              jobId,
+              jobId.getJob(),
               tableResult.getTotalRows(),
               stats.getCacheHit(),
               stats.getTotalBytesProcessed() / 1_048_576,

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -12,6 +12,7 @@ import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.ExtractJobConfiguration;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.QueryJobConfiguration;
@@ -252,23 +253,24 @@ public final class GoogleBigQuery {
             destinationTable,
             clustering,
             queryTimeout);
+    JobId jobId = JobId.of();
+    LOGGER.info("BQ SQL run: jobId: {}, sql: {}", jobId.getJob(), sql);
     return callWithRetries(
         () -> {
-          Job job = bigQuery.create(JobInfo.newBuilder(queryJobConfig.getLeft()).build());
+          Job job =
+              bigQuery.create(JobInfo.newBuilder(queryJobConfig.getLeft()).setJobId(jobId).build());
           TableResult tableResult =
               job.getQueryResults(
                   queryJobConfig.getRight().toArray(new BigQuery.QueryResultsOption[0]));
           Job completedJob = job.waitFor();
           JobStatistics.QueryStatistics stats = completedJob.getStatistics();
-          Long totalBytesProcessed = stats.getTotalBytesProcessed();
-          String jobId = completedJob.getJobId().getJob();
           LOGGER.info(
-              "BQ job: {}, total rows: {}, cache hit: {}, total data processed: {}MB, sql: {}",
+              "BQ SQL run stats: jobId={}, totalRows={}, cacheHit={}, totalMegaBytesProcessed={}, totalSlotMs={}",
               jobId,
               tableResult.getTotalRows(),
               stats.getCacheHit(),
-              totalBytesProcessed / 1_048_576,
-              sql);
+              stats.getTotalBytesProcessed() / 1_048_576,
+              stats.getTotalSlotMs());
           return tableResult;
         },
         "Error running query: " + queryJobConfig.getLeft().getQuery());
@@ -284,17 +286,20 @@ public final class GoogleBigQuery {
     Pair<QueryJobConfiguration, List<BigQuery.QueryResultsOption>> queryJobConfig =
         buildQueryJobConfig(
             sql, true, queryParams, pageToken, pageSize, destinationTable, clustering, null);
+    JobId jobId = JobId.of();
+    LOGGER.info("BQ SQL dry run sql: jobId: {}, sql: {}", jobId.getJob(), sql);
     return callWithRetries(
         () -> {
-          Job job = bigQuery.create(JobInfo.newBuilder(queryJobConfig.getLeft()).build());
-          JobStatistics.QueryStatistics queryStatistics = job.getStatistics();
+          Job job =
+              bigQuery.create(JobInfo.newBuilder(queryJobConfig.getLeft()).setJobId(jobId).build());
+          JobStatistics.QueryStatistics stats = job.getStatistics();
           LOGGER.info(
-              "SQL dry run: statementType={}, cacheHit={}, totalBytesProcessed={}, totalSlotMs={}",
-              queryStatistics.getStatementType(),
-              queryStatistics.getCacheHit(),
-              queryStatistics.getTotalBytesProcessed(),
-              queryStatistics.getTotalSlotMs());
-          return queryStatistics;
+              "BQ SQL dry run stats: statementType={}, cacheHit={}, totalMegaBytesProcessed={}, totalSlotMs={}",
+              stats.getStatementType(),
+              stats.getCacheHit(),
+              stats.getTotalBytesProcessed() / 1_048_576,
+              stats.getTotalSlotMs());
+          return stats;
         },
         "Error getting job statistics for query: " + queryJobConfig.getLeft().getQuery());
   }

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/conditionOccurrence/entity.json
@@ -77,6 +77,9 @@
   ],
   "idAttribute": "id",
   "optimizeGroupByAttributes": [ "condition_concept_id" ],
+  "optimizeSearchByAttributes": [
+    { "attributes": [ "person_id" ], "includeEntityMainColumns": true }
+  ],
   "temporalQuery": {
     "visitDateAttribute": "condition_start_datetime",
     "visitIdAttribute": "visit_occurrence_id"

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/ingredientOccurrence/entity.json
@@ -84,6 +84,9 @@
   ],
   "idAttribute": "id",
   "optimizeGroupByAttributes": [ "drug_concept_id" ],
+  "optimizeSearchByAttributes": [
+    { "attributes": [ "person_id" ], "includeEntityMainColumns": true }
+  ],
   "temporalQuery": {
     "visitDateAttribute": "drug_exposure_start_datetime",
     "visitIdAttribute": "visit_occurrence_id"

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/measurementOccurrence/entity.json
@@ -97,6 +97,9 @@
   ],
   "idAttribute": "id",
   "optimizeGroupByAttributes": [ "measurement_concept_id" ],
+  "optimizeSearchByAttributes": [
+    { "attributes": [ "person_id" ], "includeEntityMainColumns": true }
+  ],
   "temporalQuery": {
     "visitDateAttribute": "measurement_datetime",
     "visitIdAttribute": "visit_occurrence_id"

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/observationOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/observationOccurrence/entity.json
@@ -97,6 +97,9 @@
   ],
   "idAttribute": "id",
   "optimizeGroupByAttributes": [ "observation_concept_id" ],
+  "optimizeSearchByAttributes": [
+    { "attributes": [ "person_id" ], "includeEntityMainColumns": true }
+  ],
   "temporalQuery": {
     "visitDateAttribute": "observation_datetime",
     "visitIdAttribute": "visit_occurrence_id"

--- a/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/aouRT/entity/procedureOccurrence/entity.json
@@ -76,6 +76,9 @@
   ],
   "idAttribute": "id",
   "optimizeGroupByAttributes": [ "procedure_concept_id" ],
+  "optimizeSearchByAttributes": [
+    { "attributes": [ "person_id" ], "includeEntityMainColumns": true }
+  ],
   "temporalQuery": {
     "visitDateAttribute": "procedure_datetime",
     "visitIdAttribute": "visit_occurrence_id"


### PR DESCRIPTION
Issue: review of individual participants fetch concepts for each participant (person, primary entity) that are not clustered on person_id and hence slow

Fix: create additional index tables for these concepts clustered on the primary entity id

List of concepts from cohort review config (https://github.com/DataBiosphere/tanagra/blob/main/underlay/src/main/resources/config/underlay/aouSC2023Q3R2_testonly/ui.json#L47)

- "aouRT/measurementOccurrence"
- "aouRT/ingredientOccurrence"
- "aouRT/observationOccurrence"
- "aouRT/procedureOccurrence"
- "aouRT/conditionOccurrence"

Most changes are in query runner that do not have unit tests today. 

Pre-req: run indexing on above 5 entities

manual test 

(should not lead to change, expected)
```
http://localhost:3000/v2/underlays/aouSC2023Q3R2_testonly/entities/variant/instances

{"includeAttributes":["id","gene","rs_number","consequence","clinvar_significance","protein_change","allele_count","allele_number","allele_frequency"],"includeRelationshipFields":[{"relatedEntity":"person"}],"filter":{"filterType":"ATTRIBUTE","filterUnion":{"attributeFilter":{"attribute":"gene","operator":"EQUALS","values":[{"dataType":"STRING","valueUnion":{"stringVal":"GENE"}}]}}},"orderBys":[{"relationshipField":{"relatedEntity":"person"},"direction":"DESCENDING"}],"limit":10000000,"pageSize":25}


SELECT id, gene, rs_number, consequence, clinvar_significance, protein_change, allele_count, allele_number, allele_frequency, T_RCNT_variantPerson_NOHIER FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ESA_variant_gene WHERE id IN (SELECT id FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ESA_variant_gene WHERE gene = @val0) ORDER BY T_RCNT_variantPerson_NOHIER DESC LIMIT 10000000
```

(should be changed, see from clause)
```
http://localhost:3000/v2/underlays/aouSC2023Q3R2_testonly/entities/ingredientOccurrence/instancesForPrimaryEntity

{"includeAttributes":["id","person_id","drug_concept_id","standard_concept_name","standard_concept_code","standard_vocabulary","drug_exposure_start_datetime","drug_exposure_end_datetime","verbatim_end_date","drug_type_concept_id","drug_type_concept_name","stop_reason","refills","quantity","days_supply","sig","route_concept_id","route_concept_name","lot_number","visit_occurrence_id","visit_occurrence_concept_name","drug_source_value","drug_source_concept_id","source_concept_name","source_concept_code","source_vocabulary","route_source_value","dose_unit_source_value","age_at_occurrence","visit_type","ingredient"],"orderBys":[],"primaryEntityId":{"dataType":"INT64","valueUnion":{"int64Val":20351527}}}

SELECT id, person_id, drug_concept_id, standard_concept_name, T_DISP_standard_concept_name, standard_concept_code, T_DISP_standard_concept_code, standard_vocabulary, T_DISP_standard_vocabulary, drug_exposure_start_datetime, drug_exposure_end_datetime, verbatim_end_date, drug_type_concept_id, drug_type_concept_name, T_DISP_drug_type_concept_name, stop_reason, refills, quantity, days_supply, sig, route_concept_id, route_concept_name, T_DISP_route_concept_name, lot_number, visit_occurrence_id, visit_occurrence_concept_name, drug_source_value, drug_source_concept_id, source_concept_name, T_DISP_source_concept_name, source_concept_code, T_DISP_source_concept_code, source_vocabulary, T_DISP_source_vocabulary, route_source_value, dose_unit_source_value, age_at_occurrence, visit_type, T_DISP_visit_type, ingredient, T_DISP_ingredient FROM `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ESA_ingredientOccurrence_person_id WHERE person_id = @val0
```

This change also theoretically optimizes api queries for top 10 charts

```
http://localhost:3000/v2/studies/YPg3UQYWzD/cohorts/6Dw2GceXHC/counts

{"entity":"measurementOccurrence","countDistinctAttribute":"person_id","groupByAttributes":["measurement"],"limit":1000000}

SELECT
        COUNT(DISTINCT person_id) AS T_CTDT,
        measurement,
        T_DISP_measurement 
    FROM
        `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ESA_measurementOccurrence_person_id 
    WHERE
        person_id IN (SELECT
            id 
        FROM
            `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ENT_person 
        WHERE
            CAST(FLOOR(TIMESTAMP_DIFF(@currentTimestamp2, age, DAY) / 365.25) AS INT64) BETWEEN @val0 AND @val1) 
    GROUP BY
        measurement,
        T_DISP_measurement 
    ORDER BY
        T_CTDT DESC 
    LIMIT
        1000000
```
