### PR TITLE
VDA-2303-2304-Fix rollup counts and fix review filters 

### DIFF
--- a/underlay/src/main/resources/config/criteria/sd/criteriaselector/observations/observations.json
+++ b/underlay/src/main/resources/config/criteria/sd/criteriaselector/observations/observations.json
@@ -26,11 +26,6 @@
       "title": "Code"
     },
     {
-      "key": "t_rollup_count",
-      "widthDouble": 150,
-      "title": "Roll-up count"
-    },
-    {
       "key": "t_item_count",
       "widthDouble": 150,
       "title": "Item count"
@@ -61,11 +56,6 @@
       "key": "concept_code",
       "widthDouble": 120,
       "title": "Code"
-    },
-    {
-      "key": "t_rollup_count",
-      "widthDouble": 150,
-      "title": "Roll-up count"
     },
     {
       "key": "t_item_count",

--- a/underlay/src/main/resources/config/underlay/sd/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd/ui.json
@@ -311,7 +311,13 @@
               "sortable": true,
               "filterable": true
             },
-            { "key": "start_date", "width": 200, "title": "Date", "sortable": true },
+            {
+              "key": "start_date",
+              "width": 200,
+              "title": "Date",
+              "sortable": true,
+              "filterable": true
+            },
             {
               "key": "value_enum",
               "width": 200,
@@ -326,12 +332,19 @@
               "sortable": true,
               "filterable": true
             },
-            { "key": "unit", "width": 160, "title": "Unit", "sortable": true },
+            {
+              "key": "unit",
+              "width": 160,
+              "title": "Unit",
+              "sortable": true,
+              "filterable": true
+            },
             {
               "key": "measurement_type",
               "width": 250,
               "title": "Measurement type",
-              "sortable": true
+              "sortable": true,
+              "filterable": true
             },
             {
               "key": "source_value",
@@ -344,7 +357,8 @@
               "key": "age_at_occurrence",
               "width": 170,
               "title": "Age at event",
-              "sortable": true
+              "sortable": true,
+              "filterable": true
             }
           ]
         }


### PR DESCRIPTION
- VDA-2303 - Remove `Rollup counts` from observation results table 
<img width="1400" height="513" alt="Screenshot 2025-07-11 at 1 30 55 PM" src="https://github.com/user-attachments/assets/d43097ee-6de8-47fd-afaf-67d7f5a1aa10" />

- VDA-2304 - add missing filters to Review tab for Labs and Measurements
<img width="1638" height="487" alt="Screenshot 2025-07-11 at 1 31 42 PM" src="https://github.com/user-attachments/assets/0146ad65-c27a-47e4-b8d1-ed9a664c7b61" />
