### PR TITLE
Add feature set preview context to prevent redundant api calls

### DIFF
--- a/ui/src/components/tabs.tsx
+++ b/ui/src/components/tabs.tsx
@@ -4,7 +4,7 @@ import TabPanel from "@mui/lab/TabPanel";
 import Tab from "@mui/material/Tab";
 import { GridBox } from "layout/gridBox";
 import GridLayout from "layout/gridLayout";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 export type TabConfig = {
   id: string;
@@ -31,6 +31,13 @@ export function Tabs(props: TabsProps) {
   const onChange = (event: React.SyntheticEvent, newValue: string) => {
     (props.setCurrentTab ?? setCurrentTab)(newValue);
   };
+
+  useEffect(() => {
+    // If the data feature for currentTab was deleted, reset to the first in the list
+    if (!props.configs.some((c) => c.id === currentTab)) {
+      setCurrentTab(props?.configs?.[0]?.id);
+    }
+  }, [props.configs, currentTab]);
 
   return (
     <TabContext

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -322,7 +322,7 @@ function Preview() {
           sourceCriteria: of.sourceCriteria,
         })) ?? [];
       newPreviewOccurrences.sort((a, b) => a.id.localeCompare(b.id));
-      let previewOccurrencesToLoad: PreviewOccurrence[];
+      let previewOccurrencesToLoad: PreviewOccurrence[] = [];
       let updateExisting = false;
       if (newPreviewOccurrences.length > previewContext.previewData?.length) {
         previewOccurrencesToLoad = newPreviewOccurrences.filter(

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -27,7 +27,6 @@ import { TreeGrid, TreeGridData, TreeGridId } from "components/treeGrid";
 import { Criteria } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useUnderlaySource } from "data/underlaySourceContext";
-import deepEqual from "deep-equal";
 import {
   deleteFeatureSetCriteria,
   deletePredefinedFeatureSetCriteria,
@@ -35,6 +34,7 @@ import {
   toggleFeatureSetColumn,
   updateFeatureSet,
   useFeatureSetContext,
+  useFeatureSetPreviewContext,
 } from "featureSet/featureSetContext";
 import { useFeatureSet, useStudyId, useUnderlay } from "hooks";
 import emptyImage from "images/empty.svg";
@@ -49,7 +49,6 @@ import {
   useExitAction,
 } from "router";
 import { StudyName } from "studyName";
-import useSWRImmutable from "swr/immutable";
 import UndoRedoToolbar from "undoRedoToolbar";
 import { safeRegExp } from "util/safeRegExp";
 import { useGlobalSearchState, useNavigate } from "util/searchState";
@@ -290,14 +289,17 @@ function FeatureSetCriteria(props: FeatureSetCriteriaProps) {
 type PreviewOccurrence = {
   id: string;
   attributes: string[];
+  sourceCriteria: string[];
 };
 
-type PreviewTabData = {
+export type PreviewTabData = {
   name: string;
   data: TreeGridData;
+  sourceCriteria: string[];
 };
 
 function Preview() {
+  const previewContext = useFeatureSetPreviewContext();
   const featureSet = useFeatureSet();
   const underlaySource = useUnderlaySource();
   const underlay = useUnderlay();
@@ -311,112 +313,149 @@ function Preview() {
   const [previewOccurrences, setPreviewOccurrences] = useState<
     PreviewOccurrence[]
   >([]);
-  const [previewOccurrencesToLoad, setPreviewOccurrencesToLoad] = useState<
-    PreviewOccurrence[]
-  >([]);
   useEffect(() => {
-    console.log(occurrenceFiltersState.data);
-    return () => console.log("destroy fff");
-  }, []);
-  useEffect(() => {
-    const newPreviewOccurrences =
-      occurrenceFiltersState.data?.map((of) => ({
-        id: of.id,
-        attributes: of.attributes,
-      })) ?? [];
-    console.log(previewOccurrences);
-    console.log(newPreviewOccurrences);
-    console.log(occurrenceFiltersState.data);
-    console.log(previewOccurrencesToLoad);
-    if (newPreviewOccurrences.length > previewOccurrences.length) {
-      console.log("greater length");
-      setPreviewOccurrencesToLoad(
-        newPreviewOccurrences.filter(
-          (npo) => !previewOccurrences.some((po) => po.id === npo.id)
-        )
-      );
-      setPreviewOccurrences(newPreviewOccurrences);
-    } else if (newPreviewOccurrences.length === previewOccurrences.length) {
-      const updatedPreviewOccurrences = newPreviewOccurrences.filter(
-        (npo, n) => !deepEqual(npo.attributes, previewOccurrences[n].attributes)
-      );
-      if (updatedPreviewOccurrences.length > 0) {
-        console.log("updatedPreviewOccurrence");
-        setPreviewOccurrencesToLoad(updatedPreviewOccurrences);
+    if (occurrenceFiltersState.data) {
+      const newPreviewOccurrences =
+        occurrenceFiltersState.data?.map((of) => ({
+          id: of.id,
+          attributes: of.attributes,
+          sourceCriteria: of.sourceCriteria,
+        })) ?? [];
+      newPreviewOccurrences.sort((a, b) => a.id.localeCompare(b.id));
+      let previewOccurrencesToLoad: PreviewOccurrence[];
+      let updateExisting = false;
+      if (newPreviewOccurrences.length > previewContext.previewData?.length) {
+        previewOccurrencesToLoad = newPreviewOccurrences.filter(
+          (npo) => !previewContext.previewData.some((po) => po.name === npo.id)
+        );
+      } else if (
+        newPreviewOccurrences.length === previewContext.previewData?.length
+      ) {
+        const updatedPreviewOccurrences = newPreviewOccurrences.filter(
+          (npo, n) =>
+            JSON.stringify(npo.sourceCriteria) !==
+            JSON.stringify(previewContext.previewData[n].sourceCriteria)
+        );
+        if (updatedPreviewOccurrences.length > 0) {
+          previewOccurrencesToLoad = updatedPreviewOccurrences;
+          previewContext.updatePreviewData(
+            previewContext.previewData.map((pd) => {
+              const updatedIndex = updatedPreviewOccurrences.findIndex(
+                (upo) => upo.id === pd.name
+              );
+              if (updatedIndex > -1) {
+                return {
+                  ...pd,
+                  sourceCriteria:
+                    updatedPreviewOccurrences[updatedIndex].sourceCriteria,
+                };
+              } else {
+                return pd;
+              }
+            })
+          );
+          updateExisting = true;
+        }
+      } else if (
+        newPreviewOccurrences.length < previewContext.previewData?.length
+      ) {
+        const newPreviewData = previewContext.previewData.filter((pd) =>
+          newPreviewOccurrences.some((npo) => npo.id === pd.name)
+        );
+        previewContext.updatePreviewData(newPreviewData);
+      }
+      if (previewOccurrencesToLoad?.length > 0) {
+        loadNewPreviewData(
+          previewOccurrencesToLoad,
+          newPreviewOccurrences,
+          updateExisting
+        );
+      } else if (
+        newPreviewOccurrences.length > 0 &&
+        previewOccurrences.length === 0
+      ) {
         setPreviewOccurrences(newPreviewOccurrences);
       }
-    } else if (newPreviewOccurrences.length < previewOccurrences.length) {
-      setPreviewOccurrencesToLoad([]);
-      setPreviewOccurrences(newPreviewOccurrences);
     }
-  }, [occurrenceFiltersState.data, previewOccurrences]);
+    // Removed loadNewPreviewData from the deps array since it may not be initialized yet and  causes separate lint error
+    // Removed previewContext from the deps array to prevent redundant previewExport calls
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [occurrenceFiltersState.data, previewOccurrences.length]);
 
-  const tabDataState = useSWRImmutable<PreviewTabData[]>(
-    () => {
-      if (
-        !occurrenceFiltersState.data ||
-        previewOccurrencesToLoad.length === 0
-      ) {
-        return false;
-      }
-      return {
-        type: "exportPreview",
-        previewOccurrencesToLoad: previewOccurrencesToLoad,
-      };
-    },
-    async () => {
-      return Promise.all(
-        (occurrenceFiltersState.data ?? []).map(async (params) => {
-          const res = await underlaySource.exportPreview(
-            underlay.name,
-            params.id,
-            studyId,
-            [],
-            [featureSet.id],
-            true
-          );
+  const loadNewPreviewData = async (
+    newOccurrences: PreviewOccurrence[],
+    allOccurrences: PreviewOccurrence[],
+    updateExisting?: boolean
+  ) => {
+    previewContext.setUpdating(true);
+    const newOccurrenceData = await Promise.all(
+      newOccurrences.map(async (params) => {
+        const res = await underlaySource.exportPreview(
+          underlay.name,
+          params.id,
+          studyId,
+          [],
+          [featureSet.id],
+          true
+        );
 
-          const children: TreeGridId[] = [];
-          const rows = new Map();
+        const children: TreeGridId[] = [];
+        const rows = new Map();
 
-          res.data.forEach((entry, i) => {
-            rows.set(i, { data: entry });
-            children?.push(i);
-          });
+        res.data.forEach((entry, i) => {
+          rows.set(i, { data: entry });
+          children?.push(i);
+        });
 
-          return {
-            id: params.id,
-            name: params.name,
-            data: {
-              rows,
-              children,
-            },
-            attributes: params.attributes,
-          };
-        })
-      );
+        return {
+          id: params.id,
+          name: params.id,
+          data: {
+            rows,
+            children,
+          },
+          attributes: params.attributes,
+          sourceCriteria: params.sourceCriteria,
+        };
+      })
+    );
+    if (!updateExisting) {
+      const updatedPreviewData = [
+        ...previewContext.previewData,
+        ...newOccurrenceData,
+      ];
+      updatedPreviewData.sort((a, b) => a.name.localeCompare(b.name));
+      previewContext.updatePreviewData(updatedPreviewData);
     }
-  );
+    previewContext.setUpdating(false);
+    allOccurrences.sort((a, b) => a.id.localeCompare(b.id));
+    setPreviewOccurrences(allOccurrences);
+  };
 
   return (
     <GridLayout rows sx={{ pt: 1 }}>
       {featureSet.criteria.length > 0 ||
       featureSet.predefinedCriteria.length > 0 ? (
         <Loading
-          status={tabDataState}
-          isLoading={occurrenceFiltersState.isLoading || tabDataState.isLoading}
+          status={{}}
+          isLoading={
+            occurrenceFiltersState.isLoading || previewContext.updating
+          }
           showLoadingMessage={true}
         >
           <Tabs
             configs={
-              (tabDataState.data ?? []).map((data, i) => ({
+              (previewContext.previewData ?? []).map((data) => ({
                 id: data.name,
                 title: data.name,
-                render: () =>
-                  data.data.children?.length ? (
-                    previewOccurrences[i] ? (
+                render: () => {
+                  const previewOccurrence = previewOccurrences.find(
+                    (po) => po.id === data.name
+                  );
+                  return data.data.children?.length ? (
+                    previewOccurrence ? (
                       <PreviewTable
-                        occurrence={previewOccurrences[i]}
+                        occurrence={previewOccurrence}
                         data={data}
                       />
                     ) : null
@@ -429,7 +468,8 @@ function Preview() {
                         subtitle="No data in this table matched the specified cohorts and data features"
                       />
                     </GridLayout>
-                  ),
+                  );
+                },
               })) ?? []
             }
           />

--- a/ui/src/featureSet/featureSet.tsx
+++ b/ui/src/featureSet/featureSet.tsx
@@ -311,25 +311,57 @@ function Preview() {
   const [previewOccurrences, setPreviewOccurrences] = useState<
     PreviewOccurrence[]
   >([]);
+  const [previewOccurrencesToLoad, setPreviewOccurrencesToLoad] = useState<
+    PreviewOccurrence[]
+  >([]);
+  useEffect(() => {
+    console.log(occurrenceFiltersState.data);
+    return () => console.log("destroy fff");
+  }, []);
   useEffect(() => {
     const newPreviewOccurrences =
       occurrenceFiltersState.data?.map((of) => ({
         id: of.id,
         attributes: of.attributes,
       })) ?? [];
-    if (!deepEqual(newPreviewOccurrences, previewOccurrences)) {
+    console.log(previewOccurrences);
+    console.log(newPreviewOccurrences);
+    console.log(occurrenceFiltersState.data);
+    console.log(previewOccurrencesToLoad);
+    if (newPreviewOccurrences.length > previewOccurrences.length) {
+      console.log("greater length");
+      setPreviewOccurrencesToLoad(
+        newPreviewOccurrences.filter(
+          (npo) => !previewOccurrences.some((po) => po.id === npo.id)
+        )
+      );
+      setPreviewOccurrences(newPreviewOccurrences);
+    } else if (newPreviewOccurrences.length === previewOccurrences.length) {
+      const updatedPreviewOccurrences = newPreviewOccurrences.filter(
+        (npo, n) => !deepEqual(npo.attributes, previewOccurrences[n].attributes)
+      );
+      if (updatedPreviewOccurrences.length > 0) {
+        console.log("updatedPreviewOccurrence");
+        setPreviewOccurrencesToLoad(updatedPreviewOccurrences);
+        setPreviewOccurrences(newPreviewOccurrences);
+      }
+    } else if (newPreviewOccurrences.length < previewOccurrences.length) {
+      setPreviewOccurrencesToLoad([]);
       setPreviewOccurrences(newPreviewOccurrences);
     }
   }, [occurrenceFiltersState.data, previewOccurrences]);
 
   const tabDataState = useSWRImmutable<PreviewTabData[]>(
     () => {
-      if (!occurrenceFiltersState.data || previewOccurrences.length === 0) {
+      if (
+        !occurrenceFiltersState.data ||
+        previewOccurrencesToLoad.length === 0
+      ) {
         return false;
       }
       return {
         type: "exportPreview",
-        previewOccurrences: previewOccurrences,
+        previewOccurrencesToLoad: previewOccurrencesToLoad,
       };
     },
     async () => {

--- a/ui/src/featureSet/featureSetContext.ts
+++ b/ui/src/featureSet/featureSetContext.ts
@@ -2,6 +2,7 @@ import { getCriteriaTitle } from "cohort";
 import { Criteria, FeatureSet } from "data/source";
 import { useStudySource } from "data/studySourceContext";
 import { useUnderlaySource } from "data/underlaySourceContext";
+import { PreviewTabData } from "featureSet/featureSet.tsx";
 import { produce } from "immer";
 import { createContext, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
@@ -28,6 +29,25 @@ type FeatureSetContextData = {
   ) => void;
 };
 
+type FeatureSetPreviewContextData = {
+  previewData: PreviewTabData[];
+  updatePreviewData: (state: PreviewTabData[]) => void;
+  updating: boolean;
+  setUpdating: (state: boolean) => void;
+};
+
+export const FeatureSetPreviewContext =
+  createContext<FeatureSetPreviewContextData | null>(null);
+
+export function useFeatureSetPreviewContext() {
+  const context = useContext(FeatureSetPreviewContext);
+  if (!context) {
+    throw new Error(
+      "Attempting to use featureSet preview context when not provided."
+    );
+  }
+  return context;
+}
 export const FeatureSetContext = createContext<FeatureSetContextData | null>(
   null
 );

--- a/ui/src/featureSet/featureSetRoot.tsx
+++ b/ui/src/featureSet/featureSetRoot.tsx
@@ -1,7 +1,9 @@
 import Snackbar from "@mui/material/Snackbar";
 import Loading from "components/loading";
+import { PreviewTabData } from "featureSet/featureSet";
 import {
   FeatureSetContext,
+  FeatureSetPreviewContext,
   featureSetUndoRedo,
   useNewFeatureSetContext,
 } from "featureSet/featureSetContext";
@@ -15,6 +17,8 @@ export default function FeatureSetRoot() {
 
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
+  const [previewData, setPreviewData] = useState<PreviewTabData[]>([]);
+  const [updatingPreview, setUpdatingPreview] = useState<boolean>(false);
 
   const status = useNewFeatureSetContext((message: string) => {
     setMessage(message);
@@ -35,13 +39,22 @@ export default function FeatureSetRoot() {
         <UndoRedoContext.Provider
           value={featureSetUndoRedo(params, status.context)}
         >
-          <Outlet />
-          <Snackbar
-            open={open}
-            autoHideDuration={5000}
-            onClose={handleClose}
-            message={message}
-          />
+          <FeatureSetPreviewContext.Provider
+            value={{
+              previewData,
+              updatePreviewData: setPreviewData,
+              updating: updatingPreview,
+              setUpdating: setUpdatingPreview,
+            }}
+          >
+            <Outlet />
+            <Snackbar
+              open={open}
+              autoHideDuration={5000}
+              onClose={handleClose}
+              message={message}
+            />
+          </FeatureSetPreviewContext.Provider>
         </UndoRedoContext.Provider>
       </FeatureSetContext.Provider>
     </Loading>


### PR DESCRIPTION
Add new `FeatureSetPreviewContext` to store all data features/selections. This allow us to determine which data features were updated and only call `previewExport` endpoint if needed.