### PR TITLE
Add sites charts with stacked gender and race 

### DIFF
--- a/underlay/src/main/resources/config/ui/emerge/viz/sites/sites.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sites/sites.json
@@ -1,0 +1,13 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "site"
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/sites/viz.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sites/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "sites",
+  "title": "Sites",
+  "dataConfigFile": "sites.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/sitesAndGender/sitesAndGender.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sitesAndGender/sitesAndGender.json
@@ -1,0 +1,21 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "site"
+        },
+        {
+          "attribute": "gender",
+          "numericBucketing": {
+            "thresholds": [18, 45, 65],
+            "includeLesser": true,
+            "includeGreater": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/sitesAndGender/viz.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sitesAndGender/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "sitesAndGender",
+  "title": "Sites and gender",
+  "dataConfigFile": "sitesAndGender.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/sitesAndRace/sitesAndRace.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sitesAndRace/sitesAndRace.json
@@ -8,7 +8,7 @@
           "attribute": "site"
         },
         {
-          "attribute": "gender"
+          "attribute": "race"
         }
       ]
     }

--- a/underlay/src/main/resources/config/ui/emerge/viz/sitesAndRace/viz.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/sitesAndRace/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "sitesAndRace",
+  "title": "Sites and race",
+  "dataConfigFile": "sitesAndRace.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/underlay/emerge/underlay.json
+++ b/underlay/src/main/resources/config/underlay/emerge/underlay.json
@@ -69,7 +69,10 @@
   "visualizations": [
     "omop/gender",
     "omop/raceAndAge",
-    "emerge/sitesAndAge"
+    "emerge/sites",
+    "emerge/sitesAndAge",
+    "emerge/sitesAndGender",
+    "emerge/sitesAndRace"
   ],
   "metadata": {
     "displayName": "eMerge Record Counter Dataset",


### PR DESCRIPTION
Adds three visualization options to the emerge underlay: `sites`, `sitesAndGender` and `sitesAndRace`.

![Screenshot 2025-05-22 at 4 16 09 PM](https://github.com/user-attachments/assets/5b5beebb-dab4-4287-ba84-241883ef62d7)

![Screenshot 2025-05-22 at 2 27 02 PM](https://github.com/user-attachments/assets/27639513-1490-46ef-a056-0ff221fc3f5a)
