### PR TITLE
Update artifact name length limit

### DIFF
--- a/service/src/main/java/bio/terra/tanagra/service/artifact/model/Study.java
+++ b/service/src/main/java/bio/terra/tanagra/service/artifact/model/Study.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  */
 @JsonDeserialize(builder = Study.Builder.class)
 public class Study {
-  public static final int MAX_DISPLAY_NAME_LENGTH = 50;
+  public static final int MAX_DISPLAY_NAME_LENGTH = 128;
   private final String id;
   private final @Nullable String displayName;
   private final @Nullable String description;

--- a/ui/src/cohortReview/newAnnotationDialog.tsx
+++ b/ui/src/cohortReview/newAnnotationDialog.tsx
@@ -3,7 +3,7 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import { AnnotationType } from "data/source";
+import { AnnotationType, MAX_DISPLAY_NAME_LENGTH } from "data/source";
 import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
 import { Select, TextField } from "mui-rff";
@@ -72,6 +72,11 @@ export function useNewAnnotationDialog(
         validate={({ displayName }: FormData) => {
           if (!displayName) {
             return { displayName: "Display name may not be blank." };
+          }
+          if (displayName.trim().length > MAX_DISPLAY_NAME_LENGTH) {
+            return {
+              displayName: `Display ame may not exceed ${MAX_DISPLAY_NAME_LENGTH} characters`,
+            };
           }
         }}
         onSubmit={({ displayName, preset }: FormData) => {

--- a/ui/src/cohortReview/newReviewDialog.tsx
+++ b/ui/src/cohortReview/newReviewDialog.tsx
@@ -5,7 +5,7 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Loading from "components/loading";
-import { Cohort } from "data/source";
+import { Cohort, MAX_DISPLAY_NAME_LENGTH } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useStudyId } from "hooks";
 import { GridBox } from "layout/gridBox";
@@ -74,6 +74,8 @@ export function NewReviewDialog(props: NewReviewDialogProps) {
           const ret: Record<string, string> = {};
           if (!name) {
             ret.name = "Name may not be empty.";
+          } else if (name.trim().length > MAX_DISPLAY_NAME_LENGTH) {
+            ret.name = `Name may not exceed ${MAX_DISPLAY_NAME_LENGTH} characters`;
           }
 
           if (!size) {
@@ -109,9 +111,6 @@ export function NewReviewDialog(props: NewReviewDialogProps) {
                       name="name"
                       label="Cohort Review Name"
                       autoComplete="off"
-                      inputProps={{
-                        maxLength: 50,
-                      }}
                     />
                   </GridBox>
                   <GridBox sx={{ height: (theme) => theme.spacing(9) }}>

--- a/ui/src/components/textInputDialog.tsx
+++ b/ui/src/components/textInputDialog.tsx
@@ -3,6 +3,7 @@ import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import { MAX_DISPLAY_NAME_LENGTH } from "data/source";
 import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
 import { TextField } from "mui-rff";
@@ -65,6 +66,13 @@ export function useTextInputDialog(): [
             if (!text) {
               return { text: `${config.textLabel} may not be blank.` };
             }
+            if (
+              text.trim().length > (config.maxLength ?? MAX_DISPLAY_NAME_LENGTH)
+            ) {
+              return {
+                text: `${config.textLabel} exceeds the ${config.maxLength ?? MAX_DISPLAY_NAME_LENGTH} character limit.`,
+              };
+            }
           }}
           render={({ handleSubmit, invalid }) => (
             <form noValidate onSubmit={handleSubmit}>
@@ -76,9 +84,6 @@ export function useTextInputDialog(): [
                       fullWidth
                       name="text"
                       label={config.textLabel}
-                      inputProps={{
-                        maxLength: config.maxLength ?? 50,
-                      }}
                     />
                   </GridBox>
                 </GridLayout>

--- a/ui/src/data/source.tsx
+++ b/ui/src/data/source.tsx
@@ -277,6 +277,8 @@ export type Criteria = {
   predefinedDisplayName?: string;
 };
 
+export const MAX_DISPLAY_NAME_LENGTH = 128;
+
 export type ComputedProperties = {
   supportsTemporalQueries: boolean;
 };


### PR DESCRIPTION
- Update display name limit from 50 to 128
- Modify UI name validation to display help text when limit is exceeded

Limit of 12 seen in screenshots only for testing
<img width="700" height="325" alt="Screenshot 2025-09-22 at 4 01 41 PM" src="https://github.com/user-attachments/assets/d6173ba3-cb15-48f6-947f-4e562634a93c" />
<img width="748" height="360" alt="Screenshot 2025-09-22 at 4 02 06 PM" src="https://github.com/user-attachments/assets/82d60b96-ad63-423b-b948-abd7bcdaf34d" />
<img width="659" height="372" alt="Screenshot 2025-09-22 at 4 07 35 PM" src="https://github.com/user-attachments/assets/15e39904-32c0-4555-b9f7-b2185f2f3f22" />
<img width="690" height="369" alt="Screenshot 2025-09-22 at 4 23 46 PM" src="https://github.com/user-attachments/assets/280d85e7-bb01-4e2a-aa85-735498b0c139" />
