### PR TITLE
Add cohort review plugin with sub tabs for SD Vitals

### DIFF
--- a/ui/src/cohortReview/plugins/occurrenceTabs.tsx
+++ b/ui/src/cohortReview/plugins/occurrenceTabs.tsx
@@ -27,10 +27,10 @@ class _ implements CohortReviewPlugin {
     config: CohortReviewPageConfig
   ) {
     this.config = config.plugin as Config;
-    this.entities = this.config.tabs.reduce((acc, t) => {
-      acc.push(getCohortReviewPlugin(t).entities[0]);
-      return acc;
-    }, [] as string[]);
+    this.entities = this.config.tabs.reduce(
+      (acc, t) => [...acc, getCohortReviewPlugin(t).entities[0]],
+      [] as string[]
+    );
   }
 
   render() {

--- a/ui/src/cohortReview/plugins/occurrenceTabs.tsx
+++ b/ui/src/cohortReview/plugins/occurrenceTabs.tsx
@@ -1,0 +1,75 @@
+import { useCohortReviewContext } from "cohortReview/cohortReviewContext";
+import {
+  CohortReviewPlugin,
+  getCohortReviewPlugin,
+  registerCohortReviewPlugin,
+} from "cohortReview/pluginRegistry";
+import { useReviewSearchState } from "cohortReview/reviewHooks";
+import { GridBox } from "layout/gridBox";
+import { useMemo } from "react";
+import { CohortReviewPageConfig } from "underlaysSlice";
+import { Tabs } from "components/tabs";
+
+interface Config {
+  entity: string;
+  tabs: CohortReviewPageConfig[];
+}
+
+@registerCohortReviewPlugin("entityTabs")
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class _ implements CohortReviewPlugin {
+  public entities: string[];
+  private config: Config;
+
+  constructor(
+    public id: string,
+    public title: string,
+    config: CohortReviewPageConfig
+  ) {
+    this.config = config.plugin as Config;
+    this.entities = this.config.tabs.reduce((acc, t) => {
+      acc.push(getCohortReviewPlugin(t).entities[0]);
+      return acc;
+    }, [] as string[]);
+  }
+
+  render() {
+    return <OccurrenceTabs config={this.config} />;
+  }
+}
+
+function OccurrenceTabs({ config }: { config: Config }) {
+  const context = useCohortReviewContext();
+  if (!context) {
+    return null;
+  }
+
+  const pagePlugins = useMemo(
+    () => config.tabs.map((p) => getCohortReviewPlugin(p)),
+    [config.tabs]
+  );
+
+  const [searchState, updateSearchState] = useReviewSearchState();
+
+  const subTabPageId = searchState.subTabPageId ?? config.tabs[0].id;
+
+  const changePage = (newValue: string) => {
+    updateSearchState((state) => {
+      state.subTabPageId = newValue;
+    });
+  };
+
+  return (
+    <GridBox
+      sx={{
+        width: "100%",
+      }}
+    >
+      <Tabs
+        configs={pagePlugins}
+        currentTab={subTabPageId}
+        setCurrentTab={changePage}
+      />
+    </GridBox>
+  );
+}

--- a/ui/src/cohortReview/plugins/occurrenceTabs.tsx
+++ b/ui/src/cohortReview/plugins/occurrenceTabs.tsx
@@ -27,9 +27,8 @@ class _ implements CohortReviewPlugin {
     config: CohortReviewPageConfig
   ) {
     this.config = config.plugin as Config;
-    this.entities = this.config.tabs.reduce(
-      (acc, t) => [...acc, getCohortReviewPlugin(t).entities[0]],
-      [] as string[]
+    this.entities = this.config.tabs.map(
+      (t) => getCohortReviewPlugin(t).entities[0]
     );
   }
 

--- a/ui/src/cohortReview/reviewHooks.ts
+++ b/ui/src/cohortReview/reviewHooks.ts
@@ -110,6 +110,7 @@ export type PluginSearchState = {
 export type SearchState = {
   instanceIndex?: number;
   pageId?: string;
+  subTabPageId?: string;
 
   plugins?: PluginSearchState;
 };

--- a/ui/src/plugins.ts
+++ b/ui/src/plugins.ts
@@ -12,6 +12,7 @@ import "criteria/filterableGroup";
 
 // Cohort review plugins
 import "cohortReview/plugins/occurrenceTable";
+import "cohortReview/plugins/occurrenceTabs";
 import "cohortReview/plugins/textSearch";
 
 // Custom plugins

--- a/underlay/src/main/resources/config/underlay/sd/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd/ui.json
@@ -309,6 +309,229 @@
         }
       },
       {
+        "type": "entityTabs",
+        "id": "vitals",
+        "title": "Vitals",
+        "plugin": {
+          "tabs": [
+            {
+              "type": "entityTable",
+              "id": "bloodPressure",
+              "title": "Blood Pressure",
+              "plugin": {
+                "entity": "bloodPressure",
+                "columns": [
+                  {
+                    "key": "date",
+                    "width": "100%",
+                    "title": "Measurement date",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "systolic",
+                    "width": 200,
+                    "title": "Systolic",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "diastolic",
+                    "width": 200,
+                    "title": "Diastolic",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "age_at_occurrence",
+                    "width": 200,
+                    "title": "Age at Event",
+                    "sortable": true,
+                    "filterable": true
+                  }
+                ]
+              }
+            },
+            {
+              "type": "entityTable",
+              "id": "bmi",
+              "title": "BMI",
+              "plugin": {
+                "entity": "bmi",
+                "columns": [
+                  {
+                    "key": "date",
+                    "width": "100%",
+                    "title": "Measurement date",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "value_numeric",
+                    "width": 200,
+                    "title": "Value",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "is_clean",
+                    "width": 200,
+                    "title": "Raw/Cleaned",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "age_at_occurrence",
+                    "width": 200,
+                    "title": "Age at Event",
+                    "sortable": true,
+                    "filterable": true
+                  }
+                ]
+              }
+            },
+            {
+              "type": "entityTable",
+              "id": "height",
+              "title": "Height",
+              "plugin": {
+                "entity": "height",
+                "columns": [
+                  {
+                    "key": "date",
+                    "width": "100%",
+                    "title": "Measurement date",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "value_numeric",
+                    "width": 200,
+                    "title": "Value",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "is_clean",
+                    "width": 200,
+                    "title": "Raw/Cleaned",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "age_at_occurrence",
+                    "width": 200,
+                    "title": "Age at Event",
+                    "sortable": true,
+                    "filterable": true
+                  }
+                ]
+              }
+            },
+            {
+              "type": "entityTable",
+              "id": "weight",
+              "title": "Weight",
+              "plugin": {
+                "entity": "weight",
+                "columns": [
+                  {
+                    "key": "date",
+                    "width": "100%",
+                    "title": "Measurement date",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "value_numeric",
+                    "width": 200,
+                    "title": "Value",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "is_clean",
+                    "width": 200,
+                    "title": "Raw/Cleaned",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "age_at_occurrence",
+                    "width": 200,
+                    "title": "Age at Event",
+                    "sortable": true,
+                    "filterable": true
+                  }
+                ]
+              }
+            },
+            {
+              "type": "entityTable",
+              "id": "pulse",
+              "title": "Pulse",
+              "plugin": {
+                "entity": "pulse",
+                "columns": [
+                  {
+                    "key": "date",
+                    "width": "100%",
+                    "title": "Measurement date",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "value_numeric",
+                    "width": 200,
+                    "title": "Value",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "age_at_occurrence",
+                    "width": 200,
+                    "title": "Age at Event",
+                    "sortable": true,
+                    "filterable": true
+                  }
+                ]
+              }
+            },
+            {
+              "type": "entityTable",
+              "id": "respiratoryRate",
+              "title": "Respiratory Rate",
+              "plugin": {
+                "entity": "respiratoryRate",
+                "columns": [
+                  {
+                    "key": "date",
+                    "width": "100%",
+                    "title": "Measurement date",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "value_numeric",
+                    "width": 200,
+                    "title": "Value",
+                    "sortable": true,
+                    "filterable": true
+                  },
+                  {
+                    "key": "age_at_occurrence",
+                    "width": 200,
+                    "title": "Age at Event",
+                    "sortable": true,
+                    "filterable": true
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
         "type": "textSearch",
         "id": "notes",
         "title": "Documents",


### PR DESCRIPTION
First attempt at a new `entityTabs` plugin to display multiple entities within a single cohort review tab. This is for the SD Vitals entities but may be useful as a core plugin. 

![Screenshot 2025-02-07 at 3 22 54 PM](https://github.com/user-attachments/assets/38b02eed-15a2-4c71-9dc6-c71b85e5f32a)
