### PR TITLE
Reset page if no results when switching participants

### DIFF
--- a/ui/src/cohortReview/plugins/occurrenceTable.tsx
+++ b/ui/src/cohortReview/plugins/occurrenceTable.tsx
@@ -71,7 +71,7 @@ export function OccurrenceTable({
         state.currentPage = 0;
       });
     }
-  }, [searchState?.currentPage, context.totalCount]);
+  }, [context, currentPage, id, rowsPerPage]);
 
   const data = useMemo(() => {
     const children: DataKey[] = [];
@@ -129,7 +129,7 @@ export function OccurrenceTable({
         (currentPage + 1) * rowsPerPage
       );
     });
-  }, [data, searchState, filterRegExps]);
+  }, [currentPage, data, filterRegExps, rowsPerPage, searchState]);
 
   if (!context) {
     return null;


### PR DESCRIPTION
When changing participants in cohort review, reset to the first page if there are no results available on the current page

https://github.com/user-attachments/assets/c2d9c693-3cc0-46a8-b17d-b4bd627f917c

