### PR TITLE
Fix drug name column for universal search results

### DIFF
--- a/underlay/src/main/resources/config/criteria/emerge/criteriaselector/drug/drug.json
+++ b/underlay/src/main/resources/config/criteria/emerge/criteriaselector/drug/drug.json
@@ -1,9 +1,9 @@
 {
   "columns": [
     {
-      "key": "label",
+      "key": "name",
       "widthString": "100%",
-      "title": "Label"
+      "title": "Name"
     },
     {
       "key": "concept_code",

--- a/underlay/src/main/resources/config/underlay/emerge/ui.json
+++ b/underlay/src/main/resources/config/underlay/emerge/ui.json
@@ -8,7 +8,8 @@
     "columns": [
       { "key": "name", "width": "100%", "title": "Name" },
       { "key": "concept_code", "width": 120, "title": "Code" },
-      { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" }
+      { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
+      { "key": "t_item_count", "width": 150, "title": "Item Count" }
     ]
   }
 }


### PR DESCRIPTION
Renamed the column key from `label` to `name` since the `drug` entity has the same value set for both keys. Also added a column for item count as a workaround until we can update the universal search config to work for both counts.
![Screenshot 2025-05-19 at 3 26 10 PM](https://github.com/user-attachments/assets/817a9870-5612-4f16-ba5e-1836c79603e7)

