### PR TITLE
VDA-2193-Updates for using concept_synonym agnostic of domain

### DIFF
--- a/underlay/src/main/resources/config/datamapping/sd/entity/brand/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/brand/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": ["id", "name", "concept_code"],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/brand/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/brand/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/condition/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/condition/entity.json
@@ -10,7 +10,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/condition/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/condition/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/conditionNonHierarchy/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/conditionNonHierarchy/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/conditionNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/conditionNonHierarchy/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/cpt4/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/cpt4/entity.json
@@ -12,7 +12,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "code" ]
+    "attributes": [ "id", "name", "code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/cpt4/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/cpt4/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/device/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/device/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/device/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/device/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd10cm/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd10cm/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd10cm/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd10cm/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd10pcs/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd10pcs/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd10pcs/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd10pcs/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd9cm/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd9cm/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd9cm/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd9cm/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd9proc/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd9proc/entity.json
@@ -11,7 +11,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/icd9proc/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/icd9proc/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/ingredient/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/ingredient/entity.json
@@ -10,7 +10,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/ingredient/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/ingredient/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/ingredientNonHierarchy/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/ingredientNonHierarchy/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/ingredientNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/ingredientNonHierarchy/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementLoinc/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementLoinc/entity.json
@@ -10,7 +10,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementLoinc/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementLoinc/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementNonHierarchy/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementNonHierarchy/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementNonHierarchy/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementSnomed/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementSnomed/entity.json
@@ -10,7 +10,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/measurementSnomed/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/measurementSnomed/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/observation/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/observation/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/observation/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/observation/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/procedure/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/procedure/entity.json
@@ -10,7 +10,10 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   },
   "hierarchies": [
     {

--- a/underlay/src/main/resources/config/datamapping/sd/entity/procedure/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/procedure/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/procedureNonHierarchy/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/procedureNonHierarchy/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/procedureNonHierarchy/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/procedureNonHierarchy/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters

--- a/underlay/src/main/resources/config/datamapping/sd/entity/visit/entity.json
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/visit/entity.json
@@ -10,6 +10,9 @@
   ],
   "idAttribute": "id",
   "textSearch": {
-    "attributes": [ "id", "name", "concept_code" ]
+    "attributes": [ "id", "name", "concept_code" ],
+    "idTextPairsSqlFile": "textSearch.sql",
+    "idFieldName": "concept_id",
+    "textFieldName": "concept_synonym_name"
   }
 }

--- a/underlay/src/main/resources/config/datamapping/sd/entity/visit/textSearch.sql
+++ b/underlay/src/main/resources/config/datamapping/sd/entity/visit/textSearch.sql
@@ -1,0 +1,3 @@
+SELECT concept_id, concept_synonym_name
+FROM `${omopDataset}.concept_synonym`
+WHERE REGEXP_CONTAINS(concept_synonym_name, r'[\x00-\x7F]+') --only English characters


### PR DESCRIPTION
- Add `concept_synonym` to all searches
- this enables searching ehr concepts using synonyms
- Example search by "Hb S" 
  - With concept_synonym: 
<img width="1358" alt="with-concept-synonym-search" src="https://github.com/user-attachments/assets/41c0e515-d647-4d48-820f-c8bf250c61d8" />

  - Without concept_synonym: 
<img width="959" alt="no-concept-synonym-search" src="https://github.com/user-attachments/assets/fb5345e1-c4e9-4cd9-80f1-1f3cfe2fe660" />
