### PR TITLE
VDA-2181-Remove all omop/viz refs fron SD and eMerge

### DIFF
--- a/underlay/src/main/resources/config/ui/emerge/viz/gender/gender.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/gender/gender.json
@@ -1,0 +1,13 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "gender"
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/gender/viz.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/gender/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "gender",
+  "title": "Gender identity",
+  "dataConfigFile": "gender.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/raceAndAge/raceAndAge.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/raceAndAge/raceAndAge.json
@@ -1,0 +1,21 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "race"
+        },
+        {
+          "attribute": "age",
+          "numericBucketing": {
+            "thresholds": [18, 45, 65],
+            "includeLesser": true,
+            "includeGreater": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/emerge/viz/raceAndAge/viz.json
+++ b/underlay/src/main/resources/config/ui/emerge/viz/raceAndAge/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "raceAndAge",
+  "title": "Race and Age",
+  "dataConfigFile": "raceAndAge.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/age/age.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/age/age.json
@@ -1,0 +1,18 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "age",
+          "numericBucketing": {
+            "thresholds": [18, 45, 65],
+            "includeLesser": true,
+            "includeGreater": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/age/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/age/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "age",
+  "title": "Age",
+  "dataConfigFile": "age.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/gender/gender.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/gender/gender.json
@@ -1,0 +1,13 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "gender"
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/gender/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/gender/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "gender",
+  "title": "Gender identity",
+  "dataConfigFile": "gender.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/genderAndAge/genderAndAge.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/genderAndAge/genderAndAge.json
@@ -1,0 +1,21 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "gender"
+        },
+        {
+          "attribute": "age",
+          "numericBucketing": {
+            "thresholds": [18, 45, 65],
+            "includeLesser": true,
+            "includeGreater": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/genderAndAge/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/genderAndAge/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "genderAndAge",
+  "title": "Gender and age",
+  "dataConfigFile": "genderAndAge.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/race/race.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/race/race.json
@@ -1,0 +1,13 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "race"
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/race/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/race/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "race",
+  "title": "Race",
+  "dataConfigFile": "race.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/raceAndAge/raceAndAge.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/raceAndAge/raceAndAge.json
@@ -1,0 +1,21 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "demographics",
+      "joins": [],
+      "attributes": [
+        {
+          "attribute": "race"
+        },
+        {
+          "attribute": "age",
+          "numericBucketing": {
+            "thresholds": [18, 45, 65],
+            "includeLesser": true,
+            "includeGreater": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/raceAndAge/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/raceAndAge/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "raceAndAge",
+  "title": "Race and Age",
+  "dataConfigFile": "raceAndAge.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topConditions/topConditions.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topConditions/topConditions.json
@@ -1,0 +1,20 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "conditions",
+      "joins": [
+        {
+          "entity": "person"
+        }
+      ],
+      "attributes": [
+        {
+          "attribute": "condition",
+          "sortType": "VALUE",
+          "sortDescending": true,
+          "limit": 10
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topConditions/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topConditions/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "topConditions",
+  "title": "Top 10 conditions",
+  "dataConfigFile": "topConditions.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topIngredients/topIngredients.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topIngredients/topIngredients.json
@@ -1,0 +1,20 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "ingredients",
+      "joins": [
+        {
+          "entity": "person"
+        }
+      ],
+      "attributes": [
+        {
+          "attribute": "ingredient",
+          "sortType": "VALUE",
+          "sortDescending": true,
+          "limit": 10
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topIngredients/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topIngredients/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "topIngredients",
+  "title": "Top 10 drugs",
+  "dataConfigFile": "topIngredients.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topMeasurements/topMeasurements.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topMeasurements/topMeasurements.json
@@ -1,0 +1,20 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "measurements",
+      "joins": [
+        {
+          "entity": "person"
+        }
+      ],
+      "attributes": [
+        {
+          "attribute": "measurement",
+          "sortType": "VALUE",
+          "sortDescending": true,
+          "limit": 10
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topMeasurements/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topMeasurements/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "topMeasurements",
+  "title": "Top 10 labs",
+  "dataConfigFile": "topMeasurements.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topProcedures/topProcedures.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topProcedures/topProcedures.json
@@ -1,0 +1,20 @@
+{
+  "sources": [
+    {
+      "criteriaSelector": "procedures",
+      "joins": [
+        {
+          "entity": "person"
+        }
+      ],
+      "attributes": [
+        {
+          "attribute": "procedure",
+          "sortType": "VALUE",
+          "sortDescending": true,
+          "limit": 10
+        }
+      ]
+    }
+  ]
+}

--- a/underlay/src/main/resources/config/ui/sd/viz/topProcedures/viz.json
+++ b/underlay/src/main/resources/config/ui/sd/viz/topProcedures/viz.json
@@ -1,0 +1,6 @@
+{
+  "name": "topProcedures",
+  "title": "Top 10 procedures",
+  "dataConfigFile": "topProcedures.json",
+  "plugin": "core/bar"
+}

--- a/underlay/src/main/resources/config/underlay/emerge/underlay.json
+++ b/underlay/src/main/resources/config/underlay/emerge/underlay.json
@@ -67,8 +67,8 @@
     "emerge/outputUnfiltered"
   ],
   "visualizations": [
-    "omop/gender",
-    "omop/raceAndAge",
+    "emerge/gender",
+    "emerge/raceAndAge",
     "emerge/sites",
     "emerge/sitesAndAge",
     "emerge/sitesAndGender",

--- a/underlay/src/main/resources/config/underlay/sd/underlay.json
+++ b/underlay/src/main/resources/config/underlay/sd/underlay.json
@@ -126,15 +126,15 @@
     "sd/_demographics"
   ],
   "visualizations": [
-    "omop/genderAndAge",
-    "omop/raceAndAge",
-    "omop/age",
-    "omop/race",
-    "omop/gender",
-    "omop/topConditions",
-    "omop/topProcedures",
-    "omop/topIngredients",
-    "omop/topMeasurements"
+    "sd/genderAndAge",
+    "sd/raceAndAge",
+    "sd/age",
+    "sd/race",
+    "sd/gender",
+    "sd/topConditions",
+    "sd/topProcedures",
+    "sd/topIngredients",
+    "sd/topMeasurements"
   ],
   "metadata": {
     "displayName": "Synthetic Derivative Discover Dataset",


### PR DESCRIPTION
- Removed references to omop/viz and replaced with
  - sd/[visualization] for SD underlay
  -  emerge/[visualization] for eMerge underlay
  - Created sd.viz for all vizualizations as copy of omop.viz
  - Created emerge.viz/ missing visualizations as copy of omop/viz
- Tested visualizations by deploying branch version to dev environment