### PR TITLE
[BENCH-5181] Fix range data conversion in requests

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/FromApiUtils.java
@@ -509,6 +509,7 @@ public final class FromApiUtils {
               apiLiteral.getValueUnion().getInt64Val() != null
                   ? Long.parseLong(apiLiteral.getValueUnion().getInt64Val())
                   : null);
+      case DOUBLE -> Literal.forDouble(apiLiteral.getValueUnion().getDoubleVal());
       case STRING -> Literal.forString(apiLiteral.getValueUnion().getStringVal());
       case BOOLEAN -> Literal.forBoolean(apiLiteral.getValueUnion().isBoolVal());
       case DATE -> Literal.forDate(apiLiteral.getValueUnion().getDateVal());

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -1610,9 +1610,7 @@ export function literalFromDataValue(value: DataValue): tanagra.Literal {
   if (typeof value === "bigint") {
     dataType = tanagra.DataType.Int64;
   } else if (typeof value == "number") {
-    dataType = Number.isInteger(value)
-      ? tanagra.DataType.Int64
-      : tanagra.DataType.Double;
+    dataType = tanagra.DataType.Double;
   } else if (typeof value === "string") {
     dataType = tanagra.DataType.String;
   } else if (typeof value === "boolean") {


### PR DESCRIPTION
allele count filter (and other with numbers there) are broken

rc: the range fields are numbers and not bigInt.

fix: check for both before converting to literal

<img width="726" alt="image" src="https://github.com/user-attachments/assets/44b6be51-e79b-4f0b-bd2c-1ddd210acd36" />

```
    SELECT
        id,
        gene,
        rs_number,
        consequence,
        clinvar_significance,
        protein_change,
        allele_count,
        allele_number,
        allele_frequency,
        T_RCNT_variantPerson_NOHIER 
    FROM
        `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ENT_variant 
    WHERE
        (
            id IN (SELECT
                id 
            FROM
                `vwb-dev-blissful-eggplant-4805.aou_test_data_SC2023Q3R2_011625`.T_ESA_variant_gene 
            WHERE
                gene = 'GENE')
        ) 
        AND (
            allele_count BETWEEN 2 AND 490399
        ) 
        AND (
            allele_number BETWEEN 133 AND 490787
        ) 
        AND (
            allele_frequency BETWEEN 3.0E-6 AND 0.9993
        ) 
    ORDER BY
        T_RCNT_variantPerson_NOHIER DESC 
    LIMIT
        10000000
```
