### PR TITLE
Set default charts for cohorts

### DIFF
--- a/ui/src/demographicCharts.tsx
+++ b/ui/src/demographicCharts.tsx
@@ -24,7 +24,7 @@ export function DemographicCharts(props: DemographicChartsProps) {
   const underlay = useUnderlay();
 
   const [selectedVisualizations, setSelectedVisualizations] = useState(
-    getInitialVisualizations(underlay)
+    getInitialVisualizations(underlay, props.cohort?.id ?? "")
   );
 
   const onSelect = (event: SelectChangeEvent<string[]>) => {
@@ -37,7 +37,7 @@ export function DemographicCharts(props: DemographicChartsProps) {
     }
 
     setSelectedVisualizations(sel);
-    storeSelectedVisualizations(underlay.name, sel);
+    storeSelectedVisualizations(underlay.name, props.cohort?.id ?? "", sel);
   };
 
   return (
@@ -106,27 +106,34 @@ export function DemographicCharts(props: DemographicChartsProps) {
 }
 
 // TODO(tjennison): Store the selected visualizations in local storage per
-// underlay for now.  Longer term, these should be stored on the backend but
+// underlay and cohort for now.  Longer term, these should be stored on the backend but
 // there a few options about whether they should be stored attached to the
 // cohort, study, user, etc. as part of the visualiation changes.
-function storageKey(underlay: string) {
-  return `tanagra-selected-visualizations-${underlay}`;
+function storageKey(underlay: string, cohortId: string) {
+  return `tanagra-selected-visualizations-${underlay}-${cohortId}`;
 }
 
-function loadSelectedVisualizations(underlay: string): string[] | undefined {
-  const stored = localStorage.getItem(storageKey(underlay));
+function loadSelectedVisualizations(
+  underlay: string,
+  cohortId: string
+): string[] | undefined {
+  const stored = localStorage.getItem(storageKey(underlay, cohortId));
   if (!stored) {
     return undefined;
   }
   return JSON.parse(stored);
 }
 
-function storeSelectedVisualizations(underlay: string, sel: string[]) {
-  localStorage.setItem(storageKey(underlay), JSON.stringify(sel));
+function storeSelectedVisualizations(
+  underlay: string,
+  cohortId: string,
+  sel: string[]
+) {
+  localStorage.setItem(storageKey(underlay, cohortId), JSON.stringify(sel));
 }
 
-function getInitialVisualizations(underlay: Underlay) {
-  const stored = loadSelectedVisualizations(underlay.name);
+function getInitialVisualizations(underlay: Underlay, cohortId: string) {
+  const stored = loadSelectedVisualizations(underlay.name, cohortId);
   if (!stored) {
     return (
       underlay.uiConfiguration.defaultVisualizations ??

--- a/underlay/src/main/resources/config/underlay/emerge/ui.json
+++ b/underlay/src/main/resources/config/underlay/emerge/ui.json
@@ -11,5 +11,6 @@
       { "key": "t_rollup_count", "width": 150, "title": "Roll-up Count" },
       { "key": "t_item_count", "width": 150, "title": "Item Count" }
     ]
-  }
+  },
+  "defaultVisualizations": ["gender", "raceAndAge"]
 }

--- a/underlay/src/main/resources/config/underlay/sd/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd/ui.json
@@ -589,5 +589,6 @@
         }
       }
     ]
-  }
+  },
+  "defaultVisualizations": ["genderAndAge", "raceAndAge"]
 }


### PR DESCRIPTION
- Set default charts for new SD & eMERGE cohorts
- Save changes to selected charts per cohort instead of per underlay

SD defaults to `Gender and age` and `Race and age` charts
![Screenshot 2025-06-23 at 2 57 43 PM](https://github.com/user-attachments/assets/5a4e6d9c-9868-450b-9b49-33bce7bcfe95)

eMERGE defaults to `Gender identity` and `Race and age` charts
![Screenshot 2025-06-23 at 2 59 01 PM](https://github.com/user-attachments/assets/a66e67b9-b65a-4978-90b8-43e69f74b62f)