### PR TITLE
Sort HintQueryResult instead of orderBy on ELDH_IndexTable

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -359,15 +359,17 @@ public class UnderlaysApiController implements UnderlaysApi {
       implements Comparator<ApiDisplayHintEnumEnumHintValues>, Serializable {
     @Override
     public int compare(ApiDisplayHintEnumEnumHintValues o1, ApiDisplayHintEnumEnumHintValues o2) {
-      // order by: value ASC, display ASC, count DESC
+      // order by: display ASC, value ASC, count DESC
       ApiValueDisplay vd1 = o1.getEnumVal();
       ApiValueDisplay vd2 = o2.getEnumVal();
-      int result =
-          StringUtils.compare(
-              vd1.getValue().getValueUnion().getStringVal(),
-              vd2.getValue().getValueUnion().getStringVal(),
-              false);
-      result = (result != 0) ? result : StringUtils.compare(vd1.getDisplay(), vd2.getDisplay());
+      int result = StringUtils.compare(vd1.getDisplay(), vd2.getDisplay(), false);
+      result =
+          (result != 0)
+              ? result
+              : StringUtils.compare(
+                  vd1.getValue().getValueUnion().getStringVal(),
+                  vd2.getValue().getValueUnion().getStringVal(),
+                  false);
       return (result != 0) ? result : Integer.compare(o2.getCount(), o1.getCount());
     }
   }

--- a/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/UnderlaysApiController.java
@@ -17,7 +17,6 @@ import bio.terra.tanagra.api.query.list.ListQueryResult;
 import bio.terra.tanagra.api.query.list.OrderBy;
 import bio.terra.tanagra.api.shared.Literal;
 import bio.terra.tanagra.api.shared.OrderByDirection;
-import bio.terra.tanagra.api.shared.ValueDisplay;
 import bio.terra.tanagra.app.authentication.SpringAuthentication;
 import bio.terra.tanagra.app.controller.objmapping.FromApiUtils;
 import bio.terra.tanagra.app.controller.objmapping.ToApiUtils;
@@ -40,6 +39,7 @@ import bio.terra.tanagra.generated.model.ApiQueryFilterOnPrimaryEntity;
 import bio.terra.tanagra.generated.model.ApiUnderlay;
 import bio.terra.tanagra.generated.model.ApiUnderlaySerializedConfiguration;
 import bio.terra.tanagra.generated.model.ApiUnderlaySummaryList;
+import bio.terra.tanagra.generated.model.ApiValueDisplay;
 import bio.terra.tanagra.service.UnderlayService;
 import bio.terra.tanagra.service.accesscontrol.AccessControlService;
 import bio.terra.tanagra.service.accesscontrol.Permissions;
@@ -52,9 +52,12 @@ import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Attribute;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
 import bio.terra.tanagra.utils.SqlFormatter;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -65,6 +68,9 @@ public class UnderlaysApiController implements UnderlaysApi {
   private final UnderlayService underlayService;
   private final FilterBuilderService filterBuilderService;
   private final AccessControlService accessControlService;
+  private final ApiDisplayHintComparator apiDisplayHintComparator = new ApiDisplayHintComparator();
+  private final ApiDisplayHintEnumValuesComparator apiDisplayHintEnumValuesComparator =
+      new ApiDisplayHintEnumValuesComparator();
 
   @Autowired
   public UnderlaysApiController(
@@ -251,7 +257,10 @@ public class UnderlaysApiController implements UnderlaysApi {
         new ApiDisplayHintList()
             .sql(SqlFormatter.format(hintQueryResult.getSql()))
             .displayHints(
-                hintQueryResult.getHintInstances().stream().map(this::toApiObject).toList());
+                hintQueryResult.getHintInstances().stream()
+                    .map(this::toApiObject)
+                    .sorted(apiDisplayHintComparator)
+                    .toList());
     return ResponseEntity.ok(displayHintList);
   }
 
@@ -315,33 +324,51 @@ public class UnderlaysApiController implements UnderlaysApi {
   }
 
   private ApiDisplayHint toApiObject(HintInstance hintInstance) {
-    ApiDisplayHintDisplayHint apiHint = null;
+    ApiDisplayHintDisplayHint apiHint = new ApiDisplayHintDisplayHint();
     if (hintInstance.isEnumHint()) {
-      apiHint =
-          new ApiDisplayHintDisplayHint()
-              .enumHint(
-                  new ApiDisplayHintEnum()
-                      .enumHintValues(
-                          hintInstance.getEnumValueCounts().entrySet().stream()
-                              .map(
-                                  entry -> {
-                                    ValueDisplay attributeValueDisplay = entry.getKey();
-                                    Long count = entry.getValue();
-                                    return new ApiDisplayHintEnumEnumHintValues()
-                                        .enumVal(ToApiUtils.toApiObject(attributeValueDisplay))
-                                        .count(Math.toIntExact(count));
-                                  })
-                              .collect(Collectors.toList())));
+      apiHint.setEnumHint(
+          new ApiDisplayHintEnum()
+              .enumHintValues(
+                  hintInstance.getEnumValueCounts().entrySet().stream()
+                      .map(
+                          entry ->
+                              new ApiDisplayHintEnumEnumHintValues()
+                                  .enumVal(ToApiUtils.toApiObject(entry.getKey()))
+                                  .count(Math.toIntExact(entry.getValue())))
+                      .sorted(apiDisplayHintEnumValuesComparator)
+                      .collect(Collectors.toList())));
     } else if (hintInstance.isRangeHint()) {
-      apiHint =
-          new ApiDisplayHintDisplayHint()
-              .numericRangeHint(
-                  new ApiDisplayHintNumericRange()
-                      .min(hintInstance.getMin())
-                      .max(hintInstance.getMax()));
+      apiHint.setNumericRangeHint(
+          new ApiDisplayHintNumericRange().min(hintInstance.getMin()).max(hintInstance.getMax()));
     }
     return new ApiDisplayHint()
         .attribute(ToApiUtils.toApiObject(hintInstance.getAttribute()))
         .displayHint(apiHint);
+  }
+
+  private static class ApiDisplayHintComparator
+      implements Comparator<ApiDisplayHint>, Serializable {
+    @Override
+    public int compare(ApiDisplayHint o1, ApiDisplayHint o2) {
+      // order by: attribute ASC
+      return StringUtils.compare(o1.getAttribute().getName(), o2.getAttribute().getName());
+    }
+  }
+
+  private static class ApiDisplayHintEnumValuesComparator
+      implements Comparator<ApiDisplayHintEnumEnumHintValues>, Serializable {
+    @Override
+    public int compare(ApiDisplayHintEnumEnumHintValues o1, ApiDisplayHintEnumEnumHintValues o2) {
+      // order by: value ASC, display ASC, count DESC
+      ApiValueDisplay vd1 = o1.getEnumVal();
+      ApiValueDisplay vd2 = o2.getEnumVal();
+      int result =
+          StringUtils.compare(
+              vd1.getValue().getValueUnion().getStringVal(),
+              vd2.getValue().getValueUnion().getStringVal(),
+              false);
+      result = (result != 0) ? result : StringUtils.compare(vd1.getDisplay(), vd2.getDisplay());
+      return (result != 0) ? result : Integer.compare(o2.getCount(), o1.getCount());
+    }
   }
 }

--- a/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
+++ b/underlay/src/main/java/bio/terra/tanagra/query/bigquery/BQQueryRunner.java
@@ -208,7 +208,6 @@ public class BQQueryRunner implements QueryRunner {
     // Build the SQL query.
     StringBuilder sql = new StringBuilder();
     SqlParams sqlParams = new SqlParams();
-    List<String> orderBys;
 
     if (hintQueryRequest.isEntityLevel()) {
       ITEntityLevelDisplayHints eldhTable =
@@ -219,7 +218,6 @@ public class BQQueryRunner implements QueryRunner {
 
       // SELECT * FROM [entity-level hint]
       sql.append("SELECT * FROM ").append(eldhTable.getTablePointer().render());
-      orderBys = eldhTable.getOrderBys();
 
     } else {
       ITInstanceLevelDisplayHints ildhTable =
@@ -241,11 +239,7 @@ public class BQQueryRunner implements QueryRunner {
           .append(ITInstanceLevelDisplayHints.Column.ENTITY_ID.getSchema().getColumnName())
           .append(" = @")
           .append(relatedEntityIdParam);
-      orderBys = ildhTable.getOrderBys();
     }
-
-    // ORDER BY [order by fields]
-    sql.append(" ORDER BY ").append(String.join(", ", orderBys));
 
     // Execute the SQL query.
     SqlQueryRequest sqlQueryRequest =

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITEntityLevelDisplayHints.java
@@ -12,7 +12,6 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
   public static final String TABLE_NAME = "ELDH";
   private final String entity;
   private final ImmutableList<ColumnSchema> columnSchemas;
-  private final ImmutableList<String> orderBys;
 
   public ITEntityLevelDisplayHints(
       NameHelper namer, SZBigQuery.IndexData bigQueryConfig, String entity) {
@@ -21,13 +20,6 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
     this.columnSchemas =
         ImmutableList.copyOf(
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
-    // TODO(dexamundsen): move orderBys to config
-    this.orderBys =
-        ImmutableList.of(
-            Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
-            Column.ENUM_DISPLAY.getSchema().getColumnName(),
-            Column.ENUM_VALUE.getSchema().getColumnName(),
-            Column.ENUM_COUNT.getSchema().getColumnName() + " DESC");
   }
 
   public String getEntity() {
@@ -42,10 +34,6 @@ public final class ITEntityLevelDisplayHints extends IndexTable {
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
     return columnSchemas;
-  }
-
-  public ImmutableList<String> getOrderBys() {
-    return orderBys;
   }
 
   public enum Column {

--- a/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
+++ b/underlay/src/main/java/bio/terra/tanagra/underlay/indextable/ITInstanceLevelDisplayHints.java
@@ -14,7 +14,6 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
   private final String hintedEntity;
   private final String relatedEntity;
   private final ImmutableList<ColumnSchema> columnSchemas;
-  private final ImmutableList<String> orderBys;
 
   public ITInstanceLevelDisplayHints(
       NameHelper namer,
@@ -29,13 +28,6 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
     this.columnSchemas =
         ImmutableList.copyOf(
             Arrays.stream(Column.values()).map(Column::getSchema).collect(Collectors.toList()));
-    // TODO(dexamundsen): move orderBys to config
-    this.orderBys =
-        ImmutableList.of(
-            Column.ATTRIBUTE_NAME.getSchema().getColumnName(),
-            Column.ENUM_DISPLAY.getSchema().getColumnName(),
-            Column.ENUM_VALUE.getSchema().getColumnName(),
-            Column.ENUM_COUNT.getSchema().getColumnName() + " DESC");
   }
 
   public String getEntityGroup() {
@@ -58,10 +50,6 @@ public final class ITInstanceLevelDisplayHints extends IndexTable {
   @Override
   public ImmutableList<ColumnSchema> getColumnSchemas() {
     return columnSchemas;
-  }
-
-  public ImmutableList<String> getOrderBys() {
-    return orderBys;
   }
 
   public enum Column {

--- a/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/entityLevelHint.sql
@@ -2,9 +2,4 @@
     SELECT
         *      
     FROM
-        ${ELDH_person}      
-    ORDER BY
-        attribute_name,
-        enum_display,
-        enum_value,
-        enum_count DESC
+        ${ELDH_person}

--- a/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
+++ b/underlay/src/test/resources/sql/BQHintQueryTest/instanceLevelHint.sql
@@ -4,9 +4,4 @@
     FROM
         ${ILDH_measurementOccurrence_measurementLoinc}      
     WHERE
-        entity_id = @relatedEntityId0      
-    ORDER BY
-        attribute_name,
-        enum_display,
-        enum_value,
-        enum_count DESC
+        entity_id = @relatedEntityId0


### PR DESCRIPTION
move OrderBy clause from hints index table. this is not used when hints are dynamically calculated. Instead use comparators in controller. create and use comparators in the controller during object creation / conversions.