### PR TITLE
Add review config for label-only boolean attributes

### DIFF
--- a/ui/src/cohortReview/cohortReview.tsx
+++ b/ui/src/cohortReview/cohortReview.tsx
@@ -249,14 +249,19 @@ export function CohortReview() {
               <GridBox sx={{ m: 2 }} />
               <GridLayout rows>
                 {uiConfig.attributes.map((attribute) =>
-                  attribute.labelOnlyBoolean &&
+                  attribute.showIfTrue &&
                   !instance?.data?.[attribute.key] ? null : (
-                    <GridLayout cols rowAlign="baseline" key={attribute.key}>
+                    <GridLayout
+                      cols
+                      rowAlign="baseline"
+                      key={attribute.key}
+                      sx={{ color: attribute.colorOverride }}
+                    >
                       <Typography variant="body2em" sx={{ fontWeight: 700 }}>
                         {attribute.title}
-                        {!attribute.labelOnlyBoolean && ":"}&nbsp;
+                        {!attribute.showIfTrue && ":"}&nbsp;
                       </Typography>
-                      {!attribute.labelOnlyBoolean && (
+                      {!attribute.showIfTrue && (
                         <Typography variant="body2">
                           {stringifyDataValue(instance?.data?.[attribute.key])}
                         </Typography>

--- a/ui/src/underlaysSlice.ts
+++ b/ui/src/underlaysSlice.ts
@@ -75,7 +75,8 @@ export type CohortReviewConfig = {
 export type CohortReviewAttribute = {
   title: string;
   key: string;
-  labelOnlyBoolean?: boolean;
+  colorOverride?: string;
+  showIfTrue?: boolean;
 };
 
 export type CohortReviewPageConfig = {

--- a/underlay/src/main/resources/config/underlay/sd/ui.json
+++ b/underlay/src/main/resources/config/underlay/sd/ui.json
@@ -37,7 +37,8 @@
       {
         "title": "Deceased",
         "key": "is_deceased",
-        "labelOnlyBoolean": true
+        "showIfTrue": true,
+        "colorOverride": "red"
       }
     ],
     "pages": [


### PR DESCRIPTION
Add a `showIfTrue` property to the underlay config for cohort review attributes. When enabled, it will show the label of the attribute only when the value is true, currently only enabled for deceased.

https://github.com/user-attachments/assets/83ad22e9-f7b6-47aa-b9f0-800a3ec49614

Also adds a `colorOverride` property to set a custom text color

<img width="370" height="385" alt="Screenshot 2025-08-11 at 1 05 42 PM" src="https://github.com/user-attachments/assets/2b858acc-7f75-443f-a846-dbe5a8ca05bb" />
