### PR TITLE
Add orderby clause to hints query

### DIFF
--- a/cli/src/main/java/bio/terra/tanagra/cli/utils/Context.java
+++ b/cli/src/main/java/bio/terra/tanagra/cli/utils/Context.java
@@ -9,12 +9,10 @@ public final class Context {
   private static final String LOG_FILENAME = "tanagra.log";
   public static final String IS_TEST = "IS_TEST";
   private static final String IS_TEST_TRUE_VALUE = "true";
-
   // Env var name to optionally override where the context is persisted on disk.
   private static final String CONTEXT_DIR_OVERRIDE_NAME = "TANAGRA_CONTEXT_PARENT_DIR";
   // File paths related to persisting the context on disk.
   private static final String CONTEXT_DIRNAME = ".tanagra";
-
   // Singleton object that defines the current context or state.
   private static Config currentConfig;
 

--- a/indexer/src/main/java/bio/terra/tanagra/indexing/job/dataflow/beam/PathUtils.java
+++ b/indexer/src/main/java/bio/terra/tanagra/indexing/job/dataflow/beam/PathUtils.java
@@ -22,11 +22,11 @@ import org.apache.beam.sdk.values.TypeDescriptors;
     value = {"NP_NULL_PARAM_DEREF", "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"},
     justification = "PCollection is using a Nullable coder")
 public final class PathUtils {
-  private PathUtils() {}
-
   // the path of nodes is currently encoded as a string. use this as the delimiter between nodes.
   private static final String PATH_DELIMITER = ".";
   private static final String PATH_DELIMITER_REGEX = "\\.";
+
+  private PathUtils() {}
 
   /**
    * Compute one path from each node in a hierarchy to a root node. If there are multiple paths from

--- a/service/src/main/java/bio/terra/tanagra/service/authentication/AppDefaultUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/service/authentication/AppDefaultUtils.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 /** Utilities for working with Google application default credentials. */
 public final class AppDefaultUtils {
-
   private static final String GCP_ADC_JWT_ISSUER_URL = "https://accounts.google.com";
 
   private AppDefaultUtils() {}

--- a/service/src/main/java/bio/terra/tanagra/service/authentication/UserId.java
+++ b/service/src/main/java/bio/terra/tanagra/service/authentication/UserId.java
@@ -4,7 +4,6 @@ import java.io.Serializable;
 
 public final class UserId implements Serializable {
   private static final String DISABLED_AUTHENTICATION_USER_ID = "authentication-disabled";
-
   private final String subject;
   private final String email;
   private final String token;

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/Criteria.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/Criteria.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
 
 public final class Criteria {
-  private Criteria() {}
-
   public static final Pair<String, bio.terra.tanagra.service.artifact.model.Criteria>
       DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE =
           Pair.of(
@@ -67,6 +65,7 @@ public final class Criteria {
                           .build()))
               .uiConfig("")
               .build());
+
   public static final Pair<String, bio.terra.tanagra.service.artifact.model.Criteria>
       ETHNICITY_EQ_HISPANIC_OR_LATINO =
           Pair.of(
@@ -115,6 +114,7 @@ public final class Criteria {
                   .uiConfig("")
                   .tags(Map.of())
                   .build());
+
   public static final Pair<String, bio.terra.tanagra.service.artifact.model.Criteria>
       PROCEDURE_EQ_AMPUTATION =
           Pair.of(
@@ -163,4 +163,6 @@ public final class Criteria {
                               .build()))
                   .uiConfig("")
                   .build());
+
+  private Criteria() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroup.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroup.java
@@ -9,37 +9,42 @@ import bio.terra.tanagra.service.artifact.model.CohortRevision;
 import java.util.List;
 
 public final class CriteriaGroup {
-  private CriteriaGroup() {}
-
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_GENDER =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group gender")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
           .build();
+
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_AGE =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group gender")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue()))
           .build();
+
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_DEMOGRAPHICS =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group 1")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_HISPANIC_OR_LATINO.getValue()))
           .build();
+
   public static final CohortRevision.CriteriaGroup DISABLED_CRITERIA_GROUP_DEMOGRAPHICS =
       CohortRevision.CriteriaGroup.builder()
           .displayName("disabled group demographics")
           .criteria(List.of(GENDER_EQ_WOMAN.getValue(), ETHNICITY_EQ_HISPANIC_OR_LATINO.getValue()))
           .isDisabled(true)
           .build();
+
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_CONDITION =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group condition")
           .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES.getValue()))
           .build();
+
   public static final CohortRevision.CriteriaGroup CRITERIA_GROUP_PROCEDURE =
       CohortRevision.CriteriaGroup.builder()
           .displayName("group procedure")
           .criteria(List.of(PROCEDURE_EQ_AMPUTATION.getValue()))
           .build();
+
+  private CriteriaGroup() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroupSection.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/CriteriaGroupSection.java
@@ -7,23 +7,24 @@ import bio.terra.tanagra.service.artifact.model.CohortRevision;
 import java.util.List;
 
 public final class CriteriaGroupSection {
-  private CriteriaGroupSection() {}
-
   public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_GENDER =
       CohortRevision.CriteriaGroupSection.builder()
           .displayName("section gender")
           .criteriaGroups(List.of(CriteriaGroup.CRITERIA_GROUP_GENDER))
           .build();
+
   public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_AGE =
       CohortRevision.CriteriaGroupSection.builder()
           .displayName("section age")
           .criteriaGroups(List.of(CriteriaGroup.CRITERIA_GROUP_AGE))
           .build();
+
   public static final CohortRevision.CriteriaGroupSection CRITERIA_GROUP_SECTION_DEMOGRAPHICS =
       CohortRevision.CriteriaGroupSection.builder()
           .displayName("section demographics")
           .criteriaGroups(List.of(CriteriaGroup.CRITERIA_GROUP_DEMOGRAPHICS))
           .build();
+
   public static final CohortRevision.CriteriaGroupSection
       CRITERIA_GROUP_SECTION_DEMOGRAPHICS_AND_CONDITION =
           CohortRevision.CriteriaGroupSection.builder()
@@ -96,4 +97,6 @@ public final class CriteriaGroupSection {
               .joinOperatorValue(null)
               .setIsExcluded(false)
               .build();
+
+  private CriteriaGroupSection() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/FeatureSet.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/cmssynpuf/FeatureSet.java
@@ -8,8 +8,6 @@ import java.util.Map;
 public final class FeatureSet {
   private static final String UNDERLAY_NAME = "cmssynpuf";
 
-  private FeatureSet() {}
-
   public static final bio.terra.tanagra.service.artifact.model.FeatureSet CS_DEMOGRAPHICS =
       bio.terra.tanagra.service.artifact.model.FeatureSet.builder()
           .underlay(UNDERLAY_NAME)
@@ -23,4 +21,6 @@ public final class FeatureSet {
               .criteria(List.of(DEMOGRAPHICS_PREPACKAGED_DATA_FEATURE.getRight()))
               .excludeOutputAttributesPerEntity(Map.of("person", List.of("id", "gender")))
               .build();
+
+  private FeatureSet() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CohortRevision.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CohortRevision.java
@@ -9,8 +9,6 @@ import bio.terra.tanagra.service.artifact.model.Cohort;
 import java.util.List;
 
 public final class CohortRevision {
-  private CohortRevision() {}
-
   private static final String UNDERLAY_NAME = "sd";
 
   public static final bio.terra.tanagra.service.artifact.model.CohortRevision CR_EMPTY =
@@ -34,12 +32,14 @@ public final class CohortRevision {
               .sections(List.of(CGS_CONDITION_EXCLUDED, CGS_GENDER))
               .setIsMostRecent(true)
               .build();
+
   public static final bio.terra.tanagra.service.artifact.model.CohortRevision CR_PROCEDURE =
       bio.terra.tanagra.service.artifact.model.CohortRevision.builder()
           .id("cr4")
           .sections(List.of(CGS_PROCEDURE))
           .setIsMostRecent(true)
           .build();
+
   public static final bio.terra.tanagra.service.artifact.model.CohortRevision
       CR_GENDER_AND_DISABLED_CONDITION =
           bio.terra.tanagra.service.artifact.model.CohortRevision.builder()
@@ -50,18 +50,23 @@ public final class CohortRevision {
 
   public static final Cohort C_EMPTY =
       Cohort.builder().underlay(UNDERLAY_NAME).id("c1").revisions(List.of(CR_EMPTY)).build();
+
   public static final Cohort C_CONDITION_EXCLUDED =
       Cohort.builder()
           .underlay(UNDERLAY_NAME)
           .id("c2")
           .revisions(List.of(CR_CONDITION_EXCLUDED))
           .build();
+
   public static final Cohort C_CONDITION_EXCLUDED_AND_GENDER =
       Cohort.builder()
           .underlay(UNDERLAY_NAME)
           .id("c3")
           .revisions(List.of(CR_CONDITION_EXCLUDED_AND_GENDER))
           .build();
+
   public static final Cohort C_PROCEDURE =
       Cohort.builder().underlay(UNDERLAY_NAME).id("c5").revisions(List.of(CR_PROCEDURE)).build();
+
+  private CohortRevision() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/Criteria.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/Criteria.java
@@ -10,8 +10,6 @@ import bio.terra.tanagra.proto.criteriaselector.dataschema.DTUnhintedValue;
 import java.util.Map;
 
 public final class Criteria {
-  private Criteria() {}
-
   public static final bio.terra.tanagra.service.artifact.model.Criteria GENDER_EQ_WOMAN =
       bio.terra.tanagra.service.artifact.model.Criteria.builder()
           .selectorOrModifierName("tanagra-gender")
@@ -99,6 +97,7 @@ public final class Criteria {
                               .build())
                       .build()))
           .build();
+
   public static final bio.terra.tanagra.service.artifact.model.Criteria
       PROCEDURE_AGE_AT_OCCURRENCE_EQ_45 =
           bio.terra.tanagra.service.artifact.model.Criteria.builder()
@@ -126,4 +125,6 @@ public final class Criteria {
               .selectionData("")
               .uiConfig("")
               .build();
+
+  private Criteria() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroup.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroup.java
@@ -11,33 +11,37 @@ import bio.terra.tanagra.service.artifact.model.CohortRevision;
 import java.util.List;
 
 public final class CriteriaGroup {
-  private CriteriaGroup() {}
-
   public static final CohortRevision.CriteriaGroup CG_EMPTY =
       CohortRevision.CriteriaGroup.builder().id("cg1").build();
+
   public static final CohortRevision.CriteriaGroup CG_GENDER =
       CohortRevision.CriteriaGroup.builder().id("cg2").criteria(List.of(GENDER_EQ_WOMAN)).build();
+
   public static final CohortRevision.CriteriaGroup DISABLED_CG_GENDER =
       CohortRevision.CriteriaGroup.builder()
           .id("cg2d")
           .criteria(List.of(GENDER_EQ_WOMAN))
           .isDisabled(true)
           .build();
+
   public static final CohortRevision.CriteriaGroup CG_CONDITION =
       CohortRevision.CriteriaGroup.builder()
           .id("cg3")
           .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES))
           .build();
+
   public static final CohortRevision.CriteriaGroup CG_CONDITION_WITH_MODIFIER =
       CohortRevision.CriteriaGroup.builder()
           .id("cg4")
           .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES, CONDITION_AGE_AT_OCCURRENCE_EQ_65))
           .build();
+
   public static final CohortRevision.CriteriaGroup CG_CONDITION_WITH_GROUP_BY_MODIFIER =
       CohortRevision.CriteriaGroup.builder()
           .id("cg5")
           .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES, CONDITION_COUNT_GTE_2))
           .build();
+
   public static final CohortRevision.CriteriaGroup CG_PROCEDURE =
       CohortRevision.CriteriaGroup.builder()
           .id("cg6")
@@ -49,4 +53,6 @@ public final class CriteriaGroup {
           .id("cg7")
           .criteria(List.of(PROCEDURE_EQ_AMPUTATION, PROCEDURE_AGE_AT_OCCURRENCE_EQ_45))
           .build();
+
+  private CriteriaGroup() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroupSection.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/CriteriaGroupSection.java
@@ -15,16 +15,16 @@ import bio.terra.tanagra.service.artifact.model.CohortRevision;
 import java.util.List;
 
 public final class CriteriaGroupSection {
-  private CriteriaGroupSection() {}
-
   public static final CohortRevision.CriteriaGroupSection CGS_EMPTY =
       CohortRevision.CriteriaGroupSection.builder().id("cgs1").build();
+
   public static final CohortRevision.CriteriaGroupSection CGS_CONDITION_EXCLUDED =
       CohortRevision.CriteriaGroupSection.builder()
           .id("cgs2")
           .criteriaGroups(List.of(CG_CONDITION_WITH_MODIFIER))
           .setIsExcluded(true)
           .build();
+
   public static final CohortRevision.CriteriaGroupSection CGS_GENDER_AND_CONDITION =
       CohortRevision.CriteriaGroupSection.builder()
           .id("cgs3")
@@ -39,17 +39,20 @@ public final class CriteriaGroupSection {
           .setIsExcluded(true)
           .setIsDisabled(true)
           .build();
+
   public static final CohortRevision.CriteriaGroupSection CGS_CONDITION_AND_DISABLED_GENDER =
       CohortRevision.CriteriaGroupSection.builder()
           .id("cgs3d")
           .criteriaGroups(List.of(CG_CONDITION_WITH_MODIFIER, DISABLED_CG_GENDER))
           .operator(BooleanAndOrFilter.LogicalOperator.AND)
           .build();
+
   public static final CohortRevision.CriteriaGroupSection CGS_GENDER =
       CohortRevision.CriteriaGroupSection.builder()
           .id("cgs4")
           .criteriaGroups(List.of(CG_GENDER))
           .build();
+
   public static final CohortRevision.CriteriaGroupSection CGS_PROCEDURE =
       CohortRevision.CriteriaGroupSection.builder()
           .id("cgs5")
@@ -127,4 +130,6 @@ public final class CriteriaGroupSection {
               .secondConditionCriteriaGroups(List.of(CG_CONDITION_WITH_MODIFIER))
               .operator(BooleanAndOrFilter.LogicalOperator.AND)
               .build();
+
+  private CriteriaGroupSection() {}
 }

--- a/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/FeatureSet.java
+++ b/service/src/test/java/bio/terra/tanagra/service/criteriaconstants/sd/FeatureSet.java
@@ -10,8 +10,6 @@ import java.util.Map;
 public final class FeatureSet {
   private static final String UNDERLAY_NAME = "sd";
 
-  private FeatureSet() {}
-
   public static final bio.terra.tanagra.service.artifact.model.FeatureSet CS_EMPTY =
       bio.terra.tanagra.service.artifact.model.FeatureSet.builder()
           .underlay(UNDERLAY_NAME)
@@ -46,4 +44,6 @@ public final class FeatureSet {
               .underlay(UNDERLAY_NAME)
               .criteria(List.of(CONDITION_EQ_TYPE_2_DIABETES, PROCEDURE_EQ_AMPUTATION))
               .build();
+
+  private FeatureSet() {}
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -208,7 +208,7 @@ public class BQQueryRunner implements QueryRunner {
     // Build the SQL query.
     StringBuilder sql = new StringBuilder();
     SqlParams sqlParams = new SqlParams();
-    List<String> orderByColumns = new ArrayList<>();
+    List<String> orderByColumns;
 
     if (hintQueryRequest.isEntityLevel()) {
       ITEntityLevelDisplayHints eldhTable =

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -208,7 +208,7 @@ public class BQQueryRunner implements QueryRunner {
     // Build the SQL query.
     StringBuilder sql = new StringBuilder();
     SqlParams sqlParams = new SqlParams();
-    List<String> orderByColumns;
+    List<String> orderBys;
 
     if (hintQueryRequest.isEntityLevel()) {
       ITEntityLevelDisplayHints eldhTable =
@@ -219,7 +219,7 @@ public class BQQueryRunner implements QueryRunner {
 
       // SELECT * FROM [entity-level hint]
       sql.append("SELECT * FROM ").append(eldhTable.getTablePointer().render());
-      orderByColumns = eldhTable.getOrderByColumnNames();
+      orderBys = eldhTable.getOrderBys();
 
     } else {
       ITInstanceLevelDisplayHints ildhTable =
@@ -241,11 +241,11 @@ public class BQQueryRunner implements QueryRunner {
           .append(ITInstanceLevelDisplayHints.Column.ENTITY_ID.getSchema().getColumnName())
           .append(" = @")
           .append(relatedEntityIdParam);
-      orderByColumns = ildhTable.getOrderByColumnNames();
+      orderBys = ildhTable.getOrderBys();
     }
 
     // ORDER BY [order by fields]
-    sql.append(" ORDER BY ").append(String.join(", ", orderByColumns));
+    sql.append(" ORDER BY ").append(String.join(", ", orderBys));
 
     // Execute the SQL query.
     SqlQueryRequest sqlQueryRequest =

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -208,6 +208,7 @@ public class BQQueryRunner implements QueryRunner {
     // Build the SQL query.
     StringBuilder sql = new StringBuilder();
     SqlParams sqlParams = new SqlParams();
+    List<String> orderByColumns = new ArrayList<>();
 
     if (hintQueryRequest.isEntityLevel()) {
       ITEntityLevelDisplayHints eldhTable =
@@ -218,6 +219,8 @@ public class BQQueryRunner implements QueryRunner {
 
       // SELECT * FROM [entity-level hint]
       sql.append("SELECT * FROM ").append(eldhTable.getTablePointer().render());
+      orderByColumns = eldhTable.getOrderByColumnNames();
+
     } else {
       ITInstanceLevelDisplayHints ildhTable =
           hintQueryRequest
@@ -238,7 +241,11 @@ public class BQQueryRunner implements QueryRunner {
           .append(ITInstanceLevelDisplayHints.Column.ENTITY_ID.getSchema().getColumnName())
           .append(" = @")
           .append(relatedEntityIdParam);
+      orderByColumns = ildhTable.getOrderByColumnNames();
     }
+
+    // ORDER BY [order by fields]
+    sql.append(" ORDER BY ").append(String.join(", ", orderByColumns));
 
     // Execute the SQL query.
     SqlQueryRequest sqlQueryRequest =

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
@@ -12,7 +12,7 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
   public static final String TABLE_NAME = "ELDH";
   private final String entity;
   private final ImmutableList<ColumnSchema> columnSchemas;
-  private final ImmutableList<String> orderByColumnNames;
+  private final ImmutableList<String> orderBys;
 
   public ITEntityLevelDisplayHints(
       NameHelper namer, SZBigQuery.IndexData bigQueryConfig, String entity) {
@@ -21,12 +21,12 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
     this.columnSchemas =
         ImmutableList.copyOf(
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
-    this.orderByColumnNames =
+    this.orderBys =
         ImmutableList.of(
             Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
             Column.ENUM_VALUE.getSchema().getColumnName(),
             Column.ENUM_DISPLAY.getSchema().getColumnName(),
-            Column.ENUM_COUNT.getSchema().getColumnName());
+            Column.ENUM_COUNT.getSchema().getColumnName() + " DESC");
   }
 
   public String getEntity() {
@@ -43,8 +43,8 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
     return columnSchemas;
   }
 
-  public ImmutableList<String> getOrderByColumnNames() {
-    return orderByColumnNames;
+  public ImmutableList<String> getOrderBys() {
+    return orderBys;
   }
 
   public enum Column {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
@@ -23,10 +23,10 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
     this.orderByColumnNames =
         ImmutableList.of(
-            Column.ATTRIBUTE_NAME.name(),
-            Column.ENUM_VALUE.name(),
-            Column.ENUM_DISPLAY.name(),
-            Column.ENUM_COUNT.name());
+            Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
+            Column.ENUM_VALUE.getSchema().getColumnName(),
+            Column.ENUM_DISPLAY.getSchema().getColumnName(),
+            Column.ENUM_COUNT.getSchema().getColumnName());
   }
 
   public String getEntity() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
@@ -21,11 +21,12 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
     this.columnSchemas =
         ImmutableList.copyOf(
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    // TODO(dexamundsen): move orderBys to config
     this.orderBys =
         ImmutableList.of(
             Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
-            Column.ENUM_VALUE.getSchema().getColumnName(),
             Column.ENUM_DISPLAY.getSchema().getColumnName(),
+            Column.ENUM_VALUE.getSchema().getColumnName(),
             Column.ENUM_COUNT.getSchema().getColumnName() + " DESC");
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
@@ -10,13 +10,23 @@ import java.util.stream.Collectors;
 
 public final class ITEntityLevelDisplayHints extends IndexTable {
   public static final String TABLE_NAME = "ELDH";
-
   private final String entity;
+  private final ImmutableList<ColumnSchema> columnSchemas;
+  private final ImmutableList<String> orderByColumnNames;
 
   public ITEntityLevelDisplayHints(
       NameHelper namer, SZBigQuery.IndexData bigQueryConfig, String entity) {
     super(namer, bigQueryConfig);
     this.entity = entity;
+    this.columnSchemas =
+        ImmutableList.copyOf(
+            Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    this.orderByColumnNames =
+        ImmutableList.of(
+            Column.ATTRIBUTE_NAME.name(),
+            Column.ENUM_VALUE.name(),
+            Column.ENUM_DISPLAY.name(),
+            Column.ENUM_COUNT.name());
   }
 
   public String getEntity() {
@@ -30,9 +40,11 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
 
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
-    // Columns are static and don't depend on the entity.
-    return ImmutableList.copyOf(
-        Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    return columnSchemas;
+  }
+
+  public ImmutableList<String> getOrderByColumnNames() {
+    return orderByColumnNames;
   }
 
   public enum Column {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITHierarchyAncestorDescendant.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITHierarchyAncestorDescendant.java
@@ -13,12 +13,16 @@ public final class ITHierarchyAncestorDescendant extends IndexTable {
   public static final String TABLE_NAME = "HAD";
   private final String entity;
   private final String hierarchy;
+  private final ImmutableList<ColumnSchema> columnSchemas;
 
   public ITHierarchyAncestorDescendant(
       NameHelper namer, SZBigQuery.IndexData bigQueryConfig, String entity, String hierarchy) {
     super(namer, bigQueryConfig);
     this.entity = entity;
     this.hierarchy = hierarchy;
+    this.columnSchemas =
+        ImmutableList.copyOf(
+            Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
   }
 
   public String getEntity() {
@@ -36,9 +40,7 @@ public final class ITHierarchyAncestorDescendant extends IndexTable {
 
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
-    // Columns are static and don't depend on the entity or hierarchy.
-    return ImmutableList.copyOf(
-        Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    return columnSchemas;
   }
 
   public SqlField getAncestorField() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITHierarchyChildParent.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITHierarchyChildParent.java
@@ -13,12 +13,16 @@ public final class ITHierarchyChildParent extends IndexTable {
   private static final String TABLE_NAME = "HCP";
   private final String entity;
   private final String hierarchy;
+  private final ImmutableList<ColumnSchema> columnSchemas;
 
   public ITHierarchyChildParent(
       NameHelper namer, SZBigQuery.IndexData bigQueryConfig, String entity, String hierarchy) {
     super(namer, bigQueryConfig);
     this.entity = entity;
     this.hierarchy = hierarchy;
+    this.columnSchemas =
+        ImmutableList.copyOf(
+            Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
   }
 
   public String getEntity() {
@@ -36,9 +40,7 @@ public final class ITHierarchyChildParent extends IndexTable {
 
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
-    // Columns are static and don't depend on the entity or hierarchy.
-    return ImmutableList.copyOf(
-        Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    return columnSchemas;
   }
 
   public SqlField getChildField() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
@@ -3,6 +3,7 @@ package bio.terra.tanagra.underlay.indextable;
 import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.NameHelper;
+import bio.terra.tanagra.underlay.indextable.ITEntityLevelDisplayHints.Column;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
@@ -13,6 +14,8 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
   private final String entityGroup;
   private final String hintedEntity;
   private final String relatedEntity;
+  private final ImmutableList<ColumnSchema> columnSchemas;
+  private final ImmutableList<String> orderByColumnNames;
 
   public ITInstanceLevelDisplayHints(
       NameHelper namer,
@@ -24,6 +27,15 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
     this.entityGroup = entityGroup;
     this.hintedEntity = hintedEntity;
     this.relatedEntity = relatedEntity;
+    this.columnSchemas =
+        ImmutableList.copyOf(
+            Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    this.orderByColumnNames =
+        ImmutableList.of(
+            ITEntityLevelDisplayHints.Column.ATTRIBUTE_NAME.name(),
+            ITEntityLevelDisplayHints.Column.ENUM_VALUE.name(),
+            ITEntityLevelDisplayHints.Column.ENUM_DISPLAY.name(),
+            ITEntityLevelDisplayHints.Column.ENUM_COUNT.name());
   }
 
   public String getEntityGroup() {
@@ -45,9 +57,11 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
 
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
-    // Columns are static and don't depend on the entity.
-    return ImmutableList.copyOf(
-        Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    return columnSchemas;
+  }
+
+  public ImmutableList<String> getOrderByColumnNames() {
+    return orderByColumnNames;
   }
 
   public enum Column {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
@@ -14,7 +14,7 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
   private final String hintedEntity;
   private final String relatedEntity;
   private final ImmutableList<ColumnSchema> columnSchemas;
-  private final ImmutableList<String> orderByColumnNames;
+  private final ImmutableList<String> orderBys;
 
   public ITInstanceLevelDisplayHints(
       NameHelper namer,
@@ -29,12 +29,12 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
     this.columnSchemas =
         ImmutableList.copyOf(
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
-    this.orderByColumnNames =
+    this.orderBys =
         ImmutableList.of(
             Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
             Column.ENUM_VALUE.getSchema().getColumnName(),
             Column.ENUM_DISPLAY.getSchema().getColumnName(),
-            Column.ENUM_COUNT.getSchema().getColumnName());
+            Column.ENUM_COUNT.getSchema().getColumnName() + " DESC");
   }
 
   public String getEntityGroup() {
@@ -59,8 +59,8 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
     return columnSchemas;
   }
 
-  public ImmutableList<String> getOrderByColumnNames() {
-    return orderByColumnNames;
+  public ImmutableList<String> getOrderBys() {
+    return orderBys;
   }
 
   public enum Column {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
@@ -29,11 +29,12 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
     this.columnSchemas =
         ImmutableList.copyOf(
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
+    // TODO(dexamundsen): move orderBys to config
     this.orderBys =
         ImmutableList.of(
             Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
-            Column.ENUM_VALUE.getSchema().getColumnName(),
             Column.ENUM_DISPLAY.getSchema().getColumnName(),
+            Column.ENUM_VALUE.getSchema().getColumnName(),
             Column.ENUM_COUNT.getSchema().getColumnName() + " DESC");
   }
 

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
@@ -3,7 +3,6 @@ package bio.terra.tanagra.underlay.indextable;
 import bio.terra.tanagra.api.shared.DataType;
 import bio.terra.tanagra.underlay.ColumnSchema;
 import bio.terra.tanagra.underlay.NameHelper;
-import bio.terra.tanagra.underlay.indextable.ITEntityLevelDisplayHints.Column;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
@@ -32,10 +31,10 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
     this.orderByColumnNames =
         ImmutableList.of(
-            ITEntityLevelDisplayHints.Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
-            ITEntityLevelDisplayHints.Column.ENUM_VALUE.getSchema().getColumnName(),
-            ITEntityLevelDisplayHints.Column.ENUM_DISPLAY.getSchema().getColumnName(),
-            ITEntityLevelDisplayHints.Column.ENUM_COUNT.getSchema().getColumnName());
+            Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
+            Column.ENUM_VALUE.getSchema().getColumnName(),
+            Column.ENUM_DISPLAY.getSchema().getColumnName(),
+            Column.ENUM_COUNT.getSchema().getColumnName());
   }
 
   public String getEntityGroup() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
@@ -32,10 +32,10 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
     this.orderByColumnNames =
         ImmutableList.of(
-            ITEntityLevelDisplayHints.Column.ATTRIBUTE_NAME.name(),
-            ITEntityLevelDisplayHints.Column.ENUM_VALUE.name(),
-            ITEntityLevelDisplayHints.Column.ENUM_DISPLAY.name(),
-            ITEntityLevelDisplayHints.Column.ENUM_COUNT.name());
+            ITEntityLevelDisplayHints.Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
+            ITEntityLevelDisplayHints.Column.ENUM_VALUE.getSchema().getColumnName(),
+            ITEntityLevelDisplayHints.Column.ENUM_DISPLAY.getSchema().getColumnName(),
+            ITEntityLevelDisplayHints.Column.ENUM_COUNT.getSchema().getColumnName());
   }
 
   public String getEntityGroup() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITRelationshipIdPairs.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITRelationshipIdPairs.java
@@ -13,11 +13,11 @@ import java.util.stream.Collectors;
 
 public final class ITRelationshipIdPairs extends IndexTable {
   private static final String TABLE_NAME = "RIDS";
-
   private final String entityGroup;
   private final String entityA;
   private final String entityB;
   private final STRelationshipIdPairs sourceTable;
+  private final ImmutableList<ColumnSchema> columnSchemas;
 
   public ITRelationshipIdPairs(
       NameHelper namer,
@@ -30,6 +30,9 @@ public final class ITRelationshipIdPairs extends IndexTable {
     this.entityA = entityA;
     this.entityB = entityB;
     this.sourceTable = null;
+    this.columnSchemas =
+        ImmutableList.copyOf(
+            Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
   }
 
   public ITRelationshipIdPairs(
@@ -43,6 +46,7 @@ public final class ITRelationshipIdPairs extends IndexTable {
     this.entityA = entityA;
     this.entityB = entityB;
     this.sourceTable = sourceSchema.getRelationshipIdPairs(entityGroup, entityA, entityB);
+    this.columnSchemas = sourceTable.getColumnSchemas();
   }
 
   public String getEntityGroup() {
@@ -64,10 +68,7 @@ public final class ITRelationshipIdPairs extends IndexTable {
 
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
-    return sourceTable == null
-        ? ImmutableList.copyOf(
-            Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()))
-        : sourceTable.getColumnSchemas();
+    return columnSchemas;
   }
 
   public SqlField getEntityAIdField() {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/IndexTable.java
@@ -8,7 +8,6 @@ import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.indextable.ITEntityMain.ColumnTemplate;
 import bio.terra.tanagra.underlay.serialization.SZBigQuery;
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 
 public abstract class IndexTable {
   private final NameHelper namer;
@@ -40,8 +39,9 @@ public abstract class IndexTable {
 
   public abstract ImmutableList<ColumnSchema> getColumnSchemas();
 
-  public List<String> getColumnNames() {
-    return getColumnSchemas().stream().map(ColumnSchema::getColumnName).toList();
+  public ImmutableList<String> getColumnNames() {
+    return ImmutableList.copyOf(
+        getColumnSchemas().stream().map(ColumnSchema::getColumnName).toList());
   }
 
   public boolean isGeneratedIndexTable() {

--- a/underlay/src/main/java/bio/terra/tanagra/utils/BigQueryStorageWriter.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/BigQueryStorageWriter.java
@@ -37,7 +37,6 @@ import org.threeten.bp.Duration;
  */
 public final class BigQueryStorageWriter {
   private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryStorageWriter.class);
-
   private static final int BATCH_SIZE = 1000;
   private static final int MAX_BATCHES = 100;
 

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleBigQuery.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 /** Utility methods for talking to Google BigQuery. */
 public final class GoogleBigQuery {
   private static final Logger LOGGER = LoggerFactory.getLogger(GoogleBigQuery.class);
-
   // Default value for the maximum number of times to retry HTTP requests.
   public static final int BQ_MAXIMUM_RETRIES = 5;
   public static final Duration LONG_QUERY_TIMEOUT = Duration.ofHours(3);
@@ -48,7 +47,6 @@ public final class GoogleBigQuery {
       org.threeten.bp.Duration.ofHours(3);
   private static final org.threeten.bp.Duration DEFAULT_BQ_CLIENT_TIMEOUT =
       org.threeten.bp.Duration.ofMinutes(10);
-
   private final BigQuery bigQuery;
 
   private GoogleBigQuery(

--- a/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/GoogleCloudStorage.java
@@ -29,12 +29,10 @@ import org.slf4j.LoggerFactory;
 /** Utility methods for talking to Google Cloud Storage. */
 public final class GoogleCloudStorage {
   private static final Logger LOGGER = LoggerFactory.getLogger(GoogleCloudStorage.class);
-
   // default value for the maximum number of times to retry HTTP requests to GCS
   public static final int GCS_MAXIMUM_RETRIES = 5;
   private static final org.threeten.bp.Duration MAX_GCS_CLIENT_TIMEOUT =
       org.threeten.bp.Duration.ofMinutes(5);
-
   private static final long DEFAULT_SIGNED_URL_DURATION = 30;
   private static final TimeUnit DEFAULT_SIGNED_URL_UNIT = TimeUnit.MINUTES;
   private final Storage storage;

--- a/underlay/src/main/java/bio/terra/tanagra/utils/JacksonMapper.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/JacksonMapper.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("deprecation")
 public final class JacksonMapper {
   private static final Logger LOGGER = LoggerFactory.getLogger(JacksonMapper.class);
-
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
   private JacksonMapper() {}

--- a/underlay/src/main/java/bio/terra/tanagra/utils/ProtobufUtils.java
+++ b/underlay/src/main/java/bio/terra/tanagra/utils/ProtobufUtils.java
@@ -7,7 +7,6 @@ import com.google.protobuf.util.JsonFormat;
 import java.util.Base64;
 
 public final class ProtobufUtils {
-
   private ProtobufUtils() {}
 
   @SuppressWarnings({"checkstyle:EmptyCatchBlock", "PMD.EmptyCatchBlock"})

--- a/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
@@ -5,6 +5,6 @@
         ${ELDH_person}      
     ORDER BY
         attribute_name,
-        enum_value,
         enum_display,
+        enum_value,
         enum_count DESC

--- a/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
@@ -7,4 +7,4 @@
         attribute_name,
         enum_value,
         enum_display,
-        enum_count
+        enum_count DESC

--- a/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
@@ -2,4 +2,9 @@
     SELECT
         *      
     FROM
-        ${ELDH_person}
+        ${ELDH_person}      
+    ORDER BY
+        attribute_name,
+        enum_value,
+        enum_display,
+        enum_count

--- a/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
@@ -9,4 +9,4 @@
         attribute_name,
         enum_value,
         enum_display,
-        enum_count
+        enum_count DESC

--- a/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
@@ -4,4 +4,9 @@
     FROM
         ${ILDH_measurementOccurrence_measurementLoinc}      
     WHERE
-        entity_id = @relatedEntityId0
+        entity_id = @relatedEntityId0      
+    ORDER BY
+        attribute_name,
+        enum_value,
+        enum_display,
+        enum_count

--- a/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
@@ -7,6 +7,6 @@
         entity_id = @relatedEntityId0      
     ORDER BY
         attribute_name,
-        enum_value,
         enum_display,
+        enum_value,
         enum_count DESC

--- a/underlay/src/testFixtures/java/bio/terra/tanagra/testing/GeneratedSqlUtils.java
+++ b/underlay/src/testFixtures/java/bio/terra/tanagra/testing/GeneratedSqlUtils.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class GeneratedSqlUtils {
   private static final Logger LOG = LoggerFactory.getLogger(GeneratedSqlUtils.class);
-
   private static final Path GENERATED_SQL_FILES_PARENT_DIR =
       Path.of(System.getProperty("GRADLE_PROJECT_DIR")).resolve("src/test/resources/");
 


### PR DESCRIPTION
- The hints returned from backend were not always in the same order - added order by clause to maintain consistency in the user display
- new line updates