### PR TITLE
Implement hashcode and equals in EntityFilter

### DIFF
--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/EntityFilter.java
@@ -40,6 +40,7 @@ public abstract class EntityFilter {
   }
 
   // TODO: Add logic here to merge filters automatically to get a simpler filter overall.
+  // Current filter generation logic is in both UI and Underlay, hence only merge translation
   public boolean isMergeable(EntityFilter entityFilter) {
     return false;
   }
@@ -49,9 +50,15 @@ public abstract class EntityFilter {
     return null;
   }
 
-  public static boolean areSameFilterType(List<EntityFilter> filters) {
+  public static boolean areSameFilterTypeAndEntity(List<EntityFilter> filters) {
     Class<?> firstClazz = filters.get(0).getClass();
-    return filters.stream().skip(1).allMatch(filter -> filter.getClass().equals(firstClazz));
+    String firstEntityName = filters.get(0).getEntity().getName();
+    return filters.stream()
+        .skip(1)
+        .allMatch(
+            filter ->
+                filter.getClass().equals(firstClazz)
+                    && filter.getEntity().getName().equals(firstEntityName));
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyHasParentFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyHasParentFilter.java
@@ -6,6 +6,7 @@ import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
 public class HierarchyHasParentFilter extends EntityFilter {
@@ -32,5 +33,19 @@ public class HierarchyHasParentFilter extends EntityFilter {
 
   public ImmutableList<Literal> getParentIds() {
     return parentIds;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    HierarchyHasParentFilter that = (HierarchyHasParentFilter) o;
+    return hierarchy.equals(that.hierarchy) && parentIds.equals(that.parentIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), hierarchy, parentIds);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsLeafFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsLeafFilter.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.api.filter;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
+import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
 public class HierarchyIsLeafFilter extends EntityFilter {
@@ -15,5 +16,18 @@ public class HierarchyIsLeafFilter extends EntityFilter {
 
   public Hierarchy getHierarchy() {
     return hierarchy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    return hierarchy.equals(((HierarchyIsLeafFilter) o).hierarchy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), hierarchy);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsMemberFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsMemberFilter.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.api.filter;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
+import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
 public class HierarchyIsMemberFilter extends EntityFilter {
@@ -15,5 +16,18 @@ public class HierarchyIsMemberFilter extends EntityFilter {
 
   public Hierarchy getHierarchy() {
     return hierarchy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    return hierarchy.equals(((HierarchyIsMemberFilter) o).hierarchy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), hierarchy);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsRootFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/HierarchyIsRootFilter.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.api.filter;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.underlay.entitymodel.Hierarchy;
+import java.util.Objects;
 import org.slf4j.LoggerFactory;
 
 public class HierarchyIsRootFilter extends EntityFilter {
@@ -15,5 +16,18 @@ public class HierarchyIsRootFilter extends EntityFilter {
 
   public Hierarchy getHierarchy() {
     return hierarchy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    return hierarchy.equals(((HierarchyIsRootFilter) o).hierarchy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), hierarchy);
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/api/filter/PrimaryWithCriteriaFilter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/api/filter/PrimaryWithCriteriaFilter.java
@@ -46,6 +46,27 @@ public class PrimaryWithCriteriaFilter extends EntityFilter {
             : ImmutableMap.copyOf(groupByAttributesPerOccurrenceEntity);
     this.groupByCountOperator = groupByCountOperator;
     this.groupByCountValue = groupByCountValue;
+
+    // one-time checks
+    int numSubFiltersPerOccEntity = getNumSubFiltersPerOccEntity();
+    this.subFiltersPerOccurrenceEntity.forEach(
+        (occurrenceEntity, subFilters) -> {
+          if (subFilters.size() != numSubFiltersPerOccEntity) {
+            throw new InvalidQueryException(
+                "There must be the same number of sub filters for each occurrence entity: "
+                    + occurrenceEntity.getName());
+          }
+        });
+
+    int numGroupByAttributesPerOccEntity = getNumGroupByAttributesPerOccEntity();
+    this.groupByAttributesPerOccurrenceEntity.forEach(
+        (occurrenceEntity, groupByAttributes) -> {
+          if (groupByAttributes.size() != numGroupByAttributesPerOccEntity) {
+            throw new InvalidQueryException(
+                "There must be the same number of group by attributes for each occurrence entity: "
+                    + occurrenceEntity.getName());
+          }
+        });
   }
 
   public CriteriaOccurrence getCriteriaOccurrence() {
@@ -54,6 +75,10 @@ public class PrimaryWithCriteriaFilter extends EntityFilter {
 
   public EntityFilter getCriteriaSubFilter() {
     return criteriaSubFilter;
+  }
+
+  public int getNumSubFiltersPerOccEntity() {
+    return getSubFilters(criteriaOccurrence.getOccurrenceEntities().get(0)).size();
   }
 
   public boolean hasSubFilters(Entity occurrenceEntity) {
@@ -76,22 +101,12 @@ public class PrimaryWithCriteriaFilter extends EntityFilter {
         : ImmutableList.of();
   }
 
-  public int getNumGroupByAttributes() {
-    int numGroupByAttributes =
-        getGroupByAttributes(criteriaOccurrence.getOccurrenceEntities().get(0)).size();
-    groupByAttributesPerOccurrenceEntity.forEach(
-        (occurrenceEntity, groupByAttributes) -> {
-          if (groupByAttributes.size() != numGroupByAttributes) {
-            throw new InvalidQueryException(
-                "There must be the same number of group by attributes for each occurrence entity: "
-                    + occurrenceEntity.getName());
-          }
-        });
-    return numGroupByAttributes;
+  public int getNumGroupByAttributesPerOccEntity() {
+    return getGroupByAttributes(criteriaOccurrence.getOccurrenceEntities().get(0)).size();
   }
 
   public boolean hasGroupByAttributes() {
-    return getNumGroupByAttributes() > 0;
+    return getNumGroupByAttributesPerOccEntity() > 0;
   }
 
   @Nullable

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/BQApiTranslator.java
@@ -8,6 +8,7 @@ import bio.terra.tanagra.api.field.HierarchyNumChildrenField;
 import bio.terra.tanagra.api.field.HierarchyPathField;
 import bio.terra.tanagra.api.field.RelatedEntityIdCountField;
 import bio.terra.tanagra.api.filter.AttributeFilter;
+import bio.terra.tanagra.api.filter.BooleanAndOrFilter.LogicalOperator;
 import bio.terra.tanagra.api.filter.HierarchyHasAncestorFilter;
 import bio.terra.tanagra.api.filter.HierarchyHasParentFilter;
 import bio.terra.tanagra.api.filter.HierarchyIsLeafFilter;
@@ -46,6 +47,7 @@ import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public final class BQApiTranslator implements ApiTranslator {
   @Override
@@ -149,6 +151,15 @@ public final class BQApiTranslator implements ApiTranslator {
   public ApiFilterTranslator translator(
       TemporalPrimaryFilter temporalPrimaryFilter, Map<Attribute, SqlField> attributeSwapFields) {
     return new BQTemporalPrimaryFilterTranslator(this, temporalPrimaryFilter, attributeSwapFields);
+  }
+
+  @Override
+  public Optional<ApiFilterTranslator> mergedTranslatorAttributeFilter(
+      List<AttributeFilter> attributeFilters,
+      LogicalOperator logicalOperator,
+      Map<Attribute, SqlField> attributeSwapFields) {
+    return BQAttributeFilterTranslator.mergedTranslator(
+        this, attributeFilters, logicalOperator, attributeSwapFields);
   }
 
   @Override

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQPrimaryWithCriteriaFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/translator/filter/BQPrimaryWithCriteriaFilterTranslator.java
@@ -196,7 +196,7 @@ public class BQPrimaryWithCriteriaFilterTranslator extends ApiFilterTranslator {
     }
 
     List<String> groupByFieldsSql = new ArrayList<>();
-    for (int i = 0; i < primaryWithCriteriaFilter.getNumGroupByAttributes(); i++) {
+    for (int i = 0; i < primaryWithCriteriaFilter.getNumGroupByAttributesPerOccEntity(); i++) {
       groupByFieldsSql.add(groupByFieldAliasPrefix + i);
     }
     String groupByFieldsSqlJoined = String.join(", ", groupByFieldsSql);

--- a/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/BooleanAndOrFilterTranslator.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/sql/translator/filter/BooleanAndOrFilterTranslator.java
@@ -1,7 +1,6 @@
 package bio.terra.tanagra.query.sql.translator.filter;
 
 import bio.terra.tanagra.api.filter.BooleanAndOrFilter;
-import bio.terra.tanagra.api.filter.EntityFilter;
 import bio.terra.tanagra.query.sql.SqlField;
 import bio.terra.tanagra.query.sql.SqlParams;
 import bio.terra.tanagra.query.sql.translator.ApiFilterTranslator;
@@ -22,16 +21,11 @@ public class BooleanAndOrFilterTranslator extends ApiFilterTranslator {
     super(apiTranslator, attributeSwapFields);
     this.booleanAndOrFilter = booleanAndOrFilter;
 
-    // Get a single merged translator if the sub-filters are mergeable: must be of the same type
-    // Additional checks may be needed for individual sub-filter types
     Optional<ApiFilterTranslator> mergedTranslator =
-        EntityFilter.areSameFilterType(booleanAndOrFilter.getSubFilters())
-            ? apiTranslator.mergedTranslator(
-                booleanAndOrFilter.getSubFilters(),
-                booleanAndOrFilter.getOperator(),
-                attributeSwapFields)
-            : Optional.empty();
-
+        apiTranslator.mergedTranslator(
+            booleanAndOrFilter.getSubFilters(),
+            booleanAndOrFilter.getOperator(),
+            attributeSwapFields);
     this.subFilterTranslators =
         mergedTranslator
             .map(List::of)


### PR DESCRIPTION
- Implement hashcode and equals in EntityFilter
- move areSameFilterType() to parent interface and rename to areSameFilterTypeAndEntity()
- Update Utils in PrimaryWithCriteriaFilter
- update checks in BQAttributeFilterTranslator