### PR TITLE
Add Sites and age chart to eMERGE underlay

### DIFF
--- a/underlay/src/main/resources/config/ui/emerge/viz/sitesAndAge/sitesAndAge.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sitesAndAge/sitesAndAge.json
@@ -1,0 +1,20 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "site"
+        },
+        {
+          "attribute": "age",
+          "numericBucketing": {
+            "thresholds": [18, 45, 65],
+            "includeGreater": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/sitesAndAge/viz.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sitesAndAge/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "sitesAndAge",
+  "title": "Sites and age",
+  "dataConfigFile": "sitesAndAge.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/underlay/emerge/underlay.json
+++ b/underlay/src/main/resources/config/underlay/emerge/underlay.json
@@ -68,7 +68,8 @@
   ],
   "visualizations": [
     "omop/gender",
-    "omop/raceAndAge"
+    "omop/raceAndAge",
+    "emerge/sitesAndAge"
   ],
   "metadata": {
     "displayName": "eMerge Record Counter Dataset",


### PR DESCRIPTION
Add new visualization option to emerge underlay to display sites and age ranges

![Screenshot 2025-04-17 at 10 56 20 AM](https://github.com/user-attachments/assets/72de368c-8c3a-4341-9b0c-4b00d392acd0)
