### PR TITLE
Add rename group option for cohorts

### DIFF
--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -310,6 +310,22 @@ export function deleteCohortGroupSection(
   });
 }
 
+export function renameCohortGroupSection(
+  context: CohortContextData,
+  sectionId: string
+) {
+  context.updatePresent((present) => {
+    if (present.groupSections.length === 1) {
+      present.groupSections = [newSection()];
+      return;
+    }
+
+    const [, sectionIndex] = findGroupSectionAndIndex(present, sectionId);
+
+    present.groupSections.splice(sectionIndex, 1);
+  });
+}
+
 export type UpdateCohortGroupSectionParams = {
   name?: string;
   filter?: GroupSectionFilter;

--- a/ui/src/cohortContext.ts
+++ b/ui/src/cohortContext.ts
@@ -310,22 +310,6 @@ export function deleteCohortGroupSection(
   });
 }
 
-export function renameCohortGroupSection(
-  context: CohortContextData,
-  sectionId: string
-) {
-  context.updatePresent((present) => {
-    if (present.groupSections.length === 1) {
-      present.groupSections = [newSection()];
-      return;
-    }
-
-    const [, sectionIndex] = findGroupSectionAndIndex(present, sectionId);
-
-    present.groupSections.splice(sectionIndex, 1);
-  });
-}
-
 export type UpdateCohortGroupSectionParams = {
   name?: string;
   filter?: GroupSectionFilter;

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -17,7 +17,12 @@ import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import ActionBar from "actionBar";
-import { createCriteria, getCriteriaPlugin, getCriteriaTitle } from "cohort";
+import {
+  createCriteria,
+  getCriteriaPlugin,
+  getCriteriaTitle,
+  sectionName,
+} from "cohort";
 import {
   deleteCohortCriteriaModifier,
   deleteCohortGroup,
@@ -323,9 +328,35 @@ function ParticipantsGroupSection(props: {
       }}
     >
       <GridLayout rows height="auto">
-        {!!props.groupSection.name && (
-          <Typography sx={{ p: 1 }}>{props.groupSection.name}</Typography>
-        )}
+        <GridLayout
+          cols
+          sx={{
+            p: 2,
+            paddingBottom: 0,
+            backgroundColor: (theme) => theme.palette.info.main,
+          }}
+        >
+          <Typography variant="body1em">
+            {sectionName(props.groupSection, props.sectionIndex)}
+          </Typography>
+          <IconButton
+            onClick={() => {
+              showRenameTitleDialog({
+                title: "Editing group name",
+                initialText: props.groupSection.name,
+                textLabel: "Group name",
+                buttonLabel: "Update",
+                onConfirm: (name: string) => {
+                  updateCohortGroupSection(context, props.groupSection.id, {
+                    name: name,
+                  });
+                },
+              });
+            }}
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+        </GridLayout>
         <GridLayout
           cols
           fillCol={3}
@@ -574,24 +605,6 @@ function ParticipantsGroupSection(props: {
               boxShadow: (theme) => `inset 0 1px 0 ${theme.palette.divider}`,
             }}
           >
-            <Button
-              startIcon={<EditIcon />}
-              onClick={() => {
-                showRenameTitleDialog({
-                  title: "Editing group name",
-                  initialText: props.groupSection.name,
-                  textLabel: "Group name",
-                  buttonLabel: "Update",
-                  onConfirm: (name: string) => {
-                    updateCohortGroupSection(context, props.groupSection.id, {
-                      name: name,
-                    });
-                  },
-                });
-              }}
-            >
-              Rename group
-            </Button>
             <Tooltip title="Disabled groups are ignored for export and participant counts">
               <Button
                 color={props.groupSection.disabled ? "warning" : undefined}

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -274,6 +274,8 @@ function ParticipantsGroupSection(props: {
   const navigate = useNavigate();
   const { group } = useCohortGroupSectionAndGroup();
 
+  const [renameTitleDialog, showRenameTitleDialog] = useTextInputDialog();
+
   const backendGroupSection = useMemo(
     () =>
       backendCohort.groupSections.find((gs) => gs.id === props.groupSection.id),
@@ -321,6 +323,9 @@ function ParticipantsGroupSection(props: {
       }}
     >
       <GridLayout rows height="auto">
+        {!!props.groupSection.name && (
+          <Typography sx={{ p: 1 }}>{props.groupSection.name}</Typography>
+        )}
         <GridLayout
           cols
           fillCol={3}
@@ -569,6 +574,24 @@ function ParticipantsGroupSection(props: {
               boxShadow: (theme) => `inset 0 1px 0 ${theme.palette.divider}`,
             }}
           >
+            <Button
+              startIcon={<EditIcon />}
+              onClick={() => {
+                showRenameTitleDialog({
+                  title: "Editing group name",
+                  initialText: props.groupSection.name,
+                  textLabel: "Group name",
+                  buttonLabel: "Update",
+                  onConfirm: (name: string) => {
+                    updateCohortGroupSection(context, props.groupSection.id, {
+                      name: name,
+                    });
+                  },
+                });
+              }}
+            >
+              Rename group
+            </Button>
             <Tooltip title="Disabled groups are ignored for export and participant counts">
               <Button
                 color={props.groupSection.disabled ? "warning" : undefined}
@@ -597,6 +620,7 @@ function ParticipantsGroupSection(props: {
             </Button>
           </GridLayout>
         ) : null}
+        {renameTitleDialog}
       </GridLayout>
     </GridBoxPaper>
   );

--- a/ui/src/overview.tsx
+++ b/ui/src/overview.tsx
@@ -330,9 +330,10 @@ function ParticipantsGroupSection(props: {
       <GridLayout rows height="auto">
         <GridLayout
           cols
+          rowAlign="middle"
           sx={{
-            p: 2,
-            paddingBottom: 0,
+            px: 2,
+            pt: 2,
             backgroundColor: (theme) => theme.palette.info.main,
           }}
         >


### PR DESCRIPTION
Add `Rename Group` option to each cohort group section in cohort builder. 

<img width="599" alt="Screenshot 2025-01-17 at 3 30 49 PM" src="https://github.com/user-attachments/assets/0cfed779-a5ea-4d34-9fd8-028a38d129bf" />

First group in screenshot above has a custom name, second group has the default group name.