### PR TITLE
Fix month for UI date formatter

### DIFF
--- a/ui/src/util/date.ts
+++ b/ui/src/util/date.ts
@@ -1,6 +1,6 @@
 // Formats a date (without time) similar to RFC 3339 but in the local time zone.
 export function standardDateString(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth()).padStart(
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
     2,
     "0"
   )}-${String(date.getDate()).padStart(2, "0")}`;


### PR DESCRIPTION
Fixes issue where dates are displaying the zero-based index for the month
![months](https://github.com/user-attachments/assets/4a9db4e5-05a6-4898-ba56-a30fedbac548)
