### PR TITLE
Add endpoint for all cohorts

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/CohortsApiController.java
@@ -16,12 +16,14 @@ import bio.terra.tanagra.app.authentication.SpringAuthentication;
 import bio.terra.tanagra.app.controller.objmapping.FromApiUtils;
 import bio.terra.tanagra.app.controller.objmapping.ToApiUtils;
 import bio.terra.tanagra.generated.controller.CohortsApi;
+import bio.terra.tanagra.generated.model.ApiAllCohortList;
 import bio.terra.tanagra.generated.model.ApiCohort;
 import bio.terra.tanagra.generated.model.ApiCohortCloneInfo;
 import bio.terra.tanagra.generated.model.ApiCohortCountQuery;
 import bio.terra.tanagra.generated.model.ApiCohortCreateInfo;
 import bio.terra.tanagra.generated.model.ApiCohortList;
 import bio.terra.tanagra.generated.model.ApiCohortUpdateInfo;
+import bio.terra.tanagra.generated.model.ApiCohortWithStudy;
 import bio.terra.tanagra.generated.model.ApiInstanceCountList;
 import bio.terra.tanagra.service.UnderlayService;
 import bio.terra.tanagra.service.accesscontrol.AccessControlService;
@@ -37,6 +39,7 @@ import bio.terra.tanagra.service.authentication.UserId;
 import bio.terra.tanagra.service.filter.FilterBuilderService;
 import bio.terra.tanagra.underlay.Underlay;
 import bio.terra.tanagra.underlay.entitymodel.Entity;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -118,7 +121,7 @@ public class CohortsApiController implements CohortsApi {
   }
 
   @Override
-  public ResponseEntity<ApiCohortList> listAllCohorts(
+  public ResponseEntity<ApiAllCohortList> listAllCohorts(
       String userAccessGroup, Integer offset, Integer limit) {
     ResourceCollection authorizedStudyIds =
         accessControlService.listAuthorizedResources(
@@ -130,7 +133,7 @@ public class CohortsApiController implements CohortsApi {
 
     List<Study> authorizedStudies =
         studyService.listStudies(authorizedStudyIds, offset, limit, false, null);
-    ApiCohortList apiCohorts = new ApiCohortList();
+    ApiAllCohortList apiAllCohorts = new ApiAllCohortList();
     authorizedStudies.forEach(
         study -> {
           ResourceCollection authorizedCohortIds =
@@ -142,9 +145,21 @@ public class CohortsApiController implements CohortsApi {
                   limit);
           cohortService
               .listCohorts(authorizedCohortIds, offset, limit)
-              .forEach(cohort -> apiCohorts.add(ToApiUtils.toApiObject(cohort)));
+              .forEach(
+                  cohort -> {
+                    ApiCohortWithStudy cohortWithStudy = new ApiCohortWithStudy();
+                    cohortWithStudy.setId(cohort.getId());
+                    cohortWithStudy.setUnderlayName(cohort.getUnderlay());
+                    cohortWithStudy.setDisplayName(cohort.getDisplayName());
+                    cohortWithStudy.setCriteriaGroupSections(Collections.emptyList());
+                    cohortWithStudy.setCreated(cohort.getCreated());
+                    cohortWithStudy.setCreatedBy(cohort.getCreatedBy());
+                    cohortWithStudy.setLastModified(cohort.getLastModified());
+                    cohortWithStudy.setStudyId(study.getId());
+                    apiAllCohorts.add(cohortWithStudy);
+                  });
         });
-    return ResponseEntity.ok(apiCohorts);
+    return ResponseEntity.ok(apiAllCohorts);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
+++ b/service/src/main/java/bio/terra/tanagra/app/controller/objmapping/ToApiUtils.java
@@ -119,6 +119,7 @@ public final class ToApiUtils {
     return new ApiCohort()
         .id(cohort.getId())
         .underlayName(cohort.getUnderlay())
+        .studyId(cohort.getStudyId())
         .displayName(cohort.getDisplayName())
         .description(cohort.getDescription())
         .created(cohort.getCreated())

--- a/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
+++ b/service/src/main/java/bio/terra/tanagra/db/CohortDao.java
@@ -35,12 +35,13 @@ public class CohortDao {
 
   // SQL query and row mapper for reading a cohort.
   private static final String COHORT_SELECT_SQL =
-      "SELECT id, underlay, created, created_by, last_modified, last_modified_by, display_name, description, is_deleted FROM cohort";
+      "SELECT id, underlay, study_id, created, created_by, last_modified, last_modified_by, display_name, description, is_deleted FROM cohort";
   private static final RowMapper<Cohort.Builder> COHORT_ROW_MAPPER =
       (rs, rowNum) ->
           Cohort.builder()
               .id(rs.getString("id"))
               .underlay(rs.getString("underlay"))
+              .studyId(rs.getString("study_id"))
               .created(JdbcUtils.timestampToOffsetDateTime(rs.getTimestamp("created")))
               .createdBy(rs.getString("created_by"))
               .lastModified(JdbcUtils.timestampToOffsetDateTime(rs.getTimestamp("last_modified")))

--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/Cohort.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/Cohort.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 public final class Cohort {
   private final String id;
   private final String underlay;
+  private final String studyId;
   private final OffsetDateTime created;
   private final String createdBy;
   private final OffsetDateTime lastModified;
@@ -27,6 +28,7 @@ public final class Cohort {
   private Cohort(Builder builder) {
     this.id = builder.id;
     this.underlay = builder.underlay;
+    this.studyId = builder.studyId;
     this.created = builder.created;
     this.createdBy = builder.createdBy;
     this.lastModified = builder.lastModified;
@@ -47,6 +49,10 @@ public final class Cohort {
 
   public String getUnderlay() {
     return underlay;
+  }
+
+  public String getStudyId() {
+    return studyId;
   }
 
   public OffsetDateTime getCreated() {
@@ -93,6 +99,7 @@ public final class Cohort {
   public static class Builder {
     private String id;
     private String underlay;
+    private String studyId;
     private OffsetDateTime created;
     private String createdBy;
     private OffsetDateTime lastModified;
@@ -109,6 +116,11 @@ public final class Cohort {
 
     public Builder underlay(String underlay) {
       this.underlay = underlay;
+      return this;
+    }
+
+    public Builder studyId(String studyId) {
+      this.studyId = studyId;
       return this;
     }
 

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -462,7 +462,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CohortList"
+                $ref: "#/components/schemas/AllCohortList"
         500:
           $ref: "#/components/responses/ServerError"
 
@@ -2328,10 +2328,25 @@ components:
         - createdBy
         - lastModified
 
+    CohortWithStudy:
+      allOf:
+        - $ref: "#/components/schemas/Cohort"
+        - type: object
+          required:
+            - studyId
+          properties:
+            studyId:
+              type: string
+
     CohortList:
       type: array
       items:
         $ref: "#/components/schemas/Cohort"
+
+    AllCohortList:
+      type: array
+      items:
+        $ref: "#/components/schemas/CohortWithStudy"
 
     CohortId:
       type: string

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -447,6 +447,25 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
+  "/v2/studies/allCohorts":
+    get:
+      parameters:
+        - $ref: "#/components/parameters/ParamUserAccessGroup"
+        - $ref: "#/components/parameters/ParamOffset"
+        - $ref: "#/components/parameters/ParamLimit"
+      summary: List all cohorts
+      operationId: listAllCohorts
+      tags: [ Cohorts ]
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CohortList"
+        500:
+          $ref: "#/components/responses/ServerError"
+
   "/v2/studies/{studyId}/cohorts/{cohortId}":
     parameters:
       - $ref: "#/components/parameters/ParamStudyId"

--- a/service/src/main/resources/api/service_openapi.yaml
+++ b/service/src/main/resources/api/service_openapi.yaml
@@ -462,7 +462,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AllCohortList"
+                $ref: "#/components/schemas/CohortList"
         500:
           $ref: "#/components/responses/ServerError"
 
@@ -2297,6 +2297,8 @@ components:
           $ref: "#/components/schemas/CohortRevisionId"
         underlayName:
           $ref: "#/components/schemas/UnderlayName"
+        studyId:
+          $ref: "#/components/schemas/studyId"
         displayName:
           $ref: "#/components/schemas/CohortDisplayName"
         description:
@@ -2322,31 +2324,17 @@ components:
       required:
         - id
         - underlayName
+        - studyId
         - displayName
         - criteriaGroups
         - created
         - createdBy
         - lastModified
 
-    CohortWithStudy:
-      allOf:
-        - $ref: "#/components/schemas/Cohort"
-        - type: object
-          required:
-            - studyId
-          properties:
-            studyId:
-              type: string
-
     CohortList:
       type: array
       items:
         $ref: "#/components/schemas/Cohort"
-
-    AllCohortList:
-      type: array
-      items:
-        $ref: "#/components/schemas/CohortWithStudy"
 
     CohortId:
       type: string
@@ -2513,6 +2501,10 @@ components:
     UnderlayName:
       type: string
       description: Name of the underlay, immutable
+
+    studyId:
+      type: string
+      description: Name of the study
 
     CriteriaGroupSection:
       type: object

--- a/ui/src/fakeApis.ts
+++ b/ui/src/fakeApis.ts
@@ -225,6 +225,7 @@ export class FakeCohortsAPI {
         displayName: "Test Cohort",
         lastModified: new Date(),
         underlayName: "test_underlay",
+        studyId: "test_study",
         criteriaGroupSections: [],
       },
     ];


### PR DESCRIPTION
Add a new `listAllCohorts` endpoint to the cohorts api for use in SD/eMERGE admin apps. Takes a `userAccessGroup` param and should return all cohorts the current user has access to.