### PR TITLE
Add config option for code display

### DIFF
--- a/docs/generated/PROTOCOL_BUFFERS.md
+++ b/docs/generated/PROTOCOL_BUFFERS.md
@@ -247,6 +247,7 @@ which have condition_name of &#34;Diabetes&#34;).
 | limit | [int32](#int32) | optional | Number of values to display in the list view for each entity group. Otherwise, a default value is applied. |
 | nameAttribute | [string](#string) | optional | The attribute used to name selections if not the first column. This can be used to include extra context with the selected values that&#39;s not visible in the table view. |
 | codeAttributes | [string](#string) | repeated | Optional attributes to search when adding criteria by code. It&#39;s recommended to enable multi_select when using codeAttributes because multiple codes can be added at the same time which forces the criteria into multi_select mode regardless of the setting. |
+| codeDisplayAttribute | [string](#string) | optional | The attribute to specify which column to use to display the code with name for criteria selections. |
 
 
 
@@ -768,6 +769,7 @@ Data for an entity group criteria is a list of selected values.
 | key | [tanagra.Key](#tanagra-Key) |  | The key of the selected value, which references a related entity (e.g. condition for a condition_occurrence). |
 | name | [string](#string) |  | The visible name for the selection. This is stored to avoid extra lookups when rendering. |
 | entityGroup | [string](#string) |  | The entity group is stored to differentiate between them when multiple are configured within a single criteria. |
+| code | [string](#string) |  | The code for the selection. This is stored to avoid extra lookups when rendering. |
 | value_data | [tanagra.ValueData](#tanagra-ValueData) |  | Data for additional categorical or numeric values associated with the selection (e.g. a measurement value). |
 
 

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -66,6 +66,7 @@ import { isValid } from "util/valid";
 type Selection = {
   key: DataKey;
   name: string;
+  code: string;
   entityGroup: string;
   valueData?: ValueData;
 };
@@ -103,6 +104,7 @@ export interface Data {
     if (dataEntries) {
       dataEntries?.forEach((e) => {
         const name = String(e[nameAttribute(config)]);
+        const code = String(e.code);
         const entityGroup = String(e.entityGroup);
         if (!name || !entityGroup) {
           throw new Error(
@@ -113,6 +115,7 @@ export interface Data {
         data.selected.push({
           key: e.key,
           name,
+          code,
           entityGroup,
         });
       });
@@ -176,7 +179,9 @@ class _ implements CriteriaPlugin<string> {
             ? `${sel[0].name} and ${sel.length - 1} more`
             : sel[0].name,
         standaloneTitle: true,
-        additionalText: decodedData.selected.map((s) => s.name),
+        additionalText: decodedData.selected.map((s) =>
+          s.code ? `${s.code} ${s.name}` : s.name
+        ),
       };
     }
 
@@ -662,6 +667,11 @@ export function ClassificationEdit(props: ClassificationEditProps) {
                   const newItem = {
                     key: item.node.data.key,
                     name: name ? String(name) : "",
+                    code:
+                      item.data.concept_code &&
+                      item.data.standard_concept === "Source"
+                        ? String(item.data.concept_code)
+                        : "",
                     entityGroup: item.entityGroup,
                   };
 
@@ -1254,6 +1264,7 @@ function decodeData(data: string): Data {
       message.selected?.map((s) => ({
         key: dataKeyFromProto(s.key),
         name: s.name,
+        code: s.code,
         entityGroup: s.entityGroup,
         valueData:
           decodeValueDataOptional(s.valueData) ??
@@ -1267,6 +1278,7 @@ function encodeData(data: Data): string {
     selected: data.selected.map((s) => ({
       key: protoFromDataKey(s.key),
       name: s.name,
+      code: s.code,
       entityGroup: s.entityGroup,
       valueData: encodeValueDataOptional(s.valueData),
     })),

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -1295,5 +1295,5 @@ function nameAttribute(config: configProto.EntityGroup) {
 }
 
 function codeDisplayAttribute(config: configProto.EntityGroup) {
-  return config.codeDisplayAttribute ?? null;
+  return config.codeDisplayAttribute ?? "";
 }

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -179,9 +179,7 @@ class _ implements CriteriaPlugin<string> {
             ? `${sel[0].name} and ${sel.length - 1} more`
             : sel[0].name,
         standaloneTitle: true,
-        additionalText: decodedData.selected.map((s) =>
-          s.code ? `${s.code} ${s.name}` : s.name
-        ),
+        additionalText: decodedData.selected.map((s) => `${s.code} ${s.name}`),
       };
     }
 
@@ -885,7 +883,9 @@ export function ClassificationEdit(props: ClassificationEditProps) {
                                     : undefined,
                               }}
                             >
-                              <Typography variant="body2">{s.name}</Typography>
+                              <Typography variant="body2">
+                                {s.code} {s.name}
+                              </Typography>
                               <IconButton
                                 onClick={() =>
                                   updateLocalCriteria((data) => {

--- a/ui/src/criteria/classification.tsx
+++ b/ui/src/criteria/classification.tsx
@@ -662,14 +662,11 @@ export function ClassificationEdit(props: ClassificationEditProps) {
                   }
 
                   const name = item.data[nameAttribute(props.config)];
+                  const code = item.data[codeDisplayAttribute(props.config)];
                   const newItem = {
                     key: item.node.data.key,
                     name: name ? String(name) : "",
-                    code:
-                      item.data.concept_code &&
-                      item.data.standard_concept === "Source"
-                        ? String(item.data.concept_code)
-                        : "",
+                    code: code ? String(code) : "",
                     entityGroup: item.entityGroup,
                   };
 
@@ -1295,4 +1292,8 @@ function nameAttribute(config: configProto.EntityGroup) {
   return (
     config.nameAttribute ?? config.columns[config.nameColumnIndex ?? 0].key
   );
+}
+
+function codeDisplayAttribute(config: configProto.EntityGroup) {
+  return config.codeDisplayAttribute ?? null;
 }

--- a/underlay/src/main/proto/criteriaselector/configschema/entity_group.proto
+++ b/underlay/src/main/proto/criteriaselector/configschema/entity_group.proto
@@ -73,4 +73,8 @@ message EntityGroup {
   // multiple codes can be added at the same time which forces the criteria into
   // multi_select mode regardless of the setting.
   repeated string codeAttributes = 11;
+
+  // The attribute to specify which column to use to display the code with name
+  // for criteria selections.
+  optional string codeDisplayAttribute = 12;
 }

--- a/underlay/src/main/proto/criteriaselector/dataschema/entity_group.proto
+++ b/underlay/src/main/proto/criteriaselector/dataschema/entity_group.proto
@@ -24,6 +24,10 @@ message EntityGroup {
     // are configured within a single criteria.
     string entityGroup = 3;
 
+    // The code for the selection. This is stored to avoid extra lookups
+    // when rendering.
+    string code = 4;
+
     // Data for additional categorical or numeric values associated with the
     // selection (e.g. a measurement value).
     ValueData value_data = 6;

--- a/underlay/src/main/resources/config/criteria/sd/criteriaselector/cpt4/cpt4.json
+++ b/underlay/src/main/resources/config/criteria/sd/criteriaselector/cpt4/cpt4.json
@@ -83,5 +83,6 @@
     }
   ],
   "multiSelect": true,
-  "limit": 200
+  "limit": 200,
+  "codeDisplayAttribute": "concept_code"
 }

--- a/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd10CM/icd10CM.json
+++ b/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd10CM/icd10CM.json
@@ -83,5 +83,6 @@
     }
   ],
   "multiSelect": true,
-  "limit": 200
+  "limit": 200,
+  "codeDisplayAttribute": "concept_code"
 }

--- a/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd10PCS/icd10PCS.json
+++ b/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd10PCS/icd10PCS.json
@@ -83,5 +83,6 @@
     }
   ],
   "multiSelect": true,
-  "limit": 200
+  "limit": 200,
+  "codeDisplayAttribute": "concept_code"
 }

--- a/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd9CM/icd9CM.json
+++ b/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd9CM/icd9CM.json
@@ -83,5 +83,6 @@
     }
   ],
   "multiSelect": true,
-  "limit": 200
+  "limit": 200,
+  "codeDisplayAttribute": "concept_code"
 }

--- a/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd9Proc/icd9Proc.json
+++ b/underlay/src/main/resources/config/criteria/sd/criteriaselector/icd9Proc/icd9Proc.json
@@ -83,5 +83,6 @@
     }
   ],
   "multiSelect": true,
-  "limit": 200
+  "limit": 200,
+  "codeDisplayAttribute": "concept_code"
 }


### PR DESCRIPTION
Add optional `codeDisplayAttribute` to criteria config that specifies the code column. If set, the code will display along with the name in the right side selection list and on the cohort overview.

<img width="1424" height="633" alt="Screenshot 2025-07-29 at 1 27 32 AM" src="https://github.com/user-attachments/assets/93a2aaf6-6b15-455a-976f-adba36bd8666" />
<img width="591" height="519" alt="Screenshot 2025-07-29 at 1 27 48 AM" src="https://github.com/user-attachments/assets/fb34436a-d9bc-4bc3-8c7f-998f534fb4ea" />
