### PR TITLE
UI fixes for hierarchy issues

### DIFF
--- a/ui/src/components/search.tsx
+++ b/ui/src/components/search.tsx
@@ -105,7 +105,10 @@ export function Search(props: SearchProps) {
               />
               <FormSpy
                 onChange={(state) => {
-                  onChange(state.values.query);
+                  // Check if the value actually changed to prevent unneeded re-renders
+                  if (state.values.query !== state.initialValues.query) {
+                    onChange(state.values.query);
+                  }
                 }}
               />
               {props.showSearchButton ? (

--- a/ui/src/components/treeGrid.tsx
+++ b/ui/src/components/treeGrid.tsx
@@ -202,7 +202,7 @@ export function TreeGrid<ItemType extends TreeGridItem = TreeGridItem>(
         de.forEach((id) => toggleExpanded(draft, id));
       });
     }
-  }, [props.defaultExpanded, toggleExpanded, updateState]);
+  }, [props.defaultExpanded, updateState]);
 
   const onSort = useCallback(
     (col: TreeGridColumn, orders?: TreeGridSortOrder[]) => {


### PR DESCRIPTION
- Prevent reload of search that required clicking the hierarchy button twice
- Prevent reload of the hierarchy subtree on criteria change when entering at a non-root node

See the recording below where the hierarchy was entered on first click at level 2 and did not reload the tree when a selection was made

https://github.com/user-attachments/assets/abd6cb99-e798-4961-bbb5-b824b314ef90 