### PR TITLE
Refactor TreeGrid to have typed items and data

### DIFF
--- a/ui/cypress/e2e/featureSet.cy.js
+++ b/ui/cypress/e2e/featureSet.cy.js
@@ -7,14 +7,14 @@ describe("Basic tests", () => {
     cy.wait(2000);
 
     cy.iframe().find("a:Contains(Add a data feature)").first().click();
-    cy.iframe().find("[data-testid='tanagra-procedures']").click();
-    cy.iframe().find("input").type("Screening procedure");
-    cy.possiblyMultiSelect("Screening procedure");
-
-    cy.iframe().find("button:Contains(Add data feature)").click();
     cy.iframe().find("[data-testid='tanagra-conditions']").click();
     cy.iframe().find("input").type("Red color");
     cy.possiblyMultiSelect("Red color");
+
+    cy.iframe().find("button:Contains(Add data feature)").click();
+    cy.iframe().find("[data-testid='tanagra-procedures']").click();
+    cy.iframe().find("input").type("Screening procedure");
+    cy.possiblyMultiSelect("Screening procedure");
 
     cy.iframe().find("button:Contains(procedureOccurrence)").click();
     cy.iframe().find("[name='procedure']").click();

--- a/ui/src/addByCode.tsx
+++ b/ui/src/addByCode.tsx
@@ -3,7 +3,12 @@ import Chip from "@mui/material/Chip";
 import { createCriteria, lookupCriteria, LookupEntry } from "cohort";
 import Checkbox from "components/checkbox";
 import Loading from "components/loading";
-import { TreeGrid, TreeGridColumn, TreeGridId } from "components/treeGrid";
+import {
+  TreeGrid,
+  TreeGridColumn,
+  TreeGridId,
+  TreeGridItem,
+} from "components/treeGrid";
 import { useArrayAsTreeGridData } from "components/treeGridHelpers";
 import ActionBar from "actionBar";
 import { DataKey } from "data/types";
@@ -20,7 +25,7 @@ import { cohortURL, useIsSecondBlock } from "router";
 import { insertCohortCriteria, useCohortContext } from "cohortContext";
 import { isValid } from "util/valid";
 
-type LookupEntryItem = {
+type LookupEntryData = {
   config?: JSX.Element;
   code: DataKey;
   name?: string;
@@ -44,7 +49,7 @@ export function AddByCode() {
     [underlay.criteriaSelectors]
   );
 
-  const lookupEntriesState = useSWRMutation<LookupEntryItem[]>(
+  const lookupEntriesState = useSWRMutation<LookupEntryData[]>(
     {
       component: "AddByCode",
       query,
@@ -106,7 +111,7 @@ export function AddByCode() {
   const data = useArrayAsTreeGridData(lookupEntriesState?.data ?? [], "code");
 
   const onInsert = useCallback(() => {
-    const configMap = new Map<string, LookupEntryItem[]>();
+    const configMap = new Map<string, LookupEntryData[]>();
     lookupEntriesState.data?.forEach((e) => {
       if (!e.entry || !selected.has(e.code)) {
         return;
@@ -203,19 +208,13 @@ export function AddByCode() {
         </GridBox>
         <Loading immediate showProgressOnMutate status={lookupEntriesState}>
           {lookupEntriesState.data?.length ? (
-            <TreeGrid
+            <TreeGrid<TreeGridItem<LookupEntryData>>
               columns={columns}
               data={data}
-              rowCustomization={(id: TreeGridId) => {
-                if (!lookupEntriesState.data) {
-                  return undefined;
-                }
-
-                const item = data.get(id)?.data as LookupEntryItem;
-                if (!item) {
-                  return undefined;
-                }
-
+              rowCustomization={(
+                id: TreeGridId,
+                { data }: TreeGridItem<LookupEntryData>
+              ) => {
                 const sel = selected.has(id);
                 return [
                   {
@@ -225,7 +224,7 @@ export function AddByCode() {
                         size="small"
                         fontSize="inherit"
                         checked={sel}
-                        disabled={!item.entry}
+                        disabled={!data.entry}
                         onChange={() => {
                           updateSelected((selected) => {
                             if (sel) {

--- a/ui/src/addCohort.tsx
+++ b/ui/src/addCohort.tsx
@@ -48,7 +48,7 @@ export function AddCohort() {
   const navigate = useNavigate();
   const params = useBaseParams();
 
-  const cohortsState = useSWR(
+  const cohortsState = useSWR<CohortData[]>(
     {
       type: "cohorts",
       studyId,
@@ -109,16 +109,7 @@ export function AddCohort() {
             <TreeGrid
               data={data}
               columns={columns}
-              rowCustomization={(id: TreeGridId) => {
-                if (!cohortsState.data) {
-                  return undefined;
-                }
-
-                const cohortData = data.get(id)?.data as CohortData;
-                if (!cohortData) {
-                  return undefined;
-                }
-
+              rowCustomization={(id: TreeGridId, { data: cohortData }) => {
                 return [
                   {
                     column: columns.length - 2,

--- a/ui/src/cohortReview/cohortReviewList.tsx
+++ b/ui/src/cohortReview/cohortReviewList.tsx
@@ -679,16 +679,7 @@ function Annotations() {
             <TreeGrid
               data={data}
               columns={columns}
-              rowCustomization={(id: TreeGridId) => {
-                if (!annotationsState.data) {
-                  return undefined;
-                }
-
-                const annotation = data.get(id)?.data;
-                if (!annotation) {
-                  return undefined;
-                }
-
+              rowCustomization={(id: TreeGridId, { data: annotation }) => {
                 return [
                   {
                     column: columns.length - 1,

--- a/ui/src/cohortReview/participantsListDialog.tsx
+++ b/ui/src/cohortReview/participantsListDialog.tsx
@@ -11,7 +11,7 @@ import {
   useReviewSearchState,
 } from "cohortReview/reviewHooks";
 import Loading from "components/loading";
-import { TreeGrid, TreeGridData, TreeGridId } from "components/treeGrid";
+import { TreeGrid, TreeGridId } from "components/treeGrid";
 import GridLayout from "layout/gridLayout";
 import React, { useMemo } from "react";
 
@@ -108,7 +108,8 @@ function ParticipantsList(props: ParticipantsListProps) {
   );
 
   const data = useMemo(() => {
-    const data: TreeGridData = new Map([["root", { data: {}, children: [] }]]);
+    const children: TreeGridId[] = [];
+    const rows = new Map();
 
     instancesState.data
       ?.slice(
@@ -117,13 +118,13 @@ function ParticipantsList(props: ParticipantsListProps) {
       )
       .forEach((instance) => {
         const key = instance.data.key;
-        data.set(key, { data: { ...instance.data } });
-        data.get("root")?.children?.push(key);
+        rows.set(key, { data: { ...instance.data } });
+        children.push(key);
 
         annotationsState.data?.forEach((a) => {
           const values = instance.annotations.get(a.id);
           if (values) {
-            const valueData = data.get(key)?.data;
+            const valueData = rows.get(key)?.data;
             if (valueData) {
               valueData[`t_${a.id}`] = values[values.length - 1].value;
             }
@@ -131,7 +132,10 @@ function ParticipantsList(props: ParticipantsListProps) {
         });
       });
 
-    return data;
+    return {
+      rows,
+      children,
+    };
   }, [instancesState, annotationsState, props.page, props.rowsPerPage]);
 
   return (

--- a/ui/src/components/treeGrid.test.tsx
+++ b/ui/src/components/treeGrid.test.tsx
@@ -3,7 +3,7 @@ import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import IconButton from "@mui/material/IconButton";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { TreeGrid, TreeGridId, TreeGridItem } from "components/treeGrid";
+import { TreeGrid, TreeGridData, TreeGridId } from "components/treeGrid";
 
 test("Table renders correctly", async () => {
   const columns = [
@@ -26,45 +26,41 @@ test("Table renders correctly", async () => {
     },
   ];
 
-  const data = new Map<TreeGridId, TreeGridItem>([
-    [
-      "root",
-      {
-        data: {},
-        children: [1, 3],
-      },
-    ],
-    [
-      1,
-      {
-        data: {
-          col1: "1-col1",
-          col2: "1-col2",
+  const data: TreeGridData = {
+    children: [1, 3],
+    rows: new Map([
+      [
+        1,
+        {
+          data: {
+            col1: "1-col1",
+            col2: "1-col2",
+          },
+          children: [2],
         },
-        children: [2],
-      },
-    ],
-    [
-      2,
-      {
-        data: {
-          col1: "2-col1",
-          col2: "2-col2",
-          col3: "2-col3",
+      ],
+      [
+        2,
+        {
+          data: {
+            col1: "2-col1",
+            col2: "2-col2",
+            col3: "2-col3",
+          },
         },
-      },
-    ],
-    [
-      3,
-      {
-        data: {
-          col1: "3-col1",
-          col2: "3-col2",
-          col3: <AccountTreeIcon />,
+      ],
+      [
+        3,
+        {
+          data: {
+            col1: "3-col1",
+            col2: "3-col2",
+            col3: <AccountTreeIcon />,
+          },
         },
-      },
-    ],
-  ]);
+      ],
+    ]),
+  };
 
   const rowCustomization = (id: TreeGridId) => {
     // Add variety to the rows.

--- a/ui/src/components/treeGridHelpers.tsx
+++ b/ui/src/components/treeGridHelpers.tsx
@@ -14,19 +14,18 @@ export function useArrayAsTreeGridData<
 >(array: T[], key: K): TreeGridData<TreeGridItem<T>> {
   return useMemo(() => {
     const children: TreeGridId[] = [];
-    const data = new Map<TreeGridId, TreeGridItem<T>>([
-      // Force empty data here since it's never accessed but making it optional
-      // is a pain for "data" access everywhere.
-      ["root", { data: {} as T, children }],
-    ]);
+    const rows = new Map<TreeGridId, TreeGridItem<T>>();
 
     array?.forEach((a) => {
       const k = a[key] as TreeGridId;
-      data.set(k, { data: a });
+      rows.set(k, { data: a });
       children.push(k);
     });
 
-    return data;
+    return {
+      rows,
+      children,
+    };
   }, [array, key]);
 }
 export function fromProtoColumns(

--- a/ui/src/export.tsx
+++ b/ui/src/export.tsx
@@ -27,7 +27,7 @@ import Checkbox from "components/checkbox";
 import Empty from "components/empty";
 import Loading from "components/loading";
 import { Tabs as TanagraTabs } from "components/tabs";
-import { TreeGrid, TreeGridData } from "components/treeGrid";
+import { TreeGrid, TreeGridData, TreeGridId } from "components/treeGrid";
 import { Cohort, ExportModel, ExportResultLink, FeatureSet } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useUnderlaySource } from "data/underlaySourceContext";
@@ -496,19 +496,21 @@ function PreviewTable(props: PreviewTableProps) {
             props.featureSets
           );
 
-          const data: TreeGridData = new Map([
-            ["root", { data: {}, children: [] }],
-          ]);
+          const children: TreeGridId[] = [];
+          const rows = new Map();
 
           res.data.forEach((entry, i) => {
-            data.set(i, { data: entry });
-            data.get("root")?.children?.push(i);
+            rows.set(i, { data: entry });
+            children.push(i);
           });
 
           return {
             name: filters.name,
             sql: filters.sql ?? res.sql,
-            data: data,
+            data: {
+              rows,
+              children,
+            },
           };
         })
       );
@@ -572,8 +574,7 @@ function PreviewTable(props: PreviewTableProps) {
                   </Typography>
                 </GridBox>
               ) : tabDataState.data?.[tab]?.data ? (
-                tabDataState.data?.[tab]?.data?.get("root")?.children
-                  ?.length ? (
+                tabDataState.data?.[tab]?.data?.children?.length ? (
                   <TreeGrid
                     data={tabDataState.data?.[tab]?.data}
                     columns={props.occurrenceFilters[tab]?.attributes.map(

--- a/ui/src/featureSet/addFeatureSet.tsx
+++ b/ui/src/featureSet/addFeatureSet.tsx
@@ -7,7 +7,7 @@ import { generateId, getCriteriaTitle, sectionName } from "cohort";
 import { insertCohortCriteria, useCohortContext } from "cohortContext";
 import Empty from "components/empty";
 import Loading from "components/loading";
-import { TreeGrid, TreeGridId } from "components/treeGrid";
+import { TreeGrid } from "components/treeGrid";
 import { useArrayAsTreeGridData } from "components/treeGridHelpers";
 import { FeatureSet } from "data/source";
 import { useStudySource } from "data/studySourceContext";
@@ -46,7 +46,7 @@ export function AddFeatureSet() {
   const params = useBaseParams();
   const secondBlock = useIsSecondBlock();
 
-  const featureSetsState = useSWR(
+  const featureSetsState = useSWR<FeatureSetData[]>(
     {
       type: "featureSets",
       studyId,
@@ -114,16 +114,7 @@ export function AddFeatureSet() {
             <TreeGrid
               data={data}
               columns={columns}
-              rowCustomization={(id: TreeGridId) => {
-                if (!featureSetsState.data) {
-                  return undefined;
-                }
-
-                const featureSetData = data.get(id)?.data as FeatureSetData;
-                if (!featureSetData) {
-                  return undefined;
-                }
-
+              rowCustomization={(id, { data: featureSetData }) => {
                 return [
                   {
                     column: columns.length - 2,

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -23,7 +23,7 @@ import { SaveStatus } from "components/saveStatus";
 import { useSimpleDialog } from "components/simpleDialog";
 import { Tabs } from "components/tabs";
 import { useTextInputDialog } from "components/textInputDialog";
-import { TreeGrid, TreeGridData } from "components/treeGrid";
+import { TreeGrid, TreeGridData, TreeGridId } from "components/treeGrid";
 import { Criteria } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useUnderlaySource } from "data/underlaySourceContext";
@@ -344,19 +344,21 @@ function Preview() {
             true
           );
 
-          const data: TreeGridData = new Map([
-            ["root", { data: {}, children: [] }],
-          ]);
+          const children: TreeGridId[] = [];
+          const rows = new Map();
 
           res.data.forEach((entry, i) => {
-            data.set(i, { data: entry });
-            data.get("root")?.children?.push(i);
+            rows.set(i, { data: entry });
+            children?.push(i);
           });
 
           return {
             id: params.id,
             name: params.name,
-            data: data,
+            data: {
+              rows,
+              children,
+            },
             attributes: params.attributes,
           };
         })
@@ -375,7 +377,7 @@ function Preview() {
                 id: data.name,
                 title: data.name,
                 render: () =>
-                  data.data.get("root")?.children?.length ? (
+                  data.data.children?.length ? (
                     previewOccurrences[i] ? (
                       <PreviewTable
                         occurrence={previewOccurrences[i]}

--- a/ui/src/sampleApp/studiesList.tsx
+++ b/ui/src/sampleApp/studiesList.tsx
@@ -6,7 +6,7 @@ import Empty from "components/empty";
 import Loading from "components/loading";
 import { useSimpleDialog } from "components/simpleDialog";
 import { useTextInputDialog } from "components/textInputDialog";
-import { TreeGrid, TreeGridData } from "components/treeGrid";
+import { TreeGrid } from "components/treeGrid";
 import { useStudySource } from "data/studySourceContext";
 import { DataKey } from "data/types";
 import GridLayout from "layout/gridLayout";
@@ -71,7 +71,7 @@ export function StudiesList() {
 
   const data = useMemo(() => {
     const children: DataKey[] = [];
-    const data: TreeGridData = new Map([["root", { data: {}, children }]]);
+    const rows = new Map();
 
     studiesState.data?.forEach((study) => {
       const key = study.id;
@@ -117,10 +117,13 @@ export function StudiesList() {
           ),
         },
       };
-      data.set(key, item);
+      rows.set(key, item);
     });
 
-    return data;
+    return {
+      children,
+      rows,
+    };
   }, [studiesState, showConfirmDialog, listStudies, studySource]);
 
   return (
@@ -131,7 +134,7 @@ export function StudiesList() {
       <Header />
       <Loading status={studiesState}>
         <GridLayout rows spacing={4}>
-          {data?.get("root")?.children?.length ? (
+          {data?.children?.length ? (
             <TreeGrid columns={columns} data={data} />
           ) : (
             <Empty

--- a/ui/src/sampleApp/studyOverview.tsx
+++ b/ui/src/sampleApp/studyOverview.tsx
@@ -5,7 +5,7 @@ import IconButton from "@mui/material/IconButton";
 import Empty from "components/empty";
 import Loading from "components/loading";
 import { useSimpleDialog } from "components/simpleDialog";
-import { TreeGrid, TreeGridData, TreeGridId } from "components/treeGrid";
+import { TreeGrid, TreeGridId } from "components/treeGrid";
 import { useStudySource } from "data/studySourceContext";
 import { DataKey } from "data/types";
 import { useStudyId, useUnderlay } from "hooks";
@@ -114,7 +114,7 @@ export function StudyOverview() {
 
   const data = useMemo(() => {
     const children: DataKey[] = [];
-    const data: TreeGridData = new Map([["root", { data: {}, children }]]);
+    const rows = new Map();
 
     artifactsState.data?.forEach((artifact) => {
       const key = `${artifact.type}~${artifact.id}`;
@@ -147,10 +147,13 @@ export function StudyOverview() {
           ),
         },
       };
-      data.set(key, item);
+      rows.set(key, item);
     });
 
-    return data;
+    return {
+      children,
+      rows,
+    };
   }, [artifactsState.data, deleteArtifact, showConfirmDialog]);
 
   const newCohort = async () => {
@@ -200,7 +203,7 @@ export function StudyOverview() {
           </GridLayout>
         </GridBox>
         <Loading status={artifactsState}>
-          {data?.get("root")?.children?.length ? (
+          {data?.children?.length ? (
             <TreeGrid
               columns={columns}
               data={data}


### PR DESCRIPTION
* Both items and data can be typed separately, though it mostly only makes sense to customize one or the other. EntityGroup criteria have generic data and typed items to store extra associated info such as the entity group but the study pages just have typed data because it's simpler.
* Pass the item to rowCustomization callbacks since it contains the data as well. Type it appropriately.
* Split the root children out so there's no need for an awkward root object.