### PR TITLE
Remove old annotation char limit

### DIFF
--- a/ui/src/cohortReview/newAnnotationDialog.tsx
+++ b/ui/src/cohortReview/newAnnotationDialog.tsx
@@ -105,9 +105,6 @@ export function useNewAnnotationDialog(
                     required
                     name="displayName"
                     label="Display name"
-                    inputProps={{
-                      maxLength: 50,
-                    }}
                   />
                 </GridBox>
               </GridLayout>


### PR DESCRIPTION
Remove the `maxLength` prop from the annotation name text field that's no longer needed.