### PR TITLE
fix attributes for phewas occurrence modifier

### DIFF
--- a/underlay/src/main/resources/config/criteria/emerge/criteriaselector/phewas/idSeqGroupByCount.json
+++ b/underlay/src/main/resources/config/criteria/emerge/criteriaselector/phewas/idSeqGroupByCount.json
@@ -1,12 +1,29 @@
 {
   "groupByCount": true,
   "attributes": {
-    "icd9Occurrence": {
+    "icd9cmOccurrence": {
       "values": [
         "id",
         "icd9"
       ]
+    },
+    "icd9procOccurrence": {
+      "values": [
+        "id",
+        "icd9"
+      ]
+    },
+    "icd10cmOccurrence": {
+      "values": [
+        "id",
+        "icd10"
+      ]
+    },
+    "icd10pcsOccurrence": {
+      "values": [
+        "id",
+        "icd10"
+      ]
     }
   }
 }
-


### PR DESCRIPTION
The phewas occurrence modifier had an entity that didn't exist set in the criteria selector config. This config is working locally for me.
![Screenshot 2025-05-12 at 1 24 07 PM](https://github.com/user-attachments/assets/ce9d06f2-c0a9-40f5-aca5-cb80d1a2cf0b)
