### PR TITLE
Fix errors caused by numeric IDs that are too big for JS numbers

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -503,7 +503,12 @@ public final class FromApiUtils {
 
   public static Literal fromApiObject(ApiLiteral apiLiteral) {
     return switch (apiLiteral.getDataType()) {
-      case INT64 -> Literal.forInt64(apiLiteral.getValueUnion().getInt64Val());
+        // JavaScript can't handle the full int64 range when parsing JSON, so parse them as strings.
+      case INT64 ->
+          Literal.forInt64(
+              apiLiteral.getValueUnion().getInt64Val() != null
+                  ? Long.parseLong(apiLiteral.getValueUnion().getInt64Val())
+                  : null);
       case STRING -> Literal.forString(apiLiteral.getValueUnion().getStringVal());
       case BOOLEAN -> Literal.forBoolean(apiLiteral.getValueUnion().isBoolVal());
       case DATE -> Literal.forDate(apiLiteral.getValueUnion().getDateVal());

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -90,7 +90,10 @@ public final class ToApiUtils {
         new ApiLiteral().dataType(ApiDataType.fromValue(literal.getDataType().name()));
     return switch (literal.getDataType()) {
       case INT64 ->
-          apiLiteral.valueUnion(new ApiLiteralValueUnion().int64Val(literal.getInt64Val()));
+          // JavaScript can't handle the full int64 range when parsing JSON, so send them as
+          // strings.
+          apiLiteral.valueUnion(
+              new ApiLiteralValueUnion().int64Val(literal.getInt64Val().toString()));
       case STRING ->
           apiLiteral.valueUnion(new ApiLiteralValueUnion().stringVal(literal.getStringVal()));
       case BOOLEAN ->

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -1522,8 +1522,8 @@ components:
             boolVal:
               type: boolean
             int64Val:
-              type: integer
-              format: int64
+              # Transfer int64s as strings to avoid overflowing JavaScript's number precision.
+              type: string
             stringVal:
               type: string
             dateVal:

--- a/ui/codegen.sh
+++ b/ui/codegen.sh
@@ -7,4 +7,4 @@ openapi-generator-cli generate -i ../service/src/main/resources/api/service_open
 # Generate plugin proto code.
 rm -rf src/proto
 mkdir src/proto
-npx protoc --proto_path=../underlay/src/main/proto/ --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/proto/ --ts_proto_opt=esModuleInterop=true --ts_proto_opt=outputClientImpl=false ../underlay/src/main/proto/criteriaselector/dataschema/*.proto ../underlay/src/main/proto/criteriaselector/configschema/*.proto ../underlay/src/main/proto/viz/*.proto
+npx protoc --proto_path=../underlay/src/main/proto/ --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/proto/ --ts_proto_opt=esModuleInterop=true --ts_proto_opt=outputClientImpl=false --ts_proto_opt=forceLong=bigint ../underlay/src/main/proto/criteriaselector/dataschema/*.proto ../underlay/src/main/proto/criteriaselector/configschema/*.proto ../underlay/src/main/proto/viz/*.proto

--- a/ui/src/addByCode.tsx
+++ b/ui/src/addByCode.tsx
@@ -204,7 +204,7 @@ export function AddByCode() {
                   return undefined;
                 }
 
-                const item = data[id]?.data as LookupEntryItem;
+                const item = data.get(id)?.data as LookupEntryItem;
                 if (!item) {
                   return undefined;
                 }

--- a/ui/src/addCohort.tsx
+++ b/ui/src/addCohort.tsx
@@ -117,7 +117,7 @@ export function AddCohort() {
                   return undefined;
                 }
 
-                const cohortData = data[id].data as CohortData;
+                const cohortData = data.get(id)?.data as CohortData;
                 if (!cohortData) {
                   return undefined;
                 }

--- a/ui/src/cohortReview/cohortReview.tsx
+++ b/ui/src/cohortReview/cohortReview.tsx
@@ -315,7 +315,7 @@ function AnnotationComponent(props: {
 
   // TODO(tjennison): Expand handling of older and newer revisions and improve
   // their UI once the API is updated.
-  const values = props.instance?.annotations?.[props.annotation.id];
+  const values = props.instance?.annotations?.get(props.annotation.id);
   const currentValue = values?.find((v) => v.current)?.value;
   const latestValue = values?.[values?.length]?.value;
 
@@ -339,9 +339,12 @@ function AnnotationComponent(props: {
             props.instance.data.key
           ),
         (instance: ReviewInstance) => {
-          instance.annotations[props.annotation.id] = instance.annotations[
-            props.annotation.id
-          ]?.filter((v) => !v.current);
+          instance.annotations.set(
+            props.annotation.id,
+            (instance.annotations.get(props.annotation.id) ?? []).filter(
+              (v) => !v.current
+            )
+          );
         }
       );
     } else {
@@ -432,17 +435,17 @@ function createUpdateCurrentValue(
   value: DataValue
 ) {
   const annotations = instance.annotations;
-  const cur = annotations[annotationId]?.find((v) => v.current);
+  const cur = annotations.get(annotationId)?.find((v) => v.current);
   if (cur) {
     cur.value = value;
   } else {
-    annotations[annotationId] = [
-      ...(annotations[annotationId] ?? []),
+    annotations.set(annotationId, [
+      ...(annotations.get(annotationId) ?? []),
       {
         current: true,
         instanceId: instance.data.key,
         value: value,
       },
-    ];
+    ]);
   }
 }

--- a/ui/src/cohortReview/cohortReviewList.tsx
+++ b/ui/src/cohortReview/cohortReviewList.tsx
@@ -33,7 +33,7 @@ import {
   TreeGridId,
   useArrayAsTreeGridData,
 } from "components/treegrid";
-import { Annotation, AnnotationType, CohortReview } from "data/source";
+import { AnnotationType, CohortReview } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useUnderlaySource } from "data/underlaySourceContext";
 import deepEqual from "deep-equal";
@@ -692,7 +692,7 @@ function Annotations() {
                   return undefined;
                 }
 
-                const annotation = data[id].data as Annotation;
+                const annotation = data.get(id)?.data;
                 if (!annotation) {
                   return undefined;
                 }

--- a/ui/src/cohortReview/participantsList.tsx
+++ b/ui/src/cohortReview/participantsList.tsx
@@ -125,9 +125,7 @@ function ParticipantsList(props: ParticipantsListProps) {
   );
 
   const data = useMemo(() => {
-    const data: TreeGridData = {
-      root: { data: {}, children: [] },
-    };
+    const data: TreeGridData = new Map([["root", { data: {}, children: [] }]]);
 
     instancesState.data
       ?.slice(
@@ -136,13 +134,16 @@ function ParticipantsList(props: ParticipantsListProps) {
       )
       .forEach((instance) => {
         const key = instance.data.key;
-        data[key] = { data: { ...instance.data } };
-        data.root?.children?.push(key);
+        data.set(key, { data: { ...instance.data } });
+        data.get("root")?.children?.push(key);
 
         annotationsState.data?.forEach((a) => {
-          const values = instance.annotations[a.id];
+          const values = instance.annotations.get(a.id);
           if (values) {
-            data[key].data[`t_${a.id}`] = values[values.length - 1].value;
+            const valueData = data.get(key)?.data;
+            if (valueData) {
+              valueData[`t_${a.id}`] = values[values.length - 1].value;
+            }
           }
         });
       });

--- a/ui/src/cohortReview/plugins/textSearch.tsx
+++ b/ui/src/cohortReview/plugins/textSearch.tsx
@@ -185,7 +185,7 @@ function TextSearch({ id, config }: { id: string; config: Config }) {
       >
         <Stack spacing={1} alignItems="stretch">
           {entities.map((o) => (
-            <Paper key={o.key} sx={{ overflow: "hidden" }}>
+            <Paper key={String(o.key)} sx={{ overflow: "hidden" }}>
               <Stack
                 alignItems="flex-start"
                 sx={{

--- a/ui/src/components/treegrid.test.tsx
+++ b/ui/src/components/treegrid.test.tsx
@@ -3,7 +3,12 @@ import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import IconButton from "@mui/material/IconButton";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TreeGrid, TreeGridData, TreeGridId } from "components/treegrid";
+import {
+  TreeGrid,
+  TreeGridData,
+  TreeGridId,
+  TreeGridItem,
+} from "components/treegrid";
 import React from "react";
 
 test("Table renders correctly", async () => {
@@ -27,33 +32,45 @@ test("Table renders correctly", async () => {
     },
   ];
 
-  const data: TreeGridData = {
-    root: {
-      data: {},
-      children: [1, 3],
-    },
-    1: {
-      data: {
-        col1: "1-col1",
-        col2: "1-col2",
+  const data = new Map<TreeGridId, TreeGridItem>([
+    [
+      "root",
+      {
+        data: {},
+        children: [1, 3],
       },
-      children: [2],
-    },
-    2: {
-      data: {
-        col1: "2-col1",
-        col2: "2-col2",
-        col3: "2-col3",
+    ],
+    [
+      1,
+      {
+        data: {
+          col1: "1-col1",
+          col2: "1-col2",
+        },
+        children: [2],
       },
-    },
-    3: {
-      data: {
-        col1: "3-col1",
-        col2: "3-col2",
-        col3: <AccountTreeIcon />,
+    ],
+    [
+      2,
+      {
+        data: {
+          col1: "2-col1",
+          col2: "2-col2",
+          col3: "2-col3",
+        },
       },
-    },
-  };
+    ],
+    [
+      3,
+      {
+        data: {
+          col1: "3-col1",
+          col2: "3-col2",
+          col3: <AccountTreeIcon />,
+        },
+      },
+    ],
+  ]);
 
   const rowCustomization = (id: TreeGridId) => {
     // Add variety to the rows.

--- a/ui/src/criteria/attribute.tsx
+++ b/ui/src/criteria/attribute.tsx
@@ -382,7 +382,7 @@ async function search(
   hintData.enumHintOptions.forEach((hint) => {
     const key = hint.value;
     if (
-      (typeof key === "string" || typeof key === "number") &&
+      (typeof key === "string" || typeof key === "bigint") &&
       hint.name.search(re) >= 0
     ) {
       results.push({

--- a/ui/src/criteria/filterableGroup.tsx
+++ b/ui/src/criteria/filterableGroup.tsx
@@ -402,9 +402,8 @@ function FilterableGroupEdit(props: FilterableGroupEditProps) {
                     <GridLayout rows>
                       <Typography variant="body1">Query examples:</Typography>
                       {[...props.config.searchConfigs]
-                        .sort(
-                          (a, b) =>
-                            (a.displayOrder ?? 0) - (b.displayOrder ?? 0)
+                        .sort((a, b) =>
+                          Number((a.displayOrder ?? 0) - (b.displayOrder ?? 0))
                         )
                         .map((sc) => (
                           <Typography key={sc.name} variant="body2em">

--- a/ui/src/data/types.ts
+++ b/ui/src/data/types.ts
@@ -1,8 +1,8 @@
 import * as tanagraUnderlay from "tanagra-underlay/underlayConfig";
 import { standardDateString } from "util/date";
 
-export type DataKey = string | number;
-export type DataValue = null | string | number | boolean | Date;
+export type DataKey = string | number | bigint;
+export type DataValue = null | string | number | bigint | boolean | Date;
 
 export type DataEntry = {
   key: DataKey;
@@ -53,6 +53,7 @@ export function convertAttributeStringToDataValue(
 ): DataValue {
   switch (attribute.dataType) {
     case tanagraUnderlay.SZDataType.INT64:
+      return BigInt(value);
     case tanagraUnderlay.SZDataType.DOUBLE:
       return Number(value);
     case tanagraUnderlay.SZDataType.BOOLEAN:

--- a/ui/src/export.tsx
+++ b/ui/src/export.tsx
@@ -496,13 +496,13 @@ function PreviewTable(props: PreviewTableProps) {
             props.featureSets
           );
 
-          const data: TreeGridData = {
-            root: { data: {}, children: [] },
-          };
+          const data: TreeGridData = new Map([
+            ["root", { data: {}, children: [] }],
+          ]);
 
           res.data.forEach((entry, i) => {
-            data[i] = { data: entry };
-            data.root?.children?.push(i);
+            data.set(i, { data: entry });
+            data.get("root")?.children?.push(i);
           });
 
           return {
@@ -572,7 +572,8 @@ function PreviewTable(props: PreviewTableProps) {
                   </Typography>
                 </GridBox>
               ) : tabDataState.data?.[tab]?.data ? (
-                tabDataState.data?.[tab]?.data?.root?.children?.length ? (
+                tabDataState.data?.[tab]?.data?.get("root")?.children
+                  ?.length ? (
                   <TreeGrid
                     data={tabDataState.data?.[tab]?.data}
                     columns={props.occurrenceFilters[tab]?.attributes.map(

--- a/ui/src/fakeApis.ts
+++ b/ui/src/fakeApis.ts
@@ -129,7 +129,7 @@ export class FakeUnderlaysApi {
               value: {
                 dataType: tanagra.DataType.Int64,
                 valueUnion: {
-                  int64Val: 1234,
+                  int64Val: "1234",
                 },
               },
             },
@@ -163,7 +163,7 @@ export class FakeUnderlaysApi {
                     value: {
                       dataType: tanagra.DataType.Int64,
                       valueUnion: {
-                        int64Val: 8515,
+                        int64Val: "8515",
                       },
                     },
                   },
@@ -175,7 +175,7 @@ export class FakeUnderlaysApi {
                     value: {
                       dataType: tanagra.DataType.Int64,
                       valueUnion: {
-                        int64Val: 8516,
+                        int64Val: "8516",
                       },
                     },
                   },

--- a/ui/src/featureSet/addFeatureSet.tsx
+++ b/ui/src/featureSet/addFeatureSet.tsx
@@ -122,7 +122,7 @@ export function AddFeatureSet() {
                   return undefined;
                 }
 
-                const featureSetData = data[id].data as FeatureSetData;
+                const featureSetData = data.get(id)?.data as FeatureSetData;
                 if (!featureSetData) {
                   return undefined;
                 }

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -340,13 +340,13 @@ function Preview() {
             true
           );
 
-          const data: TreeGridData = {
-            root: { data: {}, children: [] },
-          };
+          const data: TreeGridData = new Map([
+            ["root", { data: {}, children: [] }],
+          ]);
 
           res.data.forEach((entry, i) => {
-            data[i] = { data: entry };
-            data.root?.children?.push(i);
+            data.set(i, { data: entry });
+            data.get("root")?.children?.push(i);
           });
 
           return {
@@ -371,7 +371,7 @@ function Preview() {
                 id: data.name,
                 title: data.name,
                 render: () =>
-                  data.data.root?.children?.length ? (
+                  data.data.get("root")?.children?.length ? (
                     previewOccurrences[i] ? (
                       <PreviewTable
                         occurrence={previewOccurrences[i]}

--- a/ui/src/sampleApp/studiesList.tsx
+++ b/ui/src/sampleApp/studiesList.tsx
@@ -78,9 +78,7 @@ export function StudiesList() {
 
   const data = useMemo(() => {
     const children: DataKey[] = [];
-    const data: TreeGridData = {
-      root: { data: {}, children },
-    };
+    const data: TreeGridData = new Map([["root", { data: {}, children }]]);
 
     studiesState.data?.forEach((study) => {
       const key = study.id;
@@ -122,7 +120,7 @@ export function StudiesList() {
           ),
         },
       };
-      data[key] = item;
+      data.set(key, item);
     });
 
     return data;
@@ -136,7 +134,7 @@ export function StudiesList() {
       <Header />
       <Loading status={studiesState}>
         <GridLayout rows spacing={4}>
-          {!!data?.root?.children?.length ? (
+          {!!data?.get("root")?.children?.length ? (
             <TreeGrid columns={columns} data={data} />
           ) : (
             <Empty

--- a/ui/src/sampleApp/studyOverview.tsx
+++ b/ui/src/sampleApp/studyOverview.tsx
@@ -110,9 +110,7 @@ export function StudyOverview() {
 
   const data = useMemo(() => {
     const children: DataKey[] = [];
-    const data: TreeGridData = {
-      root: { data: {}, children },
-    };
+    const data: TreeGridData = new Map([["root", { data: {}, children }]]);
 
     artifactsState.data?.forEach((artifact) => {
       const key = `${artifact.type}~${artifact.id}`;
@@ -144,7 +142,7 @@ export function StudyOverview() {
           ),
         },
       };
-      data[key] = item;
+      data.set(key, item);
     });
 
     return data;
@@ -202,7 +200,7 @@ export function StudyOverview() {
           </GridLayout>
         </GridBox>
         <Loading status={artifactsState}>
-          {!!data?.root?.children?.length ? (
+          {!!data?.get("root")?.children?.length ? (
             <TreeGrid
               columns={columns}
               data={data}

--- a/ui/src/viz/viz.ts
+++ b/ui/src/viz/viz.ts
@@ -62,11 +62,20 @@ export function processFilterCountValues(
         if (!isValid(value)) {
           value = "Unknown";
         }
+        if (typeof value === "bigint") {
+          value = Number(value);
+        }
 
         let name: string | undefined = undefined;
         let numericId: number | undefined = undefined;
         let stringId: string | undefined = undefined;
         if (a.numericBucketing) {
+          if (typeof value !== "number") {
+            throw new Error(
+              `Numeric bucketing cannot be applied to non-numeric ${value}.`
+            );
+          }
+
           const thresholds = a.numericBucketing.thresholds ?? [];
           if (!thresholds.length) {
             const intervals = a.numericBucketing.intervals;
@@ -76,7 +85,7 @@ export function processFilterCountValues(
               );
             }
 
-            for (let i = 0; i < intervals.count + 1; i++) {
+            for (let i = 0; i < intervals.count + 1n; i++) {
               thresholds.push(
                 intervals.min + i * (intervals.max - intervals.min)
               );
@@ -192,7 +201,7 @@ export function processFilterCountValues(
 
   const limit = vizSource.attributes[0].limit;
   if (limit) {
-    let count = 0;
+    let count = 0n;
     for (let i = 1; i < arr.length; i++) {
       const ka = arr[i].keys[0];
       const kb = arr[i - 1].keys[0];


### PR DESCRIPTION
* Numbers in JS are doubles by default. This generally works fine for numeric data but can cause truncation for IDs that use the entire space of an int64.
* The JSON functions can't correctly handle the large numbers without some change to the format. The easiest is to send int64s as strings.
* Those numbers are converted to BigInts to make them numeric but retain their precision. This requires using them throughout the code since our keys/ids are generally int64s.
* BigInts don't follow the same coercion rules as numbers, so many places that previously just worked (e.g. data maps, JSX keys) no longer do. Convert data maps to actual Map objects and explicitly convert keys to strings.
* The change to Maps exposes some clunkiness in the way TreeGrid data is handled. Sticking to a simple conversion for now but will consider other changes in a followup.