### PR TITLE
Add new API to fetch visualizations

### DIFF
--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
@@ -59,13 +59,21 @@ public class UnderlayConfigPath extends AnnotationPath {
           SZVisualization.class,
           SZVisualization.SZVisualizationDataConfig.class,
           SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin.SZVisualizationDCSJAggregation.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin.SZVisualizationDCSJAggregation.SZVisualizationDCSJAType.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.SZVisualizationDCSANumericBucketing.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.SZVisualizationDCSANumericBucketing.SZVisualizationDCSANBIntervals.class,
-          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.SZVisualizationDCSASortType.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin
+              .class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin
+              .SZVisualizationDCSJAggregation.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin
+              .SZVisualizationDCSJAggregation.SZVisualizationDCSJAType.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource
+              .SZVisualizationDCSAttribute.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource
+              .SZVisualizationDCSAttribute.SZVisualizationDCSANumericBucketing.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource
+              .SZVisualizationDCSAttribute.SZVisualizationDCSANumericBucketing
+              .SZVisualizationDCSANBIntervals.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource
+              .SZVisualizationDCSAttribute.SZVisualizationDCSASortType.class,
           SZCorePlugin.class);
 
   @Override

--- a/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
+++ b/annotationProcessor/src/main/java/bio/terra/tanagra/annotation/UnderlayConfigPath.java
@@ -57,6 +57,15 @@ public class UnderlayConfigPath extends AnnotationPath {
           SZPrepackagedCriteria.class,
           SZRollupCountsSql.class,
           SZVisualization.class,
+          SZVisualization.SZVisualizationDataConfig.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin.SZVisualizationDCSJAggregation.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSJoin.SZVisualizationDCSJAggregation.SZVisualizationDCSJAType.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.SZVisualizationDCSANumericBucketing.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.SZVisualizationDCSANumericBucketing.SZVisualizationDCSANBIntervals.class,
+          SZVisualization.SZVisualizationDataConfig.SZVisualizationDCSource.SZVisualizationDCSAttribute.SZVisualizationDCSASortType.class,
           SZCorePlugin.class);
 
   @Override

--- a/docs/generated/UNDERLAY_CONFIG.md
+++ b/docs/generated/UNDERLAY_CONFIG.md
@@ -32,6 +32,15 @@ This documentation is generated from annotations in the configuration classes.
 * [SZTextSearch](#sztextsearch)
 * [SZUnderlay](#szunderlay)
 * [SZVisualization](#szvisualization)
+* [SZVisualizationDCSANBIntervals](#szvisualizationdcsanbintervals)
+* [SZVisualizationDCSANumericBucketing](#szvisualizationdcsanumericbucketing)
+* [SZVisualizationDCSASortType](#szvisualizationdcsasorttype)
+* [SZVisualizationDCSAttribute](#szvisualizationdcsattribute)
+* [SZVisualizationDCSJAType](#szvisualizationdcsjatype)
+* [SZVisualizationDCSJAggregation](#szvisualizationdcsjaggregation)
+* [SZVisualizationDCSJoin](#szvisualizationdcsjoin)
+* [SZVisualizationDCSource](#szvisualizationdcsource)
+* [SZVisualizationDataConfig](#szvisualizationdataconfig)
 
 ## SZAttribute
 Attribute or property of an entity.
@@ -1339,6 +1348,11 @@ This file should be in the same directory as the visualization (e.g. `gender.jso
 
 If this property is specified, the value of the `config` property is ignored.
 
+### SZVisualization.dataConfigObj
+**required** [SZVisualizationDataConfig](#szvisualizationdataconfig)
+
+Deserialized configuration of the visualization. VizDataConfig protocol buffer as Java object.
+
 ### SZVisualization.name
 **required** String
 
@@ -1371,6 +1385,198 @@ If this property is specified, the value of the `pluginConfig` property is ignor
 **required** String
 
 Visible title of the visualization.
+
+
+
+## SZVisualizationDCSANBIntervals
+Intervals {min:1, max:5, count: 2}, creates buckets [1, 3) and [3, 5).
+
+### SZVisualizationDCSANBIntervals.count
+**required** int
+
+Count
+
+### SZVisualizationDCSANBIntervals.max
+**required** double
+
+Maximum
+
+### SZVisualizationDCSANBIntervals.min
+**required** double
+
+Minimum
+
+
+
+## SZVisualizationDCSANumericBucketing
+Converts a continuous numeric range into ids with count as the value.
+
+### SZVisualizationDCSANumericBucketing.includeLesser
+**optional** boolean
+
+Whether to create buckets for values lesser than the explicitly specified ones or ignore them
+
+### SZVisualizationDCSANumericBucketing.includeLesser
+**optional** boolean
+
+Whether to create buckets for values greater than the explicitly specified ones or ignore them
+
+### SZVisualizationDCSANumericBucketing.intervals
+**optional** [SZVisualizationDCSANBIntervals](#szvisualizationdcsanbintervals)
+
+Intervals
+
+### SZVisualizationDCSANumericBucketing.thresholds
+**required** List [ Double ]
+
+Buckets can be specified as either a list of thresholds or a range and number of buckets. For thresholds [18, 45, 65], results in two buckets [18, 45), and [45, 65). Lesser and greater buckets can be added if desired.
+
+
+
+## SZVisualizationDCSASortType
+Sort type.
+
+### SZVisualizationDCSASortType.NAME
+**required** [SZVisualizationDCSASortType](#szvisualizationdcsasorttype)
+
+Name.
+
+### SZVisualizationDCSASortType.UNKNOWN
+**required** [SZVisualizationDCSASortType](#szvisualizationdcsasorttype)
+
+Unknown.
+
+### SZVisualizationDCSASortType.VALUE
+**required** [SZVisualizationDCSASortType](#szvisualizationdcsasorttype)
+
+Value.
+
+
+
+## SZVisualizationDCSAttribute
+Attribute configuration.
+
+### SZVisualizationDCSAttribute.attribute
+**required** String
+
+The attribute to read.
+
+### SZVisualizationDCSAttribute.limit
+**optional** int
+
+Whether a limited amount of data should be returned (e.g. 10 most common conditions).
+
+### SZVisualizationDCSAttribute.numericBucketing
+**required** [SZVisualizationDCSANumericBucketing](#szvisualizationdcsanumericbucketing)
+
+Numeric Bucketing.
+
+### SZVisualizationDCSAttribute.sortDescending
+**optional** boolean
+
+Whether to sort in descending order.
+
+### SZVisualizationDCSAttribute.sortType
+**optional** [SZVisualizationDCSASortType](#szvisualizationdcsasorttype)
+
+How to sort this attribute for display. Defaults to NAME.
+
+*Default value:* `NAME`
+
+
+
+## SZVisualizationDCSJAType
+Aggregation type.
+
+### SZVisualizationDCSJAType.AVERAGE
+**required** [SZVisualizationDCSJAType](#szvisualizationdcsjatype)
+
+Average.
+
+### SZVisualizationDCSJAType.MAX
+**required** [SZVisualizationDCSJAType](#szvisualizationdcsjatype)
+
+Maximum.
+
+### SZVisualizationDCSJAType.MIN
+**required** [SZVisualizationDCSJAType](#szvisualizationdcsjatype)
+
+Minimum.
+
+### SZVisualizationDCSJAType.UNIQUE
+**required** [SZVisualizationDCSJAType](#szvisualizationdcsjatype)
+
+Unique.
+
+
+
+## SZVisualizationDCSJAggregation
+Aggregation configuration.
+
+### SZVisualizationDCSJAggregation.attribute
+**optional** String
+
+The output is always ids and values but aggregation may occur over another field (e.g. date to find the most recent value).
+
+### SZVisualizationDCSJAggregation.type
+**optional** [SZVisualizationDCSJAType](#szvisualizationdcsjatype)
+
+The type of aggregation being performed.
+
+
+
+## SZVisualizationDCSJoin
+Join configuration.
+
+### SZVisualizationDCSJoin.aggregation
+**required** [SZVisualizationDCSJAggregation](#szvisualizationdcsjaggregation)
+
+When joining an entity with an N:1 relationship (e.g. multiple weight values to a person), an aggregation is often required to make the data visualizable. For example to visualize weight vs. race, each person needs to have a single weight value associated with them, such as the average or most recent. For simple cases, simply counting unique instances of a related entity  may be sufficient (e.g. to count people with related condition occurrences).
+
+### SZVisualizationDCSJoin.entity
+**required** String
+
+The next entity to join to in order to eventually get to the entity the visualization is displaying (e.g. person when joining condition_occurences to age). 
+
+
+
+## SZVisualizationDCSource
+Configuration for a single visualization data config source.
+
+### SZVisualizationDCSource.attributes
+**required** List [ SZVisualization$SZVisualizationDataConfig$SZVisualizationDCSource$SZVisualizationDCSAttribute ]
+
+Attributes to be returned from the selected data source (e.g. condition_name from condition_occurrence or age from person). 
+
+### SZVisualizationDCSource.criteriaSelector
+**required** String
+
+Name of the criteriaSelector.
+
+### SZVisualizationDCSource.entity
+**optional** String
+
+Name of the entity (for criteria selectors that return more than one entity).
+
+### SZVisualizationDCSource.joins
+**required** List [ SZVisualization$SZVisualizationDataConfig$SZVisualizationDCSource$SZVisualizationDCSJoin ]
+
+To visualize data from different entities, the data must be joined to a common entity. Each source must specify a series of joins that ends up atthe same entity if it does not already come from that entity.
+
+### SZVisualizationDCSource.selectionData
+**optional** String
+
+Specified criteria selection. (e.g. to select conditions under diabetes)
+
+
+
+## SZVisualizationDataConfig
+Configuration for a single visualization data config.
+
+### SZVisualizationDataConfig.sources
+**required** List [ SZVisualization$SZVisualizationDataConfig$SZVisualizationDCSource ]
+
+List of data config sources for a single visualization.
 
 
 

--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -246,12 +246,13 @@ public class CohortsApiController implements CohortsApi {
           "visualizeCohortCounts not implemented yet for cohorts with filters");
     }
 
-    Underlay underlay = underlayService.getUnderlay(cohort.getUnderlay());
     List<ApiVisualization> vizList =
-        body.getVisualizationNames().parallelStream()
-            .map(id -> ToApiUtils.toApiObject(underlay.getPrecomputedVisualization(id)))
+        body.getVisualizationNames().stream()
+            .map(
+                vizName ->
+                    ToApiUtils.toApiObject(
+                        underlayService.getVisualization(cohort.getUnderlay(), vizName)))
             .toList();
-
     return ResponseEntity.ok(new ApiVisualizationList().visualizations(vizList));
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -35,6 +35,10 @@ import bio.terra.tanagra.generated.model.ApiReducingOperator;
 import bio.terra.tanagra.generated.model.ApiStudy;
 import bio.terra.tanagra.generated.model.ApiUnderlaySummary;
 import bio.terra.tanagra.generated.model.ApiValueDisplay;
+import bio.terra.tanagra.generated.model.ApiVisualization;
+import bio.terra.tanagra.generated.model.ApiVisualizationData;
+import bio.terra.tanagra.generated.model.ApiVisualizationDataKey;
+import bio.terra.tanagra.generated.model.ApiVisualizationDataValue;
 import bio.terra.tanagra.service.artifact.model.AnnotationValue;
 import bio.terra.tanagra.service.artifact.model.Cohort;
 import bio.terra.tanagra.service.artifact.model.CohortRevision;
@@ -42,6 +46,8 @@ import bio.terra.tanagra.service.artifact.model.Criteria;
 import bio.terra.tanagra.service.artifact.model.Study;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
+import bio.terra.tanagra.underlay.visualization.Visualization;
+import bio.terra.tanagra.underlay.visualization.VisualizationData;
 import bio.terra.tanagra.utils.SqlFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -321,5 +327,32 @@ public final class ToApiUtils {
         .displayName(underlay.getDisplayName())
         .description(underlay.getDescription())
         .primaryEntity(underlay.getPrimaryEntity().getName());
+  }
+
+  private static ApiVisualizationData toApiObject(VisualizationData vizData) {
+    return new ApiVisualizationData()
+        .keys(
+            vizData.getKeys().stream()
+                .map(
+                    k ->
+                        new ApiVisualizationDataKey()
+                            .name(k.name())
+                            .numericId(k.numericId())
+                            .stringId(k.stringId()))
+                .toList())
+        .values(
+            vizData.getValues().stream()
+                .map(
+                    v ->
+                        new ApiVisualizationDataValue()
+                            .numeric(v.numeric())
+                            .quartiles(v.quartiles()))
+                .toList());
+  }
+
+  public static ApiVisualization toApiObject(Visualization visualization) {
+    return new ApiVisualization()
+        .name(visualization.getName())
+        .vizDataList(visualization.getVizDataList().stream().map(ToApiUtils::toApiObject).toList());
   }
 }

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/Cohort.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/Cohort.java
@@ -65,10 +65,12 @@ public final class Cohort {
     return lastModifiedBy;
   }
 
+  @Nullable
   public String getDisplayName() {
     return displayName;
   }
 
+  @Nullable
   public String getDescription() {
     return description;
   }

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -556,6 +556,40 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  "/v2/studies/{studyId}/cohorts/{cohortId}/visualizations":
+    parameters:
+    - $ref: "#/components/parameters/ParamStudyId"
+    - $ref: "#/components/parameters/ParamCohortId"
+    post:
+      summary: Return visualizations for a cohort
+      operationId: visualizeCohortCounts
+      tags: [Cohorts]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                visualizationNames:
+                  type: array
+                  description: Names (IDs) of requested visualizations
+                  items:
+                    $ref: "#/components/schemas/VisualizationName"
+              required:
+              - visualizationNames
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VisualizationList"
+        404:
+          $ref: "#/components/responses/NotFound"
+        500:
+          $ref: "#/components/responses/ServerError"
+
   # --------------- Studies: Reviews ---------------
 
   "/v2/studies/{studyId}/cohorts/{cohortId}/reviews":
@@ -2122,6 +2156,16 @@ components:
         numRowsAcrossAllPages:
           $ref: "#/components/schemas/NumRowsAcrossAllPages"
 
+
+    VisualizationList:
+      type: object
+      description: List of cohort visualizations
+      properties:
+        visualizations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Visualization"
+
     DisplayHint:
       type: object
       description: Display hint for entity attribute
@@ -2363,6 +2407,68 @@ components:
     CohortDescription:
       type: string
       description: Description of the cohort
+
+    Visualization:
+      type: object
+      description: Description of the Visualization
+      properties:
+        name:
+          $ref: "#/components/schemas/VisualizationName"
+        title:
+          type: string
+          description: Visualization title
+        vizDataList:
+          type: array
+          items:
+            $ref: "#/components/schemas/VisualizationData"
+      required:
+      - name
+      - title
+      - vizDataList
+
+    VisualizationName:
+      type: string
+      description: Name (ID) of the visualization, immutable
+
+    VisualizationData:
+      type: object
+      description: Visualization data for a cohort
+      properties:
+        keys:
+          type: array
+          items:
+            $ref: "#/components/schemas/VisualizationDataKey"
+        values:
+          type: array
+          items:
+            $ref: "#/components/schemas/VisualizationDataValue"
+      required:
+      - keys
+      - values
+
+    VisualizationDataKey:
+      type: object
+      description: Visualization data key
+      properties:
+        name:
+          type: string
+        numericId:
+          type: integer
+        stringId:
+          type: string
+      required:
+      - name
+
+    VisualizationDataValue:
+      type: object
+      description: Visualization data value
+      properties:
+        numeric:
+          type: integer
+        quartiles:
+          type: array
+          items:
+            type: integer
 
     FeatureSet:
       type: object

--- a/ui/src/tanagra-underlay/underlayConfig.ts
+++ b/ui/src/tanagra-underlay/underlayConfig.ts
@@ -37,7 +37,7 @@ export enum SZCorePlugin {
   SURVEY = "SURVEY",
   TEXT_SEARCH = "TEXT_SEARCH",
   UNHINTED_VALUE = "UNHINTED_VALUE",
-}
+};
 
 export type SZCriteriaOccurrence = {
   criteriaEntity: string;
@@ -79,7 +79,7 @@ export type SZCriteriaSelectorModifier = {
   pluginConfig: string;
   pluginConfigFile: string;
   supportsTemporalQueries: boolean;
-};
+}
 
 export enum SZDataType {
   BOOLEAN = "BOOLEAN",
@@ -238,10 +238,67 @@ export type SZUnderlay = {
 export type SZVisualization = {
   dataConfig: string;
   dataConfigFile: string;
+  dataConfigObj: SZVisualizationDataConfig;
   name: string;
   plugin: string;
   pluginConfig: string;
   pluginConfigFile: string;
   title: string;
+};
+
+export type SZVisualizationDCSANBIntervals = {
+  count: number;
+  max: number;
+  min: number;
+};
+
+export type SZVisualizationDCSANumericBucketing = {
+  includeLesser?: boolean;
+  includeGreater?: boolean;
+  intervals?: SZVisualizationDCSANBIntervals;
+  thresholds: number[];
+};
+
+export enum SZVisualizationDCSASortType {
+  NAME = "NAME",
+  UNKNOWN = "UNKNOWN",
+  VALUE = "VALUE",
+};
+
+export type SZVisualizationDCSAttribute = {
+  attribute: string;
+  limit?: number;
+  numericBucketing: SZVisualizationDCSANumericBucketing;
+  sortDescending?: boolean;
+  sortType?: SZVisualizationDCSASortType;
+};
+
+export enum SZVisualizationDCSJAType {
+  AVERAGE = "AVERAGE",
+  MAX = "MAX",
+  MIN = "MIN",
+  UNIQUE = "UNIQUE",
+};
+
+export type SZVisualizationDCSJAggregation = {
+  attribute?: string;
+  type?: SZVisualizationDCSJAType;
+};
+
+export type SZVisualizationDCSJoin = {
+  aggregation: SZVisualizationDCSJAggregation;
+  entity: string;
+};
+
+export type SZVisualizationDCSource = {
+  attributes: SZVisualizationDCSAttribute[];
+  criteriaSelector: string;
+  entity?: string;
+  joins: SZVisualizationDCSJoin[];
+  selectionData?: string;
+};
+
+export type SZVisualizationDataConfig = {
+  sources: SZVisualizationDCSource[];
 };
 

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/ClientConfig.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/ClientConfig.java
@@ -43,6 +43,10 @@ public final class ClientConfig {
     this.visualizations = ImmutableList.copyOf(visualizations);
   }
 
+  public List<SZVisualization> getVisualizations() {
+    return visualizations;
+  }
+
   public String serializeUnderlay() {
     try {
       return JacksonMapper.serializeJavaObject(underlay);

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
@@ -13,15 +13,14 @@ import bio.terra.tanagra.underlay.serialization.SZPrepackagedCriteria;
 import bio.terra.tanagra.underlay.serialization.SZService;
 import bio.terra.tanagra.underlay.serialization.SZUnderlay;
 import bio.terra.tanagra.underlay.serialization.SZVisualization;
+import bio.terra.tanagra.underlay.serialization.SZVisualization.SZVisualizationDataConfig;
 import bio.terra.tanagra.utils.FileUtils;
 import bio.terra.tanagra.utils.JacksonMapper;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.annotation.Nullable;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -383,6 +382,14 @@ public final class ConfigReader {
     }
   }
 
+  public SZVisualizationDataConfig deserializeVizDataConfig(String vizDataConfig) {
+    try {
+      return JacksonMapper.deserializeJavaObject(vizDataConfig, SZVisualizationDataConfig.class);
+    } catch (IOException ioEx) {
+      throw new InvalidConfigException("Error deserializing visualization data config file", ioEx);
+    }
+  }
+
   private InputStream getStream(Path resourcesPath) {
     try {
       return useResourcesInputStream
@@ -456,15 +463,5 @@ public final class ConfigReader {
 
   public static DataType deserializeDataType(@Nullable SZDataType szDataType) {
     return szDataType == null ? null : DataType.valueOf(szDataType.name());
-  }
-
-  public static <T> T deserializeStringToObj(String str, Class<T> clazz) {
-    try {
-      return JacksonMapper.readFileIntoJavaObject(
-          new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8)), clazz);
-    } catch (IOException e) {
-      throw new InvalidConfigException(
-          "Error deserializing string to class: " + clazz.getSimpleName(), e);
-    }
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/ConfigReader.java
@@ -18,8 +18,10 @@ import bio.terra.tanagra.utils.JacksonMapper;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.annotation.Nullable;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -454,5 +456,15 @@ public final class ConfigReader {
 
   public static DataType deserializeDataType(@Nullable SZDataType szDataType) {
     return szDataType == null ? null : DataType.valueOf(szDataType.name());
+  }
+
+  public static <T> T deserializeStringToObj(String str, Class<T> clazz) {
+    try {
+      return JacksonMapper.readFileIntoJavaObject(
+          new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8)), clazz);
+    } catch (IOException e) {
+      throw new InvalidConfigException(
+          "Error deserializing string to class: " + clazz.getSimpleName(), e);
+    }
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZVisualization.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/serialization/SZVisualization.java
@@ -2,6 +2,7 @@ package bio.terra.tanagra.underlay.serialization;
 
 import bio.terra.tanagra.annotation.AnnotatedClass;
 import bio.terra.tanagra.annotation.AnnotatedField;
+import java.util.List;
 
 @AnnotatedClass(name = "SZVisualization", markdown = "Configuration for a single visualization.")
 public class SZVisualization {
@@ -9,13 +10,19 @@ public class SZVisualization {
       name = "SZVisualization.name",
       markdown =
           "Name of the visualization.\n\n"
-              + "This is the unique identifier for the vizualization. The vizualization names cannot overlap within an "
-              + "underlay.\n\n"
+              + "This is the unique identifier for the vizualization. The vizualization names "
+              + "cannot overlap within an underlay.\n\n"
               + "Name may not include spaces or special characters, only letters and numbers.")
   public String name;
 
   @AnnotatedField(name = "SZVisualization.title", markdown = "Visible title of the visualization.")
   public String title;
+
+  @AnnotatedField(
+      name = "SZVisualization.dataConfigObj",
+      markdown =
+          "Deserialized configuration of the visualization. VizDataConfig protocol buffer as Java object.")
+  public SZVisualizationDataConfig dataConfigObj;
 
   @AnnotatedField(
       name = "SZVisualization.dataConfig",
@@ -48,4 +55,209 @@ public class SZVisualization {
               + "This file should be in the same directory as the visualization (e.g. `gender.json`).\n\n"
               + "If this property is specified, the value of the `pluginConfig` property is ignored.")
   public String pluginConfigFile;
+
+  @AnnotatedClass(
+      name = "SZVisualizationDataConfig",
+      markdown = "Configuration for a single visualization data config.")
+  public static class SZVisualizationDataConfig {
+    @AnnotatedField(
+        name = "SZVisualizationDataConfig.sources",
+        markdown = "List of data config sources for a single visualization.")
+    public List<SZVisualizationDCSource> sources;
+
+    @AnnotatedClass(
+        name = "SZVisualizationDCSource",
+        markdown = "Configuration for a single visualization data config source.")
+    public static class SZVisualizationDCSource {
+      @AnnotatedField(
+          name = "SZVisualizationDCSource.criteriaSelector",
+          markdown = "Name of the criteriaSelector.")
+      public String criteriaSelector;
+
+      @AnnotatedField(
+          name = "SZVisualizationDCSource.selectionData",
+          markdown = "Specified criteria selection. (e.g. to select conditions under diabetes)",
+          optional = true)
+      public String selectionData;
+
+      @AnnotatedField(
+          name = "SZVisualizationDCSource.entity",
+          markdown =
+              "Name of the entity (for criteria selectors that return more than one entity).",
+          optional = true)
+      public String entity;
+
+      @AnnotatedField(
+          name = "SZVisualizationDCSource.joins",
+          markdown =
+              "To visualize data from different entities, the data must be joined to a "
+                  + "common entity. Each source must specify a series of joins that ends up at"
+                  + "the same entity if it does not already come from that entity.")
+      public List<SZVisualizationDCSJoin> joins;
+
+      @AnnotatedField(
+          name = "SZVisualizationDCSource.attributes",
+          markdown =
+              "Attributes to be returned from the selected data source "
+                  + "(e.g. condition_name from condition_occurrence or age from person). ")
+      public List<SZVisualizationDCSAttribute> attributes;
+
+      @AnnotatedClass(name = "SZVisualizationDCSJoin", markdown = "Join configuration.")
+      public static class SZVisualizationDCSJoin {
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSJoin.entity",
+            markdown =
+                "The next entity to join to in order to eventually get to the entity the "
+                    + "visualization is displaying (e.g. person when joining condition_occurences "
+                    + "to age). ")
+        public String entity;
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSJoin.aggregation",
+            markdown =
+                "When joining an entity with an N:1 relationship (e.g. multiple weight "
+                    + "values to a person), an aggregation is often required to make the data "
+                    + "visualizable. For example to visualize weight vs. race, each person needs to "
+                    + "have a single weight value associated with them, such as the average or most "
+                    + "recent. For simple cases, simply counting unique instances of a related entity "
+                    + " may be sufficient (e.g. to count people with related condition occurrences).")
+        public SZVisualizationDCSJAggregation aggregation;
+
+        @AnnotatedClass(
+            name = "SZVisualizationDCSJAggregation",
+            markdown = "Aggregation configuration.")
+        public static class SZVisualizationDCSJAggregation {
+          @AnnotatedField(
+              name = "SZVisualizationDCSJAggregation.type",
+              markdown = "The type of aggregation being performed.",
+              optional = true)
+          public SZVisualizationDCSJAType type;
+
+          @AnnotatedField(
+              name = "SZVisualizationDCSJAggregation.attribute",
+              markdown =
+                  "The output is always ids and values but aggregation may occur over "
+                      + "another field (e.g. date to find the most recent value).",
+              optional = true)
+          public String attribute;
+
+          @AnnotatedClass(name = "SZVisualizationDCSJAType", markdown = "Aggregation type.")
+          public enum SZVisualizationDCSJAType {
+            @AnnotatedField(name = "SZVisualizationDCSJAType.UNIQUE", markdown = "Unique.")
+            UNIQUE,
+            @AnnotatedField(name = "SZVisualizationDCSJAType.MIN", markdown = "Minimum.")
+            MIN,
+            @AnnotatedField(name = "SZVisualizationDCSJAType.MAX", markdown = "Maximum.")
+            MAX,
+            @AnnotatedField(name = "SZVisualizationDCSJAType.AVERAGE", markdown = "Average.")
+            AVERAGE
+          }
+        }
+      }
+
+      @AnnotatedClass(name = "SZVisualizationDCSAttribute", markdown = "Attribute configuration.")
+      public static class SZVisualizationDCSAttribute {
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSAttribute.attribute",
+            markdown = "The attribute to read.")
+        public String attribute;
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSAttribute.numericBucketing",
+            markdown = "Numeric Bucketing.")
+        public SZVisualizationDCSANumericBucketing numericBucketing;
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSAttribute.sortType",
+            markdown = "How to sort this attribute for display. Defaults to NAME.",
+            optional = true,
+            defaultValue = "NAME")
+        public SZVisualizationDCSASortType sortType;
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSAttribute.sortDescending",
+            markdown = "Whether to sort in descending order.",
+            optional = true)
+        public boolean sortDescending;
+
+        @AnnotatedField(
+            name = "SZVisualizationDCSAttribute.limit",
+            markdown =
+                "Whether a limited amount of data should be returned (e.g. 10 most "
+                    + "common conditions).",
+            optional = true)
+        public int limit;
+
+        @AnnotatedClass(
+            name = "SZVisualizationDCSANumericBucketing",
+            markdown = "Converts a continuous numeric range into ids with count as the value.")
+        public static final class SZVisualizationDCSANumericBucketing {
+          @AnnotatedField(
+              name = "SZVisualizationDCSANumericBucketing.thresholds",
+              markdown =
+                  "Buckets can be specified as either a list of thresholds or a range "
+                      + "and number of buckets. For thresholds [18, 45, 65], results in two buckets "
+                      + "[18, 45), and [45, 65). Lesser and greater buckets can be added if desired.")
+          public List<Double> thresholds;
+
+          @AnnotatedField(
+              name = "SZVisualizationDCSANumericBucketing.intervals",
+              markdown = "Intervals",
+              optional = true)
+          public SZVisualizationDCSANBIntervals intervals;
+
+          @AnnotatedField(
+              name = "SZVisualizationDCSANumericBucketing.includeLesser",
+              markdown =
+                  "Whether to create buckets for values lesser than the explicitly "
+                      + "specified ones or ignore them",
+              optional = true)
+          public boolean includeLesser;
+
+          @AnnotatedField(
+              name = "SZVisualizationDCSANumericBucketing.includeLesser",
+              markdown =
+                  "Whether to create buckets for values greater than the explicitly "
+                      + "specified ones or ignore them",
+              optional = true)
+          public boolean includeGreater;
+
+          @AnnotatedClass(
+              name = "SZVisualizationDCSANBIntervals",
+              markdown = "Intervals {min:1, max:5, count: 2}, creates buckets [1, 3) and [3, 5).")
+          public static class SZVisualizationDCSANBIntervals {
+            @AnnotatedField(name = "SZVisualizationDCSANBIntervals.min", markdown = "Minimum")
+            public double min;
+
+            @AnnotatedField(name = "SZVisualizationDCSANBIntervals.max", markdown = "Maximum")
+            public double max;
+
+            @AnnotatedField(name = "SZVisualizationDCSANBIntervals.count", markdown = "Count")
+            public int count;
+          }
+        }
+
+        @AnnotatedClass(name = "SZVisualizationDCSASortType", markdown = "Sort type.")
+        public enum SZVisualizationDCSASortType {
+          @AnnotatedField(name = "SZVisualizationDCSASortType.UNKNOWN", markdown = "Unknown.")
+          UNKNOWN("UNKNOWN"),
+          @AnnotatedField(name = "SZVisualizationDCSASortType.NAME", markdown = "Name.")
+          NAME("NAME"),
+          @AnnotatedField(name = "SZVisualizationDCSASortType.VALUE", markdown = "Value.")
+          VALUE("VALUE");
+          private final String sortType;
+
+          SZVisualizationDCSASortType(String sortType) {
+            this.sortType = sortType;
+          }
+
+          public String sortType() {
+            return sortType;
+          }
+        }
+      }
+    }
+  }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/Visualization.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/Visualization.java
@@ -1,24 +1,18 @@
 package bio.terra.tanagra.underlay.visualization;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Visualization {
   private final String name;
   private final String title;
-  private final List<VisualizationData> vizDataList = new ArrayList<>();
+  private final ImmutableList<VisualizationData> vizDataList;
 
   public Visualization(String name, String title, List<VisualizationData> vizDataList) {
     this.name = name;
     this.title = title;
-
-    if (vizDataList != null) {
-      this.vizDataList.addAll(vizDataList);
-    }
-  }
-
-  public void addVizData(VisualizationData vizData) {
-    vizDataList.add(vizData);
+    this.vizDataList = ImmutableList.copyOf(vizDataList);
   }
 
   public String getName() {
@@ -30,6 +24,6 @@ public class Visualization {
   }
 
   public List<VisualizationData> getVizDataList() {
-    return vizDataList;
+    return vizDataList.stream().collect(Collectors.toUnmodifiableList());
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/Visualization.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/Visualization.java
@@ -1,0 +1,35 @@
+package bio.terra.tanagra.underlay.visualization;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Visualization {
+  private final String name;
+  private final String title;
+  private final List<VisualizationData> vizDataList = new ArrayList<>();
+
+  public Visualization(String name, String title, List<VisualizationData> vizDataList) {
+    this.name = name;
+    this.title = title;
+
+    if (vizDataList != null) {
+      this.vizDataList.addAll(vizDataList);
+    }
+  }
+
+  public void addVizData(VisualizationData vizData) {
+    vizDataList.add(vizData);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public List<VisualizationData> getVizDataList() {
+    return vizDataList;
+  }
+}

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/VisualizationData.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/VisualizationData.java
@@ -1,36 +1,24 @@
 package bio.terra.tanagra.underlay.visualization;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class VisualizationData {
-  private final List<VisualizationDataKey> keys = new ArrayList<>();
-  private final List<VisualizationDataValue> values = new ArrayList<>();
+  private final ImmutableList<VisualizationDataKey> keys;
+  private final ImmutableList<VisualizationDataValue> values;
 
   public VisualizationData(List<VisualizationDataKey> keys, List<VisualizationDataValue> values) {
-    if (keys != null) {
-      this.keys.addAll(keys);
-    }
-
-    if (values != null) {
-      this.values.addAll(values);
-    }
-  }
-
-  public void addKey(VisualizationDataKey dataKey) {
-    keys.add(dataKey);
-  }
-
-  public void addValue(VisualizationDataValue dataValue) {
-    values.add(dataValue);
+    this.keys = ImmutableList.copyOf(keys);
+    this.values = ImmutableList.copyOf(values);
   }
 
   public List<VisualizationDataKey> getKeys() {
-    return keys;
+    return keys.stream().collect(Collectors.toUnmodifiableList());
   }
 
   public List<VisualizationDataValue> getValues() {
-    return values;
+    return values.stream().collect(Collectors.toUnmodifiableList());
   }
 
   public boolean isForKey(String dataKey) {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/VisualizationData.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/visualization/VisualizationData.java
@@ -1,0 +1,48 @@
+package bio.terra.tanagra.underlay.visualization;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class VisualizationData {
+  private final List<VisualizationDataKey> keys = new ArrayList<>();
+  private final List<VisualizationDataValue> values = new ArrayList<>();
+
+  public VisualizationData(List<VisualizationDataKey> keys, List<VisualizationDataValue> values) {
+    if (keys != null) {
+      this.keys.addAll(keys);
+    }
+
+    if (values != null) {
+      this.values.addAll(values);
+    }
+  }
+
+  public void addKey(VisualizationDataKey dataKey) {
+    keys.add(dataKey);
+  }
+
+  public void addValue(VisualizationDataValue dataValue) {
+    values.add(dataValue);
+  }
+
+  public List<VisualizationDataKey> getKeys() {
+    return keys;
+  }
+
+  public List<VisualizationDataValue> getValues() {
+    return values;
+  }
+
+  public boolean isForKey(String dataKey) {
+    return keys.stream()
+            .map(VisualizationDataKey::name)
+            .filter(k -> k.equals(dataKey))
+            .distinct()
+            .count()
+        == 1;
+  }
+
+  public record VisualizationDataKey(String name, Integer numericId, String stringId) {}
+
+  public record VisualizationDataValue(int numeric, List<Integer> quartiles) {}
+}


### PR DESCRIPTION
- in current PR initial cohorts (w/o filters) will be supported. it fetches precomputed values
- For those with filters - looking into adding changes to current PR, otherwise in next PR. does not include optimizing backend queries, just combines it into a single API (moving the parallel api calls from UI to backend)


---

obj struct copied from UI