### PR TITLE
Fixes for SD exports

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -117,9 +117,8 @@ public class DataExportHelper {
     exportRequest.getUnderlay().getPrimaryEntity().getAttributes().stream()
         .filter(
             attribute ->
-                attributeNames.isEmpty()
-                    || attributeNames.contains(attribute.getName())
-                        && !attribute.isSuppressedForExport())
+                (attributeNames.isEmpty() || attributeNames.contains(attribute.getName()))
+                    && !attribute.isSuppressedForExport())
         .forEach(
             attribute ->
                 selectedAttributeFields.add(

--- a/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
+++ b/service/src/main/java/bio/terra/tanagra/service/export/DataExportHelper.java
@@ -116,7 +116,10 @@ public class DataExportHelper {
     List<ValueDisplayField> selectedAttributeFields = new ArrayList<>();
     exportRequest.getUnderlay().getPrimaryEntity().getAttributes().stream()
         .filter(
-            attribute -> attributeNames.isEmpty() || attributeNames.contains(attribute.getName()))
+            attribute ->
+                attributeNames.isEmpty()
+                    || attributeNames.contains(attribute.getName())
+                        && !attribute.isSuppressedForExport())
         .forEach(
             attribute ->
                 selectedAttributeFields.add(

--- a/underlay/src/main/resources/config/datamapping/sd/entity/conditionOccurrence/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/conditionOccurrence/entity.json
@@ -28,8 +28,8 @@
     { "name": "visit_type", "dataType": "INT64", "valueFieldName": "visit_concept_id", "displayFieldName": "visit_concept_name", "isComputeDisplayHint": true,
       "sourceQuery": {
         "displayFieldName": "concept_name",
-        "displayFieldTable": "${omopDataset}.concept",
-        "displayFieldTableJoinFieldName": "concept_id"
+        "displayFieldTable": "${omopDataset}.visit_occurrence",
+        "displayFieldTableJoinFieldName": "visit_occurrence_id"
       }
     }
   ],


### PR DESCRIPTION
- Filter attributes that have been suppressed for export in the `generateSqlForPrimaryEntity` method. This should fix the error we're currently seeing in SD when attempting an export:
![Screenshot 2025-01-24 at 9 40 02 AM](https://github.com/user-attachments/assets/3fbaaac7-ebec-46f9-9561-98fe210adee6)

- Update table/join field for conditions entity